### PR TITLE
feat: Scout: Algolia v4 driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,7 @@
 # TYPESENSE_PORT=8108
 # TYPESENSE_API_KEY=secret
 # TYPESENSE_PROTOCOL=http
+
+# Algolia Integration Tests
+# ALGOLIA_APP_ID=your-app-id
+# ALGOLIA_SECRET=your-admin-api-key

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -111,3 +111,56 @@ jobs:
           TYPESENSE_API_KEY: secret
           TYPESENSE_PROTOCOL: http
         run: vendor/bin/phpunit tests/Integration/Scout/Typesense
+
+  algolia:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    container:
+      image: phpswoole/swoole:6.2.0-php8.4
+
+    strategy:
+      fail-fast: true
+
+    name: Algolia
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log trigger context
+        uses: ./.github/actions/log-trigger-context
+
+      - name: Setup PHP extensions
+        uses: ./.github/actions/setup-php
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: /root/.composer/cache
+          key: composer-8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-8.4-
+
+      - name: Install dependencies
+        run: COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist -n -o
+
+      - name: Check credentials available
+        id: creds
+        run: |
+          if [ -n "${{ secrets.ALGOLIA_APP_ID }}" ] && [ -n "${{ secrets.ALGOLIA_SECRET }}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Execute integration tests
+        if: steps.creds.outputs.present == 'true'
+        env:
+          RUN_ALGOLIA_INTEGRATION_TESTS: true
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SECRET: ${{ secrets.ALGOLIA_SECRET }}
+        run: vendor/bin/phpunit tests/Integration/Scout/Algolia
+
+      - name: Skip note (credentials not configured)
+        if: steps.creds.outputs.present != 'true'
+        run: echo "ALGOLIA_APP_ID / ALGOLIA_SECRET not configured — integration tests skipped."

--- a/composer.json
+++ b/composer.json
@@ -258,6 +258,7 @@
     },
     "require-dev": {
         "ably/ably-php": "^1.0",
+        "algolia/algoliasearch-client-php": "^4.0",
         "brianium/paratest": "^7.19",
         "composer/semver": "^3.4",
         "fakerphp/faker": "^1.24",

--- a/src/foundation/src/Testing/Concerns/InteractsWithAlgolia.php
+++ b/src/foundation/src/Testing/Concerns/InteractsWithAlgolia.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation\Testing\Concerns;
+
+use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
+use Algolia\AlgoliaSearch\Http\GuzzleHttpClient;
+use GuzzleHttp\Client as GuzzleClient;
+use Hypervel\Config\Repository;
+use Throwable;
+
+/**
+ * Provides Algolia integration testing support.
+ *
+ * Auto-called by TestCase via setUpTraits():
+ * - setUpInteractsWithAlgolia() runs after app boots
+ * - tearDownInteractsWithAlgolia() runs via beforeApplicationDestroyed()
+ *
+ * Features:
+ * - Auto-skip: Skips tests if ALGOLIA_APP_ID/ALGOLIA_SECRET are unset
+ * - Explicit-fail: If credentials ARE set but the probe fails, exceptions
+ *   propagate (matches InteractsWithTypesense's "explicit config + failure
+ *   → rethrow" pattern — we never hide misconfigured credentials)
+ * - Parallel-safe: Uses TEST_TOKEN for unique index prefixes
+ * - Auto-cleanup: Removes test indexes in teardown
+ *
+ * Usage: Add `use InteractsWithAlgolia;` to your test case and call
+ * configureAlgoliaForTesting() from defineEnvironment().
+ *
+ * Environment Variables:
+ * - ALGOLIA_APP_ID: Application ID (required)
+ * - ALGOLIA_SECRET: Admin API key (required)
+ * - TEST_TOKEN: Parallel test token from paratest (auto-set)
+ */
+trait InteractsWithAlgolia
+{
+    /**
+     * Indicates if credentials were unavailable once, skip all subsequent tests.
+     */
+    private static bool $algoliaConnectionFailed = false;
+
+    /**
+     * The test prefix for index isolation.
+     */
+    protected string $algoliaTestPrefix = '';
+
+    /**
+     * The Algolia client instance.
+     */
+    protected ?AlgoliaSearchClient $algolia = null;
+
+    /**
+     * Set up Algolia for testing (auto-called by setUpTraits).
+     *
+     * Skip conditions (credentials unavailable):
+     * - No ALGOLIA_APP_ID / ALGOLIA_SECRET env vars set (or empty)
+     *
+     * If credentials ARE set but the probe fails, the exception propagates
+     * so the test fails loudly. This matches the Typesense trait's
+     * "explicit-config-but-failing → rethrow" discipline.
+     */
+    protected function setUpInteractsWithAlgolia(): void
+    {
+        if (static::$algoliaConnectionFailed) {
+            $this->markTestSkipped(
+                'Algolia credentials unavailable. Set ALGOLIA_APP_ID & ALGOLIA_SECRET to enable ' . static::class
+            );
+        }
+
+        $appId = env('ALGOLIA_APP_ID');
+        $secret = env('ALGOLIA_SECRET');
+
+        if ($appId === null || $secret === null || $appId === '' || $secret === '') {
+            static::$algoliaConnectionFailed = true;
+            $this->markTestSkipped(
+                'Algolia credentials unavailable. Set ALGOLIA_APP_ID & ALGOLIA_SECRET to enable ' . static::class
+            );
+        }
+
+        // Credentials are explicit. Any failure from here on is a real
+        // misconfiguration — let it propagate so the test fails loudly.
+        Algolia::setHttpClient(new GuzzleHttpClient(new GuzzleClient));
+        $this->algolia = AlgoliaSearchClient::create($appId, $secret);
+        $this->algolia->listIndices();
+        $this->cleanupAlgoliaIndices();
+    }
+
+    /**
+     * Tear down Algolia (auto-called via beforeApplicationDestroyed).
+     */
+    protected function tearDownInteractsWithAlgolia(): void
+    {
+        if (static::$algoliaConnectionFailed || $this->algolia === null) {
+            return;
+        }
+
+        try {
+            $this->cleanupAlgoliaIndices();
+        } catch (Throwable) {
+            // Ignore cleanup errors
+        }
+
+        $this->algolia = null;
+    }
+
+    /**
+     * Configure Algolia for testing.
+     *
+     * Call from defineEnvironment() to set up Scout config.
+     */
+    protected function configureAlgoliaForTesting(Repository $config): void
+    {
+        $this->computeAlgoliaTestPrefix();
+
+        $config->set('scout.driver', 'algolia');
+        $config->set('scout.prefix', $this->algoliaTestPrefix);
+        $config->set('scout.algolia.id', env('ALGOLIA_APP_ID', ''));
+        $config->set('scout.algolia.secret', env('ALGOLIA_SECRET', ''));
+    }
+
+    /**
+     * Compute the test prefix for parallel-safe index names.
+     */
+    protected function computeAlgoliaTestPrefix(): void
+    {
+        $base = 'test_';
+        $token = env('TEST_TOKEN', '');
+
+        $this->algoliaTestPrefix = $token !== '' ? "{$base}{$token}_" : $base;
+    }
+
+    /**
+     * Get a prefixed index name.
+     */
+    protected function algoliaIndex(string $name): string
+    {
+        return $this->algoliaTestPrefix . $name;
+    }
+
+    /**
+     * Clean up all test indexes matching the test prefix.
+     */
+    protected function cleanupAlgoliaIndices(): void
+    {
+        if ($this->algolia === null) {
+            return;
+        }
+
+        try {
+            $indices = $this->algolia->listIndices();
+
+            foreach ($indices['items'] ?? [] as $index) {
+                $name = $index['name'] ?? null;
+
+                if (is_string($name) && str_starts_with($name, $this->algoliaTestPrefix)) {
+                    $this->algolia->deleteIndex($name);
+                }
+            }
+        } catch (Throwable) {
+            // Ignore errors during cleanup
+        }
+    }
+}

--- a/src/scout/composer.json
+++ b/src/scout/composer.json
@@ -9,6 +9,7 @@
         "scout",
         "search",
         "full-text-search",
+        "algolia",
         "meilisearch",
         "typesense",
         "database"
@@ -51,6 +52,7 @@
         "symfony/console": "^8.0"
     },
     "suggest": {
+        "algolia/algoliasearch-client-php": "Required for Algolia driver (^4.0)",
         "meilisearch/meilisearch-php": "Required for Meilisearch driver (^1.16)",
         "typesense/typesense-php": "Required for Typesense driver (^5.2)"
     },

