### PR TITLE
improve: report exceptions in coroutines

### DIFF
--- a/src/coroutine/src/Concurrent.php
+++ b/src/coroutine/src/Concurrent.php
@@ -4,8 +4,48 @@ declare(strict_types=1);
 
 namespace Hypervel\Coroutine;
 
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Coroutine\Concurrent as BaseConcurrent;
+use Hyperf\ExceptionHandler\Formatter\FormatterInterface;
+use Hypervel\Foundation\Exceptions\Contracts\ExceptionHandler as ExceptionHandlerContract;
+use Throwable;
 
 class Concurrent extends BaseConcurrent
 {
+    public function create(callable $callable): void
+    {
+        $this->channel->push(true);
+
+        Coroutine::create(function () use ($callable) {
+            try {
+                $callable();
+            } catch (Throwable $exception) {
+                $this->reportException($exception);
+            } finally {
+                $this->channel->pop();
+            }
+        });
+    }
+
+    protected function reportException(Throwable $throwable): void
+    {
+        if (! ApplicationContext::hasContainer()) {
+            return;
+        }
+
+        $container = ApplicationContext::getContainer();
+
+        if ($container->has(ExceptionHandlerContract::class)) {
+            $container->get(ExceptionHandlerContract::class)
+                ->report($throwable);
+            return;
+        }
+
+        if ($container->has(StdoutLoggerInterface::class) && $container->has(FormatterInterface::class)) {
+            $logger = $container->get(StdoutLoggerInterface::class);
+            $formatter = $container->get(FormatterInterface::class);
+            $logger->error($formatter->format($throwable));
+        }
+    }
 }

--- a/src/coroutine/src/Coroutine.php
+++ b/src/coroutine/src/Coroutine.php
@@ -4,8 +4,37 @@ declare(strict_types=1);
 
 namespace Hypervel\Coroutine;
 
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Coroutine\Coroutine as BaseCoroutine;
+use Hyperf\ExceptionHandler\Formatter\FormatterInterface;
+use Hypervel\Foundation\Exceptions\Contracts\ExceptionHandler as ExceptionHandlerContract;
+use Throwable;
 
 class Coroutine extends BaseCoroutine
 {
+    protected static function printLog(Throwable $throwable): void
+    {
+        if (! ApplicationContext::hasContainer()) {
+            return;
+        }
+
+        $container = ApplicationContext::getContainer();
+
+        if ($container->has(ExceptionHandlerContract::class)) {
+            $container->get(ExceptionHandlerContract::class)
+                ->report($throwable);
+            return;
+        }
+
+        if ($container->has(StdoutLoggerInterface::class)) {
+            $logger = $container->get(StdoutLoggerInterface::class);
+            if ($container->has(FormatterInterface::class)) {
+                $formatter = $container->get(FormatterInterface::class);
+                $logger->warning($formatter->format($throwable));
+            } else {
+                $logger->warning((string) $throwable);
+            }
+        }
+    }
 }


### PR DESCRIPTION
To report exceptions in Hyperf's coroutines, we need to catch them and report to the exception handler.