### PR TITLE
feat: first-class Postgres database pooler support (PgBouncer / PgDog)

### DIFF
--- a/src/database/src/ConnectionResolver.php
+++ b/src/database/src/ConnectionResolver.php
@@ -31,9 +31,13 @@ class ConnectionResolver implements ConnectionResolverInterface
     public const DEFAULT_CONNECTION_CONTEXT_KEY = '__database.default_connection';
 
     /**
-     * The default connection name.
+     * The config-derived default connection name, captured at construction.
+     *
+     * Serves as the fallback for getDefaultConnection() when no coroutine
+     * Context override is active. Readonly because runtime overrides go
+     * through CoroutineContext, not through this property.
      */
-    protected ?string $default;
+    protected readonly ?string $default;
 
     protected PoolFactory $factory;
 
@@ -92,8 +96,9 @@ class ConnectionResolver implements ConnectionResolverInterface
     /**
      * Get the default connection name.
      *
-     * Checks Context first for per-coroutine override (from usingConnection()),
-     * then falls back to the configured default.
+     * Checks Context first for per-coroutine override (from setDefaultConnection()
+     * or DatabaseManager::usingConnection()), then falls back to the
+     * config-derived default captured at construction.
      */
     public function getDefaultConnection(): ?string
     {
@@ -101,11 +106,19 @@ class ConnectionResolver implements ConnectionResolverInterface
     }
 
     /**
-     * Set the default connection name.
+     * Set the default connection name for the current execution context.
+     *
+     * Writes to coroutine Context so concurrent requests in the same Swoole
+     * worker are not affected. A null value clears the override and
+     * getDefaultConnection() falls back to the config-derived default.
      */
     public function setDefaultConnection(?string $name): void
     {
-        $this->default = $name;
+        if ($name === null) {
+            CoroutineContext::forget(self::DEFAULT_CONNECTION_CONTEXT_KEY);
+        } else {
+            CoroutineContext::set(self::DEFAULT_CONNECTION_CONTEXT_KEY, $name);
+        }
     }
 
     /**

--- a/src/database/src/Connectors/PostgresConnector.php
+++ b/src/database/src/Connectors/PostgresConnector.php
@@ -23,30 +23,21 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
     /**
      * Establish a database connection.
+     *
+     * Startup parameters (search_path, timezone, isolation level, synchronous
+     * commit) are baked into the DSN via libpq's "options" parameter rather
+     * than issued as post-connect SET statements. This keeps them intact on
+     * pooled connections (PgBouncer transaction pooling, pgdog, etc.) where
+     * a SET applied to one backend is lost when the pooler hands the next
+     * query to a different backend.
      */
     public function connect(array $config): PDO
     {
-        // First we'll create the basic DSN and connection instance connecting to the
-        // using the configuration option specified by the developer. We will also
-        // set the default character set on the connections to UTF-8 by default.
-        $connection = $this->createConnection(
+        return $this->createConnection(
             $this->getDsn($config),
             $config,
             $this->getOptions($config)
         );
-
-        $this->configureIsolationLevel($connection, $config);
-
-        // Next, we will check to see if a timezone has been specified in this config
-        // and if it has we will issue a statement to modify the timezone with the
-        // database. Setting this DB timezone is an optional configuration item.
-        $this->configureTimezone($connection, $config);
-
-        $this->configureSearchPath($connection, $config);
-
-        $this->configureSynchronousCommit($connection, $config);
-
-        return $connection;
     }
 
     /**
@@ -87,7 +78,61 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $dsn .= ";application_name='" . str_replace("'", "\\'", $application_name) . "'";
         }
 
+        $startupOptions = $this->buildStartupOptions($config);
+
+        if ($startupOptions !== null) {
+            $dsn .= ";options='{$startupOptions}'";
+        }
+
         return $this->addSslOptions($dsn, $config);
+    }
+
+    /**
+     * Build the libpq "options" parameter value from startup settings.
+     *
+     * Returns null when no startup settings are configured. Each setting is
+     * expressed as a "-c key=value" flag, space-separated. Values containing
+     * spaces (e.g. "read committed") are backslash-escaped so libpq preserves
+     * them as a single token when it splits the options string on whitespace.
+     */
+    protected function buildStartupOptions(array $config): ?string
+    {
+        $parts = [];
+
+        if (isset($config['search_path']) || isset($config['schema'])) {
+            $searchPath = $this->quoteSearchPath(
+                $this->parseSearchPath($config['search_path'] ?? $config['schema'])
+            );
+
+            $parts[] = '-c search_path=' . $this->escapeStartupOptionValue($searchPath);
+        }
+
+        if (isset($config['timezone'])) {
+            $parts[] = '-c TimeZone=' . $this->escapeStartupOptionValue((string) $config['timezone']);
+        }
+
+        if (isset($config['isolation_level'])) {
+            $parts[] = '-c default_transaction_isolation=' . $this->escapeStartupOptionValue((string) $config['isolation_level']);
+        }
+
+        if (isset($config['synchronous_commit'])) {
+            $parts[] = '-c synchronous_commit=' . $this->escapeStartupOptionValue((string) $config['synchronous_commit']);
+        }
+
+        return $parts !== [] ? implode(' ', $parts) : null;
+    }
+
+    /**
+     * Escape a startup option value for use inside libpq's options parameter.
+     *
+     * libpq splits the options string on unescaped whitespace, so spaces that
+     * belong to a single value (like the space in "read committed") must be
+     * backslash-escaped to stay part of that value rather than being treated
+     * as a token separator.
+     */
+    protected function escapeStartupOptionValue(string $value): string
+    {
+        return str_replace(' ', '\ ', $value);
     }
 
     /**
@@ -105,56 +150,10 @@ class PostgresConnector extends Connector implements ConnectorInterface
     }
 
     /**
-     * Set the connection transaction isolation level.
-     */
-    protected function configureIsolationLevel(PDO $connection, array $config): void
-    {
-        if (isset($config['isolation_level'])) {
-            $connection->prepare("set session characteristics as transaction isolation level {$config['isolation_level']}")->execute();
-        }
-    }
-
-    /**
-     * Set the timezone on the connection.
-     */
-    protected function configureTimezone(PDO $connection, array $config): void
-    {
-        if (isset($config['timezone'])) {
-            $timezone = $config['timezone'];
-
-            $connection->prepare("set time zone '{$timezone}'")->execute();
-        }
-    }
-
-    /**
-     * Set the "search_path" on the database connection.
-     */
-    protected function configureSearchPath(PDO $connection, array $config): void
-    {
-        if (isset($config['search_path']) || isset($config['schema'])) {
-            $searchPath = $this->quoteSearchPath(
-                $this->parseSearchPath($config['search_path'] ?? $config['schema'])
-            );
-
-            $connection->prepare("set search_path to {$searchPath}")->execute();
-        }
-    }
-
-    /**
-     * Format the search path for the DSN.
+     * Format the search path as a quoted identifier list.
      */
     protected function quoteSearchPath(array $searchPath): string
     {
         return count($searchPath) === 1 ? '"' . $searchPath[0] . '"' : '"' . implode('", "', $searchPath) . '"';
-    }
-
-    /**
-     * Configure the synchronous_commit setting.
-     */
-    protected function configureSynchronousCommit(PDO $connection, array $config): void
-    {
-        if (isset($config['synchronous_commit'])) {
-            $connection->prepare("set synchronous_commit to '{$config['synchronous_commit']}'")->execute();
-        }
     }
 }

--- a/src/database/src/Connectors/PostgresConnector.php
+++ b/src/database/src/Connectors/PostgresConnector.php
@@ -129,10 +129,17 @@ class PostgresConnector extends Connector implements ConnectorInterface
      * belong to a single value (like the space in "read committed") must be
      * backslash-escaped to stay part of that value rather than being treated
      * as a token separator.
+     *
+     * The replacement emits two backslashes before each space. PDO's DSN
+     * parser consumes one level of backslash-escaping when it extracts the
+     * single-quoted options value, so a single backslash in the DSN source
+     * is stripped before libpq sees it — leaving libpq to split on the
+     * unescaped space. Doubling the backslash survives PDO's unescape and
+     * arrives at libpq as a single `\ ` (escaped space).
      */
     protected function escapeStartupOptionValue(string $value): string
     {
-        return str_replace(' ', '\ ', $value);
+        return str_replace(' ', '\\\ ', $value);
     }
 
     /**

--- a/src/database/src/Console/Migrations/InstallCommand.php
+++ b/src/database/src/Console/Migrations/InstallCommand.php
@@ -6,6 +6,7 @@ namespace Hypervel\Database\Console\Migrations;
 
 use Hypervel\Console\Command;
 use Hypervel\Database\Migrations\MigrationRepositoryInterface;
+use Hypervel\Database\Migrations\Migrator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -42,7 +43,9 @@ class InstallCommand extends Command
      */
     public function handle(): void
     {
-        $this->repository->setSource($this->input->getOption('database'));
+        $this->repository->setSource(
+            Migrator::resolveMigrationConnectionName($this->input->getOption('database'))
+        );
 
         if (! $this->repository->repositoryExists()) {
             $this->repository->createRepository();

--- a/src/database/src/Console/Migrations/MigrateCommand.php
+++ b/src/database/src/Console/Migrations/MigrateCommand.php
@@ -111,11 +111,14 @@ class MigrateCommand extends BaseCommand implements Isolatable
             // Finally, if the "seed" option has been given, we will re-run the database
             // seed task to re-populate the database, which is convenient when adding
             // a migration and a seed at the same time, as it is only this command.
+            // Forwards the user-supplied --database so seeders run on the chosen app
+            // connection rather than silently falling back to database.default.
             if ($this->option('seed') && ! $this->option('pretend')) {
-                $this->call('db:seed', [
+                $this->call('db:seed', array_filter([
+                    '--database' => $this->option('database'),
                     '--class' => $this->option('seeder') ?: 'Database\Seeders\DatabaseSeeder',
                     '--force' => true,
-                ]);
+                ]));
             }
         });
     }

--- a/src/database/src/Console/Seeds/SeedCommand.php
+++ b/src/database/src/Console/Seeds/SeedCommand.php
@@ -7,6 +7,8 @@ namespace Hypervel\Database\Console\Seeds;
 use Hypervel\Console\Command;
 use Hypervel\Console\ConfirmableTrait;
 use Hypervel\Console\Prohibitable;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
 use Hypervel\Database\ConnectionResolverInterface;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Seeder;
