### PR TITLE
improve: make Hypervel's translation compatible with Hyperf's translation

### DIFF
--- a/src/foundation/src/Application.php
+++ b/src/foundation/src/Application.php
@@ -583,8 +583,14 @@ class Application extends Container implements ApplicationContract
                 'filesystem',
                 \Hypervel\Filesystem\FilesystemManager::class,
             ],
-            \Hypervel\Translation\Contracts\Loader::class => ['translator.loader'],
-            \Hypervel\Translation\Contracts\Translator::class => ['translator'],
+            \Hypervel\Translation\Contracts\Loader::class => [
+                'translator.loader',
+                \Hyperf\Contract\TranslatorLoaderInterface::class,
+            ],
+            \Hypervel\Translation\Contracts\Translator::class => [
+                'translator',
+                \Hyperf\Contract\TranslatorInterface::class,
+            ],
             \Hyperf\Validation\Contract\ValidatorFactoryInterface::class => ['validator'],
             \Psr\Http\Message\ServerRequestInterface::class => [
                 'request',

--- a/src/translation/composer.json
+++ b/src/translation/composer.json
@@ -30,6 +30,7 @@
     },
     "require": {
         "php": "^8.2",
+        "hyperf/contract": "~3.1.0",
         "hypervel/filesystem": "^0.1",
         "hypervel/support": "^0.1"
     },

--- a/src/translation/src/Contracts/Loader.php
+++ b/src/translation/src/Contracts/Loader.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hypervel\Translation\Contracts;
 
-interface Loader
+use Hyperf\Contract\TranslatorLoaderInterface;
+
+interface Loader extends TranslatorLoaderInterface
 {
     /**
      * Load the messages for the given locale.

--- a/src/translation/src/Contracts/Translator.php
+++ b/src/translation/src/Contracts/Translator.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Hypervel\Translation\Contracts;
 
 use Countable;
+use Hyperf\Contract\TranslatorInterface;
 
-interface Translator
+interface Translator extends TranslatorInterface
 {
     /**
      * Get the translation for a given key.

--- a/src/translation/src/Translator.php
+++ b/src/translation/src/Translator.php
@@ -484,4 +484,22 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         $this->stringableHandlers[$class] = $handler;
     }
+
+    /**
+     * Get the translation for a given key.
+     */
+    public function trans(string $key, array $replace = [], ?string $locale = null): array|string
+    {
+        return $this->get($key, $replace, $locale);
+    }
+
+    /**
+     * Get a translation according to an integer value.
+     *
+     * @param array|Countable|int $number
+     */
+    public function transChoice(string $key, $number, array $replace = [], ?string $locale = null): string
+    {
+        return $this->choice($key, $number, $replace, $locale);
+    }
 }


### PR DESCRIPTION
Because the validation component still relies on Hyperf's translation interface, we need to make Hypervel's translator compatible with Hyperf's contract.