--- a/src/scout/config/scout.php
+++ b/src/scout/config/scout.php
@@ -12,7 +12,7 @@ return [
     | using Scout. This connection is used when syncing all models to the
     | search service. You should adjust this based on your needs.
     |
-    | Supported: "meilisearch", "typesense", "database", "collection", "null"
+    | Supported: "algolia", "meilisearch", "typesense", "database", "collection", "null"
     |
     */
 
@@ -100,6 +100,44 @@ return [
     */
 
     'soft_delete' => env('SCOUT_SOFT_DELETE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identify User
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control whether to notify the search engine
+    | of the user performing the search. This is sometimes useful if the
+    | engine supports any analytics based on this application's users.
+    |
+    | Supported engines: "algolia"
+    |
+    */
+
+    'identify' => env('SCOUT_IDENTIFY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Algolia Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Algolia settings. Algolia is a cloud hosted
+    | search engine which works great with Scout out of the box. Just plug
+    | in your application ID and admin API key to get started searching.
+    |
+    */
+
+    'algolia' => [
+        'id' => env('ALGOLIA_APP_ID', ''),
+        'secret' => env('ALGOLIA_SECRET', ''),
+        'index-settings' => [
+            // Per-index settings can be defined here:
+            // 'users' => [
+            //     'searchableAttributes' => ['id', 'name', 'email'],
+            //     'attributesForFaceting' => ['filterOnly(email)'],
+            // ],
+        ],
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/scout/src/Console/DeleteAllIndexesCommand.php
+++ b/src/scout/src/Console/DeleteAllIndexesCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Scout\Console;
 
 use Exception;
+use Hypervel\Config\Repository;
 use Hypervel\Console\Command;
 use Hypervel\Scout\EngineManager;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -18,7 +19,8 @@ class DeleteAllIndexesCommand extends Command
     /**
      * The name and signature of the console command.
      */
-    protected ?string $signature = 'scout:delete-all-indexes';
+    protected ?string $signature = 'scout:delete-all-indexes
+        {--force : Delete all indexes even when scout.prefix is empty}';
 
     /**
      * The console command description.
@@ -28,8 +30,25 @@ class DeleteAllIndexesCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle(EngineManager $manager): int
+    public function handle(EngineManager $manager, Repository $config): int
     {
+        // Gate safety first, before resolving the engine. If prefix is empty
+        // and --force isn't set, we refuse without ever instantiating the
+        // driver's underlying client.
+        $prefix = $config->get('scout.prefix', '');
+        $force = (bool) $this->option('force');
+
+        if ($prefix === '' && ! $force) {
+            $this->error(
+                'Cannot safely delete all indexes: scout.prefix is not set. '
+                . 'Without a prefix, every index on the search instance would be removed, '
+                . 'including indexes belonging to other applications sharing it. '
+                . 'Set scout.prefix to scope deletion, or rerun with --force to delete unscoped.'
+            );
+
+            return self::FAILURE;
+        }
+
         $engine = $manager->engine();
 
         if (! method_exists($engine, 'deleteAllIndexes')) {
@@ -41,7 +60,7 @@ class DeleteAllIndexesCommand extends Command
         }
 
         try {
-            $engine->deleteAllIndexes();
+            $engine->deleteAllIndexes($prefix !== '' ? $prefix : null);
 
             $this->info('All indexes deleted successfully.');
 

--- a/src/scout/src/EngineManager.php
+++ b/src/scout/src/EngineManager.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Hypervel\Scout;
 
+use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
 use Closure;
 use Hypervel\Contracts\Container\Container;
+use Hypervel\Scout\Engines\AlgoliaEngine;
 use Hypervel\Scout\Engines\CollectionEngine;
 use Hypervel\Scout\Engines\DatabaseEngine;
 use Hypervel\Scout\Engines\MeilisearchEngine;
@@ -83,6 +86,38 @@ class EngineManager
     protected function callCustomCreator(string $name): Engine
     {
         return $this->customCreators[$name]($this->container);
+    }
+
+    /**
+     * Create an Algolia engine instance.
+     *
+     * @throws RuntimeException
+     */
+    public function createAlgoliaDriver(): AlgoliaEngine
+    {
+        $this->ensureAlgoliaClientIsInstalled();
+
+        return new AlgoliaEngine(
+            $this->container->make(AlgoliaSearchClient::class),
+            $this->getConfig('soft_delete', false),
+            $this->getConfig('identify', false),
+        );
+    }
+
+    /**
+     * Ensure the Algolia client is installed.
+     *
+     * @throws RuntimeException
+     */
+    protected function ensureAlgoliaClientIsInstalled(): void
+    {
+        if (class_exists(Algolia::class) && version_compare(Algolia::VERSION, '4.0.0', '>=')) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'Please install the Algolia client: algolia/algoliasearch-client-php (^4.0).'
+        );
     }
 
     /**

--- a/src/scout/src/Engines/AlgoliaEngine.php
+++ b/src/scout/src/Engines/AlgoliaEngine.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Scout\Engines;
+
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
+use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+use Hypervel\Context\RequestContext;
+use Hypervel\Database\Eloquent\Collection as EloquentCollection;
+use Hypervel\Database\Eloquent\Model;
+use Hypervel\Database\Eloquent\SoftDeletes;
+use Hypervel\Scout\Builder;
+use Hypervel\Scout\Contracts\SearchableInterface;
+use Hypervel\Scout\Contracts\UpdatesIndexSettings;
+use Hypervel\Scout\Engine;
+use Hypervel\Scout\Exceptions\NotSupportedException;
+use Hypervel\Scout\Jobs\RemoveableScoutCollection;
+use Hypervel\Support\Collection;
+use Hypervel\Support\LazyCollection;
+
+/**
+ * Algolia search engine implementation (v4 client).
+ *
+ * Uses the Algolia\AlgoliaSearch\Api\SearchClient (v4) flat API. The v3
+ * split-concrete-class layout from Laravel is collapsed into this single
+ * class because Hypervel only supports Algolia v4.
+ *
+ * Identify headers (X-Forwarded-For, X-Algolia-UserToken) are computed per
+ * request and passed as per-call request options rather than baked into
+ * default client headers at construction time. This is the deliberate
+ * divergence from Laravel's EngineManager::defaultAlgoliaHeaders() which
+ * cannot work correctly under a persistent-worker model where the engine
+ * instance is cached across requests.
+ */
+class AlgoliaEngine extends Engine implements UpdatesIndexSettings
+{
+    /**
+     * Create a new AlgoliaEngine instance.
+     */
+    public function __construct(
+        protected AlgoliaSearchClient $algolia,
+        protected bool $softDelete = false,
+        protected bool $identify = false
+    ) {
+    }
+
+    /**
+     * Update the given models in the search index.
+     *
+     * @param EloquentCollection<int, Model&SearchableInterface> $models
+     * @throws AlgoliaException
+     */
+    public function update(EloquentCollection $models): void
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        /** @var Model&SearchableInterface $firstModel */
+        $firstModel = $models->first();
+        $index = $firstModel->indexableAs();
+
+        if ($this->usesSoftDelete($firstModel) && $this->softDelete) {
+            $models->each->pushSoftDeleteMetadata();
+        }
+
+        $objects = $models->map(function (Model $model) {
+            /** @var Model&SearchableInterface $model */
+            $searchableData = $model->toSearchableArray();
+
+            if (empty($searchableData)) {
+                return null;
+            }
+
+            return array_merge(
+                $searchableData,
+                $model->scoutMetadata(),
+                ['objectID' => $model->getScoutKey()],
+            );
+        })
+            ->filter()
+            ->values()
+            ->all();
+
+        if (! empty($objects)) {
+            $this->algolia->saveObjects($index, $objects);
+        }
+    }
+
+    /**
+     * Remove the given models from the search index.
+     *
+     * @param EloquentCollection<int, Model&SearchableInterface> $models
+     */
+    public function delete(EloquentCollection $models): void
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        /** @var Model&SearchableInterface $firstModel */
+        $firstModel = $models->first();
+
+        $keys = $models instanceof RemoveableScoutCollection
+            ? $models->pluck($firstModel->getScoutKeyName())
+            : $models->map(fn (SearchableInterface $model) => $model->getScoutKey());
+
+        $this->algolia->deleteObjects($firstModel->indexableAs(), $keys->all());
+    }
+
+    /**
+     * Perform a search against the engine.
+     */
+    public function search(Builder $builder): mixed
+    {
+        return $this->performSearch($builder, array_filter([
+            'numericFilters' => $this->filters($builder),
+            'hitsPerPage' => $builder->limit,
+        ]));
+    }
+
+    /**
+     * Perform a paginated search against the engine.
+     */
+    public function paginate(Builder $builder, int $perPage, int $page): mixed
+    {
+        return $this->performSearch($builder, [
+            'numericFilters' => $this->filters($builder),
+            'hitsPerPage' => $perPage,
+            'page' => $page - 1,
+        ]);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     */
+    protected function performSearch(Builder $builder, array $options = []): mixed
+    {
+        $options = array_merge($builder->options, $options);
+
+        if ($builder->callback !== null) {
+            return call_user_func(
+                $builder->callback,
+                $this->algolia,
+                $builder->query,
+                $options,
+            );
+        }
+
+        $queryParams = array_merge(['query' => $builder->query], $options);
+
+        $requestOptions = [];
+        if ($this->identify) {
+            $headers = $this->identifyHeaders();
+            if ($headers !== []) {
+                $requestOptions['headers'] = $headers;
+            }
+        }
+
+        return $this->algolia->searchSingleIndex(
+            $builder->index ?: $builder->model->searchableAs(),
+            $queryParams,
+            $requestOptions,
+        );
+    }
+
+    /**
+     * Build per-request identify headers for the current request.
+     *
+     * Reads the current coroutine-local request directly from RequestContext
+     * rather than via the request() helper. Matches the pattern used by
+     * CookieJar and other Hypervel code that needs request state without
+     * depending on HttpServiceProvider being registered. Returns an empty
+     * array when no request is in context (e.g. CLI, queue jobs), the IP
+     * is missing or private/reserved, or no authenticated user is present.
+     *
+     * @return array<string, string>
+     */
+    protected function identifyHeaders(): array
+    {
+        $headers = [];
+        $request = RequestContext::getOrNull();
+
+        if ($request === null) {
+            return $headers;
+        }
+
+        $ip = $request->ip();
+        if (is_string($ip) && filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false) {
+            $headers['X-Forwarded-For'] = $ip;
+        }
+
+        $user = $request->user();
+        if ($user !== null && method_exists($user, 'getKey')) {
+            $key = $user->getKey();
+            if ($key !== null) {
+                $headers['X-Algolia-UserToken'] = (string) $key;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Get the filter array for the query.
+     *
+     * @return array<int, mixed>
+     */
+    protected function filters(Builder $builder): array
+    {
+        $wheres = collect($builder->wheres)
+            ->map(fn ($value, $key) => $key . '=' . $value)
+            ->values();
+
+        $whereIns = collect($builder->whereIns)->map(function ($values, $key) {
+            if (empty($values)) {
+                return '0=1';
+            }
+
+            return collect($values)
+                ->map(fn ($value) => $key . '=' . $value)
+                ->all();
+        })->values();
+
+        $whereNotIns = collect($builder->whereNotIns)->flatMap(function ($values, $key) {
+            if (empty($values)) {
+                return [];
+            }
+
+            return collect($values)
+                ->map(fn ($value) => $key . '!=' . $value)
+                ->all();
+        });
+
+        return $wheres->merge($whereIns)->merge($whereNotIns)->values()->all();
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     */
+    public function mapIds(mixed $results): Collection
+    {
+        return collect($results['hits'])->pluck('objectID')->values();
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @param Model&SearchableInterface $model
+     */
+    public function map(Builder $builder, mixed $results, Model $model): EloquentCollection
+    {
+        if (count($results['hits']) === 0) {
+            return $model->newCollection();
+        }
+
+        $objectIds = collect($results['hits'])->pluck('objectID')->values()->all();
+
+        /** @var array<int|string> $objectIds */
+        $objectIdPositions = array_flip($objectIds);
+
+        /** @var EloquentCollection<int, Model&SearchableInterface> $scoutModels */
+        $scoutModels = $model->getScoutModelsByIds($builder, $objectIds);
+
+        $mapped = $scoutModels
+            ->filter(fn ($m) => in_array($m->getScoutKey(), $objectIds))
+            ->map(function ($m) use ($results, $objectIdPositions) {
+                /** @var Model&SearchableInterface $m */
+                $result = $results['hits'][$objectIdPositions[$m->getScoutKey()]] ?? [];
+
+                foreach ($result as $key => $value) {
+                    if (str_starts_with($key, '_')) {
+                        $m->withScoutMetadata($key, $value);
+                    }
+                }
+
+                return $m;
+            })
+            ->sortBy(fn ($m) => $objectIdPositions[$m->getScoutKey()])
+            ->values();
+
+        return $model->newCollection($mapped->all());
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param Model&SearchableInterface $model
+     */
+    public function lazyMap(Builder $builder, mixed $results, Model $model): LazyCollection
+    {
+        if (count($results['hits']) === 0) {
+            return LazyCollection::empty();
+        }
+
+        $objectIds = collect($results['hits'])->pluck('objectID')->values()->all();
+
+        /** @var array<int|string> $objectIds */
+        $objectIdPositions = array_flip($objectIds);
+
+        /** @var LazyCollection<int, Model&SearchableInterface> $cursor */
+        $cursor = $model->queryScoutModelsByIds($builder, $objectIds)->cursor();
+
+        return $cursor
+            ->filter(fn ($m) => in_array($m->getScoutKey(), $objectIds))
+            ->map(function ($m) use ($results, $objectIdPositions) {
+                /** @var Model&SearchableInterface $m */
+                $result = $results['hits'][$objectIdPositions[$m->getScoutKey()]] ?? [];
+
+                foreach ($result as $key => $value) {
+                    if (str_starts_with($key, '_')) {
+                        $m->withScoutMetadata($key, $value);
+                    }
+                }
+
+                return $m;
+            })
+            ->sortBy(fn ($m) => $objectIdPositions[$m->getScoutKey()])
+            ->values();
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     */
+    public function getTotalCount(mixed $results): int
+    {
+        return $results['nbHits'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param Model&SearchableInterface $model
+     */
+    public function flush(Model $model): void
+    {
+        $this->algolia->clearObjects($model->indexableAs());
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @throws NotSupportedException
+     */
+    public function createIndex(string $name, array $options = []): mixed
+    {
+        throw new NotSupportedException('Algolia indexes are created automatically upon adding objects.');
+    }
+
+    /**
+     * Delete a search index.
+     */
+    public function deleteIndex(string $name): mixed
+    {
+        return $this->algolia->deleteIndex($name);
+    }
+
+    /**
+     * Delete all search indexes, optionally scoped by name prefix.
+     *
+     * When $prefix is non-empty, only indexes whose name starts with $prefix
+     * are deleted. When $prefix is null (or empty string, which str_starts_with
+     * matches against every string), every index in the Algolia application
+     * is deleted.
+     *
+     * @return array<int, mixed> Task/response objects from each deleteIndex call
+     */
+    public function deleteAllIndexes(?string $prefix = null): array
+    {
+        $responses = [];
+        $indices = $this->algolia->listIndices();
+
+        foreach ($indices['items'] ?? [] as $index) {
+            $name = $index['name'] ?? null;
+
+            if (! is_string($name)) {
+                continue;
+            }
+
+            if ($prefix === null || str_starts_with($name, $prefix)) {
+                $responses[] = $this->algolia->deleteIndex($name);
+            }
+        }
+
+        return $responses;
+    }
+
+    /**
+     * Update the index settings for the given index.
+     */
+    public function updateIndexSettings(string $name, array $settings = []): void
+    {
+        $this->algolia->setSettings($name, $settings);
+    }
+
+    /**
+     * Configure the soft delete filter within the given settings.
+     *
+     * @param array<string, mixed> $settings
+     * @return array<string, mixed>
+     */
+    public function configureSoftDeleteFilter(array $settings = []): array
+    {
+        $settings['attributesForFaceting'][] = 'filterOnly(__soft_deleted)';
+
+        return $settings;
+    }
+
+    /**
+     * Determine if the given model uses soft deletes.
+     */
+    protected function usesSoftDelete(Model $model): bool
+    {
+        return in_array(SoftDeletes::class, class_uses_recursive($model));
+    }
+
+    /**
+     * Dynamically call the Algolia client instance.
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->algolia->{$method}(...$parameters);
+    }
+}

--- a/src/scout/src/Engines/MeilisearchEngine.php
+++ b/src/scout/src/Engines/MeilisearchEngine.php
@@ -408,11 +408,16 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
     }
 
     /**
-     * Delete all search indexes.
+     * Delete all search indexes, optionally scoped by uid prefix.
+     *
+     * When $prefix is non-empty, only indexes whose uid starts with $prefix
+     * are deleted. When $prefix is null (or empty string, which str_starts_with
+     * matches against every string), every index on the Meilisearch server
+     * is deleted.
      *
      * @return array<mixed>
      */
-    public function deleteAllIndexes(): array
+    public function deleteAllIndexes(?string $prefix = null): array
     {
         $tasks = [];
         $limit = 1000000;
@@ -423,7 +428,15 @@ class MeilisearchEngine extends Engine implements UpdatesIndexSettings
         $indexes = $this->meilisearch->getIndexes($query);
 
         foreach ($indexes->getResults() as $index) {
-            $tasks[] = $index->delete();
+            $uid = $index->getUid();
+
+            if ($uid === null) {
+                continue;
+            }
+
+            if ($prefix === null || str_starts_with($uid, $prefix)) {
+                $tasks[] = $index->delete();
+            }
         }
 
         return $tasks;

--- a/src/scout/src/ScoutServiceProvider.php
+++ b/src/scout/src/ScoutServiceProvider.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Hypervel\Scout;
 
+use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig as AlgoliaSearchConfig;
+use Algolia\AlgoliaSearch\Http\GuzzleHttpClient;
+use Algolia\AlgoliaSearch\Support\AlgoliaAgent;
 use GuzzleHttp\Client as GuzzleClient;
+use Hypervel\Foundation\Application as HypervelApplication;
 use Hypervel\Scout\Console\DeleteAllIndexesCommand;
 use Hypervel\Scout\Console\DeleteIndexCommand;
 use Hypervel\Scout\Console\FlushCommand;
@@ -29,12 +35,47 @@ class ScoutServiceProvider extends ServiceProvider
 
         $this->app->singleton(EngineManager::class, EngineManager::class);
 
+        $this->app->singleton(AlgoliaSearchClient::class, function () {
+            $config = $this->app->make('config');
+
+            // Pin the HTTP client to Guzzle explicitly rather than relying on
+            // Algolia::getHttpClient()'s internal auto-decide heuristic. The
+            // heuristic can change under ^4.0 minor releases (swap to PSR-18
+            // discovery, reorder Guzzle detection, etc.) with no semver signal.
+            // Explicit injection pins the HTTP client choice at our boundary.
+            Algolia::setHttpClient(new GuzzleHttpClient(new GuzzleClient));
+
+            AlgoliaAgent::addAlgoliaAgent('Hypervel Scout', 'Hypervel Scout', HypervelApplication::VERSION);
+
+            $algoliaConfig = new AlgoliaSearchConfig([
+                'appId' => $config->get('scout.algolia.id'),
+                'apiKey' => $config->get('scout.algolia.secret'),
+            ]);
+
+            if (is_int($connectTimeout = $config->get('scout.algolia.connect_timeout'))) {
+                $algoliaConfig->setConnectTimeout($connectTimeout);
+            }
+            if (is_int($readTimeout = $config->get('scout.algolia.read_timeout'))) {
+                $algoliaConfig->setReadTimeout($readTimeout);
+            }
+            if (is_int($writeTimeout = $config->get('scout.algolia.write_timeout'))) {
+                $algoliaConfig->setWriteTimeout($writeTimeout);
+            }
+
+            return AlgoliaSearchClient::createWithConfig($algoliaConfig);
+        });
+
         $this->app->singleton(MeilisearchClient::class, function () {
             $config = $this->app->make('config');
 
+            // Inject Guzzle explicitly so the Meilisearch client never falls
+            // back to Psr18ClientDiscovery::find(), which may resolve to a
+            // Swoole-unsafe PSR-18 implementation (e.g. Symfony's
+            // CurlHttpClient). Mirrors the Typesense binding's defensive pattern.
             return new MeilisearchClient(
                 $config->get('scout.meilisearch.host', 'http://localhost:7700'),
-                $config->get('scout.meilisearch.key')
+                $config->get('scout.meilisearch.key'),
+                new GuzzleClient,
             );
         });
 

--- a/tests/Integration/Scout/Algolia/AlgoliaCommandsIntegrationTest.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaCommandsIntegrationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Hypervel\Tests\Scout\Models\SearchableModel;
+use Throwable;
+
+/**
+ * Integration tests for Scout console commands with Algolia.
+ */
+class AlgoliaCommandsIntegrationTest extends AlgoliaScoutIntegrationTestCase
+{
+    public function testImportCommandIndexesModels(): void
+    {
+        SearchableModel::withoutSyncingToSearch(function (): void {
+            SearchableModel::create(['title' => 'First Document', 'body' => 'Content']);
+            SearchableModel::create(['title' => 'Second Document', 'body' => 'Content']);
+            SearchableModel::create(['title' => 'Third Document', 'body' => 'Content']);
+        });
+
+        $this->assertCount(3, SearchableModel::all());
+
+        $this->artisan('scout:import', ['model' => SearchableModel::class])
+            ->expectsOutputToContain('have been imported')
+            ->assertOk();
+
+        $index = (new SearchableModel)->searchableAs();
+        $hits = $this->pollSearch($index, 'Document', 3);
+
+        $this->assertCount(3, $hits);
+    }
+
+    public function testFlushCommandRemovesModels(): void
+    {
+        SearchableModel::withoutSyncingToSearch(function (): void {
+            SearchableModel::create(['title' => 'First', 'body' => 'Content']);
+            SearchableModel::create(['title' => 'Second', 'body' => 'Content']);
+        });
+
+        $this->artisan('scout:import', ['model' => SearchableModel::class])->assertOk();
+        $index = (new SearchableModel)->searchableAs();
+        $this->pollSearch($index, '', 2);
+
+        $this->artisan('scout:flush', ['model' => SearchableModel::class])->assertOk();
+
+        $hits = $this->pollSearch($index, '', 0);
+        $this->assertCount(0, $hits);
+    }
+
+    public function testDeleteIndexCommandRemovesIndex(): void
+    {
+        SearchableModel::withoutSyncingToSearch(function (): void {
+            SearchableModel::create(['title' => 'One', 'body' => 'x']);
+        });
+
+        $this->artisan('scout:import', ['model' => SearchableModel::class])->assertOk();
+
+        $index = (new SearchableModel)->searchableAs();
+        $this->pollSearch($index, '', 1);
+
+        $this->artisan('scout:delete-index', ['name' => $index])->assertOk();
+
+        // After deletion the index should not appear in listIndices.
+        $deadline = microtime(true) + 10;
+        $stillThere = true;
+        while (microtime(true) < $deadline) {
+            $response = $this->algolia->listIndices();
+            $names = collect($response['items'] ?? [])->pluck('name')->all();
+            if (! in_array($index, $names, true)) {
+                $stillThere = false;
+                break;
+            }
+            usleep(200_000);
+        }
+
+        $this->assertFalse($stillThere, "Index {$index} still listed after delete-index command");
+    }
+
+    /**
+     * Poll an Algolia index until the search returns the expected hit count.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pollSearch(string $index, string $query, int $expectedCount, int $timeoutMs = 15000): array
+    {
+        $deadline = microtime(true) + ($timeoutMs / 1000);
+        $hits = [];
+
+        while (microtime(true) < $deadline) {
+            try {
+                $response = $this->algolia->searchSingleIndex($index, ['query' => $query]);
+                $hits = $response['hits'] ?? [];
+
+                if (count($hits) === $expectedCount) {
+                    return $hits;
+                }
+            } catch (Throwable) {
+                // Index may not exist yet — keep polling until timeout.
+            }
+
+            usleep(200_000);
+        }
+
+        return $hits;
+    }
+}

--- a/tests/Integration/Scout/Algolia/AlgoliaConnectionTest.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaConnectionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Hypervel\Tests\Support\AlgoliaIntegrationTestCase;
+
+/**
+ * Basic connectivity test for Algolia.
+ */
+class AlgoliaConnectionTest extends AlgoliaIntegrationTestCase
+{
+    protected function setUpInCoroutine(): void
+    {
+        $this->initializeAlgolia();
+    }
+
+    public function testCanConnectToAlgolia(): void
+    {
+        $response = $this->algolia->listIndices();
+
+        $this->assertIsArray($response);
+        $this->assertArrayHasKey('items', $response);
+    }
+
+    public function testCanCreateAndDeleteIndex(): void
+    {
+        $indexName = $this->algoliaIndex('connection_test');
+
+        // Algolia indexes are created implicitly on first write. Save a
+        // single object to materialise the index, then assert it appears in
+        // listIndices, then delete it.
+        $this->algolia->saveObject($indexName, ['objectID' => '1', 'title' => 'hello']);
+
+        $this->waitForIndex($indexName);
+
+        $response = $this->algolia->listIndices();
+        $names = collect($response['items'] ?? [])->pluck('name')->all();
+        $this->assertContains($indexName, $names);
+
+        $this->algolia->deleteIndex($indexName);
+    }
+
+    /**
+     * Poll listIndices until the given index appears or timeout.
+     *
+     * Algolia index creation is eventually consistent — saveObject returns
+     * a taskID but the index may not be visible in listIndices immediately.
+     */
+    protected function waitForIndex(string $name, int $timeoutMs = 10000): void
+    {
+        $deadline = microtime(true) + ($timeoutMs / 1000);
+
+        while (microtime(true) < $deadline) {
+            $response = $this->algolia->listIndices();
+            $names = collect($response['items'] ?? [])->pluck('name')->all();
+
+            if (in_array($name, $names, true)) {
+                return;
+            }
+
+            usleep(200_000);
+        }
+    }
+}

--- a/tests/Integration/Scout/Algolia/AlgoliaEngineIntegrationTest.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaEngineIntegrationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Hypervel\Database\Eloquent\Collection as EloquentCollection;
+use Hypervel\Tests\Scout\Models\SearchableModel;
+use Throwable;
+
+/**
+ * Integration tests for AlgoliaEngine core operations against a live index.
+ */
+class AlgoliaEngineIntegrationTest extends AlgoliaScoutIntegrationTestCase
+{
+    public function testUpdateIndexesModelsInAlgolia(): void
+    {
+        $model = SearchableModel::create(['title' => 'Test Document', 'body' => 'Content here']);
+
+        $this->engine->update(new EloquentCollection([$model]));
+
+        $hits = $this->pollSearch($model->searchableAs(), 'Test', expectedCount: 1);
+
+        $this->assertCount(1, $hits);
+        $this->assertSame('Test Document', $hits[0]['title']);
+    }
+
+    public function testUpdateWithMultipleModels(): void
+    {
+        $models = new EloquentCollection([
+            SearchableModel::create(['title' => 'First', 'body' => 'Body 1']),
+            SearchableModel::create(['title' => 'Second', 'body' => 'Body 2']),
+            SearchableModel::create(['title' => 'Third', 'body' => 'Body 3']),
+        ]);
+
+        $this->engine->update($models);
+
+        $hits = $this->pollSearch($models->first()->searchableAs(), '', expectedCount: 3);
+
+        $this->assertCount(3, $hits);
+    }
+
+    public function testDeleteRemovesModelsFromAlgolia(): void
+    {
+        $model = SearchableModel::create(['title' => 'To Delete', 'body' => 'Content']);
+
+        $this->engine->update(new EloquentCollection([$model]));
+        $this->pollSearch($model->searchableAs(), 'Delete', expectedCount: 1);
+
+        $this->engine->delete(new EloquentCollection([$model]));
+
+        $hits = $this->pollSearch($model->searchableAs(), 'Delete', expectedCount: 0);
+        $this->assertCount(0, $hits);
+    }
+
+    public function testFlushClearsEntireIndex(): void
+    {
+        SearchableModel::create(['title' => 'First', 'body' => 'Body']);
+        SearchableModel::create(['title' => 'Second', 'body' => 'Body']);
+
+        $models = SearchableModel::all();
+        $this->engine->update($models);
+        $this->pollSearch($models->first()->searchableAs(), '', expectedCount: 2);
+
+        $this->engine->flush($models->first());
+
+        $hits = $this->pollSearch($models->first()->searchableAs(), '', expectedCount: 0);
+        $this->assertCount(0, $hits);
+    }
+
+    /**
+     * Poll an Algolia index until the search returns the expected hit count.
+     *
+     * Algolia writes are eventually consistent — saveObjects returns quickly
+     * but the index isn't immediately queryable. Poll until we see the
+     * expected count or hit the timeout.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pollSearch(string $index, string $query, int $expectedCount, int $timeoutMs = 10000): array
+    {
+        $deadline = microtime(true) + ($timeoutMs / 1000);
+        $hits = [];
+
+        while (microtime(true) < $deadline) {
+            try {
+                $response = $this->algolia->searchSingleIndex($index, ['query' => $query]);
+                $hits = $response['hits'] ?? [];
+
+                if (count($hits) === $expectedCount) {
+                    return $hits;
+                }
+            } catch (Throwable) {
+                // Index may not exist yet — keep polling until timeout.
+            }
+
+            usleep(200_000);
+        }
+
+        return $hits;
+    }
+}

--- a/tests/Integration/Scout/Algolia/AlgoliaFilteringIntegrationTest.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaFilteringIntegrationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Hypervel\Tests\Scout\Models\SearchableModel;
+use Throwable;
+
+/**
+ * Integration tests for Algolia where/whereIn/whereNotIn filtering.
+ */
+class AlgoliaFilteringIntegrationTest extends AlgoliaScoutIntegrationTestCase
+{
+    protected function setUpInCoroutine(): void
+    {
+        parent::setUpInCoroutine();
+
+        $this->configureFilterableIndex();
+    }
+
+    /**
+     * Configure attributesForFaceting so Algolia accepts numericFilters
+     * on id/title/body. Required before indexing data.
+     */
+    protected function configureFilterableIndex(): void
+    {
+        $indexName = $this->prefixedIndexName('searchable_models');
+
+        $this->algolia->setSettings($indexName, [
+            'attributesForFaceting' => ['filterOnly(id)', 'filterOnly(title)', 'filterOnly(body)'],
+        ]);
+    }
+
+    public function testWhereFiltersResultsByExactMatch(): void
+    {
+        $first = SearchableModel::create(['title' => 'PHP Guide', 'body' => 'Learn PHP']);
+        SearchableModel::create(['title' => 'JavaScript Guide', 'body' => 'Learn JS']);
+        SearchableModel::create(['title' => 'PHP Advanced', 'body' => 'Advanced PHP']);
+
+        $this->engine->update(SearchableModel::all());
+        $this->pollSearch($first->searchableAs(), '', 3);
+
+        $results = SearchableModel::search('')
+            ->where('id', $first->id)
+            ->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('PHP Guide', $results->first()->title);
+    }
+
+    public function testWhereInFiltersResultsByMultipleValues(): void
+    {
+        $first = SearchableModel::create(['title' => 'First', 'body' => 'Body']);
+        $second = SearchableModel::create(['title' => 'Second', 'body' => 'Body']);
+        $third = SearchableModel::create(['title' => 'Third', 'body' => 'Body']);
+
+        $this->engine->update(SearchableModel::all());
+        $this->pollSearch($first->searchableAs(), '', 3);
+
+        $results = SearchableModel::search('')
+            ->whereIn('id', [$first->id, $third->id])
+            ->get();
+
+        $this->assertCount(2, $results);
+        $this->assertTrue($results->contains('id', $first->id));
+        $this->assertTrue($results->contains('id', $third->id));
+        $this->assertFalse($results->contains('id', $second->id));
+    }
+
+    public function testWhereNotInExcludesSpecifiedValues(): void
+    {
+        $first = SearchableModel::create(['title' => 'First', 'body' => 'Body']);
+        $second = SearchableModel::create(['title' => 'Second', 'body' => 'Body']);
+        $third = SearchableModel::create(['title' => 'Third', 'body' => 'Body']);
+
+        $this->engine->update(SearchableModel::all());
+        $this->pollSearch($first->searchableAs(), '', 3);
+
+        $results = SearchableModel::search('')
+            ->whereNotIn('id', [$second->id])
+            ->get();
+
+        $this->assertCount(2, $results);
+        $this->assertTrue($results->contains('id', $first->id));
+        $this->assertTrue($results->contains('id', $third->id));
+        $this->assertFalse($results->contains('id', $second->id));
+    }
+
+    /**
+     * Poll an Algolia index until the search returns the expected hit count.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pollSearch(string $index, string $query, int $expectedCount, int $timeoutMs = 10000): array
+    {
+        $deadline = microtime(true) + ($timeoutMs / 1000);
+        $hits = [];
+
+        while (microtime(true) < $deadline) {
+            try {
+                $response = $this->algolia->searchSingleIndex($index, ['query' => $query]);
+                $hits = $response['hits'] ?? [];
+
+                if (count($hits) === $expectedCount) {
+                    return $hits;
+                }
+            } catch (Throwable) {
+                // Index may not exist yet — keep polling until timeout.
+            }
+
+            usleep(200_000);
+        }
+
+        return $hits;
+    }
+}

--- a/tests/Integration/Scout/Algolia/AlgoliaIdentifyIntegrationTest.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaIdentifyIntegrationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Algolia\AlgoliaSearch\Algolia;
+use Hypervel\Context\RequestContext;
+use Hypervel\Http\Request;
+use Hypervel\Scout\EngineManager;
+use Hypervel\Scout\Engines\AlgoliaEngine;
+use Hypervel\Tests\Scout\Models\SearchableModel;
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * Real-wire regression test for the identify divergence from Laravel.
+ *
+ * Laravel bakes X-Forwarded-For / X-Algolia-UserToken into default client
+ * headers at driver-creation time, which breaks on a persistent worker
+ * where the engine is cached across requests. Hypervel computes these
+ * headers per-call from the current RequestContext and passes them via
+ * the searchSingleIndex $requestOptions['headers'] parameter.
+ *
+ * This test seeds two different requests and verifies that each search's
+ * outgoing HTTP request carries its own X-Forwarded-For — captured via
+ * the Algolia SDK's PSR-3 debug logger.
+ */
+class AlgoliaIdentifyIntegrationTest extends AlgoliaScoutIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make('config')->set('scout.identify', true);
+    }
+
+    public function testIdentifyHeadersAreSentPerRequestNotBakedIn(): void
+    {
+        // Capture outgoing request headers via the SDK's debug logger.
+        $logger = new class extends AbstractLogger {
+            /** @var array<int, array<string, mixed>> */
+            public array $records = [];
+
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                if (str_contains((string) $message, 'Request headers:')) {
+                    $this->records[] = $context;
+                }
+            }
+        };
+
+        Algolia::setLogger($logger);
+
+        // Re-resolve the engine so it picks up the identify=true config.
+        $this->app->make(EngineManager::class)->forgetEngines();
+        /** @var AlgoliaEngine $engine */
+        $engine = $this->app->make(EngineManager::class)->engine('algolia');
+
+        // Materialise an index to query (contents don't matter — we're
+        // asserting on the outgoing HTTP headers, not the response).
+        SearchableModel::create(['title' => 'Probe', 'body' => 'x']);
+        $indexName = (new SearchableModel)->searchableAs();
+        $this->pollIndexExists($indexName);
+
+        $builder = SearchableModel::search('');
+
+        // Phase A: request from 203.0.113.10
+        try {
+            RequestContext::set(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.10']));
+            $engine->search($builder);
+        } finally {
+            RequestContext::forget();
+        }
+
+        // Phase B: request from 198.51.100.20
+        try {
+            RequestContext::set(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '198.51.100.20']));
+            $engine->search($builder);
+        } finally {
+            RequestContext::forget();
+        }
+
+        $forwardedFor = array_values(array_filter(array_map(
+            fn (array $context) => $this->extractHeader($context['headers'] ?? [], 'X-Forwarded-For'),
+            $logger->records,
+        )));
+
+        $this->assertContains('203.0.113.10', $forwardedFor, 'Phase A header missing from captured requests');
+        $this->assertContains('198.51.100.20', $forwardedFor, 'Phase B header missing from captured requests');
+
+        Algolia::setLogger(new \Algolia\AlgoliaSearch\Log\DebugLogger);
+    }
+
+    /**
+     * Extract a header value case-insensitively from the Algolia log context.
+     *
+     * Algolia's RequestOptionsFactory lowercases header keys before merging,
+     * so the captured context typically uses lowercase keys.
+     */
+    protected function extractHeader(array $headers, string $name): ?string
+    {
+        $lower = strtolower($name);
+
+        foreach ($headers as $key => $value) {
+            if (strtolower((string) $key) === $lower) {
+                return is_string($value) ? $value : null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Poll until the index appears in listIndices or timeout.
+     */
+    protected function pollIndexExists(string $index, int $timeoutMs = 15000): void
+    {
+        $deadline = microtime(true) + ($timeoutMs / 1000);
+
+        while (microtime(true) < $deadline) {
+            $response = $this->algolia->listIndices();
+            $names = collect($response['items'] ?? [])->pluck('name')->all();
+
+            if (in_array($index, $names, true)) {
+                return;
+            }
+
+            usleep(200_000);
+        }
+    }
+}

--- a/tests/Integration/Scout/Algolia/AlgoliaScoutIntegrationTestCase.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaScoutIntegrationTestCase.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Hypervel\Foundation\Testing\RefreshDatabase;
+use Hypervel\Scout\Console\DeleteAllIndexesCommand;
+use Hypervel\Scout\Console\DeleteIndexCommand;
+use Hypervel\Scout\Console\FlushCommand;
+use Hypervel\Scout\Console\ImportCommand;
+use Hypervel\Scout\Console\IndexCommand;
+use Hypervel\Scout\Console\SyncIndexSettingsCommand;
+use Hypervel\Scout\EngineManager;
+use Hypervel\Scout\Engines\AlgoliaEngine;
+use Hypervel\Support\Facades\Artisan;
+use Hypervel\Tests\Support\AlgoliaIntegrationTestCase;
+
+/**
+ * Base test case for Algolia Scout integration tests.
+ *
+ * Extends the generic Algolia test case with Scout-specific setup:
+ * database migrations, Scout commands, and engine initialization.
+ */
+abstract class AlgoliaScoutIntegrationTestCase extends AlgoliaIntegrationTestCase
+{
+    use RefreshDatabase;
+
+    protected bool $migrateRefresh = true;
+
+    protected string $basePrefix = 'scout_int_';
+
+    protected AlgoliaEngine $engine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerScoutCommands();
+
+        // Clear cached engines so they're recreated with our test config
+        $this->app->make(EngineManager::class)->forgetEngines();
+    }
+
+    protected function setUpInCoroutine(): void
+    {
+        $this->initializeAlgolia();
+        $this->engine = $this->app->make(EngineManager::class)->engine('algolia');
+    }
+
+    protected function tearDownInCoroutine(): void
+    {
+        $this->cleanupAlgoliaIndices();
+    }
+
+    /**
+     * Register Scout commands with the Artisan application.
+     */
+    protected function registerScoutCommands(): void
+    {
+        Artisan::getArtisan()->resolveCommands([
+            DeleteAllIndexesCommand::class,
+            DeleteIndexCommand::class,
+            FlushCommand::class,
+            ImportCommand::class,
+            IndexCommand::class,
+            SyncIndexSettingsCommand::class,
+        ]);
+    }
+
+    protected function migrateFreshUsing(): array
+    {
+        return [
+            '--seed' => $this->shouldSeed(),
+            '--database' => $this->getRefreshConnection(),
+            '--realpath' => true,
+            '--path' => [
+                dirname(__DIR__, 3) . '/Scout/migrations',
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Scout/Algolia/AlgoliaSoftDeleteIntegrationTest.php
+++ b/tests/Integration/Scout/Algolia/AlgoliaSoftDeleteIntegrationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Scout\Algolia;
+
+use Hypervel\Database\Eloquent\Collection as EloquentCollection;
+use Hypervel\Tests\Scout\Models\SoftDeleteSearchableModel;
+use Throwable;
+
+/**
+ * Integration tests for Scout soft delete behavior with Algolia.
+ */
+class AlgoliaSoftDeleteIntegrationTest extends AlgoliaScoutIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make('config')->set('scout.soft_delete', true);
+    }
+
+    protected function setUpInCoroutine(): void
+    {
+        parent::setUpInCoroutine();
+
+        $this->configureSoftDeleteIndex();
+    }
+
+    /**
+     * Configure the soft-delete index with the __soft_deleted facet so Scout's
+     * soft-delete filter works. Mirrors what AlgoliaEngine::configureSoftDeleteFilter
+     * would do on the settings side.
+     */
+    protected function configureSoftDeleteIndex(): void
+    {
+        $indexName = $this->prefixedIndexName('soft_deletable_searchable_models');
+
+        $this->algolia->setSettings($indexName, [
+            'attributesForFaceting' => ['filterOnly(__soft_deleted)'],
+        ]);
+    }
+
+    public function testSoftDeletedModelsArePushedWithSoftDeleteMetadata(): void
+    {
+        $model = SoftDeleteSearchableModel::create(['title' => 'Active', 'body' => 'Content']);
+
+        $this->engine->update(new EloquentCollection([$model]));
+        $hits = $this->pollSearch($model->searchableAs(), '', 1);
+
+        $this->assertCount(1, $hits);
+        $this->assertArrayHasKey('__soft_deleted', $hits[0]);
+        $this->assertSame(0, $hits[0]['__soft_deleted']);
+
+        $model->delete();
+        $this->engine->update(new EloquentCollection([$model->fresh()]));
+        $hits = $this->pollSearchFor(
+            $model->searchableAs(),
+            '',
+            fn (array $h) => ($h[0]['__soft_deleted'] ?? null) === 1,
+        );
+
+        $this->assertSame(1, $hits[0]['__soft_deleted']);
+    }
+
+    /**
+     * Poll an Algolia index until the search returns the expected hit count.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pollSearch(string $index, string $query, int $expectedCount, int $timeoutMs = 10000): array
+    {
+        return $this->pollSearchFor(
+            $index,
+            $query,
+            fn (array $hits) => count($hits) === $expectedCount,
+            $timeoutMs,
+        );
+    }
+
+    /**
+     * Poll an Algolia index until the hits pass the given predicate, or timeout.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pollSearchFor(string $index, string $query, callable $predicate, int $timeoutMs = 10000): array
+    {
+        $deadline = microtime(true) + ($timeoutMs / 1000);
+        $hits = [];
+
+        while (microtime(true) < $deadline) {
+            try {
+                $response = $this->algolia->searchSingleIndex($index, ['query' => $query]);
+                $hits = $response['hits'] ?? [];
+
+                if ($predicate($hits)) {
+                    return $hits;
+                }
+            } catch (Throwable) {
+                // Index may not exist yet — keep polling until timeout.
+            }
+
+            usleep(200_000);
+        }
+
+        return $hits;
+    }
+}

--- a/tests/Integration/Scout/Meilisearch/MeilisearchCommandsIntegrationTest.php
+++ b/tests/Integration/Scout/Meilisearch/MeilisearchCommandsIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\Scout\Meilisearch;
 
 use Hypervel\Tests\Scout\Models\SearchableModel;
+use Throwable;
 
 /**
  * Integration tests for Scout console commands with Meilisearch.
@@ -90,5 +91,53 @@ class MeilisearchCommandsIntegrationTest extends MeilisearchScoutIntegrationTest
         // Searching should now fail or return empty because index is gone
         // After deleting the index, Meilisearch will auto-create on next search
         // so we just verify the command executed successfully
+    }
+
+    public function testScopedDeleteAllIndexesPreservesUnrelatedIndexes(): void
+    {
+        // Real-wire regression test for the deleteAllIndexes scoping fix.
+        // Creates two prefixed indexes (will be deleted by scoped call) and
+        // one unprefixed index (must survive). Verifies only the prefixed
+        // ones are removed.
+        $unrelatedIndex = 'other_data_not_scope';
+
+        try {
+            // Two prefixed indexes — tracked for cleanup by the base class.
+            $this->createTestIndex('scoped_a');
+            $this->createTestIndex('scoped_b');
+
+            // One unprefixed index — create directly, clean up manually below.
+            $this->meilisearch->createIndex($unrelatedIndex);
+
+            $this->waitForMeilisearchTasks();
+
+            // Verify all three exist before the scoped delete.
+            $uids = collect($this->meilisearch->getIndexes()->getResults())
+                ->map(fn ($i) => $i->getUid())
+                ->all();
+            $this->assertContains($this->prefixedIndexName('scoped_a'), $uids);
+            $this->assertContains($this->prefixedIndexName('scoped_b'), $uids);
+            $this->assertContains($unrelatedIndex, $uids);
+
+            // Scoped delete — should remove only the prefixed indexes.
+            $this->engine->deleteAllIndexes($this->testPrefix);
+
+            $this->waitForMeilisearchTasks();
+
+            // Re-fetch and assert: unrelated index survives, prefixed ones gone.
+            $uids = collect($this->meilisearch->getIndexes()->getResults())
+                ->map(fn ($i) => $i->getUid())
+                ->all();
+            $this->assertNotContains($this->prefixedIndexName('scoped_a'), $uids);
+            $this->assertNotContains($this->prefixedIndexName('scoped_b'), $uids);
+            $this->assertContains($unrelatedIndex, $uids);
+        } finally {
+            // Clean up the unrelated index regardless of pass/fail.
+            try {
+                $this->meilisearch->deleteIndex($unrelatedIndex);
+            } catch (Throwable) {
+                // Ignore cleanup errors.
+            }
+        }
     }
 }

--- a/tests/Scout/Unit/ConfigFileTest.php
+++ b/tests/Scout/Unit/ConfigFileTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Scout\Unit;
+
+use Hypervel\Tests\TestCase;
+
+/**
+ * Tests for the on-disk scout config file defaults.
+ *
+ * Deliberately does NOT extend ScoutTestCase — that base class's setUp()
+ * replaces the entire scout config array with a minimal fixture, so reading
+ * config('scout.algolia') there tests the fixture, not the real defaults
+ * shipped in src/scout/config/scout.php. Loading the file directly bypasses
+ * any container/config harness.
+ */
+class ConfigFileTest extends TestCase
+{
+    public function testAlgoliaDefaultsArePresentInConfigFile(): void
+    {
+        $config = require dirname(__DIR__, 3) . '/src/scout/config/scout.php';
+
+        $this->assertIsArray($config);
+
+        $this->assertArrayHasKey('identify', $config);
+        $this->assertFalse($config['identify']);
+
+        $this->assertArrayHasKey('algolia', $config);
+        $this->assertIsArray($config['algolia']);
+        $this->assertArrayHasKey('id', $config['algolia']);
+        $this->assertArrayHasKey('secret', $config['algolia']);
+        $this->assertArrayHasKey('index-settings', $config['algolia']);
+        $this->assertIsArray($config['algolia']['index-settings']);
+    }
+}

--- a/tests/Scout/Unit/Console/DeleteAllIndexesCommandTest.php
+++ b/tests/Scout/Unit/Console/DeleteAllIndexesCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Scout\Unit\Console;
 
 use Exception;
+use Hypervel\Config\Repository;
 use Hypervel\Scout\Console\DeleteAllIndexesCommand;
 use Hypervel\Scout\EngineManager;
 use Hypervel\Scout\Engines\CollectionEngine;
@@ -19,6 +20,7 @@ class DeleteAllIndexesCommandTest extends TestCase
         $engine = m::mock(MeilisearchEngine::class);
         $engine->shouldReceive('deleteAllIndexes')
             ->once()
+            ->with('test_')
             ->andReturn([]);
 
         $manager = m::mock(EngineManager::class);
@@ -26,12 +28,15 @@ class DeleteAllIndexesCommandTest extends TestCase
             ->once()
             ->andReturn($engine);
 
+        $config = $this->configWithPrefix('test_');
+
         $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldReceive('info')
             ->once()
             ->with('All indexes deleted successfully.');
 
-        $result = $command->handle($manager);
+        $result = $command->handle($manager, $config);
 
         $this->assertSame(0, $result);
     }
@@ -48,12 +53,18 @@ class DeleteAllIndexesCommandTest extends TestCase
             ->once()
             ->andReturn('collection');
 
+        // Must set a non-empty prefix: the safety gate runs BEFORE engine
+        // resolution, and with an empty prefix we'd hit the refusal message
+        // rather than the "does not support" path.
+        $config = $this->configWithPrefix('test_');
+
         $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldReceive('error')
             ->once()
             ->with('The [collection] engine does not support deleting all indexes.');
 
-        $result = $command->handle($manager);
+        $result = $command->handle($manager, $config);
 
         $this->assertSame(1, $result);
     }
@@ -63,6 +74,7 @@ class DeleteAllIndexesCommandTest extends TestCase
         $engine = m::mock(MeilisearchEngine::class);
         $engine->shouldReceive('deleteAllIndexes')
             ->once()
+            ->with('test_')
             ->andThrow(new Exception('Connection failed'));
 
         $manager = m::mock(EngineManager::class);
@@ -70,13 +82,125 @@ class DeleteAllIndexesCommandTest extends TestCase
             ->once()
             ->andReturn($engine);
 
+        $config = $this->configWithPrefix('test_');
+
         $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldReceive('error')
             ->once()
             ->with('Connection failed');
 
-        $result = $command->handle($manager);
+        $result = $command->handle($manager, $config);
 
         $this->assertSame(1, $result);
+    }
+
+    public function testRefusesWhenPrefixEmptyAndNotForced(): void
+    {
+        $manager = m::mock(EngineManager::class);
+        // Safety gate runs first; engine is never resolved.
+        $manager->shouldNotReceive('engine');
+
+        $config = $this->configWithPrefix('');
+
+        $capturedMessage = null;
+        $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(false);
+        $command->shouldReceive('error')
+            ->once()
+            ->with(m::on(function (string $message) use (&$capturedMessage) {
+                $capturedMessage = $message;
+
+                return true;
+            }));
+
+        $result = $command->handle($manager, $config);
+
+        $this->assertSame(1, $result);
+        $this->assertStringContainsString('scout.prefix', $capturedMessage);
+        $this->assertStringContainsString('--force', $capturedMessage);
+    }
+
+    public function testRunsUnscopedWhenForcedWithEmptyPrefix(): void
+    {
+        $engine = m::mock(MeilisearchEngine::class);
+        $engine->shouldReceive('deleteAllIndexes')
+            ->once()
+            ->with(null)
+            ->andReturn([]);
+
+        $manager = m::mock(EngineManager::class);
+        $manager->shouldReceive('engine')
+            ->once()
+            ->andReturn($engine);
+
+        $config = $this->configWithPrefix('');
+
+        $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(true);
+        $command->shouldReceive('info')->once();
+
+        $result = $command->handle($manager, $config);
+
+        $this->assertSame(0, $result);
+    }
+
+    public function testRunsScopedWhenPrefixSet(): void
+    {
+        $engine = m::mock(MeilisearchEngine::class);
+        $engine->shouldReceive('deleteAllIndexes')
+            ->once()
+            ->with('app_')
+            ->andReturn([]);
+
+        $manager = m::mock(EngineManager::class);
+        $manager->shouldReceive('engine')
+            ->once()
+            ->andReturn($engine);
+
+        $config = $this->configWithPrefix('app_');
+
+        $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(false);
+        $command->shouldReceive('info')->once();
+
+        $result = $command->handle($manager, $config);
+
+        $this->assertSame(0, $result);
+    }
+
+    public function testForceDoesNotOverrideScopingWhenPrefixSet(): void
+    {
+        $engine = m::mock(MeilisearchEngine::class);
+        // Even with --force, the configured prefix still scopes the deletion.
+        $engine->shouldReceive('deleteAllIndexes')
+            ->once()
+            ->with('app_')
+            ->andReturn([]);
+
+        $manager = m::mock(EngineManager::class);
+        $manager->shouldReceive('engine')
+            ->once()
+            ->andReturn($engine);
+
+        $config = $this->configWithPrefix('app_');
+
+        $command = m::mock(DeleteAllIndexesCommand::class)->makePartial();
+        $command->shouldReceive('option')->with('force')->andReturn(true);
+        $command->shouldReceive('info')->once();
+
+        $result = $command->handle($manager, $config);
+
+        $this->assertSame(0, $result);
+    }
+
+    protected function configWithPrefix(string $prefix): Repository
+    {
+        $config = m::mock(Repository::class);
+        $config->shouldReceive('get')
+            ->with('scout.prefix', '')
+            ->andReturn($prefix);
+
+        return $config;
     }
 }

--- a/tests/Scout/Unit/EngineManagerTest.php
+++ b/tests/Scout/Unit/EngineManagerTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Scout\Unit;
 
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
 use Hypervel\Config\Repository;
 use Hypervel\Contracts\Container\Container;
 use Hypervel\Scout\Engine;
 use Hypervel\Scout\EngineManager;
+use Hypervel\Scout\Engines\AlgoliaEngine;
 use Hypervel\Scout\Engines\CollectionEngine;
 use Hypervel\Scout\Engines\DatabaseEngine;
 use Hypervel\Scout\Engines\MeilisearchEngine;
 use Hypervel\Scout\Engines\NullEngine;
 use Hypervel\Scout\Engines\TypesenseEngine;
+use Hypervel\Support\ClassInvoker;
 use Hypervel\Tests\TestCase;
 use InvalidArgumentException;
 use Meilisearch\Client as MeilisearchClient;
@@ -47,6 +50,65 @@ class EngineManagerTest extends TestCase
         $engine = $manager->engine('collection');
 
         $this->assertInstanceOf(CollectionEngine::class, $engine);
+    }
+
+    public function testResolveAlgoliaEngine()
+    {
+        $container = $this->createMockContainerWithAlgolia([
+            'driver' => 'algolia',
+            'soft_delete' => false,
+            'identify' => false,
+        ]);
+
+        $algoliaClient = m::mock(AlgoliaSearchClient::class);
+        $container->shouldReceive('make')
+            ->with(AlgoliaSearchClient::class)
+            ->andReturn($algoliaClient);
+
+        $manager = new EngineManager($container);
+        $engine = $manager->engine('algolia');
+
+        $this->assertInstanceOf(AlgoliaEngine::class, $engine);
+    }
+
+    public function testResolveAlgoliaEngineWithSoftDelete()
+    {
+        $container = $this->createMockContainerWithAlgolia([
+            'driver' => 'algolia',
+            'soft_delete' => true,
+            'identify' => false,
+        ]);
+
+        $algoliaClient = m::mock(AlgoliaSearchClient::class);
+        $container->shouldReceive('make')
+            ->with(AlgoliaSearchClient::class)
+            ->andReturn($algoliaClient);
+
+        $manager = new EngineManager($container);
+        $engine = $manager->engine('algolia');
+
+        $this->assertInstanceOf(AlgoliaEngine::class, $engine);
+        $this->assertTrue((new ClassInvoker($engine))->softDelete);
+    }
+
+    public function testResolveAlgoliaEngineWithIdentify()
+    {
+        $container = $this->createMockContainerWithAlgolia([
+            'driver' => 'algolia',
+            'soft_delete' => false,
+            'identify' => true,
+        ]);
+
+        $algoliaClient = m::mock(AlgoliaSearchClient::class);
+        $container->shouldReceive('make')
+            ->with(AlgoliaSearchClient::class)
+            ->andReturn($algoliaClient);
+
+        $manager = new EngineManager($container);
+        $engine = $manager->engine('algolia');
+
+        $this->assertInstanceOf(AlgoliaEngine::class, $engine);
+        $this->assertTrue((new ClassInvoker($engine))->identify);
     }
 
     public function testResolveMeilisearchEngine()
@@ -303,6 +365,28 @@ class EngineManagerTest extends TestCase
         $configService->shouldReceive('get')
             ->with('scout.typesense.max_total_results', m::any())
             ->andReturn($config['max_total_results'] ?? 1000);
+
+        $container->shouldReceive('make')
+            ->with('config')
+            ->andReturn($configService);
+
+        return $container;
+    }
+
+    protected function createMockContainerWithAlgolia(array $config): m\MockInterface&Container
+    {
+        $container = m::mock(Container::class);
+
+        $configService = m::mock(Repository::class);
+        $configService->shouldReceive('get')
+            ->with('scout.driver', m::any())
+            ->andReturn($config['driver'] ?? null);
+        $configService->shouldReceive('get')
+            ->with('scout.soft_delete', m::any())
+            ->andReturn($config['soft_delete'] ?? false);
+        $configService->shouldReceive('get')
+            ->with('scout.identify', m::any())
+            ->andReturn($config['identify'] ?? false);
 
         $container->shouldReceive('make')
             ->with('config')

--- a/tests/Scout/Unit/Engines/AlgoliaEngineTest.php
+++ b/tests/Scout/Unit/Engines/AlgoliaEngineTest.php
@@ -1,0 +1,995 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Scout\Unit\Engines;
+
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
+use Hypervel\Context\RequestContext;
+use Hypervel\Coroutine\WaitGroup;
+use Hypervel\Database\Eloquent\Collection as EloquentCollection;
+use Hypervel\Database\Eloquent\Model;
+use Hypervel\Database\Eloquent\SoftDeletes;
+use Hypervel\Http\Request;
+use Hypervel\Scout\Builder;
+use Hypervel\Scout\Contracts\SearchableInterface;
+use Hypervel\Scout\Engines\AlgoliaEngine;
+use Hypervel\Scout\Exceptions\NotSupportedException;
+use Hypervel\Scout\Jobs\RemoveableScoutCollection;
+use Hypervel\Scout\Searchable;
+use Hypervel\Support\LazyCollection;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+
+use function Hypervel\Coroutine\go;
+
+class AlgoliaEngineTest extends TestCase
+{
+    public function testUpdateSavesObjects()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('saveObjects')
+            ->once()
+            ->with('users', [
+                ['id' => 1, 'name' => 'Taylor', 'objectID' => 1],
+            ]);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = $this->createSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('users');
+        $model->shouldReceive('toSearchableArray')->andReturn(['id' => 1, 'name' => 'Taylor']);
+        $model->shouldReceive('scoutMetadata')->andReturn([]);
+        $model->shouldReceive('getScoutKey')->andReturn(1);
+
+        $engine->update(new EloquentCollection([$model]));
+    }
+
+    public function testUpdateEmptyCollectionDoesNothing()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $client->shouldNotReceive('saveObjects');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->update(new EloquentCollection);
+
+        $this->assertTrue(true);
+    }
+
+    public function testUpdateFiltersOutEmptySearchableArrays()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $client->shouldNotReceive('saveObjects');
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = $this->createSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('users');
+        $model->shouldReceive('toSearchableArray')->andReturn([]);
+
+        $engine->update(new EloquentCollection([$model]));
+    }
+
+    public function testUpdateIncludesScoutMetadata()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('saveObjects')
+            ->once()
+            ->with('users', [
+                ['id' => 1, 'name' => 'Taylor', 'foo' => 'bar', 'objectID' => 1],
+            ]);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = $this->createSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('users');
+        $model->shouldReceive('toSearchableArray')->andReturn(['id' => 1, 'name' => 'Taylor']);
+        $model->shouldReceive('scoutMetadata')->andReturn(['foo' => 'bar']);
+        $model->shouldReceive('getScoutKey')->andReturn(1);
+
+        $engine->update(new EloquentCollection([$model]));
+    }
+
+    public function testUpdateWithSoftDeletesAddsSoftDeleteMetadata()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('saveObjects')
+            ->once()
+            ->with('users', m::on(function ($objects) {
+                return isset($objects[0]['__soft_deleted']);
+            }));
+
+        $engine = new AlgoliaEngine($client, softDelete: true);
+
+        $model = $this->createSoftDeleteSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('users');
+        $model->shouldReceive('toSearchableArray')->andReturn(['id' => 1, 'name' => 'Taylor']);
+        $model->shouldReceive('scoutMetadata')->andReturn(['__soft_deleted' => 0]);
+        $model->shouldReceive('getScoutKey')->andReturn(1);
+        $model->shouldReceive('pushSoftDeleteMetadata')->once()->andReturnSelf();
+
+        $engine->update(new EloquentCollection([$model]));
+    }
+
+    public function testDeleteRemovesObjects()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('deleteObjects')
+            ->once()
+            ->with('users', [1]);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = $this->createSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('users');
+        $model->shouldReceive('getScoutKey')->andReturn(1);
+        $model->shouldReceive('getScoutKeyName')->andReturn('id');
+
+        $engine->delete(new EloquentCollection([$model]));
+    }
+
+    public function testDeleteWithCustomScoutKey()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('deleteObjects')
+            ->once()
+            ->with('chirps', ['my-key']);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = $this->createSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('chirps');
+        $model->shouldReceive('getScoutKey')->andReturn('my-key');
+        $model->shouldReceive('getScoutKeyName')->andReturn('scout_id');
+
+        $engine->delete(new EloquentCollection([$model]));
+    }
+
+    public function testDeleteWithRemoveableScoutCollection()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('deleteObjects')
+            ->once()
+            ->with('chirps', ['my-key']);
+
+        $engine = new AlgoliaEngine($client);
+
+        // RemoveableScoutCollection's delete path uses pluck($keyName) which
+        // reads attributes directly via data_get. A Mockery mock can't satisfy
+        // that because Model::__set routes through setAttribute (intercepted).
+        // A real fixture model with setRawAttributes works cleanly — no DB
+        // needed because delete() never hits the database.
+        $model = new AlgoliaTestChirpModel;
+        $model->setRawAttributes(['scout_id' => 'my-key']);
+
+        $collection = new RemoveableScoutCollection([$model]);
+
+        $engine->delete($collection);
+    }
+
+    public function testDeleteEmptyCollection()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $client->shouldNotReceive('deleteObjects');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->delete(new EloquentCollection);
+
+        $this->assertTrue(true);
+    }
+
+    public function testDeleteIndex()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('deleteIndex')
+            ->once()
+            ->with('users')
+            ->andReturn(['taskID' => 123]);
+
+        $engine = new AlgoliaEngine($client);
+
+        $result = $engine->deleteIndex('users');
+
+        $this->assertEquals(['taskID' => 123], $result);
+    }
+
+    public function testFlush()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('clearObjects')
+            ->once()
+            ->with('users');
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = $this->createSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('users');
+
+        $engine->flush($model);
+    }
+
+    public function testUpdateIndexSettings()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('setSettings')
+            ->once()
+            ->with('users', ['searchableAttributes' => ['name', 'email']]);
+
+        $engine = new AlgoliaEngine($client);
+        $engine->updateIndexSettings('users', ['searchableAttributes' => ['name', 'email']]);
+    }
+
+    public function testCreateIndexThrows()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $this->expectException(NotSupportedException::class);
+
+        $engine->createIndex('users');
+    }
+
+    public function testSearchSendsCorrectParameters()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', ['query' => 'zonda', 'numericFilters' => ['foo=1']], []);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'zonda');
+        $builder->where('foo', 1);
+
+        $engine->search($builder);
+    }
+
+    public function testSearchSendsCorrectParametersForWhereInSearch()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar=1', 'bar=2']]], []);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'zonda');
+        $builder->where('foo', 1)->whereIn('bar', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function testSearchSendsCorrectParametersForEmptyWhereInSearch()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', ['query' => 'zonda', 'numericFilters' => ['foo=1', '0=1']], []);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'zonda');
+        $builder->where('foo', 1)->whereIn('bar', []);
+
+        $engine->search($builder);
+    }
+
+    public function testSearchSendsCorrectParametersForWhereNotInSearch()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', ['query' => 'zonda', 'numericFilters' => ['foo!=1', 'foo!=2']], []);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'zonda');
+        $builder->whereNotIn('foo', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function testSearchIgnoresEmptyWhereNotIn()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', ['query' => 'zonda'], []);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'zonda');
+        $builder->whereNotIn('foo', []);
+
+        $engine->search($builder);
+    }
+
+    public function testSearchSendsCorrectParametersForMixedSearch()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with(
+                'users',
+                ['query' => 'zonda', 'numericFilters' => ['foo=1', ['bar=1', 'bar=2'], 'baz!=1', 'baz!=2']],
+                [],
+            );
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'zonda');
+        $builder->where('foo', 1)
+            ->whereIn('bar', [1, 2])
+            ->whereNotIn('baz', [1, 2]);
+
+        $engine->search($builder);
+    }
+
+    public function testSearchWithCallbackUsesCallback()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $client->shouldNotReceive('searchSingleIndex');
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $called = false;
+        $builder = new Builder($model, 'zonda', function ($c, $query, $options) use ($client, &$called) {
+            $called = true;
+            $this->assertSame($client, $c);
+            $this->assertSame('zonda', $query);
+
+            return ['hits' => [], 'nbHits' => 0];
+        });
+
+        $result = $engine->search($builder);
+
+        $this->assertTrue($called);
+        $this->assertEquals(['hits' => [], 'nbHits' => 0], $result);
+    }
+
+    public function testPaginateComputesCorrectPage()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', m::on(function ($params) {
+                return $params['hitsPerPage'] === 15 && $params['page'] === 1;
+            }), []);
+
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        $engine->paginate($builder, 15, 2);
+    }
+
+    public function testMapReturnsEmptyWhenNoHits()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('newCollection')->andReturn(new EloquentCollection);
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->map($builder, ['hits' => []], $model);
+
+        $this->assertCount(0, $results);
+    }
+
+    public function testMapPopulatesScoutMetadataFromUnderscoreKeys()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $searchableModel = m::mock(Model::class . ', ' . SearchableInterface::class);
+        $searchableModel->shouldReceive('getScoutKey')->andReturn(1);
+        $searchableModel->shouldReceive('withScoutMetadata')
+            ->with('_rankingInfo', ['nbTypos' => 0])
+            ->once()
+            ->andReturnSelf();
+
+        $model = m::mock(Model::class . ', ' . SearchableInterface::class);
+        $model->shouldReceive('getScoutModelsByIds')->andReturn(new EloquentCollection([$searchableModel]));
+        $model->shouldReceive('newCollection')
+            ->andReturnUsing(fn ($models) => new EloquentCollection($models));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->map($builder, [
+            'nbHits' => 1,
+            'hits' => [
+                ['objectID' => 1, 'id' => 1, '_rankingInfo' => ['nbTypos' => 0]],
+            ],
+        ], $model);
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testMapRespectsOrder()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $mockModels = [];
+        foreach ([1, 2, 3, 4] as $id) {
+            $mock = m::mock(Model::class . ', ' . SearchableInterface::class);
+            $mock->shouldReceive('getScoutKey')->andReturn($id);
+            $mockModels[] = $mock;
+        }
+
+        $models = new EloquentCollection($mockModels);
+
+        $model = m::mock(Model::class . ', ' . SearchableInterface::class);
+        $model->shouldReceive('getScoutModelsByIds')->andReturn($models);
+        $model->shouldReceive('newCollection')
+            ->andReturnUsing(fn ($models) => new EloquentCollection($models));
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->map($builder, [
+            'nbHits' => 4,
+            'hits' => [
+                ['objectID' => 1, 'id' => 1],
+                ['objectID' => 2, 'id' => 2],
+                ['objectID' => 4, 'id' => 4],
+                ['objectID' => 3, 'id' => 3],
+            ],
+        ], $model);
+
+        $this->assertCount(4, $results);
+        $resultIds = $results->map(fn ($m) => $m->getScoutKey())->all();
+        $this->assertEquals([1, 2, 4, 3], $resultIds);
+    }
+
+    public function testLazyMapRespectsOrder()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $mockModels = [];
+        foreach ([1, 2, 3, 4] as $id) {
+            $mock = m::mock(Model::class . ', ' . SearchableInterface::class);
+            $mock->shouldReceive('getScoutKey')->andReturn($id);
+            $mockModels[] = $mock;
+        }
+
+        $lazy = LazyCollection::make($mockModels);
+
+        $queryBuilder = m::mock(\Hypervel\Database\Eloquent\Builder::class);
+        $queryBuilder->shouldReceive('cursor')->andReturn($lazy);
+
+        $model = m::mock(Model::class . ', ' . SearchableInterface::class);
+        $model->shouldReceive('queryScoutModelsByIds')->andReturn($queryBuilder);
+
+        $builder = m::mock(Builder::class);
+
+        $results = $engine->lazyMap($builder, [
+            'nbHits' => 4,
+            'hits' => [
+                ['objectID' => 1, 'id' => 1],
+                ['objectID' => 2, 'id' => 2],
+                ['objectID' => 4, 'id' => 4],
+                ['objectID' => 3, 'id' => 3],
+            ],
+        ], $model);
+
+        $this->assertInstanceOf(LazyCollection::class, $results);
+        $resultIds = $results->map(fn ($m) => $m->getScoutKey())->all();
+        $this->assertEquals([1, 2, 4, 3], $resultIds);
+    }
+
+    public function testGetTotalCount()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $this->assertEquals(42, $engine->getTotalCount(['nbHits' => 42]));
+    }
+
+    public function testMapIdsReturnsObjectIDs()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $results = $engine->mapIds([
+            'nbHits' => 3,
+            'hits' => [
+                ['objectID' => 'a', 'id' => 1],
+                ['objectID' => 'b', 'id' => 2],
+                ['objectID' => 'c', 'id' => 3],
+            ],
+        ]);
+
+        $this->assertEquals(['a', 'b', 'c'], $results->all());
+    }
+
+    public function testConfigureSoftDeleteFilter()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+        $engine = new AlgoliaEngine($client);
+
+        $result = $engine->configureSoftDeleteFilter([
+            'attributesForFaceting' => ['existing'],
+        ]);
+
+        $this->assertEquals(
+            ['attributesForFaceting' => ['existing', 'filterOnly(__soft_deleted)']],
+            $result,
+        );
+    }
+
+    public function testIdentifyDisabledSendsEmptyRequestOptions()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', m::any(), []);
+
+        $engine = new AlgoliaEngine($client, identify: false);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        $engine->search($builder);
+    }
+
+    public function testIdentifyEnabledSendsHeadersFromRequest()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', m::any(), ['headers' => ['X-Forwarded-For' => '203.0.113.10']]);
+
+        $engine = new AlgoliaEngine($client, identify: true);
+
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.10']);
+        RequestContext::set($request);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        $engine->search($builder);
+    }
+
+    public function testIdentifyEnabledWithAuthenticatedUserAddsUserToken()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', m::any(), m::on(function ($requestOptions) {
+                return isset($requestOptions['headers']['X-Algolia-UserToken'])
+                    && $requestOptions['headers']['X-Algolia-UserToken'] === '42';
+            }));
+
+        $engine = new AlgoliaEngine($client, identify: true);
+
+        // Using a real fixture class (not a Mockery mock) because the engine
+        // calls method_exists($user, 'getKey') — Mockery's __call-based method
+        // stubs are not detected by method_exists, so a mock would be rejected.
+        $user = new AlgoliaTestUser(42);
+
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.10']);
+        $request->setUserResolver(fn () => $user);
+        RequestContext::set($request);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        $engine->search($builder);
+    }
+
+    public function testIdentifyIgnoresPrivateIPs()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', m::any(), []);
+
+        $engine = new AlgoliaEngine($client, identify: true);
+
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+        RequestContext::set($request);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        $engine->search($builder);
+    }
+
+    public function testIdentifyHeadersReflectTheCurrentRequestNotTheCachedOne()
+    {
+        // Regression test for the deliberate divergence from Laravel's
+        // EngineManager::defaultAlgoliaHeaders(). The engine is constructed
+        // ONCE (as it would be in a Swoole worker) and must pick up the
+        // current request's IP on every search — not the IP of whichever
+        // request happened to trigger engine construction.
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $capturedHeaders = [];
+        $client->shouldReceive('searchSingleIndex')
+            ->twice()
+            ->with('users', m::any(), m::on(function ($opts) use (&$capturedHeaders) {
+                $capturedHeaders[] = $opts['headers']['X-Forwarded-For'] ?? null;
+
+                return true;
+            }));
+
+        $engine = new AlgoliaEngine($client, identify: true);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        try {
+            RequestContext::set(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.10']));
+            $engine->search($builder);
+        } finally {
+            RequestContext::forget();
+        }
+
+        try {
+            RequestContext::set(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '198.51.100.20']));
+            $engine->search($builder);
+        } finally {
+            RequestContext::forget();
+        }
+
+        $this->assertSame(['203.0.113.10', '198.51.100.20'], $capturedHeaders);
+    }
+
+    public function testIdentifyHeadersDoNotLeakAcrossCoroutines()
+    {
+        // Companion regression test: RequestContext is coroutine-local, so
+        // two concurrent coroutines each seeding their own request must each
+        // see their own headers in the resulting search call — never the
+        // other coroutine's.
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $capturedHeaders = [];
+        $client->shouldReceive('searchSingleIndex')
+            ->twice()
+            ->with('users', m::any(), m::on(function ($opts) use (&$capturedHeaders) {
+                $capturedHeaders[] = $opts['headers']['X-Forwarded-For'] ?? null;
+
+                return true;
+            }));
+
+        $engine = new AlgoliaEngine($client, identify: true);
+
+        $model = m::mock(AlgoliaTestSearchableModel::class);
+        $model->shouldReceive('searchableAs')->andReturn('users');
+
+        $builder = new Builder($model, 'query');
+
+        $waiter = new WaitGroup;
+        $waiter->add(2);
+
+        go(function () use ($engine, $builder, $waiter) {
+            RequestContext::set(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.10']));
+            $engine->search($builder);
+            $waiter->done();
+        });
+
+        go(function () use ($engine, $builder, $waiter) {
+            RequestContext::set(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '198.51.100.20']));
+            $engine->search($builder);
+            $waiter->done();
+        });
+
+        $waiter->wait();
+
+        sort($capturedHeaders);
+        $this->assertSame(['198.51.100.20', '203.0.113.10'], $capturedHeaders);
+    }
+
+    public function testUpdateSoftDeletedWithEmptySearchableArrayDoesNotSave()
+    {
+        // Covers the Laravel Feature-test gap (test_update_empty_searchable_
+        // array_from_soft_deleted_model_does_not_add_objects_to_index). With
+        // softDelete enabled and an empty toSearchableArray(), the engine
+        // still calls pushSoftDeleteMetadata (runs before the empty check)
+        // but does not call saveObjects.
+        $client = m::mock(AlgoliaSearchClient::class);
+        $client->shouldNotReceive('saveObjects');
+
+        $engine = new AlgoliaEngine($client, softDelete: true);
+
+        $model = $this->createSoftDeleteSearchableModelMock();
+        $model->shouldReceive('indexableAs')->andReturn('chirps');
+        $model->shouldReceive('toSearchableArray')->andReturn([]);
+        $model->shouldReceive('pushSoftDeleteMetadata')->once()->andReturnSelf();
+
+        $engine->update(new EloquentCollection([$model]));
+    }
+
+    public function testCallForwardsUnknownMethodsToClient()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('customMethod')
+            ->once()
+            ->with('arg')
+            ->andReturn('result');
+
+        $engine = new AlgoliaEngine($client);
+
+        $this->assertEquals('result', $engine->customMethod('arg'));
+    }
+
+    public function testDeleteAllIndexesWithPrefixScopesToPrefixedIndexes()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('listIndices')
+            ->once()
+            ->andReturn([
+                'items' => [
+                    ['name' => 'test_users'],
+                    ['name' => 'test_posts'],
+                    ['name' => 'other_data'],
+                ],
+            ]);
+
+        $client->shouldReceive('deleteIndex')->once()->with('test_users');
+        $client->shouldReceive('deleteIndex')->once()->with('test_posts');
+        $client->shouldNotReceive('deleteIndex')->with('other_data');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->deleteAllIndexes('test_');
+    }
+
+    public function testDeleteAllIndexesWithNullPrefixDeletesEverything()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('listIndices')
+            ->once()
+            ->andReturn([
+                'items' => [
+                    ['name' => 'test_users'],
+                    ['name' => 'test_posts'],
+                    ['name' => 'other_data'],
+                ],
+            ]);
+
+        $client->shouldReceive('deleteIndex')->once()->with('test_users');
+        $client->shouldReceive('deleteIndex')->once()->with('test_posts');
+        $client->shouldReceive('deleteIndex')->once()->with('other_data');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->deleteAllIndexes(null);
+    }
+
+    public function testDeleteAllIndexesWithEmptyStringPrefixDeletesEverything()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('listIndices')
+            ->once()
+            ->andReturn([
+                'items' => [
+                    ['name' => 'test_users'],
+                    ['name' => 'test_posts'],
+                    ['name' => 'other_data'],
+                ],
+            ]);
+
+        $client->shouldReceive('deleteIndex')->once()->with('test_users');
+        $client->shouldReceive('deleteIndex')->once()->with('test_posts');
+        $client->shouldReceive('deleteIndex')->once()->with('other_data');
+
+        $engine = new AlgoliaEngine($client);
+        $engine->deleteAllIndexes('');
+    }
+
+    public function testDeleteAllIndexesReturnsResponses()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('listIndices')
+            ->once()
+            ->andReturn([
+                'items' => [
+                    ['name' => 'test_users'],
+                    ['name' => 'test_posts'],
+                ],
+            ]);
+
+        $client->shouldReceive('deleteIndex')->with('test_users')->andReturn(['taskID' => 1]);
+        $client->shouldReceive('deleteIndex')->with('test_posts')->andReturn(['taskID' => 2]);
+
+        $engine = new AlgoliaEngine($client);
+        $responses = $engine->deleteAllIndexes('test_');
+
+        $this->assertEquals([['taskID' => 1], ['taskID' => 2]], $responses);
+    }
+
+    public function testDeleteAllIndexesWithNoIndexesReturnsEmptyArray()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('listIndices')
+            ->once()
+            ->andReturn(['items' => []]);
+
+        $client->shouldNotReceive('deleteIndex');
+
+        $engine = new AlgoliaEngine($client);
+        $result = $engine->deleteAllIndexes('test_');
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testDeleteAllIndexesSkipsEntriesWithoutStringNames()
+    {
+        $client = m::mock(AlgoliaSearchClient::class);
+
+        $client->shouldReceive('listIndices')
+            ->once()
+            ->andReturn([
+                'items' => [
+                    ['name' => 'test_users'],
+                    ['name' => 42],          // non-string, should skip
+                    ['no_name_field' => 'x'], // missing name, should skip
+                    ['name' => 'test_posts'],
+                ],
+            ]);
+
+        $client->shouldReceive('deleteIndex')->once()->with('test_users');
+        $client->shouldReceive('deleteIndex')->once()->with('test_posts');
+        $client->shouldNotReceive('deleteIndex')->with(42);
+
+        $engine = new AlgoliaEngine($client);
+        $responses = $engine->deleteAllIndexes('test_');
+
+        $this->assertCount(2, $responses);
+    }
+
+    protected function createSearchableModelMock(): m\MockInterface
+    {
+        return m::mock(Model::class . ', ' . SearchableInterface::class);
+    }
+
+    protected function createSoftDeleteSearchableModelMock(): m\MockInterface
+    {
+        // Must mock a class that uses SoftDeletes for usesSoftDelete() to return true
+        return m::mock(AlgoliaTestSoftDeleteModel::class . ', ' . SearchableInterface::class);
+    }
+}
+
+/**
+ * Test model for AlgoliaEngine tests.
+ */
+class AlgoliaTestSearchableModel extends Model implements SearchableInterface
+{
+    use Searchable;
+
+    protected array $guarded = [];
+
+    public bool $timestamps = false;
+}
+
+/**
+ * Test model with soft deletes for AlgoliaEngine tests.
+ */
+class AlgoliaTestSoftDeleteModel extends Model implements SearchableInterface
+{
+    use Searchable;
+    use SoftDeletes;
+
+    protected array $guarded = [];
+
+    public bool $timestamps = false;
+}
+
+/**
+ * Test model with a custom scout key for AlgoliaEngine tests.
+ *
+ * Exercises the RemoveableScoutCollection delete path, which uses
+ * pluck($scoutKeyName) — reading attribute values directly rather than
+ * calling getScoutKey(). Needs a real Eloquent model so setRawAttributes
+ * populates the attributes array for data_get to find.
+ *
+ * Deliberately does NOT use the Searchable trait: bootSearchable()
+ * instantiates ModelObserver, which in its constructor reads from the
+ * Config facade. Without a facade root (bare unit test), that throws.
+ * The engine's delete() path only calls getScoutKeyName() and
+ * indexableAs() at runtime; no SearchableInterface runtime check.
+ */
+class AlgoliaTestChirpModel extends Model
+{
+    protected ?string $table = 'chirps';
+
+    protected array $guarded = [];
+
+    public bool $timestamps = false;
+
+    public function getScoutKey(): mixed
+    {
+        return $this->getAttribute('scout_id');
+    }
+
+    public function getScoutKeyName(): string
+    {
+        return 'scout_id';
+    }
+
+    public function indexableAs(): string
+    {
+        return $this->getTable();
+    }
+}
+
+/**
+ * Minimal user stub for identifyHeaders() tests.
+ *
+ * Needs a real class (not a Mockery mock) because the engine uses
+ * method_exists($user, 'getKey') to detect the presence of the method.
+ * Mockery stubs methods via __call which are invisible to method_exists.
+ */
+class AlgoliaTestUser
+{
+    public function __construct(private mixed $key)
+    {
+    }
+
+    public function getKey(): mixed
+    {
+        return $this->key;
+    }
+}