@@ -47,6 +49,10 @@ class SeedCommand extends Command
 
     /**
      * Execute the console command.
+     *
+     * The seed connection is applied via coroutine Context, mirroring the
+     * pattern used by Migrator and DatabaseManager::usingConnection(). No
+     * worker-global state is mutated; concurrent coroutines are unaffected.
      */
     public function handle(): int
     {
@@ -57,16 +63,20 @@ class SeedCommand extends Command
 
         $this->components->info('Seeding database.');
 
-        $previousConnection = $this->resolver->getDefaultConnection();
+        $previousContext = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
 
         try {
-            $this->resolver->setDefaultConnection($this->getDatabase());
+            CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $this->getDatabase());
 
             Model::unguarded(function () {
                 $this->getSeeder()->__invoke();
             });
         } finally {
-            $this->resolver->setDefaultConnection($previousConnection);
+            if ($previousContext === null) {
+                CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+            } else {
+                CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $previousContext);
+            }
         }
 
         return 0;
@@ -95,12 +105,16 @@ class SeedCommand extends Command
 
     /**
      * Get the name of the database connection to use.
+     *
+     * Reads the current default via the resolver (which respects any active
+     * Context override) rather than going straight to config, so seeding
+     * honors scoped overrides applied by callers like Migrator::usingConnection().
      */
     protected function getDatabase(): string
     {
         $database = $this->input->getOption('database');
 
-        return $database ?: $this->hypervel['config']['database.default'];
+        return $database ?: $this->resolver->getDefaultConnection();
     }
 
     /**

--- a/src/database/src/Console/WipeCommand.php
+++ b/src/database/src/Console/WipeCommand.php
@@ -7,6 +7,7 @@ namespace Hypervel\Database\Console;
 use Hypervel\Console\Command;
 use Hypervel\Console\ConfirmableTrait;
 use Hypervel\Console\Prohibitable;
+use Hypervel\Database\Migrations\Migrator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -36,7 +37,9 @@ class WipeCommand extends Command
             return Command::FAILURE;
         }
 
-        $database = $this->input->getOption('database');
+        $database = Migrator::resolveMigrationConnectionName(
+            $this->input->getOption('database')
+        );
 
         if ($this->option('drop-views')) {
             $this->dropAllViews($database);

--- a/src/database/src/DatabaseManager.php
+++ b/src/database/src/DatabaseManager.php
@@ -354,11 +354,19 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
-     * Set the default connection name.
+     * Set the default connection name for the current execution context.
+     *
+     * Writes to coroutine Context so concurrent requests in the same Swoole
+     * worker are not affected. A null value clears the override and
+     * getDefaultConnection() falls back to config('database.default').
      */
     public function setDefaultConnection(?string $name): void
     {
-        $this->app['config']['database.default'] = $name;
+        if ($name === null) {
+            CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        } else {
+            CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $name);
+        }
     }
 
     /**

--- a/src/database/src/Migrations/Migrator.php
+++ b/src/database/src/Migrations/Migrator.php
@@ -446,24 +446,21 @@ class Migrator
     /**
      * Run a migration method on the given connection.
      *
-     * Sets both the resolver default and the coroutine Context key so that
-     * Schema/DB facade calls inside the migration body resolve to the correct
-     * connection. This handles both the migrator's --database override and
-     * per-migration $connection properties.
+     * Sets the coroutine Context key so Schema/DB facade calls inside the
+     * migration body resolve to the correct connection. This handles both
+     * the migrator's --database override and per-migration $connection
+     * properties. Context is the single source of truth for the scoped
+     * default — no worker-global state is mutated.
      */
     protected function runMethod(Connection $connection, object $migration, string $method): void
     {
-        $previousConnection = $this->resolver->getDefaultConnection();
         $previousContext = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
 
         try {
-            $this->resolver->setDefaultConnection($connection->getName());
             CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $connection->getName());
 
             $migration->{$method}();
         } finally {
-            $this->resolver->setDefaultConnection($previousConnection);
-
             if ($previousContext === null) {
                 CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
             } else {
@@ -585,28 +582,97 @@ class Migrator
     }
 
     /**
+     * Resolve a connection name through the "migrations_connection" config key.
+     *
+     * Allows pooled connections (PgBouncer, pgdog, Neon, Supabase, etc.) to declare
+     * an unpooled sibling that migration operations should route through. Session
+     * state required by migrations — advisory locks, LOCK TABLE, temp tables — is
+     * incompatible with transaction-pooling mode.
+     *
+     * When $name is null, falls back to the "effective default connection" —
+     * the current coroutine's Context override first, then the configured
+     * default (database.default). This mirrors DatabaseManager::getDefaultConnection()
+     * so programmatic flows that wrap migrations in DB::usingConnection() or
+     * DatabaseManager::setDefaultConnection() route through the scoped default.
+     *
+     * Defensively passes the name through when the container has no "config"
+     * binding so unit tests that construct Migrator without a booted framework
+     * still work.
+     */
+    public static function resolveMigrationConnectionName(?string $name): ?string
+    {
+        $container = Container::getInstance();
+
+        if (! $container->bound('config')) {
+            return $name;
+        }
+
+        $config = $container->make('config');
+
+        if ($name === null) {
+            $name = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY)
+                ?? $config->get('database.default');
+
+            if ($name === null) {
+                return null;
+            }
+        }
+
+        return $config->get(
+            "database.connections.{$name}.migrations_connection",
+            $name,
+        );
+    }
+
+    /**
      * Execute the given callback using the given connection as the default connection.
+     *
+     * Snapshots the prior coroutine Context value and the stored migrator
+     * connection on entry, then restores them directly in finally without
+     * routing back through setConnection() — otherwise the restoration would
+     * apply migrations_connection to the saved alias and leave the wrong
+     * default in place.
      */
     public function usingConnection(?string $name, callable $callback): mixed
     {
-        $previousConnection = $this->resolver->getDefaultConnection();
+        $previousStored = $this->connection;
+        $previousContext = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
 
         $this->setConnection($name);
 
         try {
             return $callback();
         } finally {
-            $this->setConnection($previousConnection);
+            $this->connection = $previousStored;
+            $this->repository->setSource($previousStored);
+
+            if ($previousContext === null) {
+                CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+            } else {
+                CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $previousContext);
+            }
         }
     }
 
     /**
      * Set the default connection name.
+     *
+     * Honors the target connection's "migrations_connection" config key. The
+     * swapped name is propagated via coroutine Context (so Schema/DB facade
+     * calls during migration resolve correctly), via the repository source
+     * (so the migrations table lands on the same target), and via the stored
+     * connection (so subsequent resolveConnection() calls use it). Uses
+     * CoroutineContext rather than $this->resolver->setDefaultConnection() so
+     * no worker-global state is mutated — concurrent coroutines are unaffected.
      */
     public function setConnection(?string $name): void
     {
-        if (! is_null($name)) {
-            $this->resolver->setDefaultConnection($name);
+        $name = static::resolveMigrationConnectionName($name);
+
+        if ($name === null) {
+            CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        } else {
+            CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $name);
         }
 
         $this->repository->setSource($name);
@@ -616,18 +682,26 @@ class Migrator
 
     /**
      * Resolve the database connection instance.
+     *
+     * Applies the "migrations_connection" swap so per-migration connection
+     * overrides (via Migration::getConnection()) are also routed to the
+     * unpooled sibling when the named connection opts in.
      */
     public function resolveConnection(?string $connection): Connection
     {
+        $connection = static::resolveMigrationConnectionName(
+            $connection ?: $this->connection
+        );
+
         if (static::$connectionResolverCallback) {
             return call_user_func(
                 static::$connectionResolverCallback,
                 $this->resolver,
-                $connection ?: $this->connection
+                $connection
             );
         }
         // @phpstan-ignore return.type (resolver returns ConnectionInterface but concrete Connection in practice)
-        return $this->resolver->connection($connection ?: $this->connection);
+        return $this->resolver->connection($connection);
     }
 
     /**

--- a/src/foundation/config/database.php
+++ b/src/foundation/config/database.php
@@ -126,6 +126,33 @@ return [
                 'max_idle_time' => (float) env('DB_MAX_IDLE_TIME', 60),
             ],
         ],
+
+        'pgsql-pooled' => [
+            'driver' => 'pgsql',
+            'url' => env('DB_POOLED_URL', env('DB_URL')),
+            'host' => env('DB_POOLED_HOST', 'localhost'),
+            'port' => env('DB_POOLED_PORT', 6432),
+            'database' => env('DB_POOLED_DATABASE', env('DB_DATABASE', 'hypervel')),
+            'username' => env('DB_POOLED_USERNAME', env('DB_USERNAME', 'root')),
+            'password' => env('DB_POOLED_PASSWORD', env('DB_PASSWORD', '')),
+            'charset' => env('DB_CHARSET', 'utf8'),
+            'prefix' => env('DB_PREFIX', ''),
+            'prefix_indexes' => true,
+            'search_path' => 'public',
+            'sslmode' => env('DB_POOLED_SSLMODE', env('DB_SSLMODE', 'prefer')),
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => true,
+            ],
+            'migrations_connection' => 'pgsql',
+            'pool' => [
+                'min_connections' => (int) env('DB_POOLED_MIN_CONNECTIONS', 1),
+                'max_connections' => (int) env('DB_POOLED_MAX_CONNECTIONS', 20),
+                'connect_timeout' => 10.0,
+                'wait_timeout' => 3.0,
+                'heartbeat' => -1,
+                'max_idle_time' => (float) env('DB_POOLED_MAX_IDLE_TIME', 60),
+            ],
+        ],
     ],
 
     /*

--- a/src/foundation/config/database.php
+++ b/src/foundation/config/database.php
@@ -130,7 +130,7 @@ return [
         'pgsql-pooled' => [
             'driver' => 'pgsql',
             'url' => env('DB_POOLED_URL', env('DB_URL')),
-            'host' => env('DB_POOLED_HOST', 'localhost'),
+            'host' => env('DB_POOLED_HOST', env('DB_HOST', 'localhost')),
             'port' => env('DB_POOLED_PORT', 6432),
             'database' => env('DB_POOLED_DATABASE', env('DB_DATABASE', 'hypervel')),
             'username' => env('DB_POOLED_USERNAME', env('DB_USERNAME', 'root')),

--- a/src/foundation/src/Providers/FoundationServiceProvider.php
+++ b/src/foundation/src/Providers/FoundationServiceProvider.php
@@ -112,7 +112,6 @@ class FoundationServiceProvider extends ServiceProvider
     {
         $this->setDefaultTimezone();
         $this->setInternalEncoding();
-        $this->setDatabaseConnection();
 
         $events = $this->app->make('events');
 
@@ -247,13 +246,6 @@ class FoundationServiceProvider extends ServiceProvider
             $this->app->make(DeferredCallbackCollection::class)
                 ->invokeWhen(fn (DeferredCallback $callback) => $event->successful() || $callback->always);
         });
-    }
-
-    protected function setDatabaseConnection(): void
-    {
-        $connection = $this->config->get('database.default', 'mysql');
-        $this->app->make('db')
-            ->setDefaultConnection($connection);
     }
 
     /**

--- a/tests/Database/ConnectionResolverSetDefaultConnectionTest.php
+++ b/tests/Database/ConnectionResolverSetDefaultConnectionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Config\Repository;
+use Hypervel\Container\Container;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
+use Hypervel\Database\Pool\PoolFactory;
+use Hypervel\Engine\Coroutine;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+
+/**
+ * Regression tests for ConnectionResolver::setDefaultConnection() using
+ * CoroutineContext. Mirrors the DatabaseManager tests since both
+ * implementations share the same Context key and semantics.
+ */
+class ConnectionResolverSetDefaultConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function testSetDefaultConnectionWritesToCoroutineContext()
+    {
+        $resolver = $this->makeResolver('pgsql');
+
+        $resolver->setDefaultConnection('reporting');
+
+        $this->assertSame(
+            'reporting',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+        );
+    }
+
+    public function testSetDefaultConnectionWithNullClearsContextOverride()
+    {
+        $resolver = $this->makeResolver('pgsql');
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'reporting');
+
+        $resolver->setDefaultConnection(null);
+
+        $this->assertNull(
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+        );
+    }
+
+    public function testGetDefaultConnectionFallsBackToConfigCapturedAtConstruction()
+    {
+        $resolver = $this->makeResolver('pgsql');
+
+        // No override set — should fall back to the config-captured default
+        $this->assertSame('pgsql', $resolver->getDefaultConnection());
+
+        // Override, then clear — should fall back again
+        $resolver->setDefaultConnection('reporting');
+        $this->assertSame('reporting', $resolver->getDefaultConnection());
+
+        $resolver->setDefaultConnection(null);
+        $this->assertSame('pgsql', $resolver->getDefaultConnection());
+    }
+
+    public function testOverrideInOneCoroutineIsNotVisibleInSibling()
+    {
+        $resolver = $this->makeResolver('pgsql');
+
+        $observations = [];
+
+        Coroutine::create(function () use ($resolver, &$observations) {
+            $resolver->setDefaultConnection('reporting');
+            $observations['parent'] = $resolver->getDefaultConnection();
+
+            Coroutine::create(function () use ($resolver, &$observations) {
+                $observations['sibling'] = $resolver->getDefaultConnection();
+            });
+        });
+
+        $this->assertSame('reporting', $observations['parent']);
+        $this->assertSame(
+            'pgsql',
+            $observations['sibling'],
+            'Sibling coroutine must see config-derived default, not the parent\'s override',
+        );
+    }
+
+    public function testNestedOverrideRestoresExactPriorValue()
+    {
+        $resolver = $this->makeResolver('pgsql');
+
+        $resolver->setDefaultConnection('outer');
+        $this->assertSame('outer', $resolver->getDefaultConnection());
+
+        $previous = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        try {
+            $resolver->setDefaultConnection('inner');
+            $this->assertSame('inner', $resolver->getDefaultConnection());
+        } finally {
+            if ($previous === null) {
+                CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+            } else {
+                CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, $previous);
+            }
+        }
+
+        $this->assertSame('outer', $resolver->getDefaultConnection());
+    }
+
+    protected function makeResolver(string $configuredDefault): ConnectionResolver
+    {
+        $app = Container::getInstance();
+        $app->instance('config', new Repository([
+            'database' => ['default' => $configuredDefault],
+        ]));
+        $app->instance(PoolFactory::class, m::mock(PoolFactory::class));
+
+        return new ConnectionResolver($app);
+    }
+}

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -83,7 +83,10 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresSearchPathIsBakedIntoDsn($searchPath, $expectedSearchPath)
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => $searchPath, 'charset' => 'utf8'];
-        $escaped = str_replace(' ', '\ ', $expectedSearchPath);
+        // Two backslashes land in the DSN; PDO consumes one while parsing the
+        // single-quoted options value, leaving libpq with a single backslash
+        // that escapes the following space.
+        $escaped = str_replace(' ', '\\\ ', $expectedSearchPath);
         $dsn = "pgsql:host=foo;dbname='bar';client_encoding='utf8';options='-c search_path={$escaped}'";
 
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
@@ -168,7 +171,7 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresSearchPathFallbackToConfigKeySchemaIsBakedIntoDsn()
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', '"user"'], 'charset' => 'utf8'];
-        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\';options=\'-c search_path="public",\ "user"\'';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\';options=\'-c search_path="public",\\\ "user"\'';
 
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
@@ -233,7 +236,7 @@ class DatabaseConnectorTest extends TestCase
 
     public function testPostgresIsolationLevelWithSpaceIsBackslashEscaped()
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\';options=\'-c default_transaction_isolation=read\ committed\'';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';options=\'-c default_transaction_isolation=read\\\ committed\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'isolation_level' => 'read committed'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -11,7 +11,6 @@ use Hypervel\Database\Connectors\SQLiteConnector;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
 use PDO;
