### PR TITLE
feat: implement api-client package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
             "Illuminate\\Events\\": "src/event/illuminate/",
             "Workbench\\App\\": "src/testbench/workbench/app/",
             "Hypervel\\": "src/core/src/",
+            "Hypervel\\ApiClient\\": "src/api-client/src/",
             "Hypervel\\Auth\\": "src/auth/src/",
             "Hypervel\\Broadcasting\\": "src/broadcasting/src/",
             "Hypervel\\Bus\\": "src/bus/src/",
@@ -131,6 +132,7 @@
         "phpseclib/phpseclib": "^3.0"
     },
     "replace": {
+        "hypervel/api-client": "self.version",
         "hypervel/auth": "self.version",
         "hypervel/broadcasting": "self.version",
         "hypervel/bus": "self.version",

--- a/src/api-client/LICENSE.md
+++ b/src/api-client/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Hypervel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/api-client/README.md
+++ b/src/api-client/README.md
@@ -1,0 +1,4 @@
+Api Client for Hypervel
+===
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hypervel/api-client)

--- a/src/api-client/composer.json
+++ b/src/api-client/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "hypervel/api-client",
+    "description": "The api client package for Hypervel.",
+    "license": "MIT",
+    "keywords": [
+        "php",
+        "hyperf",
+        "api",
+        "client",
+        "swoole",
+        "hypervel"
+    ],
+    "support": {
+        "issues": "https://github.com/hypervel/components/issues",
+        "source": "https://github.com/hypervel/components"
+    },
+    "authors": [
+        {
+            "name": "Albert Chen",
+            "email": "albert@hypervel.org"
+        }
+    ],
+    "require": {
+        "php": "^8.2",
+        "hypervel/support": "^0.2",
+        "hypervel/api-client": "^0.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Hypervel\\ApiClient\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.2-dev"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev"
+}

