### PR TITLE
fix: fix role permission caching

### DIFF
--- a/src/permission/src/Traits/HasPermission.php
+++ b/src/permission/src/Traits/HasPermission.php
@@ -63,7 +63,7 @@ trait HasPermission
 
         if (is_a($this->getOwnerType(), Role::class, true)) {
             $cachedPermissions = $manager->getAllRolesWithPermissions()[$this->getKey()]['permissions'];
-
+            /* @phpstan-ignore-next-line */
             return $this->permissions()->getRelated()->hydrate($cachedPermissions);
         }
 

--- a/tests/Permission/HasPermissionTest.php
+++ b/tests/Permission/HasPermissionTest.php
@@ -789,7 +789,6 @@ class HasPermissionTest extends PermissionTestCase
         $this->assertCount(2, $permissionNames);
     }
 
-
     public function testRoleCanBeGivenForbiddenPermission()
     {
         $this->adminRole->giveForbiddenTo('manage');


### PR DESCRIPTION
This pull request includes enhancements to permission handling and caching logic, along with the addition of new test cases to ensure robust functionality for roles and permissions. 

### Enhancements to Permission Handling:

* [`src/permission/src/Traits/HasPermission.php`](diffhunk://#diff-cb2800cb55a0699a19016769ed8bf167890679709bc9293d05d2e65ae2e44598R63-R69): Updated `getCachedPermissions()` to handle permissions for roles specifically by hydrating cached permissions when the owner type is a `Role`. Added logic to clear all roles' permissions cache in `revokePermissionTo()` when permissions are revoked for roles. [[1]](diffhunk://#diff-cb2800cb55a0699a19016769ed8bf167890679709bc9293d05d2e65ae2e44598R63-R69) [[2]](diffhunk://#diff-cb2800cb55a0699a19016769ed8bf167890679709bc9293d05d2e65ae2e44598R315-R320)

### Bug Fixes:

* [`src/permission/src/Traits/HasPermission.php`](diffhunk://#diff-cb2800cb55a0699a19016769ed8bf167890679709bc9293d05d2e65ae2e44598L100-R107): Fixed a typo in the comment for the `permissions()` method, correcting "direcstly" to "directly."

### Expanded Test Coverage:

* `tests/Permission/HasPermissionTest.php`: Added multiple new test cases to validate role-specific permission functionality, including:
  - Testing that roles can sync permissions (`testRoleCanSyncPermissions`).
  - Ensuring roles can be assigned forbidden permissions (`testRoleCanBeGivenForbiddenPermission`).
  - Verifying roles can revoke permissions (`testRoleCanRevokePermission`).
  - Checking that roles exclude forbidden permissions in `getAllPermissions` (`testRoleGetAllPermissionsExcludesForbiddenPermissions`).

These changes improve the clarity, reliability, and testability of the permission system, particularly for role-based scenarios.