-use PDOStatement;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class DatabaseConnectorTest extends TestCase
@@ -71,30 +70,26 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
-        $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
     }
 
     /**
-     * @param string $searchPath
-     * @param string $expectedSql
+     * @param array|string $searchPath
+     * @param string $expectedSearchPath Quoted search path (output of quoteSearchPath)
      */
     #[DataProvider('provideSearchPaths')]
-    public function testPostgresSearchPathIsSet($searchPath, $expectedSql)
+    public function testPostgresSearchPathIsBakedIntoDsn($searchPath, $expectedSearchPath)
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => $searchPath, 'charset' => 'utf8'];
+        $escaped = str_replace(' ', '\ ', $expectedSearchPath);
+        $dsn = "pgsql:host=foo;dbname='bar';client_encoding='utf8';options='-c search_path={$escaped}'";
+
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with($expectedSql)->andReturn($statement);
-        $statement->shouldReceive('execute')->once();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -105,82 +100,80 @@ class DatabaseConnectorTest extends TestCase
         return [
             'all-lowercase' => [
                 'public',
-                'set search_path to "public"',
+                '"public"',
             ],
             'case-sensitive' => [
                 'Public',
-                'set search_path to "Public"',
+                '"Public"',
             ],
             'special characters' => [
                 '¡foo_bar-Baz!.Áüõß',
-                'set search_path to "¡foo_bar-Baz!.Áüõß"',
+                '"¡foo_bar-Baz!.Áüõß"',
             ],
             'single-quoted' => [
                 "'public'",
-                'set search_path to "public"',
+                '"public"',
             ],
             'double-quoted' => [
                 '"public"',
-                'set search_path to "public"',
+                '"public"',
             ],
             'variable' => [
                 '$user',
-                'set search_path to "$user"',
+                '"$user"',
             ],
             'delimit space' => [
                 'public user',
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'delimit newline' => [
                 "public\nuser\r\n\ttest",
-                'set search_path to "public", "user", "test"',
+                '"public", "user", "test"',
             ],
             'delimit comma' => [
                 'public,user',
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'delimit comma and space' => [
                 'public, user',
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'single-quoted many' => [
                 "'public', 'user'",
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'double-quoted many' => [
                 '"public", "user"',
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'quoted space is unsupported in string' => [
                 '"public user"',
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'array' => [
                 ['public', 'user'],
-                'set search_path to "public", "user"',
+                '"public", "user"',
             ],
             'array with variable' => [
                 ['public', '$user'],
-                'set search_path to "public", "$user"',
+                '"public", "$user"',
             ],
             'array with delimiter characters' => [
                 ['public', '"user"', "'test'", 'spaced schema'],
-                'set search_path to "public", "user", "test", "spaced schema"',
+                '"public", "user", "test", "spaced schema"',
             ],
         ];
     }
 
-    public function testPostgresSearchPathFallbackToConfigKeySchema()
+    public function testPostgresSearchPathFallbackToConfigKeySchemaIsBakedIntoDsn()
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', '"user"'], 'charset' => 'utf8'];
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';client_encoding=\'utf8\';options=\'-c search_path="public",\ "user"\'';
+
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($statement);
-        $statement->shouldReceive('execute')->once();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -194,9 +187,6 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
-        $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -210,9 +200,6 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
-        $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -226,26 +213,91 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
-        $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
     }
 
-    public function testPostgresConnectorReadsIsolationLevelFromConfig()
+    public function testPostgresIsolationLevelIsBakedIntoDsn()
     {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111;options=\'-c default_transaction_isolation=SERIALIZABLE\'';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'isolation_level' => 'SERIALIZABLE'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set session characteristics as transaction isolation level SERIALIZABLE')->andReturn($statement);
-        $statement->shouldReceive('execute')->zeroOrMoreTimes();
-        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testPostgresIsolationLevelWithSpaceIsBackslashEscaped()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';options=\'-c default_transaction_isolation=read\ committed\'';
+        $config = ['host' => 'foo', 'database' => 'bar', 'isolation_level' => 'read committed'];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testPostgresTimezoneIsBakedIntoDsn()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';options=\'-c TimeZone=UTC\'';
+        $config = ['host' => 'foo', 'database' => 'bar', 'timezone' => 'UTC'];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testPostgresSynchronousCommitIsBakedIntoDsn()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';options=\'-c synchronous_commit=off\'';
+        $config = ['host' => 'foo', 'database' => 'bar', 'synchronous_commit' => 'off'];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testPostgresCombinesMultipleStartupParamsInDsn()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';options=\'-c search_path="public" -c TimeZone=UTC -c default_transaction_isolation=SERIALIZABLE -c synchronous_commit=on\'';
+        $config = [
+            'host' => 'foo',
+            'database' => 'bar',
+            'search_path' => 'public',
+            'timezone' => 'UTC',
+            'isolation_level' => 'SERIALIZABLE',
+            'synchronous_commit' => 'on',
+        ];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testPostgresNoStartupParamsOmitsOptionsFromDsn()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\'';
+        $config = ['host' => 'foo', 'database' => 'bar'];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);

--- a/tests/Database/DatabaseManagerSetDefaultConnectionTest.php
+++ b/tests/Database/DatabaseManagerSetDefaultConnectionTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Config\Repository;
+use Hypervel\Container\Container;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
+use Hypervel\Database\DatabaseManager;
+use Hypervel\Database\Pool\PoolFactory;
+use Hypervel\Engine\Coroutine;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+
+/**
+ * Regression tests for DatabaseManager::setDefaultConnection() using
+ * CoroutineContext instead of mutating config. The companion read path
+ * (getDefaultConnection) and coroutine isolation semantics are also
+ * verified here since they're meaningless without each other.
+ */
+class DatabaseManagerSetDefaultConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function testSetDefaultConnectionWritesToCoroutineContext()
+    {
+        $manager = $this->makeManager(['default' => 'pgsql']);
+
+        $manager->setDefaultConnection('reporting');
+
+        $this->assertSame(
+            'reporting',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'setDefaultConnection must write to coroutine Context',
+        );
+    }
+
+    public function testSetDefaultConnectionWithNullClearsContextOverride()
+    {
+        $manager = $this->makeManager(['default' => 'pgsql']);
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'something');
+
+        $manager->setDefaultConnection(null);
+
+        $this->assertNull(
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'setDefaultConnection(null) must forget the Context override',
+        );
+    }
+
+    public function testSetDefaultConnectionDoesNotMutateConfig()
+    {
+        $config = new Repository(['database' => ['default' => 'pgsql']]);
+        $manager = $this->makeManager([], $config);
+
+        $manager->setDefaultConnection('reporting');
+
+        $this->assertSame(
+            'pgsql',
+            $config->get('database.default'),
+            'config("database.default") must be untouched — the override lives in Context only',
+        );
+    }
+
+    public function testGetDefaultConnectionReturnsContextOverrideWhenSet()
+    {
+        $manager = $this->makeManager(['default' => 'pgsql']);
+
+        $manager->setDefaultConnection('reporting');
+
+        $this->assertSame('reporting', $manager->getDefaultConnection());
+    }
+
+    public function testGetDefaultConnectionFallsBackToConfigWhenContextIsCleared()
+    {
+        $manager = $this->makeManager(['default' => 'pgsql']);
+
+        $manager->setDefaultConnection('reporting');
+        $manager->setDefaultConnection(null);
+
+        $this->assertSame('pgsql', $manager->getDefaultConnection());
+    }
+
+    public function testOverrideInOneCoroutineIsNotVisibleInSibling()
+    {
+        $manager = $this->makeManager(['default' => 'pgsql']);
+
+        $observations = [];
+
+        $parent = Coroutine::create(function () use ($manager, &$observations) {
+            $manager->setDefaultConnection('reporting');
+            $observations['parent'] = $manager->getDefaultConnection();
+
+            // A freshly-spawned sibling coroutine must not see our override
+            $sibling = Coroutine::create(function () use ($manager, &$observations) {
+                $observations['sibling'] = $manager->getDefaultConnection();
+            });
+        });
+
+        $this->assertSame('reporting', $observations['parent']);
+        $this->assertSame(
+            'pgsql',
+            $observations['sibling'],
+            'Child coroutines must NOT inherit their parent\'s scoped override',
+        );
+    }
+
+    /**
+     * Build a DatabaseManager wired up enough to exercise the setter/getter.
+     * The pool/factory machinery isn't needed since no connection is opened.
+     */
+    protected function makeManager(array $databaseConfig, ?Repository $config = null): DatabaseManager
+    {
+        $config ??= new Repository(['database' => $databaseConfig]);
+
+        $app = Container::getInstance();
+        $app->instance('config', $config);
+        $app->instance(PoolFactory::class, m::mock(PoolFactory::class));
+
+        $factory = m::mock(\Hypervel\Database\Connectors\ConnectionFactory::class);
+
+        return new DatabaseManager($app, $factory);
+    }
+}

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database;
 
+use Hypervel\Config\Repository;
 use Hypervel\Console\CommandMutex;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
 use Hypervel\Database\Console\Migrations\InstallCommand;
 use Hypervel\Database\Migrations\MigrationRepositoryInterface;
 use Hypervel\Foundation\Application;
@@ -15,6 +18,13 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class DatabaseMigrationInstallCommandTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+
+        parent::tearDown();
+    }
+
     public function testFireCallsRepositoryToInstall()
     {
         $app = new ApplicationDatabaseInstallStub;
@@ -36,6 +46,85 @@ class DatabaseMigrationInstallCommandTest extends TestCase
         $repo->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
+    }
+
+    public function testSetSourceReceivesSwappedNameWhenMigrationsConnectionConfigured()
+    {
+        $app = new ApplicationDatabaseInstallStub;
+        $app->instance('config', new Repository([
+            'database' => [
+                'connections' => [
+                    'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                    'pgsql' => ['driver' => 'pgsql'],
+                ],
+            ],
+        ]));
+
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setHypervel($app);
+        $repo->shouldReceive('setSource')->once()->with('pgsql');
+        $repo->shouldReceive('repositoryExists')->once()->andReturn(false);
+        $repo->shouldReceive('createRepository')->once();
+
+        $this->runCommand($command, ['--database' => 'pgsql-pooled']);
+    }
+
+    public function testSetSourceRoutesThroughDefaultWhenNoDatabaseOptionGiven()
+    {
+        // Regression for the null-handling fix: when no --database is passed
+        // and the configured default is a pooled connection with a
+        // migrations_connection sibling, install must still route to the
+        // direct connection rather than landing on the pooled one.
+        $app = new ApplicationDatabaseInstallStub;
+        $app->instance('config', new Repository([
+            'database' => [
+                'default' => 'pgsql-pooled',
+                'connections' => [
+                    'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                    'pgsql' => ['driver' => 'pgsql'],
+                ],
+            ],
+        ]));
+
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setHypervel($app);
+        $repo->shouldReceive('setSource')->once()->with('pgsql');
+        $repo->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command);
+    }
+
+    public function testSetSourceHonorsContextOverrideWhenNoDatabaseOptionGiven()
+    {
+        // End-to-end regression for the "effective default" fix at the
+        // command level. Scenario: a caller wraps the command in
+        // DB::usingConnection('tenant-pooled', ...) so Context holds the
+        // scoped default. config.default is unrelated. migrate:install must
+        // route to the Context target's migrations_connection, not to the
+        // configured default's sibling.
+        $app = new ApplicationDatabaseInstallStub;
+        $app->instance('config', new Repository([
+            'database' => [
+                'default' => 'pgsql',
+                'connections' => [
+                    'pgsql' => ['driver' => 'pgsql'],
+                    'tenant-pooled' => [
+                        'driver' => 'pgsql',
+                        'migrations_connection' => 'tenant-direct',
+                    ],
+                    'tenant-direct' => ['driver' => 'pgsql'],
+                ],
+            ],
+        ]));
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'tenant-pooled');
+
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setHypervel($app);
+        $repo->shouldReceive('setSource')->once()->with('tenant-direct');
+        $repo->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command);
     }
 
     protected function runCommand($command, $options = [])

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -181,6 +181,86 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command, ['--seed' => true, '--seeder' => 'Database\Seeders\CustomSeeder']);
     }
 