--- a/src/api-client/src/ApiClient.php
+++ b/src/api-client/src/ApiClient.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use Hypervel\Support\DataObject;
+
+/**
+ * @mixin PendingRequest
+ */
+class ApiClient
+{
+    protected ?DataObject $config = null;
+
+    protected string $resource = ApiResource::class;
+
+    protected bool $enableMiddleware = true;
+
+    /**
+     * @var array<RequestMiddleware|string>
+     */
+    protected array $requestMiddleware = [];
+
+    /**
+     * @var array<ResponseMiddleware|string>
+     */
+    protected array $responseMiddleware = [];
+
+    /**
+     * Dynamically pass method calls to the underlying resource.
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->getClient()
+            ->{$method}(...$parameters);
+    }
+
+    public function getConfig(): ?DataObject
+    {
+        return $this->config;
+    }
+
+    public function getResource(): string
+    {
+        return $this->resource;
+    }
+
+    public function getEnableMiddleware(): bool
+    {
+        return $this->enableMiddleware;
+    }
+
+    public function enableMiddleware(): static
+    {
+        $this->enableMiddleware = true;
+
+        return $this;
+    }
+
+    public function disableMiddleware(): static
+    {
+        $this->enableMiddleware = false;
+
+        return $this;
+    }
+
+    public function getRequestMiddleware(): array
+    {
+        return $this->requestMiddleware;
+    }
+
+    public function getResponseMiddleware(): array
+    {
+        return $this->responseMiddleware;
+    }
+
+    public function getClient(): PendingRequest
+    {
+        return new PendingRequest($this);
+    }
+}

--- a/src/api-client/src/ApiRequest.php
+++ b/src/api-client/src/ApiRequest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use GuzzleHttp\Psr7\Uri;
+use Hyperf\Engine\Http\Stream;
+use Hypervel\HttpClient\Request as HttpClientRequest;
+use Psr\Http\Message\RequestInterface;
+
+class ApiRequest extends HttpClientRequest
+{
+    /**
+     * Determine if the request data has changed.
+     */
+    protected bool $dataChanged = false;
+
+    /**
+     * Set the request method.
+     */
+    public function withMethod(string $method): static
+    {
+        $this->request = $this->request->withMethod($method);
+
+        return $this;
+    }
+
+    /**
+     * Set the request URL.
+     */
+    public function withUrl(callable|string $url, bool $preserveHost = false): static
+    {
+        if (is_callable($url)) {
+            $url = $url((string) $this->request->getUri());
+        }
+
+        $this->request = $this->request->withUri(new Uri($url), $preserveHost);
+
+        return $this;
+    }
+
+    /**
+     * Add the request header.
+     */
+    public function withHeader(string $key, string $value): static
+    {
+        return $this->withHeaders([$key => $value]);
+    }
+
+    /**
+     * Add the request headers.
+     */
+    public function withHeaders(array $headers): static
+    {
+        foreach ($headers as $key => $value) {
+            $this->request = $this->request->withHeader($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a request header.
+     */
+    public function withAddedHeader(string $key, string $value): static
+    {
+        return $this->withAddedHeaders([$key => $value]);
+    }
+
+    /**
+     * Add request headers.
+     */
+    public function withAddedHeaders(array $headers): static
+    {
+        foreach ($headers as $key => $value) {
+            $this->request = $this->request->withAddedHeader($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a request header.
+     */
+    public function withoutHeader(string $header): static
+    {
+        return $this->withoutHeaders([$header]);
+    }
+
+    /**
+     * Remove request headers.
+     */
+    public function withoutHeaders(array $headers): static
+    {
+        foreach ($headers as $header) {
+            $this->request = $this->request->withoutHeader($header);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the request body.
+     */
+    public function withBody(string $body): static
+    {
+        $this->request = $this->request->withBody(new Stream($body));
+
+        return $this;
+    }
+
+    /**
+     * Add the request data.
+     */
+    public function withData(array $data): static
+    {
+        $this->data = array_merge($this->data(), $data);
+        $this->dataChanged = true;
+
+        return $this;
+    }
+
+    /**
+     * Remove the request data.
+     */
+    public function withoutData(array $data): static
+    {
+        $this->data();
+        foreach ($data as $key) {
+            unset($this->data[$key]);
+        }
+
+        $this->dataChanged = true;
+
+        return $this;
+    }
+
+    /**
+     * Get the underlying PSR compliant request instance.
+     */
+    public function toPsrRequest(): RequestInterface
+    {
+        if ($this->dataChanged) {
+            $this->applyChangedData();
+        }
+
+        return $this->request;
+    }
+
+    protected function applyChangedData(): void
+    {
+        $data = $this->data;
+        if ($this->isForm()) {
+            $data = http_build_query($this->data, '', '&');
+        } elseif ($this->isJson() || ! $this->hasHeader('Content-Type')) {
+            $data = json_encode($this->data);
+        }
+
+        $this->request = $this->request->withBody(
+            new Stream($data)
+        );
+
+        $this->dataChanged = false;
+    }
+}

--- a/src/api-client/src/ApiResource.php
+++ b/src/api-client/src/ApiResource.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use ArrayAccess;
+use BadMethodCallException;
+use Hyperf\Contract\Arrayable;
+use Hyperf\Contract\Jsonable;
+use Hyperf\Support\Traits\ForwardsCalls;
+use Hypervel\HttpClient\Request;
+use Hypervel\HttpClient\Response;
+use JsonSerializable;
+
+/**
+ * @mixin ApiResponse
+ */
+class ApiResource implements ArrayAccess, JsonSerializable, Arrayable, Jsonable
+{
+    use ForwardsCalls;
+
+    /**
+     * Create a new resource instance.
+     */
+    public function __construct(
+        protected Response $response,
+        protected Request $request
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->response->body();
+    }
+
+    /**
+     * Determine if an attribute exists on the resource.
+     */
+    public function __isset(string $key): bool
+    {
+        return isset($this->response->json()[$key]);
+    }
+
+    /**
+     * Unset an attribute on the resource.
+     */
+    public function __unset(string $key): void
+    {
+        $this->response->offsetUnset($key);
+    }
+
+    /**
+     * Dynamically get properties from the underlying resource.
+     */
+    public function __get(string $key): mixed
+    {
+        return $this->response->offsetGet($key);
+    }
+
+    /**
+     * Dynamically pass method calls to the underlying resource.
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        if (! method_exists($this->response, $method)) {
+            throw new BadMethodCallException(
+                sprintf('Method %s does not exist on %s', $method, get_class($this->response))
+            );
+        }
+
+        return $this->forwardCallTo($this->response, $method, $parameters);
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    /**
+     * Create a new resource instance.
+     */
+    public static function make(mixed ...$parameters): static
+    {
+        return new static(...$parameters);
+    }
+
+    /**
+     * Resolve the resource to an array.
+     */
+    public function resolve(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(): array
+    {
+        return $this->response->json();
+    }
+
+    /**
+     * Prepare the resource for JSON serialization.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->resolve();
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetExists.
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->response->offsetExists($offset);
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetGet.
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->response->offsetGet($offset);
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetSet.
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->response->offsetSet($offset, $value);
+    }
+
+    /**
+     * Implementation of ArrayAccess::offsetUnset.
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->response->offsetUnset($offset);
+    }
+}

--- a/src/api-client/src/ApiResponse.php
+++ b/src/api-client/src/ApiResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use Hypervel\HttpClient\Response as HttpClientResponse;
+
+class ApiResponse extends HttpClientResponse
+{
+}

--- a/src/api-client/src/PendingRequest.php
+++ b/src/api-client/src/PendingRequest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Hypervel\HttpClient\ConnectionException;
+use Hypervel\HttpClient\PendingRequest as ClientPendingRequest;
+use Hypervel\HttpClient\Request;
+use Hypervel\Support\Facades\Http;
+use Hypervel\Support\Traits\Conditionable;
+use InvalidArgumentException;
+use JsonSerializable;
+use Throwable;
+
+class PendingRequest
+{
+    use Conditionable;
+
+    protected string $resource = ApiResource::class;
+
+    protected bool $enableMiddleware = true;
+
+    protected bool $enableRequestLog = true;
+
+    protected array $middlewareOptions = [];
+
+    protected array $guzzleOptions = [];
+
+    /**
+     * @var array<RequestMiddleware|string>
+     */
+    protected array $requestMiddleware = [];
+
+    /**
+     * @var array<ResponseMiddleware|string>
+     */
+    protected array $responseMiddleware = [];
+
+    public function __construct(
+        protected ApiClient $client,
+    ) {
+        $this->resource = $this->client->getResource();
+        $this->enableMiddleware = $this->client->getEnableMiddleware();
+        $this->requestMiddleware = $this->client->getRequestMiddleware();
+        $this->responseMiddleware = $this->client->getResponseMiddleware();
+    }
+
+    public function enableMiddleware(): static
+    {
+        $this->enableMiddleware = true;
+
+        return $this;
+    }
+
+    public function disableMiddleware(): static
+    {
+        $this->enableMiddleware = false;
+
+        return $this;
+    }
+
+    public function enableRequestLog(): static
+    {
+        $this->enableRequestLog = true;
+
+        return $this;
+    }
+
+    public function disableRequestLog(): static
+    {
+        $this->enableRequestLog = false;
+
+        return $this;
+    }
+
+    public function withMiddlewareOptions(array $options): static
+    {
+        $this->middlewareOptions = $options;
+
+        return $this;
+    }
+
+    public function withGuzzleOptions(array $options): static
+    {
+        $this->guzzleOptions = $options;
+
+        return $this;
+    }
+
+    public function withRequestMiddleware(array $middleware): static
+    {
+        $this->requestMiddleware = $middleware;
+
+        return $this;
+    }
+
+    public function withAddedRequestMiddleware(array $middleware): static
+    {
+        $this->requestMiddleware = array_merge($this->requestMiddleware, $middleware);
+
+        return $this;
+    }
+
+    public function withResponseMiddleware(array $middleware): static
+    {
+        $this->responseMiddleware = $middleware;
+
+        return $this;
+    }
+
+    public function withAddedResponseMiddleware(array $middleware): static
+    {
+        $this->responseMiddleware = array_merge($this->responseMiddleware, $middleware);
+
+        return $this;
+    }
+
+    public function withResource(string $resource): static
+    {
+        if (! class_exists($resource)) {
+            throw new InvalidArgumentException(
+                sprintf('Resource class `%s` does not exist', $resource)
+            );
+        }
+
+        if (! is_subclass_of($resource, ApiResource::class)) {
+            throw new InvalidArgumentException(
+                sprintf('Resource class `%s` must be a subclass of `%s`', $resource, ApiResource::class)
+            );
+        }
+
+        $this->resource = $resource;
+
+        return $this;
+    }
+
+    public function timeout(float|int $timeout): static
+    {
+        $this->guzzleOptions['timeout'] = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Issue a GET request to the given URL.
+     *
+     * @throws ConnectionException
+     */
+    public function get(string $url, null|array|JsonSerializable|string $query = null): ApiResource
+    {
+        return $this->sendRequest('get', $url, $query);
+    }
+
+    /**
+     * Issue a HEAD request to the given URL.
+     *
+     * @throws ConnectionException
+     */
+    public function head(string $url, null|array|string $query = null): ApiResource
+    {
+        return $this->sendRequest('head', $url, $query);
+    }
+
+    /**
+     * Issue a POST request to the given URL.
+     *
+     * @throws ConnectionException
+     */
+    public function post(string $url, array|JsonSerializable $data = []): ApiResource
+    {
+        return $this->sendRequest('post', $url, $data);
+    }
+
+    /**
+     * Issue a PATCH request to the given URL.
+     *
+     * @throws ConnectionException
+     */
+    public function patch(string $url, array $data = []): ApiResource
+    {
+        return $this->sendRequest('patch', $url, $data);
+    }
+
+    /**
+     * Issue a PUT request to the given URL.
+     *
+     * @throws ConnectionException
+     */
+    public function put(string $url, array $data = []): ApiResource
+    {
+        return $this->sendRequest('put', $url, $data);
+    }
+
+    /**
+     * Issue a DELETE request to the given URL.
+     *
+     * @throws ConnectionException
+     */
+    public function delete(string $url, array $data = []): ApiResource
+    {
+        return $this->sendRequest('delete', $url, $data);
+    }
+
+    /**
+     * Send the request to the given URL.
+     *
+     * @throws ConnectionException|Throwable
+     */
+    public function send(string $method, string $url, array $options = []): ApiResource
+    {
+        return $this->sendRequest('send', $method, $url, $options);
+    }
+
+    protected function sendRequest(): ApiResource
+    {
+        $arguments = func_get_args();
+        $method = array_shift($arguments);
+
+        $request = null;
+        $response = $this->getClient()
+            ->beforeSending(function (Request $httpRequest) use (&$request) {
+                $request = $httpRequest;
+            })->{$method}(...$arguments);
+
+        if ($response instanceof PromiseInterface) {
+            throw new InvalidArgumentException('Api client does not support async requests');
+        }
+
+        return $this->resource::make($response, $request);
+    }
+
+    protected function createMiddleware(array $middlewareClasses, array $options): array
+    {
+        $middleware = [];
+        foreach ($middlewareClasses as $value) {
+            if (! class_exists($value)) {
+                throw new InvalidArgumentException(
+                    sprintf('Middleware class `%s` does not exist', $value)
+                );
+            }
+
+            $middleware[] = new $value($this->client->getConfig(), $options);
+        }
+
+        return $middleware;
+    }
+
+    protected function getClient(): ClientPendingRequest
+    {
+        $request = Http::throw();
+
+        if ($this->guzzleOptions) {
+            $request->withOptions($this->guzzleOptions);
+        }
+
+        if (! $this->enableMiddleware) {
+            return $request;
+        }
+
+        foreach ($this->createMiddleware($this->requestMiddleware, $this->middlewareOptions) as $middleware) {
+            $request->withRequestMiddleware($middleware);
+        }
+
+        foreach ($this->createMiddleware($this->responseMiddleware, $this->middlewareOptions) as $middleware) {
+            $request->withResponseMiddleware($middleware);
+        }
+
+        return $request;
+    }
+}

--- a/src/api-client/src/RequestMiddleware.php
+++ b/src/api-client/src/RequestMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use Psr\Http\Message\RequestInterface;
+
+abstract class RequestMiddleware
+{
+    public function __invoke(RequestInterface $request): RequestInterface
+    {
+        return $this->handle(new ApiRequest($request))
+            ->toPsrRequest();
+    }
+
+    abstract public function handle(ApiRequest $request): ApiRequest;
+}

--- a/src/api-client/src/ResponseMiddleware.php
+++ b/src/api-client/src/ResponseMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\ApiClient;
+
+use Psr\Http\Message\ResponseInterface;
+
+abstract class ResponseMiddleware
+{
+    public function __invoke(ResponseInterface $response): ResponseInterface
+    {
+        return $this->handle(new ApiResponse($response))
+            ->toPsrResponse();
+    }
+
+    abstract public function handle(ApiResponse $response): ApiResponse;
+}

--- a/tests/ApiClient/ApiClientTest.php
+++ b/tests/ApiClient/ApiClientTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\ApiClient;
+
+use Hypervel\ApiClient\ApiClient;
+use Hypervel\ApiClient\ApiResource;
+use Hypervel\HttpClient\Request;
+use Hypervel\HttpClient\Response;
+use Hypervel\Support\Facades\Http;
+use Hypervel\Testbench\TestCase;
+
+/**
+ * @internal
+ * @covers \Hypervel\ApiClient\ApiClient
+ */
+class ApiClientTest extends TestCase
+{
+    public function testSendRequest(): void
+    {
+        Http::preventStrayRequests();
+
+        Http::fake([
+            'test-endpoint' => Http::response('{"success": true}'),
+        ]);
+
+        $client = new ApiClient();
+        $response = $client->post('test-endpoint', ['foo' => 'bar']);
+
+        $this->assertInstanceOf(ApiResource::class, $response);
+        $this->assertInstanceOf(Response::class, $response->getResponse());
+        $this->assertInstanceOf(Request::class, $response->getRequest());
+        $this->assertSame(['foo' => 'bar'], $response->getRequest()->data());
+        $this->assertSame(['success' => true], $response->json());
+        $this->assertSame('{"success": true}', $response->body());
+        $this->assertTrue($response['success']);
+
+        Http::assertSent(function (Request $request) {
+            return $request['foo'] === 'bar';
+        });
+    }
+}

--- a/tests/ApiClient/ApiRequestTest.php
+++ b/tests/ApiClient/ApiRequestTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\ApiClient;
+
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use Hypervel\ApiClient\ApiRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @covers \Hypervel\ApiClient\ApiRequest
+ */
+class ApiRequestTest extends TestCase
+{
+    private ApiRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $psrRequest = new Psr7Request('GET', 'https://api.example.com');
+        $this->request = new ApiRequest($psrRequest);
+    }
+
+    public function testWithMethod(): void
+    {
+        $request = $this->request->withMethod('POST');
+        $this->assertSame('POST', $request->toPsrRequest()->getMethod());
+    }
+
+    public function testWithUrl(): void
+    {
+        $newUrl = 'https://api.example.com/users';
+        $request = $this->request->withUrl($newUrl);
+        $this->assertSame($newUrl, (string) $request->toPsrRequest()->getUri());
+
+        // Test with callable
+        $request = $this->request->withUrl(fn (string $url) => $url . '/posts');
+        $this->assertSame('https://api.example.com/users/posts', (string) $request->toPsrRequest()->getUri());
+    }
+
+    public function testWithHeader(): void
+    {
+        $request = $this->request->withHeader('X-Test', 'value');
+        $this->assertTrue($request->toPsrRequest()->hasHeader('X-Test'));
+        $this->assertSame(['value'], $request->toPsrRequest()->getHeader('X-Test'));
+    }
+
+    public function testWithHeaders(): void
+    {
+        $headers = [
+            'X-Test-1' => 'value1',
+            'X-Test-2' => 'value2',
+        ];
+        $request = $this->request->withHeaders($headers);
+
+        foreach ($headers as $key => $value) {
+            $this->assertTrue($request->toPsrRequest()->hasHeader($key));
+            $this->assertSame([$value], $request->toPsrRequest()->getHeader($key));
+        }
+    }
+
+    public function testWithAddedHeader(): void
+    {
+        $request = $this->request
+            ->withHeader('X-Test', 'value1')
+            ->withAddedHeader('X-Test', 'value2');
+
+        $this->assertSame(['value1', 'value2'], $request->toPsrRequest()->getHeader('X-Test'));
+    }
+
+    public function testWithAddedHeaders(): void
+    {
+        $request = $this->request
+            ->withHeaders(['X-Test' => 'value1'])
+            ->withAddedHeaders(['X-Test' => 'value2']);
+
+        $this->assertSame(['value1', 'value2'], $request->toPsrRequest()->getHeader('X-Test'));
+    }
+
+    public function testWithoutHeader(): void
+    {
+        $request = $this->request
+            ->withHeader('X-Test', 'value')
+            ->withoutHeader('X-Test');
+
+        $this->assertFalse($request->toPsrRequest()->hasHeader('X-Test'));
+    }
+
+    public function testWithoutHeaders(): void
+    {
+        $request = $this->request
+            ->withHeaders([
+                'X-Test-1' => 'value1',
+                'X-Test-2' => 'value2',
+            ])
+            ->withoutHeaders(['X-Test-1', 'X-Test-2']);
+
+        $this->assertFalse($request->toPsrRequest()->hasHeader('X-Test-1'));
+        $this->assertFalse($request->toPsrRequest()->hasHeader('X-Test-2'));
+    }
+
+    public function testWithBody(): void
+    {
+        $body = 'test body content';
+        $request = $this->request->withBody($body);
+
+        $psrRequest = $request->toPsrRequest();
+        $this->assertSame($body, $psrRequest->getBody()->getContents());
+    }
+
+    public function testWithData(): void
+    {
+        $data = ['key' => 'value'];
+        $request = $this->request
+            ->withHeader('Content-Type', 'application/json')
+            ->withData($data);
+
+        $psrRequest = $request->toPsrRequest();
+
+        $this->assertSame(json_encode($data), $psrRequest->getBody()->getContents());
+    }
+
+    public function testWithoutData(): void
+    {
+        $request = $this->request
+            ->withHeader('Content-Type', 'application/json')
+            ->withData(['key1' => 'value1', 'key2' => 'value2'])
+            ->withoutData(['key1']);
+
+        $psrRequest = $request->toPsrRequest();
+        $this->assertSame(json_encode(['key2' => 'value2']), $psrRequest->getBody()->getContents());
+    }
+}

--- a/tests/ApiClient/ApiResourceTest.php
+++ b/tests/ApiClient/ApiResourceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\ApiClient;
+
+use BadMethodCallException;
+use Hypervel\ApiClient\ApiResource;
+use Hypervel\HttpClient\Request;
+use Hypervel\HttpClient\Response;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @covers \Hypervel\ApiClient\ApiResource
+ */
+class ApiResourceTest extends TestCase
+{
+    /**
+     * @var MockObject&Response
+     */
+    private $response;
+
+    /**
+     * @var MockObject&Request
+     */
+    private $request;
+
+    private ApiResource $resource;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create mock objects for the Response and Request
+        $this->response = $this->createMock(Response::class);
+        $this->request = $this->createMock(Request::class);
+
+        // Create the resource with our mocks
+        $this->resource = new ApiResource($this->response, $this->request);
+    }
+
+    public function testMakeFactoryMethod(): void
+    {
+        $resource = ApiResource::make($this->response, $this->request);
+
+        $this->assertInstanceOf(ApiResource::class, $resource);
+        $this->assertSame($this->response, $resource->getResponse());
+        $this->assertSame($this->request, $resource->getRequest());
+    }
+
+    public function testToString(): void
+    {
+        $this->response
+            ->method('body')
+            ->willReturn($responseBody = '{"key": "value"}');
+
+        $this->assertEquals($responseBody, (string) $this->resource);
+    }
+
+    public function testResolve(): void
+    {
+        $this->response
+            ->method('json')
+            ->willReturn($jsonData = ['key' => 'value']);
+
+        $this->assertEquals($jsonData, $this->resource->resolve());
+    }
+
+    public function testToArray(): void
+    {
+        $this->response
+            ->method('json')
+            ->willReturn($jsonData = ['key' => 'value']);
+
+        $this->assertEquals($jsonData, $this->resource->toArray());
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $this->response
+            ->method('json')
+            ->willReturn($jsonData = ['key' => 'value']);
+
+        $this->assertEquals($jsonData, $this->resource->jsonSerialize());
+    }
+
+    public function testArrayAccessOffsetExists(): void
+    {
+        $this->response->method('offsetExists')
+            ->with('key')
+            ->willReturn(true);
+
+        $this->assertTrue($this->resource->offsetExists('key'));
+    }
+
+    public function testArrayAccessOffsetGet(): void
+    {
+        $this->response->method('offsetGet')
+            ->with('key')
+            ->willReturn($value = 'someValue');
+
+        $this->assertEquals($value, $this->resource->offsetGet('key'));
+    }
+
+    public function testArrayAccessOffsetSet(): void
+    {
+        $this->response->expects($this->once())
+            ->method('offsetSet')
+            ->with($key = 'key', $value = 'value');
+
+        $this->resource->offsetSet($key, $value);
+    }
+
+    public function testArrayAccessOffsetUnset(): void
+    {
+        $this->response->expects($this->once())
+            ->method('offsetUnset')
+            ->with($key = 'key');
+
+        $this->resource->offsetUnset($key);
+    }
+
+    public function testMagicIssetMethod(): void
+    {
+        $this->response
+            ->method('json')
+            ->willReturn($jsonData = ['existingKey' => 'value']);
+
+        $this->assertTrue(isset($this->resource->existingKey));
+        $this->assertFalse(isset($this->resource->nonExistingKey));
+    }
+
+    public function testMagicUnsetMethod(): void
+    {
+        $this->response->expects($this->once())
+            ->method('offsetUnset')
+            ->with('key');
+
+        unset($this->resource->key);
+    }
+
+    public function testMagicGetMethod(): void
+    {
+        $this->response->method('offsetGet')
+            ->with('key')
+            ->willReturn($value = 'value');
+
+        /* @phpstan-ignore-next-line */
+        $this->assertEquals($value, $this->resource->key);
+    }
+
+    public function testCallMethodOnResponse(): void
+    {
+        $this->response->method('status')
+            ->willReturn($expectedResult = 200);
+
+        $this->assertEquals($expectedResult, $this->resource->status());
+    }
+
+    public function testCallNonExistentMethodThrowsException(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        /* @phpstan-ignore-next-line */
+        $this->resource->nonExistentMethod();
+    }
+}


### PR DESCRIPTION
This PR introduces a new api-client package, which is based on http-client package. It helps developers to develop api clients in most situations.

An api client consists of `request middleware`, 'response middleware` and `resource`.