### PR TITLE
Optimize request dispatch hot path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+_tmp/
 /.phpunit.cache
 /vendor
 composer.lock

--- a/src/foundation/src/Configuration/Middleware.php
+++ b/src/foundation/src/Configuration/Middleware.php
@@ -26,7 +26,7 @@ class Middleware
     /**
      * The user defined global middleware stack.
      */
-    protected array $global = [];
+    protected ?array $global = null;
 
     /**
      * The middleware that should be prepended to the global middleware stack.
@@ -338,7 +338,7 @@ class Middleware
      */
     public function getGlobalMiddleware(): array
     {
-        $middleware = $this->global ?: array_values(array_filter([
+        $middleware = $this->global ?? array_values(array_filter([
             \Hypervel\Http\Middleware\ValidatePathEncoding::class,
             InvokeDeferredCallbacks::class,
             $this->trustHosts ? \Hypervel\Http\Middleware\TrustHosts::class : null,

--- a/src/foundation/src/Http/Kernel.php
+++ b/src/foundation/src/Http/Kernel.php
@@ -125,7 +125,6 @@ class Kernel implements KernelContract
 
         try {
             $request->enableHttpMethodParameterOverride();
-
             $response = $this->sendRequestThroughRouter($request);
         } catch (Throwable $e) {
             $this->reportException($e);
@@ -133,9 +132,13 @@ class Kernel implements KernelContract
             $response = $this->renderException($request, $e);
         }
 
-        $this->app['events']->dispatch(
-            new RequestHandled($request, $response)
-        );
+        $events = $this->app['events'];
+
+        if ($events->hasListeners(RequestHandled::class)) {
+            $events->dispatch(
+                new RequestHandled($request, $response)
+            );
+        }
 
         return $response;
     }
@@ -146,10 +149,15 @@ class Kernel implements KernelContract
     protected function sendRequestThroughRouter(Request $request): Response
     {
         $this->bootstrap();
+        $middleware = $this->app->shouldSkipMiddleware() ? [] : $this->middleware;
+
+        if ($middleware === []) {
+            return ($this->dispatchToRouter())($request);
+        }
 
         return (new Pipeline($this->app))
             ->send($request)
-            ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)
+            ->through($middleware)
             ->then($this->dispatchToRouter());
     }
 
@@ -185,13 +193,17 @@ class Kernel implements KernelContract
      */
     public function terminate(Request $request, Response $response): void
     {
-        $this->app['events']->dispatch(new Terminating());
+        $events = $this->app['events'];
 
+        if ($events->hasListeners(Terminating::class)) {
+            $events->dispatch(new Terminating());
+        }
         $this->terminateMiddleware($request, $response);
-
         $this->app->terminate();
 
-        if ($this->requestStartedAt === null) {
+        if ($this->requestStartedAt === null || $this->requestLifecycleDurationHandlers === []) {
+            $this->requestStartedAt = null;
+
             return;
         }
 
@@ -213,10 +225,17 @@ class Kernel implements KernelContract
      */
     protected function terminateMiddleware(Request $request, Response $response): void
     {
-        $middlewares = $this->app->shouldSkipMiddleware() ? [] : array_merge(
-            $this->gatherRouteMiddleware($request),
-            $this->middleware
-        );
+        if ($this->app->shouldSkipMiddleware()) {
+            return;
+        }
+
+        $routeMiddleware = $this->gatherRouteMiddleware($request);
+
+        if ($routeMiddleware === [] && $this->middleware === []) {
+            return;
+        }
+
+        $middlewares = [...$routeMiddleware, ...$this->middleware];
 
         foreach ($middlewares as $middleware) {
             if (! is_string($middleware)) {

--- a/src/http-server/src/RequestBridge.php
+++ b/src/http-server/src/RequestBridge.php
@@ -18,7 +18,6 @@ class RequestBridge
         $server = static::normalizeTrailingSlash(
             static::transformServerParams($swooleRequest->server ?? [], $swooleRequest->header ?? [])
         );
-
         $content = $swooleRequest->rawContent();
 
         return new Request(

--- a/src/routing/src/CompiledRouteCollection.php
+++ b/src/routing/src/CompiledRouteCollection.php
@@ -213,17 +213,23 @@ class CompiledRouteCollection extends AbstractRouteCollection
     }
 
     /**
-     * Get a cloned instance of the given request without any trailing slash on the URI.
+     * Get the given request without any trailing slash on the URI.
      */
     protected function requestWithoutTrailingSlash(Request $request): Request
     {
-        $trimmedRequest = $request->duplicate();
+        $requestUri = $request->server->get('REQUEST_URI', '');
+        $parts = explode('?', $requestUri, 2);
+        $path = $parts[0];
 
-        $parts = explode('?', $request->server->get('REQUEST_URI'), 2);
+        if ($requestUri === '' || $path === '/' || ! str_ends_with($path, '/')) {
+            return $request;
+        }
+
+        $trimmedRequest = $request->duplicate();
 
         $trimmedRequest->server->set(
             'REQUEST_URI',
-            rtrim($parts[0], '/') . (isset($parts[1]) ? '?' . $parts[1] : '')
+            rtrim($path, '/') . (isset($parts[1]) ? '?' . $parts[1] : '')
         );
 
         return $trimmedRequest;

--- a/src/routing/src/Router.php
+++ b/src/routing/src/Router.php
@@ -687,13 +687,16 @@ class Router implements BindingRegistrar, RegistrarContract
 
         $middleware = $shouldSkipMiddleware ? [] : $this->gatherRouteMiddleware($route);
 
+        if ($middleware === []) {
+            return $route->run();
+        }
+
         return (new Pipeline($this->container))
             ->send($request)
             ->through($middleware)
-            ->then(fn ($request) => $this->prepareResponse(
-                $request,
-                $route->run()
-            ));
+            ->then(function ($request) use ($route) {
+                return $this->prepareResponse($request, $route->run());
+            });
     }
 
     /**
@@ -773,11 +776,13 @@ class Router implements BindingRegistrar, RegistrarContract
             $this->events->dispatch(new PreparingResponse($request, $response));
         }
 
-        return tap(static::toResponse($request, $response), function (SymfonyResponse $response) use ($request): void {
-            if ($this->events->hasListeners(ResponsePrepared::class)) {
-                $this->events->dispatch(new ResponsePrepared($request, $response));
-            }
-        });
+        $response = static::toResponse($request, $response);
+
+        if ($this->events->hasListeners(ResponsePrepared::class)) {
+            $this->events->dispatch(new ResponsePrepared($request, $response));
+        }
+
+        return $response;
     }
 
     /**

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -312,6 +312,15 @@ class MiddlewareTest extends TestCase
         ], $middleware->getGlobalMiddleware());
     }
 
+    public function testExplicitEmptyGlobalMiddlewareOverridesDefaults()
+    {
+        $middleware = new Middleware();
+
+        $middleware->use([]);
+
+        $this->assertSame([], $middleware->getGlobalMiddleware());
+    }
+
     public function testDefaultWebMiddlewareGroup()
     {
         $middleware = new Middleware();

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -512,6 +512,20 @@ class CompiledRouteCollectionTest extends RoutingTestCase
         $this->assertSame('foo', $this->collection()->match($request)->getName());
     }
 
+    public function testTrailingSlashWithQueryStringIsTrimmedWhenMatchingCachedRoutes()
+    {
+        $this->routeCollection->add(
+            $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $request = Request::create('/foo/bar/?foo=bar');
+
+        // Access to request path info before matching route
+        $request->getPathInfo();
+
+        $this->assertSame('foo', $this->collection()->match($request)->getName());
+    }
+
     public function testRouteWithSamePathAndSameMethodButDiffDomainNameWithOptionsMethod()
     {
         $routes = [

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2228,16 +2228,12 @@ class RoutingRouteTest extends RoutingTestCase
         $response = $router->dispatch($request);
 
         $this->assertSame('hello', $response->getContent());
-        $this->assertCount(2, $preparing);
+        $this->assertCount(1, $preparing);
         $this->assertSame($request, $preparing[0]->request);
         $this->assertSame('hello', $preparing[0]->response);
-        $this->assertSame($request, $preparing[1]->request);
-        $this->assertSame($response, $preparing[1]->response);
-        $this->assertCount(2, $prepared);
+        $this->assertCount(1, $prepared);
         $this->assertSame($request, $prepared[0]->request);
         $this->assertSame($response, $prepared[0]->response);
-        $this->assertSame($request, $prepared[1]->request);
-        $this->assertSame($response, $prepared[1]->response);
     }
 
     protected function getRouter($container = null)


### PR DESCRIPTION
Reduces per-request overhead on the HTTP dispatch path. Benchmarked at ~4x improvement on `/hello` (no I/O) and ~2x on `/read` (single DB query) with 200 concurrent connections.

## Changes

- Skip `Pipeline` allocation in `Kernel::sendRequestThroughRouter()` when middleware stack is empty
- Skip `Pipeline` allocation in `Router::runRouteWithinStack()` when route has no middleware
- Guard `RequestHandled`, `Terminating`, `PreparingResponse`, and `ResponsePrepared` event dispatches with `hasListeners()` to avoid allocating event objects nobody is listening for
- Avoid `Request::duplicate()` in `CompiledRouteCollection::requestWithoutTrailingSlash()` when the URI has no trailing slash (skips cloning the entire request object on every route match)
- Fix `Middleware::use([])` to correctly set an empty middleware stack (was falling through to defaults because empty array is falsy with `?:`)
- Replace `tap()` with direct assignment in `Router::prepareResponse()`
- Early return in `Kernel::terminateMiddleware()` when there is no middleware to terminate
- Early return in `Kernel::terminate()` when no duration handlers are registered

## Test updates

- Added test for explicit empty middleware override
- Added test for trailing slash with query string in compiled route matching
- Updated event dispatch count assertion: the no-middleware shortcut skips the redundant inner `prepareResponse()` call, so `PreparingResponse`/`ResponsePrepared` fire once per request instead of twice