### PR TITLE
WebsocketKernel allow CoreMiddleware overrides

### DIFF
--- a/src/foundation/src/Http/WebsocketKernel.php
+++ b/src/foundation/src/Http/WebsocketKernel.php
@@ -27,6 +27,7 @@ use Swoole\Http\Request;
 use Swoole\Http\Response as SwooleResponse;
 use Swow\Psr7\Server\ServerConnection as SwowServerConnection;
 use Throwable;
+use function Hyperf\Support\make;
 
 class WebsocketKernel extends WebSocketServer implements MiddlewareContract
 {
@@ -35,7 +36,7 @@ class WebsocketKernel extends WebSocketServer implements MiddlewareContract
     public function initCoreMiddleware(string $serverName): void
     {
         $this->serverName = $serverName;
-        $this->coreMiddleware = new CoreMiddleware($this->container, $serverName);
+        $this->coreMiddleware = make(CoreMiddleware::class, [$this->container, $serverName]);
 
         $config = $this->container->get(ConfigInterface::class);
         $this->exceptionHandlers = $config->get('exceptions.handler.' . $serverName, [


### PR DESCRIPTION
Instead of hard-coded instantiating `new CoreMiddleware`
Do the same as `Hypervel\Foundation\Http\Kernel` > `Hyperf\HttpServer\Server::createCoreMiddleware` method
Use container make() so it can use overrides of custom CoreMiddleware from config/dependencies.php

Related https://github.com/hyperf/hyperf/pull/7454