### PR TITLE
improve: improve default connection in RedisBroadcaster

### DIFF
--- a/src/broadcasting/src/BroadcastManager.php
+++ b/src/broadcasting/src/BroadcastManager.php
@@ -354,7 +354,7 @@ class BroadcastManager implements BroadcastingFactoryContract
         return new RedisBroadcaster(
             $this->app,
             $this->app->get(RedisFactory::class),
-            $config['connection'] ?? null,
+            $config['connection'] ?? 'default',
             $this->app->get(ConfigInterface::class)->get('database.redis.options.prefix', ''),
         );
     }

--- a/src/broadcasting/src/Broadcasters/RedisBroadcaster.php
+++ b/src/broadcasting/src/Broadcasters/RedisBroadcaster.php
@@ -23,7 +23,7 @@ class RedisBroadcaster extends Broadcaster
     public function __construct(
         protected ContainerInterface $container,
         protected RedisFactory $factory,
-        protected ?string $connection = null,
+        protected string $connection = 'default',
         protected string $prefix = ''
     ) {
     }
@@ -66,8 +66,8 @@ class RedisBroadcaster extends Broadcaster
         $user = $this->retrieveUser($channelName);
 
         $broadcastIdentifier = method_exists($user, 'getAuthIdentifierForBroadcasting')
-                        ? $user->getAuthIdentifierForBroadcasting()
-                        : $user->getAuthIdentifier();
+            ? $user->getAuthIdentifierForBroadcasting()
+            : $user->getAuthIdentifier();
 
         return json_encode(['channel_data' => [
             'user_id' => $broadcastIdentifier,

--- a/src/broadcasting/src/Contracts/ShouldBroadcast.php
+++ b/src/broadcasting/src/Contracts/ShouldBroadcast.php
@@ -11,7 +11,7 @@ interface ShouldBroadcast
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return Channel[]|string[]
+     * @return Channel|Channel[]|string[]
      */
-    public function broadcastOn(): array;
+    public function broadcastOn(): array|Channel;
 }


### PR DESCRIPTION
The default connection for redis should be `default` instead of `null` in redis broadcaster.