### PR TITLE
Fix RunTestsInCoroutine for PHPUnit 10.5+

### DIFF
--- a/src/foundation/src/Testing/Concerns/RunTestsInCoroutine.php
+++ b/src/foundation/src/Testing/Concerns/RunTestsInCoroutine.php
@@ -14,6 +14,13 @@ use Throwable;
 use function Hypervel\Coroutine\run;
 
 /**
+ * Wraps each test method in a Swoole coroutine so that database connections,
+ * channels, and other coroutine-dependent APIs work correctly during tests.
+ *
+ * PHPUnit 10.5 made runTest() private, so we can no longer override it.
+ * Instead, we swap the test method name during setUp() — which runs before
+ * PHPUnit's private runTest() calls $this->{$this->name}().
+ *
  * @method string name()
  */
 trait RunTestsInCoroutine
@@ -24,9 +31,22 @@ trait RunTestsInCoroutine
 
     protected string $realTestName = '';
 
+    /**
+     * Swap the test method name so PHPUnit's private runTest() calls
+     * runTestsInCoroutine() instead of the real test method.
+     * The real test method is then executed inside a Swoole coroutine.
+     */
+    protected function setUpCoroutineTest(): void
+    {
+        if (Coroutine::getCid() === -1 && $this->enableCoroutine) {
+            $this->realTestName = $this->name();
+            $this->setName('runTestsInCoroutine');
+        }
+    }
+
     final protected function runTestsInCoroutine(...$arguments)
     {
-        parent::setName($this->realTestName);
+        $this->setName($this->realTestName);
 
         $testResult = null;
         $exception = null;
@@ -54,16 +74,6 @@ trait RunTestsInCoroutine
         }
 
         return $testResult;
-    }
-
-    final protected function runTest(): mixed
-    {
-        if (Coroutine::getCid() === -1 && $this->enableCoroutine) {
-            $this->realTestName = $this->name();
-            parent::setName('runTestsInCoroutine');
-        }
-
-        return parent::runTest();
     }
 
     protected function invokeSetupInCoroutine(): void

--- a/src/foundation/src/Testing/TestCase.php
+++ b/src/foundation/src/Testing/TestCase.php
@@ -70,6 +70,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         }
 
         $this->setUpHasRun = true;