+    public function testSeedOptionForwardsDatabaseToSeedCommand(): void
+    {
+        // migrate --database=X --seed must forward --database=X to db:seed
+        // so the seeder runs on the user's chosen connection rather than
+        // silently falling back to database.default.
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command = $this->getMockBuilder(MigrateCommand::class)
+            ->onlyMethods(['call'])
+            ->setConstructorArgs([$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)])
+            ->getMock();
+        $command->setHypervel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once();
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $command->expects($this->once())->method('call')->with('db:seed', [
+            '--database' => 'pgsql-pooled',
+            '--class' => 'Database\Seeders\DatabaseSeeder',
+            '--force' => true,
+        ]);
+
+        $this->runCommand($command, ['--database' => 'pgsql-pooled', '--seed' => true]);
+    }
+
+    public function testMigrateWithSeedDoesNotLeakConnectionStateOrMutateConfig(): void
+    {
+        // Regression guard: after migrate --database=X --seed completes, the
+        // worker-global config('database.default') must be untouched and the
+        // coroutine Context must not retain any connection-default override.
+        // This catches regressions where MigrateCommand itself starts
+        // mutating config or Context in a way that escapes the command boundary.
+        $config = new \Hypervel\Config\Repository(['database' => ['default' => 'pgsql']]);
+
+        $app = new ApplicationDatabaseMigrationStub([
+            'path.database' => __DIR__,
+            'config' => $config,
+        ]);
+        $app->useDatabasePath(__DIR__);
+
+        $command = $this->getMockBuilder(MigrateCommand::class)
+            ->onlyMethods(['call'])
+            ->setConstructorArgs([$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)])
+            ->getMock();
+        $command->setHypervel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once();
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $command->expects($this->once())->method('call');
+
+        $contextBefore = \Hypervel\Context\CoroutineContext::get(
+            \Hypervel\Database\ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY
+        );
+
+        $this->runCommand($command, ['--database' => 'pgsql-pooled', '--seed' => true]);
+
+        $this->assertSame(
+            'pgsql',
+            $config->get('database.default'),
+            'config("database.default") must not be mutated by migrate --seed',
+        );
+
+        $this->assertSame(
+            $contextBefore,
+            \Hypervel\Context\CoroutineContext::get(
+                \Hypervel\Database\ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY
+            ),
+            'Context key must be in the same state as before the command ran',
+        );
+    }
+
     public function testCreateMissingSqliteDatabaseWithForceOption(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'hypervel-sqlite-');

