### PR TITLE
Remove ResumeExitCoordinatorListener

### DIFF
--- a/src/foundation/src/ConfigProvider.php
+++ b/src/foundation/src/ConfigProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Hypervel\Foundation;
 
 use Hyperf\Contract\ApplicationInterface;
-use Hyperf\Coordinator\Listener\ResumeExitCoordinatorListener;
 use Hyperf\ExceptionHandler\Listener\ErrorExceptionHandler;
 use Hyperf\Server\Listener\InitProcessTitleListener;
 use Hypervel\Console\ApplicationFactory;
@@ -27,7 +26,6 @@ class ConfigProvider
             ],
             'listeners' => [
                 ErrorExceptionHandler::class,
-                ResumeExitCoordinatorListener::class,
                 ReloadDotenvAndConfig::class,
             ],
             'commands' => [


### PR DESCRIPTION
- Hyperf [will remove](https://github.com/hyperf/hyperf/blob/4d96bed942b76c25d1b2d3a4485faecf0baaaaad/src/coordinator/src/Listener/ResumeExitCoordinatorListener.php#L21) `ResumeExitCoordinatorListener` in 3.2
    - `@deprecated since v3.1, will be removed in v3.2`
- Hyperf never seems to actually use this `ResumeExitCoordinatorListener` even in current/earlier versions! Ever!
- Trying to build hypervel on Hyperf 3.2 branch breaks with error about this class not existing