### PR TITLE
feat: implement delay function in coroutine queue and defer queue

### DIFF
--- a/src/queue/src/CoroutineQueue.php
+++ b/src/queue/src/CoroutineQueue.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hypervel\Queue;
 
+use DateInterval;
+use DateTimeInterface;
+use Hyperf\Coordinator\Timer;
 use Hypervel\Coroutine\Coroutine;
 use Hypervel\Database\TransactionManager;
 use Throwable;
@@ -16,6 +19,18 @@ class CoroutineQueue extends SyncQueue
      * @var null|callable
      */
     protected $exceptionCallback;
+
+    /**
+     * Create a new coroutine queue instance.
+     */
+    public function __construct(
+        protected bool $dispatchAfterCommit = false,
+        protected ?Timer $timer = null
+    ) {
+        if (! $this->timer) {
+            $this->timer = new Timer();
+        }
+    }
 
     /**
      * Push a new job onto the queue.
@@ -35,6 +50,17 @@ class CoroutineQueue extends SyncQueue
         $this->executeJob($job, $data, $queue);
 
         return null;
+    }
+
+    /**
+     * Push a new job onto the queue after (n) seconds.
+     */
+    public function later(DateInterval|DateTimeInterface|int $delay, object|string $job, mixed $data = '', ?string $queue = null): mixed
+    {
+        return $this->timer->after(
+            (float) $this->secondsUntil($delay),
+            fn () => $this->push($job, $data, $queue)
+        );
     }
 
     /**

--- a/src/queue/src/DeferQueue.php
+++ b/src/queue/src/DeferQueue.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Hypervel\Queue;
 
+use DateInterval;
+use DateTimeInterface;
+use Hyperf\Coordinator\Timer;
 use Hyperf\Engine\Coroutine;
 use Hypervel\Database\TransactionManager;
 use Throwable;
@@ -16,6 +19,18 @@ class DeferQueue extends SyncQueue
      * @var null|callable
      */
     protected $exceptionCallback;
