### PR TITLE
feat: support prefix option in routes

### DIFF
--- a/src/router/src/RouteCollector.php
+++ b/src/router/src/RouteCollector.php
@@ -52,7 +52,9 @@ class RouteCollector extends BaseRouteCollector
 
     public function addRoute(array|string $httpMethod, string $route, mixed $handler, array $options = []): void
     {
-        $route = $this->getRouteWithGroupPrefix($route);
+        $route = $this->getRouteWithGroupPrefix(
+            $this->getRouteWithPrefix($route, $options['prefix'] ?? '/')
+        );
         $routeDataList = $this->routeParser->parse($route);
 
         [$handler, $options] = $this->parseHandlerAndOptions($handler, $options);
@@ -162,7 +164,15 @@ class RouteCollector extends BaseRouteCollector
 
     private function getRouteWithGroupPrefix(string $route): string
     {
-        $prefix = trim($this->currentGroupPrefix, '/');
+        return $this->getRouteWithPrefix(
+            $this->getRouteWithPrefix($route, $this->currentGroupPrefix),
+            $this->currentGroupOptions['prefix'] ?? '/'
+        );
+    }
+
+    private function getRouteWithPrefix(string $route, string $prefix): string
+    {
+        $prefix = trim($prefix, '/');
         $route = trim($route, '/');
 
         if (empty($prefix) || $prefix === '/') {

--- a/tests/Router/RouteCollectorTest.php
+++ b/tests/Router/RouteCollectorTest.php
@@ -44,6 +44,22 @@ class RouteCollectorTest extends TestCase
         $this->assertSame('Handler::ApiPost', $data['POST']['/api']->callback);
     }
 
+    public function testAddWithPrefix()
+    {
+        $parser = new Std();
+        $generator = new DataGenerator();
+        $collector = new RouteCollector($parser, $generator);
+
+        $collector->get('/foo', 'Handler::Get', ['prefix' => 'bar']);
+        $collector->addGroup('/api', function ($collector) {
+            $collector->post('/', 'Handler::ApiPost');
+        }, ['prefix' => 'foo']);
+
+        $data = $collector->getData()[0];
+        $this->assertSame('Handler::Get', $data['GET']['/bar/foo']->callback);
+        $this->assertSame('Handler::ApiPost', $data['POST']['/foo/api']->callback);
+    }
+
     public function testGetRouteParser()
     {
         $parser = new Std();


### PR DESCRIPTION
This PR implements `prefix` option support for routes, so developers can define routes like this:

```php
Route::get('users', function () {
    // Matches The "/api/users" URL
}, ['prefix' => 'api']);

Route::group('/admin', function () {
    Route::get('/users', function () {
         // Matches The "/api/admin/users" URL
    });
}, ['prefix' => 'api']);
```