### PR TITLE
Add Postgres package to core

### DIFF
--- a/src/core/composer.json
+++ b/src/core/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": "^8.2",
         "hyperf/database": "~3.1.0",
+        "hyperf/database-pgsql": "~3.1.0",
         "hyperf/http-message": "~3.1.0",
         "hyperf/context": "~3.1.0",
         "hyperf/redis": "~3.1.0"


### PR DESCRIPTION
Postgres is the database of choice for most developers nowadays: https://www.webcreek.com/en/blog/software-development/the-most-popular-databases-used-in-2025/. And this trend is growing every year.

I think it's really important that Postgres support is included in core. Laravel Cloud's recommeded db type is Postgres, and a lot of popular DB-As-A-Service platforms like Neon use Postgres too.

I'll add the config in a separate PR. 

