### PR TITLE
improve: make service providers compatible with loading as config providers

### DIFF
--- a/src/config/src/ProviderConfig.php
+++ b/src/config/src/ProviderConfig.php
@@ -36,6 +36,7 @@ class ProviderConfig extends HyperfProviderConfig
             fn (array $package) => array_merge(
                 Arr::wrap(($package['hyperf']['config'] ?? []) ?? []),
                 Arr::wrap(($package['hypervel']['config'] ?? []) ?? []),
+                Arr::wrap(($package['hypervel']['providers'] ?? []) ?? []),
             ),
             Composer::getMergedExtra()
         );


### PR DESCRIPTION
This PR makes service providers can be loaded as config providers. With this support, developers don't need to write additional config providers to configure `class map` .