### PR TITLE
 fix: cast SMTP port to int to resolve Symfony Mailer TypeError

### DIFF
--- a/src/mail/src/MailManager.php
+++ b/src/mail/src/MailManager.php
@@ -207,7 +207,7 @@ class MailManager implements FactoryContract
             $config['host'],
             $config['username'] ?? null,
             $config['password'] ?? null,
-            $config['port'] ?? null,
+            isset($config['port']) ? (int) $config['port'] : null,
             $config
         ));
 


### PR DESCRIPTION
environment variables return strings but symfony Dsn expects ?int for port parameter