### PR TITLE
fix: fix version of phpunit to 10.5.45 to prevent from breaking change for runTest method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,7 +184,7 @@
         "nunomaduro/collision": "^8.5",
         "pda/pheanstalk": "v5.0.9",
         "phpstan/phpstan": "^1.11.5",
-        "phpunit/phpunit": "^10.0.7",
+        "phpunit/phpunit": "10.5.45",
         "pusher/pusher-php-server": "^7.2",
         "swoole/ide-helper": "~5.1.0"
     },


### PR DESCRIPTION
PHPUnit suddenly has a breaking change to `runTest` function in `TestCase` class, which leads failure for coroutine wrappings in test cases.

https://github.com/sebastianbergmann/phpunit/commit/8f0f8205e3a38675392da55afc573c6bb6a43f4e

Try to find another way to fix it in the future.