--- a/tests/Scout/Unit/Engines/MeilisearchEngineTest.php
+++ b/tests/Scout/Unit/Engines/MeilisearchEngineTest.php
@@ -14,6 +14,7 @@ use Hypervel\Scout\Searchable;
 use Hypervel\Support\LazyCollection;
 use Hypervel\Tests\TestCase;
 use Meilisearch\Client;
+use Meilisearch\Contracts\IndexesResults;
 use Meilisearch\Endpoints\Indexes;
 use Mockery as m;
 
@@ -445,6 +446,104 @@ class MeilisearchEngineTest extends TestCase
         $result = $engine->deleteIndex('test_index');
 
         $this->assertEquals(['taskUid' => 1], $result);
+    }
+
+    public function testDeleteAllIndexesWithPrefixScopesToPrefixedUids()
+    {
+        $client = m::mock(Client::class);
+
+        $testUsers = m::mock(Indexes::class);
+        $testUsers->shouldReceive('getUid')->andReturn('test_users');
+        $testUsers->shouldReceive('delete')->once()->andReturn(['taskUid' => 1]);
+
+        $testPosts = m::mock(Indexes::class);
+        $testPosts->shouldReceive('getUid')->andReturn('test_posts');
+        $testPosts->shouldReceive('delete')->once()->andReturn(['taskUid' => 2]);
+
+        $otherData = m::mock(Indexes::class);
+        $otherData->shouldReceive('getUid')->andReturn('other_data');
+        $otherData->shouldNotReceive('delete');
+
+        $results = m::mock(IndexesResults::class);
+        $results->shouldReceive('getResults')->andReturn([$testUsers, $testPosts, $otherData]);
+
+        $client->shouldReceive('getIndexes')->once()->andReturn($results);
+
+        $engine = new MeilisearchEngine($client);
+        $engine->deleteAllIndexes('test_');
+    }
+
+    public function testDeleteAllIndexesWithNullPrefixDeletesEverything()
+    {
+        $client = m::mock(Client::class);
+
+        $testUsers = m::mock(Indexes::class);
+        $testUsers->shouldReceive('getUid')->andReturn('test_users');
+        $testUsers->shouldReceive('delete')->once();
+
+        $testPosts = m::mock(Indexes::class);
+        $testPosts->shouldReceive('getUid')->andReturn('test_posts');
+        $testPosts->shouldReceive('delete')->once();
+
+        $otherData = m::mock(Indexes::class);
+        $otherData->shouldReceive('getUid')->andReturn('other_data');
+        $otherData->shouldReceive('delete')->once();
+
+        $results = m::mock(IndexesResults::class);
+        $results->shouldReceive('getResults')->andReturn([$testUsers, $testPosts, $otherData]);
+
+        $client->shouldReceive('getIndexes')->once()->andReturn($results);
+
+        $engine = new MeilisearchEngine($client);
+        $engine->deleteAllIndexes(null);
+    }
+
+    public function testDeleteAllIndexesWithEmptyStringPrefixDeletesEverything()
+    {
+        $client = m::mock(Client::class);
+
+        $testUsers = m::mock(Indexes::class);
+        $testUsers->shouldReceive('getUid')->andReturn('test_users');
+        $testUsers->shouldReceive('delete')->once();
+
+        $testPosts = m::mock(Indexes::class);
+        $testPosts->shouldReceive('getUid')->andReturn('test_posts');
+        $testPosts->shouldReceive('delete')->once();
+
+        $otherData = m::mock(Indexes::class);
+        $otherData->shouldReceive('getUid')->andReturn('other_data');
+        $otherData->shouldReceive('delete')->once();
+
+        $results = m::mock(IndexesResults::class);
+        $results->shouldReceive('getResults')->andReturn([$testUsers, $testPosts, $otherData]);
+
+        $client->shouldReceive('getIndexes')->once()->andReturn($results);
+
+        $engine = new MeilisearchEngine($client);
+        $engine->deleteAllIndexes('');
+    }
+
+    public function testDeleteAllIndexesReturnsTasks()
+    {
+        $client = m::mock(Client::class);
+
+        $testUsers = m::mock(Indexes::class);
+        $testUsers->shouldReceive('getUid')->andReturn('test_users');
+        $testUsers->shouldReceive('delete')->andReturn(['taskUid' => 1]);
+
+        $testPosts = m::mock(Indexes::class);
+        $testPosts->shouldReceive('getUid')->andReturn('test_posts');
+        $testPosts->shouldReceive('delete')->andReturn(['taskUid' => 2]);
+
+        $results = m::mock(IndexesResults::class);
+        $results->shouldReceive('getResults')->andReturn([$testUsers, $testPosts]);
+
+        $client->shouldReceive('getIndexes')->andReturn($results);
+
+        $engine = new MeilisearchEngine($client);
+        $tasks = $engine->deleteAllIndexes('test_');
+
+        $this->assertEquals([['taskUid' => 1], ['taskUid' => 2]], $tasks);
     }
 
     public function testUpdateIndexSettingsWithEmbedders()