--- a/tests/Database/DatabaseMigratorConnectionRoutingTest.php
+++ b/tests/Database/DatabaseMigratorConnectionRoutingTest.php
@@ -1,0 +1,508 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Config\Repository;
+use Hypervel\Container\Container;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\Connection;
+use Hypervel\Database\ConnectionResolver;
+use Hypervel\Database\ConnectionResolverInterface as Resolver;
+use Hypervel\Database\Migrations\MigrationRepositoryInterface;
+use Hypervel\Database\Migrations\Migrator;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+use ReflectionClass;
+
+class DatabaseMigratorConnectionRoutingTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // Reset the static callback to prevent cross-test leakage.
+        $reflection = new ReflectionClass(Migrator::class);
+        $property = $reflection->getProperty('connectionResolverCallback');
+        $property->setValue(null, null);
+
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function testResolveMigrationConnectionNameReturnsNullForNullInput()
+    {
+        $this->bindConfig([]);
+
+        $this->assertNull(Migrator::resolveMigrationConnectionName(null));
+    }
+
+    public function testResolveMigrationConnectionNameReturnsOriginalWhenNoMigrationsConnectionConfigured()
+    {
+        $this->bindConfig([
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $this->assertSame('pgsql', Migrator::resolveMigrationConnectionName('pgsql'));
+    }
+
+    public function testResolveMigrationConnectionNameReturnsMigrationsConnectionWhenConfigured()
+    {
+        $this->bindConfig([
+            'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $this->assertSame('pgsql', Migrator::resolveMigrationConnectionName('pgsql-pooled'));
+    }
+
+    public function testResolveMigrationConnectionNameIsDriverAgnostic()
+    {
+        $this->bindConfig([
+            'mysql-pooled' => ['driver' => 'mysql', 'migrations_connection' => 'mysql'],
+            'mysql' => ['driver' => 'mysql'],
+        ]);
+
+        $this->assertSame('mysql', Migrator::resolveMigrationConnectionName('mysql-pooled'));
+    }
+
+    public function testResolveMigrationConnectionNameReturnsOriginalWhenConfigBindingMissing()
+    {
+        // No container/config set up — helper should pass the name through
+        // rather than throw. Protects unit tests that construct Migrator
+        // without a fully booted framework.
+        Container::setInstance(null);
+
+        $this->assertSame('pgsql-pooled', Migrator::resolveMigrationConnectionName('pgsql-pooled'));
+    }
+
+    public function testResolveMigrationConnectionNameReturnsOriginalWhenTargetConnectionUnknown()
+    {
+        // If the named connection doesn't exist in config, we pass through;
+        // the resolver (not our helper) surfaces the "not configured" error.
+        $this->bindConfig([]);
+
+        $this->assertSame('ghost', Migrator::resolveMigrationConnectionName('ghost'));
+    }
+
+    public function testResolveMigrationConnectionNameNullPrefersContextOverConfigDefault()
+    {
+        // Regression for the "effective default" fix. Scenario:
+        //   DB::usingConnection('tenant-pooled', fn () => Artisan::call('migrate'))
+        // Context holds 'tenant-pooled' via the outer scope. config.default is
+        // something unrelated ('pgsql'). The Migrator helper must route via
+        // the Context value — otherwise programmatic migrations inside a
+        // scoped override silently hit the configured default instead.
+        $this->bindConfig(
+            connections: [
+                'pgsql' => ['driver' => 'pgsql'],
+                'tenant-pooled' => [
+                    'driver' => 'pgsql',
+                    'migrations_connection' => 'tenant-direct',
+                ],
+                'tenant-direct' => ['driver' => 'pgsql'],
+            ],
+            default: 'pgsql',
+        );
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'tenant-pooled');
+
+        $this->assertSame(
+            'tenant-direct',
+            Migrator::resolveMigrationConnectionName(null),
+            'Null input must resolve via the Context override, not the configured default',
+        );
+    }
+
+    public function testResolveMigrationConnectionNameNullReturnsContextValueWhenNoMigrationsConnection()
+    {
+        // Edge case: Context override is set, but that connection has no
+        // migrations_connection key. Helper returns the Context value unchanged
+        // — no unexpected swap.
+        $this->bindConfig(
+            connections: [
+                'plain-conn' => ['driver' => 'pgsql'],
+            ],
+            default: null,
+        );
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'plain-conn');
+
+        $this->assertSame(
+            'plain-conn',
+            Migrator::resolveMigrationConnectionName(null),
+        );
+    }
+
+    public function testResolveMigrationConnectionNameNullFallsBackToConfigWhenNoContext()
+    {
+        // Regression guard: the config-default fallback path still works when
+        // no Context override is present. This is the CLI migration path
+        // (fresh coroutine, no outer scope).
+        $this->bindConfig(
+            connections: [
+                'tenant-pooled' => [
+                    'driver' => 'pgsql',
+                    'migrations_connection' => 'tenant-direct',
+                ],
+                'tenant-direct' => ['driver' => 'pgsql'],
+            ],
+            default: 'tenant-pooled',
+        );
+
+        // Context is not set.
+        $this->assertSame(
+            'tenant-direct',
+            Migrator::resolveMigrationConnectionName(null),
+        );
+    }
+
+    public function testSetConnectionWritesContextRepositorySourceAndStoredName()
+    {
+        $this->bindConfig([
+            'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+
+        $repository->shouldReceive('setSource')->once()->with('pgsql');
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+        $migrator->setConnection('pgsql-pooled');
+
+        $this->assertSame('pgsql', $migrator->getConnection());
+        $this->assertSame(
+            'pgsql',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'setConnection should write the swapped name to coroutine Context',
+        );
+    }
+
+    public function testSetConnectionWithNullAndNoEffectiveDefaultStoresNull()
+    {
+        // No Context override AND no database.default — there's nothing to
+        // fall back to, so setConnection(null) stores null and leaves Context
+        // untouched (already absent).
+        $this->bindConfig([]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $repository->shouldReceive('setSource')->once()->with(null);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+        $migrator->setConnection(null);
+
+        $this->assertNull($migrator->getConnection());
+        $this->assertNull(
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+        );
+    }
+
+    public function testSetConnectionDoesNotSwapWhenNoMigrationsConnectionKey()
+    {
+        $this->bindConfig([
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+
+        $repository->shouldReceive('setSource')->once()->with('pgsql');
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+        $migrator->setConnection('pgsql');
+
+        $this->assertSame('pgsql', $migrator->getConnection());
+        $this->assertSame(
+            'pgsql',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+        );
+    }
+
+    public function testResolveConnectionUsesStoredConnectionWhenArgumentIsNull()
+    {
+        $this->bindConfig([
+            'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $resolvedConnection = m::mock(Connection::class);
+
+        $repository->shouldReceive('setSource')->once()->with('pgsql');
+        $resolver->shouldReceive('connection')->once()->with('pgsql')->andReturn($resolvedConnection);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+        $migrator->setConnection('pgsql-pooled');
+
+        $this->assertSame($resolvedConnection, $migrator->resolveConnection(null));
+    }
+
+    public function testResolveConnectionSwapsPerMigrationConnectionOverride()
+    {
+        // A migration file can return a specific connection name from its
+        // getConnection(). If that connection has migrations_connection set,
+        // the override should still route through the sibling.
+        $this->bindConfig([
+            'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $resolvedConnection = m::mock(Connection::class);
+
+        $resolver->shouldReceive('connection')->once()->with('pgsql')->andReturn($resolvedConnection);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+
+        $this->assertSame($resolvedConnection, $migrator->resolveConnection('pgsql-pooled'));
+    }
+
+    public function testResolveConnectionPassesSwappedNameToCustomCallback()
+    {
+        $this->bindConfig([
+            'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $resolvedConnection = m::mock(Connection::class);
+
+        $capturedName = null;
+        Migrator::resolveConnectionsUsing(function (Resolver $r, ?string $name) use (&$capturedName, $resolvedConnection) {
+            $capturedName = $name;
+            return $resolvedConnection;
+        });
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+        $result = $migrator->resolveConnection('pgsql-pooled');
+
+        $this->assertSame('pgsql', $capturedName, 'Custom callback should receive the swapped connection name');
+        $this->assertSame($resolvedConnection, $result);
+    }
+
+    public function testResolveConnectionPassesOriginalNameWhenNoMigrationsConnection()
+    {
+        $this->bindConfig([
+            'pgsql' => ['driver' => 'pgsql'],
+        ]);
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $resolvedConnection = m::mock(Connection::class);
+
+        $resolver->shouldReceive('connection')->once()->with('pgsql')->andReturn($resolvedConnection);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+
+        $this->assertSame($resolvedConnection, $migrator->resolveConnection('pgsql'));
+    }
+
+    public function testSetConnectionWithNullAndPooledDefaultRoutesToDirect()
+    {
+        // Regression: null name must resolve via database.default. When the
+        // app default is pooled, setConnection(null) should end up at the
+        // direct sibling, not leave migrations running against the pooler.
+        $this->bindConfig(
+            connections: [
+                'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                'pgsql' => ['driver' => 'pgsql'],
+            ],
+            default: 'pgsql-pooled',
+        );
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $repository->shouldReceive('setSource')->once()->with('pgsql');
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+        $migrator->setConnection(null);
+
+        $this->assertSame('pgsql', $migrator->getConnection());
+        $this->assertSame(
+            'pgsql',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+        );
+    }
+
+    public function testResolveConnectionWithNullAndPooledDefaultRoutesToDirect()
+    {
+        // Regression: fresh Migrator (no setConnection called) handling a
+        // per-migration override of null (or missing getConnection()). The
+        // helper's null fallback via database.default should still route
+        // to the direct sibling.
+        $this->bindConfig(
+            connections: [
+                'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                'pgsql' => ['driver' => 'pgsql'],
+            ],
+            default: 'pgsql-pooled',
+        );
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+        $resolvedConnection = m::mock(Connection::class);
+
+        $resolver->shouldReceive('connection')->once()->with('pgsql')->andReturn($resolvedConnection);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+
+        $this->assertSame($resolvedConnection, $migrator->resolveConnection(null));
+    }
+
+    public function testUsingConnectionRestoresExactPriorState()
+    {
+        // Regression for issue 2: usingConnection must restore the user-facing
+        // alias, not the swapped direct name. Simulate pre-existing state: a
+        // prior Context override of 'pgsql-pooled' (as if some outer scope
+        // had set it) and a stored migrator connection.
+        $this->bindConfig(
+            connections: [
+                'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                'pgsql' => ['driver' => 'pgsql'],
+            ],
+            default: 'pgsql-pooled',
+        );
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'pgsql-pooled');
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+
+        // setConnection inside usingConnection sets source to 'pgsql'.
+        // Finally restores source to null (the migrator's previous stored state).
+        $repository->shouldReceive('setSource')->once()->with('pgsql');
+        $repository->shouldReceive('setSource')->once()->with(null);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+
+        $innerContext = null;
+        $migrator->usingConnection('pgsql-pooled', function () use (&$innerContext) {
+            $innerContext = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        });
+
+        $this->assertSame('pgsql', $innerContext, 'Inside the callback, Context should be the swapped name');
+        $this->assertSame(
+            'pgsql-pooled',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'After the callback, Context must be restored to the exact prior alias — not the swapped name',
+        );
+        $this->assertNull($migrator->getConnection(), 'Stored connection should be restored to the prior null value');
+    }
+
+    public function testUsingConnectionWithNullAndPooledDefaultRoutesAndRestores()
+    {
+        // Combined regression for issues 1 and 2: null input must route via
+        // database.default, AND the restoration must bring back the exact
+        // prior Context value (here: null/cleared).
+        $this->bindConfig(
+            connections: [
+                'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                'pgsql' => ['driver' => 'pgsql'],
+            ],
+            default: 'pgsql-pooled',
+        );
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+
+        $repository->shouldReceive('setSource')->once()->with('pgsql');
+        $repository->shouldReceive('setSource')->once()->with(null);
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+
+        $innerStored = null;
+        $innerContext = null;
+        $migrator->usingConnection(null, function () use (&$innerStored, &$innerContext, $migrator) {
+            $innerStored = $migrator->getConnection();
+            $innerContext = CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+        });
+
+        $this->assertSame('pgsql', $innerStored);
+        $this->assertSame('pgsql', $innerContext);
+        $this->assertNull(
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'Context must be cleared after usingConnection if there was no prior override',
+        );
+        $this->assertNull($migrator->getConnection());
+    }
+
+    public function testNestedUsingConnectionPreservesEachLevelsState()
+    {
+        // Regression guard: each frame must snapshot and restore its own
+        // prior state. Outer sets 'pgsql-pooled' → 'pgsql'. Inner sets
+        // 'mysql-pooled' → 'mysql'. When inner unwinds, Context/stored
+        // should return to outer's values ('pgsql'), not be forgotten or
+        // left at 'mysql'.
+        $this->bindConfig(
+            connections: [
+                'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                'pgsql' => ['driver' => 'pgsql'],
+                'mysql-pooled' => ['driver' => 'mysql', 'migrations_connection' => 'mysql'],
+                'mysql' => ['driver' => 'mysql'],
+            ],
+            default: null,
+        );
+
+        $resolver = m::mock(Resolver::class);
+        $repository = m::mock(MigrationRepositoryInterface::class);
+
+        // Outer enter: setSource('pgsql'). Inner enter: setSource('mysql').
+        // Inner exit: setSource back to 'pgsql' (outer's stored). Outer exit:
+        // setSource back to null.
+        $repository->shouldReceive('setSource')->with('pgsql')->twice();
+        $repository->shouldReceive('setSource')->with('mysql')->once();
+        $repository->shouldReceive('setSource')->with(null)->once();
+
+        $migrator = new Migrator($repository, $resolver, new Filesystem);
+
+        $observations = [];
+
+        $migrator->usingConnection('pgsql-pooled', function () use ($migrator, &$observations) {
+            $observations['outer-entered'] = [
+                'stored' => $migrator->getConnection(),
+                'context' => CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            ];
+
+            $migrator->usingConnection('mysql-pooled', function () use ($migrator, &$observations) {
+                $observations['inner-entered'] = [
+                    'stored' => $migrator->getConnection(),
+                    'context' => CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+                ];
+            });
+
+            $observations['after-inner'] = [
+                'stored' => $migrator->getConnection(),
+                'context' => CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            ];
+        });
+
+        $observations['after-outer'] = [
+            'stored' => $migrator->getConnection(),
+            'context' => CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+        ];
+
+        $this->assertSame(['stored' => 'pgsql', 'context' => 'pgsql'], $observations['outer-entered']);
+        $this->assertSame(['stored' => 'mysql', 'context' => 'mysql'], $observations['inner-entered']);
+        $this->assertSame(['stored' => 'pgsql', 'context' => 'pgsql'], $observations['after-inner']);
+        $this->assertSame(['stored' => null, 'context' => null], $observations['after-outer']);
+    }
+
+    protected function bindConfig(array $connections, ?string $default = null): void
+    {
+        $container = Container::getInstance();
+        $container->instance('config', new Repository([
+            'database' => [
+                'default' => $default,
+                'connections' => $connections,
+            ],
+        ]));
+    }
+}

--- a/tests/Database/DatabaseWipeCommandTest.php
+++ b/tests/Database/DatabaseWipeCommandTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database;
 
+use Hypervel\Config\Repository;
 use Hypervel\Console\CommandMutex;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
 use Hypervel\Database\Console\WipeCommand;
 use Hypervel\Foundation\Application;
 use Hypervel\Tests\TestCase;
@@ -14,6 +17,13 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class DatabaseWipeCommandTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+
+        parent::tearDown();
+    }
+
     public function testWipeCommandDropsSchemaObjectsAndPurgesConnection()
     {
         $schemaBuilder = m::mock();
@@ -40,6 +50,123 @@ class DatabaseWipeCommandTest extends TestCase
             '--drop-views' => true,
             '--drop-types' => true,
         ]);
+
+        $this->assertSame(0, $code);
+    }
+
+    public function testWipeCommandRoutesToMigrationsConnection()
+    {
+        $schemaBuilder = m::mock();
+        $schemaBuilder->shouldReceive('dropAllTables')->once();
+
+        $connection = m::mock();
+        $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schemaBuilder);
+
+        $db = m::mock();
+        // db:wipe --database=pgsql-pooled should route to 'pgsql' because
+        // pgsql-pooled has migrations_connection => 'pgsql'. Schema drops
+        // need a direct (unpooled) connection.
+        $db->shouldReceive('connection')->once()->with('pgsql')->andReturn($connection);
+        $db->shouldReceive('purge')->once()->with('pgsql');
+
+        $app = new ApplicationDatabaseWipeStub([
+            'db' => $db,
+        ]);
+        $app->instance('config', new Repository([
+            'database' => [
+                'connections' => [
+                    'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                    'pgsql' => ['driver' => 'pgsql'],
+                ],
+            ],
+        ]));
+
+        $command = new WipeCommand;
+        $command->setHypervel($app);
+
+        $code = $this->runCommand($command, [
+            '--database' => 'pgsql-pooled',
+        ]);
+
+        $this->assertSame(0, $code);
+    }
+
+    public function testWipeCommandRoutesThroughDefaultWhenNoDatabaseOptionGiven()
+    {
+        // Regression for the null-handling fix: db:wipe with no --database
+        // should use the configured default — and if that default has a
+        // migrations_connection, should route to it rather than dropping
+        // tables on the pooled connection.
+        $schemaBuilder = m::mock();
+        $schemaBuilder->shouldReceive('dropAllTables')->once();
+
+        $connection = m::mock();
+        $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schemaBuilder);
+
+        $db = m::mock();
+        $db->shouldReceive('connection')->once()->with('pgsql')->andReturn($connection);
+        $db->shouldReceive('purge')->once()->with('pgsql');
+
+        $app = new ApplicationDatabaseWipeStub([
+            'db' => $db,
+        ]);
+        $app->instance('config', new Repository([
+            'database' => [
+                'default' => 'pgsql-pooled',
+                'connections' => [
+                    'pgsql-pooled' => ['driver' => 'pgsql', 'migrations_connection' => 'pgsql'],
+                    'pgsql' => ['driver' => 'pgsql'],
+                ],
+            ],
+        ]));
+
+        $command = new WipeCommand;
+        $command->setHypervel($app);
+
+        $code = $this->runCommand($command);
+
+        $this->assertSame(0, $code);
+    }
+
+    public function testWipeCommandHonorsContextOverrideWhenNoDatabaseOptionGiven()
+    {
+        // End-to-end regression for "effective default" at the command level:
+        // when an outer scope has set Context (e.g. via DB::usingConnection),
+        // db:wipe with no --database must route to that Context target's
+        // migrations_connection, not to the configured default's sibling.
+        $schemaBuilder = m::mock();
+        $schemaBuilder->shouldReceive('dropAllTables')->once();
+
+        $connection = m::mock();
+        $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schemaBuilder);
+
+        $db = m::mock();
+        $db->shouldReceive('connection')->once()->with('tenant-direct')->andReturn($connection);
+        $db->shouldReceive('purge')->once()->with('tenant-direct');
+
+        $app = new ApplicationDatabaseWipeStub([
+            'db' => $db,
+        ]);
+        $app->instance('config', new Repository([
+            'database' => [
+                'default' => 'pgsql',
+                'connections' => [
+                    'pgsql' => ['driver' => 'pgsql'],
+                    'tenant-pooled' => [
+                        'driver' => 'pgsql',
+                        'migrations_connection' => 'tenant-direct',
+                    ],
+                    'tenant-direct' => ['driver' => 'pgsql'],
+                ],
+            ],
+        ]));
+
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'tenant-pooled');
+
+        $command = new WipeCommand;
+        $command->setHypervel($app);
+
+        $code = $this->runCommand($command);
 
         $this->assertSame(0, $code);
     }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -6,6 +6,8 @@ namespace Hypervel\Tests\Database;
 
 use Hypervel\Console\Command;
 use Hypervel\Console\CommandMutex;
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
 use Hypervel\Database\ConnectionResolverInterface;
 use Hypervel\Database\Console\Seeds\SeedCommand;
 use Hypervel\Database\Console\Seeds\WithoutModelEvents;
@@ -22,17 +24,27 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class SeedCommandTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+
+        parent::tearDown();
+    }
+
     public function testHandle()
     {
         $seeder = m::mock(Seeder::class);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
         $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
-        $seeder->shouldReceive('__invoke')->once();
+        $seeder->shouldReceive('__invoke')->once()->andReturnUsing(function () {
+            Assert::assertSame(
+                'sqlite',
+                CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+                'Seed connection should be set in Context during seeder invocation',
+            );
+        });
 
         $resolver = m::mock(ConnectionResolverInterface::class);
-        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn('mysql');
-        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
-        $resolver->shouldReceive('setDefaultConnection')->once()->with('mysql');
 
         $app = new ApplicationDatabaseSeedStub([
             ConnectionResolverInterface::class => $resolver,
@@ -46,6 +58,11 @@ class SeedCommandTest extends TestCase
             new ArrayInput(['--force' => true, '--database' => 'sqlite']),
             new NullOutput,
         );
+
+        $this->assertNull(
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'Context should be cleared after seeding completes',
+        );
     }
 
     public function testWithoutModelEvents()
@@ -57,9 +74,6 @@ class SeedCommandTest extends TestCase
         $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
 
         $resolver = m::mock(ConnectionResolverInterface::class);
-        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn('mysql');
-        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
-        $resolver->shouldReceive('setDefaultConnection')->once()->with('mysql');
 
         $app = new ApplicationDatabaseSeedStub([
             ConnectionResolverInterface::class => $resolver,
@@ -85,10 +99,12 @@ class SeedCommandTest extends TestCase
 
     public function testHandleRestoresPreviousConnectionWhenSeederThrows()
     {
+        // Simulate a pre-existing Context override (e.g., from an outer
+        // migrator run) — seeding should restore that exact value if the
+        // seeder throws, not leak 'sqlite' or clear it entirely.
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'pgsql');
+
         $resolver = m::mock(ConnectionResolverInterface::class);
-        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn('pgsql');
-        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
-        $resolver->shouldReceive('setDefaultConnection')->once()->with('pgsql');
 
         $app = new ApplicationDatabaseSeedStub([
             ConnectionResolverInterface::class => $resolver,
@@ -112,6 +128,12 @@ class SeedCommandTest extends TestCase
         } catch (RuntimeException $exception) {
             self::assertSame('Seeder failed', $exception->getMessage());
         }
+
+        Assert::assertSame(
+            'pgsql',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'Context should be restored to the pre-seed value even on exception',
+        );
     }
 
     public function testProhibitable()
@@ -130,6 +152,72 @@ class SeedCommandTest extends TestCase
         $code = $command->run(new ArrayInput([]), new NullOutput);
 
         Assert::assertSame(Command::FAILURE, $code);
+    }
+
+    public function testHandleWithoutDatabaseOptionUsesResolverDefault()
+    {
+        // Regression for the SeedCommand::getDatabase() change: when no
+        // --database is given, SeedCommand should read the current default
+        // from the resolver (which respects an active Context override)
+        // rather than going straight to config. This lets an outer scope's
+        // Context override flow through to db:seed correctly.
+        $seeder = m::mock(Seeder::class);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldReceive('__invoke')->once()->andReturnUsing(function () {
+            Assert::assertSame(
+                'tenant_reporting',
+                CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+                'Seeder should run with the resolver-derived default in Context',
+            );
+        });
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn('tenant_reporting');
+
+        $app = new ApplicationDatabaseSeedStub([
+            ConnectionResolverInterface::class => $resolver,
+            'DatabaseSeeder' => $seeder,
+        ]);
+
+        $command = new SeedCommand($resolver);
+        $command->setHypervel($app);
+
+        $command->run(new ArrayInput(['--force' => true]), new NullOutput);
+    }
+
+    public function testHandleDoesNotMutateConfigDatabaseDefault()
+    {
+        // Regression: db:seed must use Context, not config mutation. config
+        // ('database.default') should be untouched after a seed run.
+        $seeder = m::mock(Seeder::class);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldReceive('__invoke')->once();
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+
+        $config = new \Hypervel\Config\Repository(['database' => ['default' => 'pgsql']]);
+
+        $app = new ApplicationDatabaseSeedStub([
+            ConnectionResolverInterface::class => $resolver,
+            'DatabaseSeeder' => $seeder,
+            'config' => $config,
+        ]);
+
+        $command = new SeedCommand($resolver);
+        $command->setHypervel($app);
+
+        $command->run(
+            new ArrayInput(['--force' => true, '--database' => 'sqlite']),
+            new NullOutput,
+        );
+
+        Assert::assertSame(
+            'pgsql',
+            $config->get('database.default'),
+            'db:seed must not mutate config("database.default")',
+        );
     }
 }
 

--- a/tests/Database/SimpleConnectionResolverIsolationTest.php
+++ b/tests/Database/SimpleConnectionResolverIsolationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Database\ConnectionResolver;
+use Hypervel\Database\DatabaseManager;
+use Hypervel\Database\SimpleConnectionResolver;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+
+/**
+ * Regression guard: SimpleConnectionResolver must keep its default connection
+ * in an instance-local property rather than in CoroutineContext.
+ *
+ * Why this matters: outside a coroutine, CoroutineContext falls back to a
+ * static $nonCoroutineContext map (see CoroutineContext.php). Routing
+ * SimpleConnectionResolver's default through that map would collapse the
+ * instance-level isolation that Capsule and test harnesses rely on — two
+ * separate resolvers would share the same default override slot.
+ *
+ * This test exists purely to break loudly if someone "cleans up" the two
+ * resolver implementations by making them use the same Context mechanism.
+ */
+class SimpleConnectionResolverIsolationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+
+        parent::tearDown();
+    }
+
+    public function testTwoInstancesHaveIndependentDefaults()
+    {
+        $resolverA = new SimpleConnectionResolver(m::mock(DatabaseManager::class));
+        $resolverB = new SimpleConnectionResolver(m::mock(DatabaseManager::class));
+
+        $resolverA->setDefaultConnection('alpha');
+        $resolverB->setDefaultConnection('beta');
+
+        $this->assertSame('alpha', $resolverA->getDefaultConnection());
+        $this->assertSame('beta', $resolverB->getDefaultConnection());
+    }
+
+    public function testSetDefaultConnectionDoesNotWriteToSharedContext()
+    {
+        $resolver = new SimpleConnectionResolver(m::mock(DatabaseManager::class));
+
+        // Pre-set Context to a sentinel — SimpleConnectionResolver must NOT
+        // touch this key, otherwise its setter is leaking into the pooled
+        // ConnectionResolver's state.
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'sentinel');
+
+        $resolver->setDefaultConnection('something');
+
+        $this->assertSame(
+            'sentinel',
+            CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+            'SimpleConnectionResolver must not mutate the Context key owned by ConnectionResolver',
+        );
+    }
+}

--- a/tests/Integration/Database/MigrationsConnectionRoutingTest.php
+++ b/tests/Integration/Database/MigrationsConnectionRoutingTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Database;
+
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Database\ConnectionResolver;
+use Hypervel\Database\DatabaseManager;
+use Hypervel\Database\Migrations\Migrator;
+use Hypervel\Database\Schema\Blueprint;
+use Hypervel\Support\Facades\File;
+use Hypervel\Testbench\TestCase;
+
+/**
+ * End-to-end proof that the "migrations_connection" config key routes migration
+ * SQL, the migration repository, and the Migrator's resolver through the swapped
+ * connection — not just the execution path.
+ *
+ * The two SQLite connections point at DIFFERENT files so we can assert which
+ * database the migrations table actually landed in. If the migrations table
+ * ever shows up in "primary", routing is broken.
+ */
+class MigrationsConnectionRoutingTest extends TestCase
+{
+    protected string $primaryPath;
+
+    protected string $migrationsPath;
+
+    protected string $otherPath;
+
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        // Paths resolve inside testbench's disposable cloned workspace so the
+        // committed source tree is never written to. Testbench sweeps the
+        // whole workspace on shutdown.
+        $this->primaryPath = $app->databasePath('primary.sqlite');
+        $this->migrationsPath = $app->databasePath('primary-migrations.sqlite');
+        $this->otherPath = $app->databasePath('other.sqlite');
+
+        // SQLite requires the file to exist — Hypervel (like Laravel) refuses
+        // to auto-create missing database files. touch() creates an empty
+        // file, which SQLite happily treats as a fresh, empty database.
+        touch($this->primaryPath);
+        touch($this->migrationsPath);
+        touch($this->otherPath);
+
+        $config = $app->make('config');
+
+        $config->set('database.default', 'primary');
+
+        $config->set('database.connections.primary', [
+            'driver' => 'sqlite',
+            'database' => $this->primaryPath,
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+            'migrations_connection' => 'primary-migrations',
+        ]);
+
+        $config->set('database.connections.primary-migrations', [
+            'driver' => 'sqlite',
+            'database' => $this->migrationsPath,
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+
+        // Third connection used only by the scoped-override test — never
+        // the routing target for anyone; provides a third SQLite file so
+        // we can prove routing didn't silently fall back to the configured
+        // default.
+        $config->set('database.connections.other', [
+            'driver' => 'sqlite',
+            'database' => $this->otherPath,
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        /** @var DatabaseManager $db */
+        $db = $this->app->make('db');
+        $db->purge('primary');
+        $db->purge('primary-migrations');
+        $db->purge('other');
+
+        CoroutineContext::forget(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY);
+
+        File::delete($this->primaryPath);
+        File::delete($this->migrationsPath);
+        File::delete($this->otherPath);
+
+        parent::tearDown();
+    }
+
+    public function testMigrationRepositoryLandsOnMigrationsConnection(): void
+    {
+        // setConnection() swaps the name via resolveMigrationConnectionName()
+        // and propagates the swapped name to the shared repository singleton
+        // via $repository->setSource(). After that, any call on the repository
+        // (like createRepository) targets the migrations_connection sibling.
+        /** @var Migrator $migrator */
+        $migrator = $this->app->make('migrator');
+        $migrator->setConnection('primary');
+
+        $this->assertSame('primary-migrations', $migrator->getConnection());
+
+        $repository = $this->app->make('migration.repository');
+        $repository->createRepository();
+
+        /** @var DatabaseManager $db */
+        $db = $this->app->make('db');
+
+        $this->assertTrue(
+            $db->connection('primary-migrations')->getSchemaBuilder()->hasTable('migrations'),
+            'Migrations table must live on the primary-migrations connection',
+        );
+
+        $this->assertFalse(
+            $db->connection('primary')->getSchemaBuilder()->hasTable('migrations'),
+            'Migrations table must NOT live on the pooled primary connection',
+        );
+    }
+
+    public function testResolveConnectionRoutesToMigrationsConnection(): void
+    {
+        /** @var Migrator $migrator */
+        $migrator = $this->app->make('migrator');
+
+        $connection = $migrator->resolveConnection('primary');
+
+        $this->assertSame(
+            'primary-migrations',
+            $connection->getName(),
+            'resolveConnection("primary") must return the primary-migrations connection',
+        );
+    }
+
+    public function testMigrationSqlExecutesOnMigrationsConnection(): void
+    {
+        /** @var Migrator $migrator */
+        $migrator = $this->app->make('migrator');
+
+        // Resolve the migration connection and create a real table through it.
+        $connection = $migrator->resolveConnection('primary');
+        $connection->getSchemaBuilder()->create('probe', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        /** @var DatabaseManager $db */
+        $db = $this->app->make('db');
+
+        $this->assertTrue(
+            $db->connection('primary-migrations')->getSchemaBuilder()->hasTable('probe'),
+            'Schema change should land on primary-migrations',
+        );
+
+        $this->assertFalse(
+            $db->connection('primary')->getSchemaBuilder()->hasTable('probe'),
+            'Schema change must not land on the primary (pooled) connection',
+        );
+    }
+
+    public function testUsingConnectionWithNullRoutesViaConfiguredDefault(): void
+    {
+        // End-to-end equivalent of `php artisan migrate` with no --database:
+        // the app default 'primary' has migrations_connection => 'primary-migrations',
+        // so the Migrator must route the null-name call through the default
+        // to the direct sibling. A schema change performed inside the
+        // usingConnection(null) block should land on primary-migrations.
+        /** @var Migrator $migrator */
+        $migrator = $this->app->make('migrator');
+
+        $migrator->usingConnection(null, function () use ($migrator) {
+            $migrator->resolveConnection(null)
+                ->getSchemaBuilder()
+                ->create('default_probe', function (Blueprint $table) {
+                    $table->increments('id');
+                });
+        });
+
+        /** @var DatabaseManager $db */
+        $db = $this->app->make('db');
+
+        $this->assertTrue(
+            $db->connection('primary-migrations')->getSchemaBuilder()->hasTable('default_probe'),
+            'null-routed schema change should land on primary-migrations',
+        );
+
+        $this->assertFalse(
+            $db->connection('primary')->getSchemaBuilder()->hasTable('default_probe'),
+            'null-routed schema change must not land on the pooled primary',
+        );
+    }
+
+    public function testScopedDefaultOverrideRoutesMigrationsToContextSibling(): void
+    {
+        // End-to-end regression for the real-world scenario GPT flagged:
+        //
+        //     DB::usingConnection('primary', fn () => run migrations);
+        //
+        // config.default points at an UNRELATED connection ('other'). The
+        // outer scope sets a Context override to 'primary'. A migration
+        // operation inside that scope with no explicit --database must route
+        // via the Context override's migrations_connection ('primary-migrations'),
+        // NOT via the configured default ('other').
+        //
+        // If routing is wrong, the probe table will land on 'other' or
+        // 'primary' — both failures prove the regression is back.
+        /** @var DatabaseManager $db */
+        $db = $this->app->make('db');
+
+        // Temporarily flip the configured default away from 'primary' so we
+        // can tell Context-vs-config apart. Restored manually below because
+        // DatabaseManager::setDefaultConnection writes to Context, not config.
+        $this->app->make('config')->set('database.default', 'other');
+
+        // Simulate the outer DB::usingConnection('primary', ...) scope.
+        CoroutineContext::set(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY, 'primary');
+
+        try {
+            /** @var Migrator $migrator */
+            $migrator = $this->app->make('migrator');
+
+            $migrator->usingConnection(null, function () use ($migrator) {
+                $migrator->resolveConnection(null)
+                    ->getSchemaBuilder()
+                    ->create('scoped_probe', function (Blueprint $table) {
+                        $table->increments('id');
+                    });
+            });
+
+            $this->assertTrue(
+                $db->connection('primary-migrations')->getSchemaBuilder()->hasTable('scoped_probe'),
+                'Schema change must land on primary-migrations (Context target\'s sibling)',
+            );
+
+            $this->assertFalse(
+                $db->connection('primary')->getSchemaBuilder()->hasTable('scoped_probe'),
+                'Schema change must NOT land on the pooled Context target',
+            );
+
+            $this->assertFalse(
+                $db->connection('other')->getSchemaBuilder()->hasTable('scoped_probe'),
+                'Schema change must NOT land on the configured default — '
+                . 'Context must override config for effective-default resolution',
+            );
+
+            $this->assertSame(
+                'primary',
+                CoroutineContext::get(ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY),
+                'Outer scope\'s Context override must be restored after the inner usingConnection',
+            );
+        } finally {
+            $this->app->make('config')->set('database.default', 'primary');
+        }
+    }
+}

--- a/tests/Integration/Database/Postgres/PostgresStartupOptionsTest.php
+++ b/tests/Integration/Database/Postgres/PostgresStartupOptionsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Database\Postgres;
+
+use Hypervel\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+/**
+ * Proves that startup parameters baked into the DSN via libpq's "options"
+ * parameter actually land on the backend with their intended values.
+ *
+ * The unit tests in DatabaseConnectorTest only assert on the DSN string
+ * that PostgresConnector generates — they don't exercise PDO's DSN parser
+ * or libpq, so they cannot catch escape-passthrough regressions. PDO
+ * consumes one level of backslash escaping when extracting a single-quoted
+ * value from the DSN, so a single backslash before a space in the DSN source
+ * is stripped before libpq ever sees it. That was the root cause of the
+ * regression where multi-entry search_path like "public,private" arrived
+ * at the backend as the invalid list "public", — the space-escape was gone.
+ *
+ * These tests connect for real and ask the backend what it received via
+ * SHOW, which is the only way to prove the full chain works.
+ */
+#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresPhpExtension('pdo_pgsql')]
+class PostgresStartupOptionsTest extends PostgresTestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        $base = $app['config']->get('database.connections.pgsql');
+
+        $app['config']->set('database.connections.pgsql_startup_search_path', array_merge($base, [
+            'search_path' => 'public,private',
+        ]));
+
+        $app['config']->set('database.connections.pgsql_startup_isolation', array_merge($base, [
+            'isolation_level' => 'read committed',
+        ]));
+
+        $app['config']->set('database.connections.pgsql_startup_combined', array_merge($base, [
+            'search_path' => 'public,private',
+            'timezone' => 'UTC',
+            'isolation_level' => 'read committed',
+            'synchronous_commit' => 'off',
+        ]));
+    }
+
+    public function testMultiEntrySearchPathSurvivesDsnTransit(): void
+    {
+        // The regression case: space after comma in the quoted identifier
+        // list must be preserved across PDO → libpq → Postgres.
+        $value = DB::connection('pgsql_startup_search_path')
+            ->selectOne('SHOW search_path')
+            ->search_path;
+
+        $this->assertSame('"public", "private"', $value);
+    }
+
+    public function testIsolationLevelWithEmbeddedSpaceSurvivesDsnTransit(): void
+    {
+        $value = DB::connection('pgsql_startup_isolation')
+            ->selectOne('SHOW default_transaction_isolation')
+            ->default_transaction_isolation;
+
+        $this->assertSame('read committed', $value);
+    }
+
+    public function testCombinedStartupOptionsAllSurviveDsnTransit(): void
+    {
+        $connection = DB::connection('pgsql_startup_combined');
+
+        $this->assertSame(
+            '"public", "private"',
+            $connection->selectOne('SHOW search_path')->search_path,
+        );
+        $this->assertSame(
+            'UTC',
+            $connection->selectOne('SHOW TimeZone')->TimeZone,
+        );
+        $this->assertSame(
+            'read committed',
+            $connection->selectOne('SHOW default_transaction_isolation')->default_transaction_isolation,
+        );
+        $this->assertSame(
+            'off',
+            $connection->selectOne('SHOW synchronous_commit')->synchronous_commit,
+        );
+    }
+}


### PR DESCRIPTION
There are several issues with Laravel's database package and transaction-pooling routers (eg. PgBouncer and PgDog).

First, migrations need session state that transaction pooling throws away - advisory locks for migration concurrency control, LOCK TABLE, temp tables, the lot. None of that survives a pooler handing out a different backend for the next transaction.

Second, the framework was applying startup settings like `search_path`, `timezone`, and `isolation_level` as SET statements issued after connect. Those only affect whichever backend the pooler happened to give you at that moment. Next transaction rolls around, different backend, settings gone. Schema resolution drifts, timezones come back wrong, isolation level resets to the server default. These kinds of things are very difficult to debug.

This PR makes pooled connections first-class citizens.

## Shipped config

A new `pgsql-pooled` entry in the default `database.php`, with `DB_POOLED_HOST` falling back to `DB_HOST` and the other shared settings (`url`, `database`, `username`, `password`, `sslmode`) falling back to the usual `DB_*` vars. Default port stays 6432 (PgBouncer / PgDog convention). `PDO::ATTR_EMULATE_PREPARES` is on by default. Pool `max_connections` defaults to 20 instead of 10, since client-side slots to a pooler are cheaper.

For setups where more than host/port differs, there are independent `DB_POOLED_URL`, `DB_POOLED_DATABASE`, `DB_POOLED_USERNAME`, `DB_POOLED_PASSWORD`, and `DB_POOLED_SSLMODE` vars that only need to be set if they need to differ from the direct connection.

## migrations_connection

Any connection can now declare `'migrations_connection' => 'sibling-name'`. If set, the Migrator routes migration execution, the migrations table, and `db:wipe` through the sibling. The shipped `pgsql-pooled` points at `pgsql`, so `php artisan migrate` just works with no extra flags. Not pgsql-specific - drivers like MySQL behind ProxySQL can use the same mechanism by declaring their own pair.

Routing is honored for explicit `--database=pgsql-pooled` too, and for per-migration `public function getConnection()` overrides in migration files. `db:seed` intentionally stays on the normal app connection since seeders are app data, not schema management.

`migrate --database=X --seed` now forwards `--database=X` to `db:seed` properly - previously it would silently fall back to `database.default` for the seed step.

## Postgres startup params moved into the DSN

`search_path`, `timezone`, `isolation_level`, and `synchronous_commit` are now composed into libpq's `options` connection parameter via `-c` flags in the DSN, rather than issued as post-connect SETs. Startup parameters get forwarded by every mainstream PostgreSQL pooler when they open a fresh backend connection, so the values survive backend handoffs instead of getting lost. Values with embedded spaces (like `read committed`) are backslash-escaped so libpq preserves them as single tokens.

Direct connections are unaffected behaviorally and get one fewer round-trip per connection open as a bonus.

## The Swoole safety side

While fixing the migration routing, it turned out `DatabaseManager::setDefaultConnection` was mutating `$this->app['config']['database.default']` directly, and `ConnectionResolver::setDefaultConnection` was mutating an instance property. In Swoole those are worker-global - a request calling `DB::setDefaultConnection('foo')` would silently change the default for every other coroutine running in that worker.

Both now write to `CoroutineContext` using the existing `ConnectionResolver::DEFAULT_CONNECTION_CONTEXT_KEY`. The read path on `getDefaultConnection` already checked Context first, so no read-side changes were needed. `SeedCommand`, `Migrator::setConnection`, `Migrator::usingConnection`, and `Migrator::runMethod` all use Context consistently now - zero worker-global state mutation during migrations or seeds.

`SimpleConnectionResolver` stays on its instance property since it's the non-pooled resolver for tests and Capsule, and CoroutineContext's non-coroutine fallback is a single process-wide static, which would break instance isolation between separate resolvers. There's a regression test that locks that in so nobody accidentally "cleans it up" later.

Also deleted `FoundationServiceProvider::setDatabaseConnection` - a boot-time no-op that read `database.default` and wrote it straight back. It's not present in Laravel and is no longer needed.

## Programmatic usage now works correctly too

```php
DB::usingConnection('tenant-pooled', function () {
    Artisan::call('migrate');
});
```

Context now flows through. The migration helper's null-fallback reads CoroutineContext first, then config, mirroring `DatabaseManager::getDefaultConnection`'s precedence. Migrations in that callback route via `tenant-pooled`'s `migrations_connection`, not the worker's configured default. When the callback returns, CoroutineContext is restored to whatever it was on entry.

## Tests

39 new tests across unit and integration files. The integration test uses three SQLite files as connection targets so assertions can check which physical file a schema change actually landed in. That catches silent routing regressions that mocks can't see.