### PR TITLE
Feat: support PHP 8.4

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
           - php: "8.3"
             swoole: "5.1.6"
           - php: "8.4"
-            swoole: "5.1.6"
+            swoole: "6.0.2"
 
     name: PHP ${{ matrix.php }} (swoole-${{ matrix.swoole }})
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,6 +17,8 @@ jobs:
             swoole: "5.1.6"
           - php: "8.3"
             swoole: "5.1.6"
+          - php: "8.4"
+            swoole: "5.1.6"
 
     name: PHP ${{ matrix.php }} (swoole-${{ matrix.swoole }})
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           - php: "8.3"
             swoole: "5.1.6"
           - php: "8.4"
-            swoole: "5.1.6"
+            swoole: "6.0.2"
 
     name: PHP ${{ matrix.php }} (swoole-${{ matrix.swoole }})
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
             swoole: "5.1.6"
           - php: "8.3"
             swoole: "5.1.6"
+          - php: "8.4"
+            swoole: "5.1.6"
 
     name: PHP ${{ matrix.php }} (swoole-${{ matrix.swoole }})
 

--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,8 @@
         "symfony/mailer": "^6.2",
         "tijsverkoyen/css-to-inline-styles": "^2.2.5",
         "symfony/process": "^6.2",
-        "dragonmantank/cron-expression": "^3.3.2"
+        "dragonmantank/cron-expression": "^3.3.2",
+        "hypervel/laminas-mime": "^0.1.0"
     },
     "replace": {
         "hypervel/auth": "self.version",
@@ -155,8 +156,7 @@
         "hypervel/session": "self.version",
         "hypervel/support": "self.version",
         "hypervel/telescope": "self.version",
-        "hypervel/testbench": "self.version",
-        "hypervel/laminas-mime": "*"
+        "hypervel/testbench": "self.version"
     },
     "suggest": {
         "hyperf/redis": "Required to use redis driver. (^3.1).",

--- a/composer.json
+++ b/composer.json
@@ -172,7 +172,7 @@
     },
     "require-dev": {
         "ably/ably-php": "^1.0",
-        "fakerphp/faker": "^2.0",
+        "fakerphp/faker": "^1.24.1",
         "filp/whoops": "^2.15",
         "friendsofphp/php-cs-fixer": "^3.57.2",
         "hyperf/devtool": "~3.1.0",
@@ -184,7 +184,7 @@
         "league/flysystem-google-cloud-storage": "^3.0",
         "league/flysystem-path-prefixing": "^3.3",
         "league/flysystem-read-only": "^3.3",
-        "mockery/mockery": "^1.5.1",
+        "mockery/mockery": "1.6.x-dev",
         "nunomaduro/collision": "^8.5",
         "pda/pheanstalk": "v5.0.9",
         "phpstan/phpstan": "^1.11.5",

--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,8 @@
         "hypervel/session": "self.version",
         "hypervel/support": "self.version",
         "hypervel/telescope": "self.version",
-        "hypervel/testbench": "self.version"
+        "hypervel/testbench": "self.version",
+        "hypervel/laminas-mime": "*"
     },
     "suggest": {
         "hyperf/redis": "Required to use redis driver. (^3.1).",

--- a/src/cache/src/LimitedMaxHeap.php
+++ b/src/cache/src/LimitedMaxHeap.php
@@ -15,13 +15,16 @@ class LimitedMaxHeap extends SplMaxHeap
     public function insert(mixed $value): true
     {
         if ($this->count() < $this->limit) {
-            return parent::insert($value);
+            parent::insert($value);
+            return true;
         }
 
         if ($this->compare($value, $this->top()) < 0) {
             $this->extract();
         }
 
-        return parent::insert($value);
+        parent::insert($value);
+
+        return true;
     }
 }

--- a/src/cache/src/LimitedMaxHeap.php
+++ b/src/cache/src/LimitedMaxHeap.php
@@ -12,7 +12,7 @@ class LimitedMaxHeap extends SplMaxHeap
     {
     }
 
-    public function insert(mixed $value): bool
+    public function insert(mixed $value): true
     {
         if ($this->count() < $this->limit) {
             return parent::insert($value);
@@ -20,10 +20,8 @@ class LimitedMaxHeap extends SplMaxHeap
 
         if ($this->compare($value, $this->top()) < 0) {
             $this->extract();
-
-            return parent::insert($value);
         }
 
-        return false;
+        return parent::insert($value);
     }
 }

--- a/src/core/composer.json
+++ b/src/core/composer.json
@@ -30,7 +30,8 @@
         "hyperf/database": "~3.1.0",
         "hyperf/http-message": "~3.1.0",
         "hyperf/context": "~3.1.0",
-        "hyperf/redis": "~3.1.0"
+        "hyperf/redis": "~3.1.0",
+        "hypervel/laminas-mime": "^0.1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^2.0"

--- a/src/core/composer.json
+++ b/src/core/composer.json
@@ -30,8 +30,7 @@
         "hyperf/database": "~3.1.0",
         "hyperf/http-message": "~3.1.0",
         "hyperf/context": "~3.1.0",
-        "hyperf/redis": "~3.1.0",
-        "hypervel/laminas-mime": "^0.1.0"
+        "hyperf/redis": "~3.1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^2.0"


### PR DESCRIPTION
Because `laminas/laminas-mime` package is abandoned, the project installation will occur error in PHP 8.4.
To fix this we replace this abandoned package with an alternative, and upgrade versions of mockery and faker in dev.