### PR TITLE
Bugfix: Hypervel\\Cache\\RateLimiting\\Limit::$responseCallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /.phpunit.cache
 /vendor
 composer.lock

--- a/src/cache/src/RateLimiting/Limit.php
+++ b/src/cache/src/RateLimiting/Limit.php
@@ -26,7 +26,7 @@ class Limit
     /**
      * The response generator callback.
      */
-    public Closure $responseCallback;
+    public ?Closure $responseCallback = null;
 
     /**
      * Create a new limit instance.


### PR DESCRIPTION
Bugfix: Typed property Hypervel\\Cache\\RateLimiting\\Limit::$responseCallback must not be accessed before initialization