+
+    /**
+     * Create a new defer queue instance.
+     */
+    public function __construct(
+        protected bool $dispatchAfterCommit = false,
+        protected ?Timer $timer = null
+    ) {
+        if (! $this->timer) {
+            $this->timer = new Timer();
+        }
+    }
 
     /**
      * Push a new job onto the queue.
@@ -34,6 +49,17 @@ class DeferQueue extends SyncQueue
         $this->deferJob($job, $data, $queue);
 
         return null;
+    }
+
+    /**
+     * Push a new job onto the queue after (n) seconds.
+     */
+    public function later(DateInterval|DateTimeInterface|int $delay, object|string $job, mixed $data = '', ?string $queue = null): mixed
+    {
+        return $this->timer->after(
+            (float) $this->secondsUntil($delay),
+            fn () => $this->deferJob($job, $data, $queue)
+        );
     }
 
     /**

--- a/tests/Queue/QueueCoroutineQueueTest.php
+++ b/tests/Queue/QueueCoroutineQueueTest.php
@@ -173,13 +173,6 @@ class QueueCoroutineQueueTest extends TestCase
         Carbon::setTestNow();
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        Carbon::setTestNow();
-        m::close();
-    }
-
     protected function getContainer(): Container
     {
         return new Container(

--- a/tests/Queue/QueueCoroutineQueueTest.php
+++ b/tests/Queue/QueueCoroutineQueueTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Queue;
 
+use DateInterval;
 use Exception;
+use Hyperf\Coordinator\Timer;
 use Hyperf\Di\Container;
 use Hyperf\Di\Definition\DefinitionSource;
 use Hypervel\Database\TransactionManager;
@@ -13,6 +15,7 @@ use Hypervel\Queue\Contracts\ShouldQueueAfterCommit;
 use Hypervel\Queue\CoroutineQueue;
 use Hypervel\Queue\InteractsWithQueue;
 use Hypervel\Queue\Jobs\SyncJob;
+use Hypervel\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -90,6 +93,93 @@ class QueueCoroutineQueueTest extends TestCase
         run(fn () => $coroutine->push(new CoroutineQueueAfterCommitInterfaceJob()));
     }
 
+    public function testLaterSchedulesJobWithDelay()
+    {
+        $timer = m::mock(Timer::class);
+        $timer->shouldReceive('after')
+            ->once()
+            ->with(5.0, m::type('Closure'))
+            ->andReturnUsing(function ($_, $callback) {
+                $callback();
+                return 1;
+            });
+
+        $coroutine = new CoroutineQueue(timer: $timer);
+        $coroutine->setConnectionName('coroutine');
+        $container = $this->getContainer();
+        $coroutine->setContainer($container);
+
+        unset($_SERVER['__coroutine.later.test']);
+
+        run(fn () => $coroutine->later(5, CoroutineQueueLaterTestHandler::class, ['foo' => 'bar']));
+
+        $this->assertInstanceOf(SyncJob::class, $_SERVER['__coroutine.later.test'][0]);
+        $this->assertEquals(['foo' => 'bar'], $_SERVER['__coroutine.later.test'][1]);
+    }
+
+    public function testLaterWithDateInterval()
+    {
+        $timer = m::mock(Timer::class);
+        $interval = new DateInterval('PT10S');
+
+        $timer->shouldReceive('after')
+            ->once()
+            ->with(10.0, m::type('Closure'))
+            ->andReturnUsing(function ($_, $callback) {
+                $callback();
+                return 1;
+            });
+
+        $coroutine = new CoroutineQueue(timer: $timer);
+        $coroutine->setConnectionName('coroutine');
+        $container = $this->getContainer();
+        $coroutine->setContainer($container);
+
+        unset($_SERVER['__coroutine.later.interval.test']);
+
+        run(fn () => $coroutine->later($interval, CoroutineQueueLaterIntervalTestHandler::class, ['baz' => 'qux']));
+
+        $this->assertInstanceOf(SyncJob::class, $_SERVER['__coroutine.later.interval.test'][0]);
+        $this->assertEquals(['baz' => 'qux'], $_SERVER['__coroutine.later.interval.test'][1]);
+    }
+
+    public function testLaterWithDateTime()
+    {
+        Carbon::setTestNow('2024-01-01 12:00:00');
+
+        $timer = m::mock(Timer::class);
+        $dateTime = Carbon::parse('2024-01-01 12:00:15');
+
+        $timer->shouldReceive('after')
+            ->once()
+            ->with(15.0, m::type('Closure'))
+            ->andReturnUsing(function ($_, $callback) {
+                $callback();
+                return 1;
+            });
+
+        $coroutine = new CoroutineQueue(timer: $timer);
+        $coroutine->setConnectionName('coroutine');
+        $container = $this->getContainer();
+        $coroutine->setContainer($container);
+
+        unset($_SERVER['__coroutine.later.datetime.test']);
+
+        run(fn () => $coroutine->later($dateTime, CoroutineQueueLaterDateTimeTestHandler::class, ['test' => 'data']));
+
+        $this->assertInstanceOf(SyncJob::class, $_SERVER['__coroutine.later.datetime.test'][0]);
+        $this->assertEquals(['test' => 'data'], $_SERVER['__coroutine.later.datetime.test'][1]);
+
+        Carbon::setTestNow();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Carbon::setTestNow();
+        m::close();
+    }
+
     protected function getContainer(): Container
     {
         return new Container(
@@ -154,5 +244,29 @@ class CoroutineQueueAfterCommitInterfaceJob implements ShouldQueueAfterCommit
 
     public function handle()
     {
+    }
+}
+
+class CoroutineQueueLaterTestHandler
+{
+    public function fire($job, $data)
+    {
+        $_SERVER['__coroutine.later.test'] = func_get_args();
+    }
+}
+
+class CoroutineQueueLaterIntervalTestHandler
+{
+    public function fire($job, $data)
+    {
+        $_SERVER['__coroutine.later.interval.test'] = func_get_args();
+    }
+}
+
+class CoroutineQueueLaterDateTimeTestHandler
+{
+    public function fire($job, $data)
+    {
+        $_SERVER['__coroutine.later.datetime.test'] = func_get_args();
     }
 }

--- a/tests/Queue/QueueDeferQueueTest.php
+++ b/tests/Queue/QueueDeferQueueTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Queue;
 
+use DateInterval;
 use Exception;
+use Hyperf\Coordinator\Timer;
 use Hyperf\Di\Container;
 use Hyperf\Di\Definition\DefinitionSource;
 use Hypervel\Database\TransactionManager;
@@ -13,6 +15,7 @@ use Hypervel\Queue\Contracts\ShouldQueueAfterCommit;
 use Hypervel\Queue\DeferQueue;
 use Hypervel\Queue\InteractsWithQueue;
 use Hypervel\Queue\Jobs\SyncJob;
+use Hypervel\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -90,6 +93,93 @@ class QueueDeferQueueTest extends TestCase
         run(fn () => $defer->push(new DeferQueueAfterCommitInterfaceJob()));
     }
 
+    public function testLaterSchedulesJobWithDelay()
+    {
+        $timer = m::mock(Timer::class);
+        $timer->shouldReceive('after')
+            ->once()
+            ->with(5.0, m::type('Closure'))
+            ->andReturnUsing(function ($delay, $callback) {
+                $callback();
+                return 1;
+            });
+
+        $defer = new DeferQueue(timer: $timer);
+        $defer->setConnectionName('defer');
+        $container = $this->getContainer();
+        $defer->setContainer($container);
+
+        unset($_SERVER['__defer.later.test']);
+
+        run(fn () => $defer->later(5, DeferQueueLaterTestHandler::class, ['foo' => 'bar']));
+
+        $this->assertInstanceOf(SyncJob::class, $_SERVER['__defer.later.test'][0]);
+        $this->assertEquals(['foo' => 'bar'], $_SERVER['__defer.later.test'][1]);
+    }
+
+    public function testLaterWithDateInterval()
+    {
+        $timer = m::mock(Timer::class);
+        $interval = new DateInterval('PT10S');
+
+        $timer->shouldReceive('after')
+            ->once()
+            ->with(10.0, m::type('Closure'))
+            ->andReturnUsing(function ($delay, $callback) {
+                $callback();
+                return 1;
+            });
+
+        $defer = new DeferQueue(timer: $timer);
+        $defer->setConnectionName('defer');
+        $container = $this->getContainer();
+        $defer->setContainer($container);
+
+        unset($_SERVER['__defer.later.interval.test']);
+
+        run(fn () => $defer->later($interval, DeferQueueLaterIntervalTestHandler::class, ['baz' => 'qux']));
+
+        $this->assertInstanceOf(SyncJob::class, $_SERVER['__defer.later.interval.test'][0]);
+        $this->assertEquals(['baz' => 'qux'], $_SERVER['__defer.later.interval.test'][1]);
+    }
+
+    public function testLaterWithDateTime()
+    {
+        Carbon::setTestNow('2024-01-01 12:00:00');
+
+        $timer = m::mock(Timer::class);
+        $dateTime = Carbon::parse('2024-01-01 12:00:15');
+
+        $timer->shouldReceive('after')
+            ->once()
+            ->with(15.0, m::type('Closure'))
+            ->andReturnUsing(function ($delay, $callback) {
+                $callback();
+                return 1;
+            });
+
+        $defer = new DeferQueue(timer: $timer);
+        $defer->setConnectionName('defer');
+        $container = $this->getContainer();
+        $defer->setContainer($container);
+
+        unset($_SERVER['__defer.later.datetime.test']);
+
+        run(fn () => $defer->later($dateTime, DeferQueueLaterDateTimeTestHandler::class, ['test' => 'data']));
+
+        $this->assertInstanceOf(SyncJob::class, $_SERVER['__defer.later.datetime.test'][0]);
+        $this->assertEquals(['test' => 'data'], $_SERVER['__defer.later.datetime.test'][1]);
+
+        Carbon::setTestNow();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Carbon::setTestNow();
+        m::close();
+    }
+
     protected function getContainer(): Container
     {
         return new Container(
@@ -154,5 +244,29 @@ class DeferQueueAfterCommitInterfaceJob implements ShouldQueueAfterCommit
 
     public function handle()
     {
+    }
+}
+
+class DeferQueueLaterTestHandler
+{
+    public function fire($job, $data)
+    {
+        $_SERVER['__defer.later.test'] = func_get_args();
+    }
+}
+
+class DeferQueueLaterIntervalTestHandler
+{
+    public function fire($job, $data)
+    {
+        $_SERVER['__defer.later.interval.test'] = func_get_args();
+    }
+}
+
+class DeferQueueLaterDateTimeTestHandler
+{
+    public function fire($job, $data)
+    {
+        $_SERVER['__defer.later.datetime.test'] = func_get_args();
     }
 }

--- a/tests/Queue/QueueDeferQueueTest.php
+++ b/tests/Queue/QueueDeferQueueTest.php
@@ -173,13 +173,6 @@ class QueueDeferQueueTest extends TestCase
         Carbon::setTestNow();
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        Carbon::setTestNow();
-        m::close();
-    }
-
     protected function getContainer(): Container
     {
         return new Container(


### PR DESCRIPTION
The `defer` function in `CoroutineQueue` and `DeferQueue` has no effect before. This PR implemented `defer` function with Swoole's timer.