### PR TITLE
improve: avoid invalid decoded response body in Response of http client

### DIFF
--- a/src/http-client/src/Response.php
+++ b/src/http-client/src/Response.php
@@ -64,7 +64,7 @@ class Response implements ArrayAccess, Stringable
     public function json(?string $key = null, mixed $default = null): mixed
     {
         if (! $this->decoded) {
-            $this->decoded = json_decode($this->body(), true);
+            $this->decoded = json_decode($this->body(), true) ?? [];
         }
 
         if (is_null($key)) {


### PR DESCRIPTION
Cannot assign null to property Hypervel\\HttpClient\\Response::$decoded of type array at /var/www/html/vendor/hypervel/http-client/src/Response.php:67)