+
+        // Swap the test method name for coroutine wrapping.
+        // This must happen AFTER setUp completes but BEFORE PHPUnit's
+        // private runTest() calls $this->{$this->name}().
+        // PHPUnit 10.5 made runTest() private, so we can no longer
+        // override it — the name swap in setUp() is the only hook point.
+        if (method_exists($this, 'setUpCoroutineTest')) {
+            $this->setUpCoroutineTest();
+        }
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/RunTestsInCoroutineTest.php
+++ b/tests/Foundation/Testing/Concerns/RunTestsInCoroutineTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation\Testing\Concerns;
+
+use Hypervel\Foundation\Testing\Concerns\RunTestsInCoroutine;
+use Hypervel\Tests\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+use Swoole\Coroutine;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class RunTestsInCoroutineTest extends TestCase
+{
+    public function testSetUpCoroutineTestSwapsNameOutsideCoroutine()
+    {
+        $testCase = new CoroutineTestStub('myTestMethod');
+
+        $this->assertSame(-1, Coroutine::getCid());
+        $this->assertSame('myTestMethod', $testCase->name());
+
+        $method = new ReflectionMethod($testCase, 'setUpCoroutineTest');
+        $method->invoke($testCase);
+
+        $this->assertSame('runTestsInCoroutine', $testCase->name());
+
+        $realName = new ReflectionProperty($testCase, 'realTestName');
+        $this->assertSame('myTestMethod', $realName->getValue($testCase));
+    }
+
+    public function testSetUpCoroutineTestDoesNotSwapWhenCoroutineDisabled()
+    {
+        $testCase = new CoroutineDisabledTestStub('myTestMethod');
+
+        $method = new ReflectionMethod($testCase, 'setUpCoroutineTest');
+        $method->invoke($testCase);
+
+        $this->assertSame('myTestMethod', $testCase->name());
+    }
+
+    public function testSetUpCoroutineTestIsNoOpInsideCoroutine()
+    {
+        $testCase = new CoroutineTestStub('myTestMethod');
+
+        \Hypervel\Coroutine\run(function () use ($testCase) {
+            $this->assertGreaterThan(-1, Coroutine::getCid());
+
+            $method = new ReflectionMethod($testCase, 'setUpCoroutineTest');
+            $method->invoke($testCase);
+
+            $this->assertSame('myTestMethod', $testCase->name());
+        });
+    }
+
+    public function testRunTestsInCoroutineExecutesInCoroutine()
+    {
+        $testCase = new CoroutineTestStub('myTestMethod');
+
+        $setUp = new ReflectionMethod($testCase, 'setUpCoroutineTest');
+        $setUp->invoke($testCase);
+
+        $run = new ReflectionMethod($testCase, 'runTestsInCoroutine');
+        $run->invoke($testCase);
+
+        $this->assertTrue($testCase->executedInCoroutine);
+    }
+
+    public function testRunTestsInCoroutineRestoresOriginalName()
+    {
+        $testCase = new CoroutineTestStub('myTestMethod');
+
+        $setUp = new ReflectionMethod($testCase, 'setUpCoroutineTest');
+        $setUp->invoke($testCase);
+
+        $this->assertSame('runTestsInCoroutine', $testCase->name());
+
+        $run = new ReflectionMethod($testCase, 'runTestsInCoroutine');
+        $run->invoke($testCase);
+
+        $this->assertSame('myTestMethod', $testCase->name());
+    }
+
+    public function testRunTestsInCoroutinePropagatesExceptions()
+    {
+        $testCase = new CoroutineExceptionTestStub('throwingMethod');
+
+        $setUp = new ReflectionMethod($testCase, 'setUpCoroutineTest');
+        $setUp->invoke($testCase);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Test exception from coroutine');
+
+        $run = new ReflectionMethod($testCase, 'runTestsInCoroutine');
+        $run->invoke($testCase);
+    }
+}
+
+/**
+ * @internal
+ */
+class CoroutineTestStub extends \PHPUnit\Framework\TestCase
+{
+    use RunTestsInCoroutine;
+
+    public bool $executedInCoroutine = false;
+
+    public function myTestMethod(): void
+    {
+        $this->executedInCoroutine = Coroutine::getCid() > -1;
+    }
+}
+
+/**
+ * @internal
+ */
+class CoroutineDisabledTestStub extends \PHPUnit\Framework\TestCase
+{
+    use RunTestsInCoroutine;
+
+    public function __construct(string $name)
+    {
+        parent::__construct($name);
+        $this->enableCoroutine = false;
+    }
+
+    public function myTestMethod(): void
+    {
+    }
+}
+
+/**
+ * @internal
+ */
+class CoroutineExceptionTestStub extends \PHPUnit\Framework\TestCase
+{
+    use RunTestsInCoroutine;
+
+    public function throwingMethod(): void
+    {
+        throw new \RuntimeException('Test exception from coroutine');
+    }
+}

--- a/tests/Foundation/Testing/Concerns/RunTestsInCoroutineTest.php
+++ b/tests/Foundation/Testing/Concerns/RunTestsInCoroutineTest.php
@@ -8,6 +8,7 @@ use Hypervel\Foundation\Testing\Concerns\RunTestsInCoroutine;
 use Hypervel\Tests\TestCase;
 use ReflectionMethod;
 use ReflectionProperty;
