### PR TITLE
chore: remove unused crontab config in FoundationServiceProvider

### DIFF
--- a/src/foundation/src/Providers/FoundationServiceProvider.php
+++ b/src/foundation/src/Providers/FoundationServiceProvider.php
@@ -107,7 +107,6 @@ class FoundationServiceProvider extends ServiceProvider
             'databases.default' => $connections[$this->config->get('database.default')] ?? [],
             'databases.default.migrations' => $migration,
             'redis' => $this->getRedisConfig(),
-            'crontab.enable' => $this->config->get('crontab.enable', true),
         ];
 
         foreach ($configs as $key => $value) {


### PR DESCRIPTION
Since we have deprecated Hyperf's crontab component, this config is not needed anymore.