### PR TITLE
Correct migration destination path in ConfigProvider

### DIFF
--- a/src/permission/src/ConfigProvider.php
+++ b/src/permission/src/ConfigProvider.php
@@ -29,7 +29,7 @@ class ConfigProvider
                     'id' => 'migrations',
                     'description' => 'The migrations for permission.',
                     'source' => __DIR__ . '/../database/migrations/2025_07_02_000000_create_permission_tables.php',
-                    'destination' => BASE_PATH . '/migrations/migrations/2025_07_02_000000_create_permission_tables.php',
+                    'destination' => BASE_PATH . '/database/migrations/2025_07_02_000000_create_permission_tables.php',
                 ],
             ],
         ];


### PR DESCRIPTION
This pull request includes a small change to the `src/permission/src/ConfigProvider.php` file. The change updates the `destination` path for migrations to correctly point to the `database/migrations` directory instead of the `migrations/migrations` directory.