### PR TITLE
feat: enhance Request::all() method with selective field filtering

### DIFF
--- a/src/foundation/src/Http/FormRequest.php
+++ b/src/foundation/src/Http/FormRequest.php
@@ -127,19 +127,11 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function createDefaultValidator(ValidationFactory $factory): Validator
     {
         return $factory->make(
-            $this->validationData(),
+            $this->all(),
             $this->getRules(),
             $this->messages(),
             $this->attributes()
         );
-    }
-
-    /**
-     * Get data to be validated from the request.
-     */
-    protected function validationData(): array
-    {
-        return array_merge_recursive($this->all(), $this->getUploadedFiles());
     }
 
     /**

--- a/src/http/src/Request.php
+++ b/src/http/src/Request.php
@@ -404,6 +404,26 @@ class Request extends HyperfRequest implements RequestContract
     }
 
     /**
+     * Get all the input and files for the request.
+     */
+    public function all(mixed $keys = null): array
+    {
+        $input = array_replace_recursive($this->getInputData(), $this->allFiles());
+
+        if (! $keys) {
+            return $input;
+        }
+
+        $results = [];
+
+        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
+            Arr::set($results, $key, Arr::get($input, $key));
+        }
+
+        return $results;
+    }
+
+    /**
      * Gets the scheme and HTTP host.
      *
      * If the URL was called with basic authentication, the user

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -77,6 +77,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John', 'age' => 30]);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -122,6 +123,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John', 'age' => 30, 'email' => 'john@example.com']);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -184,6 +186,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John', 'age' => 30]);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -307,6 +310,10 @@ class RequestTest extends TestCase
 
     public function testMerge()
     {
+        $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
+        Context::set(ServerRequestInterface::class, $psrRequest);
+
         Context::set('http.request.parsedData', ['name' => 'John']);
         $request = new Request();
 
@@ -316,6 +323,10 @@ class RequestTest extends TestCase
 
     public function testReplace()
     {
+        $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
+        Context::set(ServerRequestInterface::class, $psrRequest);
+
         Context::set('http.request.parsedData', ['name' => 'John', 'age' => 30]);
         $request = new Request();
 
@@ -328,6 +339,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John']);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -352,6 +364,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John', 'age' => 30, 'email' => 'john@example.com']);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -456,6 +469,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['key' => 'value']);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -477,6 +491,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['key' => 'value']);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 
@@ -692,6 +707,7 @@ class RequestTest extends TestCase
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
         $psrRequest->shouldReceive('getQueryParams')->andReturn([]);
         $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John Doe']);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([]);
         Context::set(ServerRequestInterface::class, $psrRequest);
         $request = new Request();
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -59,6 +59,36 @@ class RequestTest extends TestCase
         $this->assertFalse($request->anyFilled(['age', 'email']));
     }
 
+    public function testAll()
+    {
+        $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);
+        $psrRequest->shouldReceive('getParsedBody')->andReturn(['name' => 'John', 'email' => '']);
+        $psrRequest->shouldReceive('getQueryParams')->andReturn(['foo' => 'bar']);
+        $psrRequest->shouldReceive('getUploadedFiles')->andReturn([
+            'file' => new UploadedFile('/tmp/tmp_name', 32, 0),
+            'avatar' => new UploadedFile('/tmp/avatar.jpg', 512, 0),
+        ]);
+        Context::set(ServerRequestInterface::class, $psrRequest);
+        $request = new Request();
+
+        $allData = $request->all();
+        $expected = [
+            'name' => 'John',
+            'email' => '',
+            'foo' => 'bar',
+            'file' => new UploadedFile('/tmp/tmp_name', 32, 0),
+            'avatar' => new UploadedFile('/tmp/avatar.jpg', 512, 0),
+        ];
+        $this->assertEquals($expected, $allData);
+
+        $specificData = $request->all(['name', 'avatar']);
+        $expectedSpecific = [
+            'name' => 'John',
+            'avatar' => new UploadedFile('/tmp/avatar.jpg', 512, 0),
+        ];
+        $this->assertEquals($expectedSpecific, $specificData);
+    }
+
     public function testBoolean()
     {
         $psrRequest = Mockery::mock(ServerRequestPlusInterface::class);


### PR DESCRIPTION
Enhanced Request all() method with selective field filtering

Previously, file validation rules would fail because `validate()` uses `all()` internally, 
but `all()` didn't include uploaded files