+use RuntimeException;
 use Swoole\Coroutine;
 
 /**
@@ -91,7 +92,7 @@ class RunTestsInCoroutineTest extends TestCase
         $setUp = new ReflectionMethod($testCase, 'setUpCoroutineTest');
         $setUp->invoke($testCase);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Test exception from coroutine');
 
         $run = new ReflectionMethod($testCase, 'runTestsInCoroutine');
@@ -101,6 +102,7 @@ class RunTestsInCoroutineTest extends TestCase
 
 /**
  * @internal
+ * @coversNothing
  */
 class CoroutineTestStub extends \PHPUnit\Framework\TestCase
 {
@@ -116,6 +118,7 @@ class CoroutineTestStub extends \PHPUnit\Framework\TestCase
 
 /**
  * @internal
+ * @coversNothing
  */
 class CoroutineDisabledTestStub extends \PHPUnit\Framework\TestCase
 {
@@ -134,6 +137,7 @@ class CoroutineDisabledTestStub extends \PHPUnit\Framework\TestCase
 
 /**
  * @internal
+ * @coversNothing
  */
 class CoroutineExceptionTestStub extends \PHPUnit\Framework\TestCase
 {
@@ -141,6 +145,6 @@ class CoroutineExceptionTestStub extends \PHPUnit\Framework\TestCase
 
     public function throwingMethod(): void
     {
-        throw new \RuntimeException('Test exception from coroutine');
+        throw new RuntimeException('Test exception from coroutine');
     }
 }


### PR DESCRIPTION
## Problem

PHPUnit 10.5 changed `runTest()` from `protected` to `private`:

```php
// PHPUnit < 10.5
protected function runTest(): mixed { ... }

// PHPUnit 10.5+
private function runTest(): mixed { ... }
```

The `RunTestsInCoroutine` trait overrides `runTest()` as `final protected` to swap the test method name and wrap execution in a Swoole coroutine via `run()`. But since PHPUnit's `runTest()` is now `private`, PHP treats the trait's method as a completely separate method — PHPUnit's `runBare()` calls its own private `runTest()`, never the trait's.

The result: test methods execute outside a Swoole coroutine. Any operation that requires coroutine context (database connections, channels, HTTP client) crashes with:

```
Swoole\Error: API must be called in the coroutine
```

This affects **every** Hypervel test that uses `RunTestsInCoroutine` — including the default `ExampleTest` in a fresh `composer create-project hypervel/hypervel` app.

## Reproduction

```bash
composer create-project hypervel/hypervel test-app
cd test-app
composer require pestphp/pest --dev -W
./vendor/bin/pest
```

What is not important now is to wonder why I chose pest instead of phpunit. The default phpunit setup with a bare app leads to segmentation fault and that's a different matter as evidenced below 
```
./vendor/bin/phpunit 
PHPUnit 10.5.45 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /home/richard/Codes/Tutorials/Laravel/hyper-app/phpunit.xml.dist

..Segmentation fault (core dumped)
```

Unit tests pass, but the Feature `ExampleTest` (which calls `$this->get('/')`) crashes with `API must be called in the coroutine`.

## Root Cause

PHPUnit's `runBare()` calls its private `runTest()` at line ~689:

```php
// PHPUnit\Framework\TestCase::runBare()
$this->testResult = $this->runTest();
```

The private `runTest()` calls the test method by name:

```php
// PHPUnit\Framework\TestCase::runTest() [private]
$testResult = $this->{$this->name}(...array_values($testArguments));
```

The trait's approach was to intercept `runTest()`, rename `$this->name` to `runTestsInCoroutine`, then call `parent::runTest()`. But since the trait's `runTest()` is never called by PHPUnit (it's a different method due to `private` visibility), the name swap never happens and the test runs without a coroutine.

## Fix

Move the name swap from the unreachable `runTest()` override to `setUp()`, which IS called before PHPUnit's private `runTest()` and IS overridable (`protected`).

### RunTestsInCoroutine.php

Replaced the broken `final protected function runTest()` with `setUpCoroutineTest()`:

```php
protected function setUpCoroutineTest(): void
{
    if (Coroutine::getCid() === -1 && $this->enableCoroutine) {
        $this->realTestName = $this->name();
        $this->setName('runTestsInCoroutine');
    }
}
```

When PHPUnit's private `runTest()` reads `$this->name`, it finds `runTestsInCoroutine` instead of the real test name. It calls `$this->runTestsInCoroutine()` which wraps the real test method in `Hypervel\Coroutine\run()`.

### TestCase.php

Added the call at the end of `setUp()`:

```php
if (method_exists($this, 'setUpCoroutineTest')) {
    $this->setUpCoroutineTest();
}
```

This runs after all trait setup (including `RefreshDatabase::refreshDatabase()`) but before PHPUnit's `runTest()`.

## Files Changed

- `src/foundation/src/Testing/Concerns/RunTestsInCoroutine.php` — removed broken `runTest()` override, added `setUpCoroutineTest()`
- `src/foundation/src/Testing/TestCase.php` — calls `setUpCoroutineTest()` at end of `setUp()`

## Backward Compatibility

- Users who don't use `RunTestsInCoroutine` are unaffected (the `method_exists` check handles this)
- Users who DO use the trait get working coroutine wrapping again
- The `runTestsInCoroutine()` method, `invokeSetupInCoroutine()`, `invokeTearDownInCoroutine()`, and the `$enableCoroutine` / `$copyNonCoroutineContext` properties are unchanged
- The removed `runTest()` method was non-functional in PHPUnit 10.5+ anyway

## Known Remaining Issue

After this fix, tests run inside coroutines correctly. However, `RefreshDatabase::beginDatabaseTransaction()` has a separate issue: the transaction `beginTransaction()` and `rollBack()` execute in different coroutines (setUp's coroutine vs tearDown's coroutine). Hyperf's connection pooling binds PDO sockets to the coroutine that opened them, so the rollback coroutine gets `Swoole\Error: Socket has already been bound to another coroutine`.

This is an architectural limitation of Hyperf's database connection pooling under Swoole's coroutine model, and is being addressed separately by PR #349 which replaces the Hyperf DB layer entirely.