--- a/tests/Scout/Unit/ScoutServiceProviderTest.php
+++ b/tests/Scout/Unit/ScoutServiceProviderTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Scout\Unit;
 
+use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Api\SearchClient as AlgoliaSearchClient;
+use Algolia\AlgoliaSearch\Http\GuzzleHttpClient;
 use GuzzleHttp\Client as GuzzleClient;
 use Http\Client\Common\HttpMethodsClient;
 use Hypervel\Contracts\Foundation\Application;
 use Hypervel\Scout\ScoutServiceProvider;
+use Hypervel\Support\ClassInvoker;
 use Hypervel\Testbench\TestCase;
+use Meilisearch\Client as MeilisearchClient;
 use Psr\Http\Client\ClientInterface;
 use ReflectionProperty;
 use Typesense\Client as TypesenseClient;
@@ -72,5 +77,56 @@ class ScoutServiceProviderTest extends TestCase
         // When a user provides their own client, it should be used as-is
         // (not overwritten by our default GuzzleClient).
         $this->assertSame($customClient, $client);
+    }
+
+    public function testMeilisearchClientUsesExplicitGuzzle()
+    {
+        // Closes the pre-existing gap where the binding fell through to
+        // Psr18ClientDiscovery::find(). Verifies our explicit Guzzle injection
+        // reaches the adapter's inner PSR-18 client.
+        $client = $this->app->make(MeilisearchClient::class);
+
+        // Meilisearch\Client::$http is the MeilisearchClientAdapter
+        // (Meilisearch\Http\Client); that adapter's private $http is the
+        // PSR-18 implementation we injected.
+        $adapter = (new ClassInvoker($client))->http;
+        $psr18 = (new ClassInvoker($adapter))->http;
+
+        $this->assertInstanceOf(GuzzleClient::class, $psr18);
+    }
+
+    public function testAlgoliaClientIsRegistered()
+    {
+        // Algolia4SearchConfig throws if appId or apiKey is empty, so seed
+        // non-empty credentials before resolving.
+        $this->app->make('config')->set('scout.algolia.id', 'test-app-id');
+        $this->app->make('config')->set('scout.algolia.secret', 'test-secret');
+        $this->app->forgetInstance(AlgoliaSearchClient::class);
+
+        $client = $this->app->make(AlgoliaSearchClient::class);
+
+        $this->assertInstanceOf(AlgoliaSearchClient::class, $client);
+    }
+
+    public function testAlgoliaClientUsesExplicitGuzzle()
+    {
+        // Pins the behaviour: the Algolia binding calls
+        // Algolia::setHttpClient(new GuzzleHttpClient(new GuzzleClient))
+        // and that client is what the Algolia SDK uses afterwards.
+        $this->app->make('config')->set('scout.algolia.id', 'test-app-id');
+        $this->app->make('config')->set('scout.algolia.secret', 'test-secret');
+        $this->app->forgetInstance(AlgoliaSearchClient::class);
+
+        // Resolving triggers the binding closure which calls setHttpClient.
+        $this->app->make(AlgoliaSearchClient::class);
+
+        $wrapper = Algolia::getHttpClient();
+        $this->assertInstanceOf(GuzzleHttpClient::class, $wrapper);
+
+        // GuzzleHttpClient stores the injected Guzzle in a private $client
+        // property (see vendor/algolia/algoliasearch-client-php/lib/Http/
+        // GuzzleHttpClient.php). Verify it's a real GuzzleHttp\Client.
+        $inner = (new ClassInvoker($wrapper))->client;
+        $this->assertInstanceOf(GuzzleClient::class, $inner);
     }
 }

--- a/tests/Support/AlgoliaIntegrationTestCase.php
+++ b/tests/Support/AlgoliaIntegrationTestCase.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Support;
+
+use Hypervel\Foundation\Testing\Concerns\InteractsWithAlgolia;
+use Hypervel\Scout\ScoutServiceProvider;
+use Hypervel\Testbench\TestCase;
+
+/**
+ * Base test case for Algolia integration tests.
+ *
+ * Uses InteractsWithAlgolia trait for:
+ * - Auto-skip: Skips tests when ALGOLIA_APP_ID/ALGOLIA_SECRET are unset
+ * - Explicit-fail: Credentials set but probe fails → exception propagates
+ * - Parallel-safe: Uses TEST_TOKEN for unique index prefixes
+ * - Auto-cleanup: Removes test indexes in teardown
+ *
+ * NOTE: This base class does NOT include RunTestsInCoroutine. Subclasses
+ * should add the trait if they need coroutine context for their tests.
+ */
+abstract class AlgoliaIntegrationTestCase extends TestCase
+{
+    use InteractsWithAlgolia;
+
+    /**
+     * Base index prefix for integration tests.
+     */
+    protected string $basePrefix = 'int_test';
+
+    /**
+     * Computed prefix (includes TEST_TOKEN if running in parallel).
+     */
+    protected string $testPrefix;
+
+    protected function setUp(): void
+    {
+        $this->computeTestPrefix();
+        $this->algoliaTestPrefix = $this->testPrefix;
+
+        parent::setUp();
+
+        $this->app->register(ScoutServiceProvider::class);
+        $this->configureAlgolia();
+    }
+
+    /**
+     * Initialize the Algolia client and clean up stale test indexes.
+     *
+     * Subclasses using RunTestsInCoroutine should call this in setUpInCoroutine().
+     * Subclasses NOT using the trait should call this at the end of setUp().
+     *
+     * Uses the trait's skip logic — skips if credentials are absent.
+     */
+    protected function initializeAlgolia(): void
+    {
+        $this->setUpInteractsWithAlgolia();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownInteractsWithAlgolia();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Compute parallel-safe prefix based on TEST_TOKEN from paratest.
+     */
+    protected function computeTestPrefix(): void
+    {
+        $testToken = env('TEST_TOKEN', '');
+
+        if ($testToken !== '') {
+            $this->testPrefix = "{$this->basePrefix}_{$testToken}_";
+        } else {
+            $this->testPrefix = "{$this->basePrefix}_";
+        }
+    }
+
+    /**
+     * Configure Algolia from environment variables.
+     */
+    protected function configureAlgolia(): void
+    {
+        $config = $this->app->make('config');
+
+        $config->set('scout.driver', 'algolia');
+        $config->set('scout.prefix', $this->testPrefix);
+        $config->set('scout.algolia.id', env('ALGOLIA_APP_ID', ''));
+        $config->set('scout.algolia.secret', env('ALGOLIA_SECRET', ''));
+    }
+
+    /**
+     * Get a prefixed index name.
+     */
+    protected function prefixedIndexName(string $name): string
+    {
+        return $this->testPrefix . $name;
+    }
+}


### PR DESCRIPTION
Adds the Algolia driver to Scout. Also fixes a few issues with the existing Meilisearch driver.

## Algolia

- New `AlgoliaEngine` for the v4 client. Laravel has separate abstract + concrete classes because they support both v3 and v4. Since we only support v4, there's just one class.
- Config picks up `scout.identify` and `scout.algolia` (id, secret, index-settings). The Scout commands work with it, except `scout:index` which throws `NotSupportedException` since Algolia creates indexes implicitly on first write (which matches Laravel's behaviour).

### Identify headers are per-call, not default

Laravel's approach of setting `X-Forwarded-For` and `X-Algolia-UserToken` as default headers at driver-creation time doesn't work for us. `EngineManager` caches the engine, so headers from the first request leak to every subsequent one on the same worker.

Moved this to per-call: compute from the current `RequestContext` and pass via `$requestOptions['headers']` on each search call. Persistent workers stay clean.

### HTTP client pinning

All three drivers (Algolia, Meilisearch, Typesense) now pin Guzzle explicitly in the service provider instead of relying on SDK/default client selection. That selection could potentially land on Symfony's `CurlHttpClient` or something other than Guzzle, which aren't coroutine-safe. Meilisearch was previously relying on auto-discovery, so fixed that as well. Algolia's current client selection logic is safe at the moment but there's no guarantee it'll stay that way so using an explicit client is better.

## scout:delete-all-indexes safety

Previously the command would silently wipe every index on the server, which is a problem on shared instances (Meilisearch Cloud, or when multiple environments share one Algolia app).

- Both engines' `deleteAllIndexes` now take an optional `$prefix` parameter and only delete matching indexes.
- The command now refuses to run when `scout.prefix` is empty unless a new `--force` flag is passed. The error message explains the risk.

This is a behaviour change but I it's an important improvement.

## Tests

- New unit tests for `AlgoliaEngine` (update, delete, search, map, identify, deleteAllIndexes).
- New Meilisearch unit tests for scoped delete.
- `DeleteAllIndexesCommandTest`: 3 existing tests updated for the new `handle()` signature, 4 new tests for the safety gate.
- 3 new Algolia resolution tests in `EngineManagerTest`.
- 3 new service provider tests: one asserts the Algolia client is registered, the other two assert Guzzle was actually injected into the Meilisearch and Algolia clients (via reflection on their internal state).
- Config defaults shape test.
- Algolia integration test files covering connectivity, end-to-end flow, filtering, soft-delete, commands, and a real-wire regression for per-call identify headers. All skip automatically without `ALGOLIA_APP_ID` / `ALGOLIA_SECRET`.
- 1 new Meilisearch integration test for scoped deleteAllIndexes.

## CI

New `algolia` job in `.github/workflows/scout.yml`. Gated on `ALGOLIA_APP_ID` and `ALGOLIA_SECRET` repo secrets being set (Algolia is cloud-only, no this isn't something we can test wth a sidecar container).
