### PR TITLE
feat: Cache `Model::getCasts()` merged result per instance

### DIFF
--- a/src/database/src/Eloquent/Concerns/HasAttributes.php
+++ b/src/database/src/Eloquent/Concerns/HasAttributes.php
@@ -99,6 +99,11 @@ trait HasAttributes
     protected array $attributeCastCache = [];
 
     /**
+     * The cached merged casts array for this instance.
+     */
+    protected ?array $mergedCastsCache = null;
+
+    /**
      * The built-in, primitive cast types supported by Eloquent.
      *
      * @var string[]
@@ -193,6 +198,8 @@ trait HasAttributes
         $this->casts = $this->ensureCastsAreStringValues(
             array_merge($this->casts, $this->casts()),
         );
+
+        $this->mergedCastsCache = null;
     }
 
     /**
@@ -710,6 +717,8 @@ trait HasAttributes
         $casts = $this->ensureCastsAreStringValues($casts);
 
         $this->casts = array_merge($this->casts, $casts);
+
+        $this->mergedCastsCache = null;
 
         return $this;
     }
@@ -1500,7 +1509,10 @@ trait HasAttributes
     public function getCasts(): array
     {
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+            return $this->mergedCastsCache ??= array_merge(
+                [$this->getKeyName() => $this->getKeyType()],
+                $this->casts,
+            );
         }
 
         return $this->casts;

--- a/src/database/src/Eloquent/Model.php
+++ b/src/database/src/Eloquent/Model.php
@@ -1865,6 +1865,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $this->primaryKey = $key;
 
+        $this->mergedCastsCache = null;
+
         return $this;
     }
 
@@ -1891,6 +1893,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $this->keyType = $type;
 
+        $this->mergedCastsCache = null;
+
         return $this;
     }
 
@@ -1908,6 +1912,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function setIncrementing(bool $value): static
     {
         $this->incrementing = $value;
+
+        $this->mergedCastsCache = null;
 
         return $this;
     }
@@ -2308,6 +2314,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->classCastCache = [];
         $this->attributeCastCache = [];
+        $this->mergedCastsCache = null;
         $this->relationAutoloadCallback = null;
         $this->relationAutoloadContext = null;
 

--- a/src/database/src/Eloquent/SoftDeletes.php
+++ b/src/database/src/Eloquent/SoftDeletes.php
@@ -37,6 +37,8 @@ trait SoftDeletes
         if (! isset($this->casts[$this->getDeletedAtColumn()])) {
             $this->casts[$this->getDeletedAtColumn()] = 'datetime';
         }
+
+        $this->mergedCastsCache = null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -44,9 +44,11 @@ use Hypervel\Database\Eloquent\MissingAttributeException;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\BelongsTo;
 use Hypervel\Database\Eloquent\Relations\Relation;
+use Hypervel\Database\Eloquent\SoftDeletes;
 use Hypervel\Database\Query\Builder as BaseBuilder;
 use Hypervel\Database\Query\Grammars\Grammar;
 use Hypervel\Database\Query\Processors\Processor;
+use Hypervel\Events\Dispatcher as EventDispatcher;
 use Hypervel\Support\Carbon;
 use Hypervel\Support\Collection as BaseCollection;
 use Hypervel\Support\Fluent;
@@ -2904,6 +2906,151 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayHasKey('foo', $model->getCasts());
     }
 
+    public function testGetCastsCacheIsInvalidatedByMergeCasts()
+    {
+        $model = new ModelStub;
+
+        $before = $model->getCasts();
+        $this->assertArrayNotHasKey('foo', $before);
+
+        $model->mergeCasts(['foo' => 'date']);
+
+        $after = $model->getCasts();
+        $this->assertArrayHasKey('foo', $after);
+        $this->assertSame('date', $after['foo']);
+    }
+
+    public function testGetCastsCacheIsInvalidatedBySetKeyName()
+    {
+        $model = new ModelStub;
+
+        $before = $model->getCasts();
+        $this->assertArrayHasKey('id', $before);
+
+        $model->setKeyName('uuid');
+
+        $after = $model->getCasts();
+        $this->assertArrayHasKey('uuid', $after);
+        $this->assertArrayNotHasKey('id', $after);
+    }
+
+    public function testGetCastsCacheIsInvalidatedBySetKeyType()
+    {
+        $model = new ModelStub;
+
+        $before = $model->getCasts();
+        $this->assertSame('int', $before[$model->getKeyName()]);
+
+        $model->setKeyType('string');
+
+        $after = $model->getCasts();
+        $this->assertSame('string', $after[$model->getKeyName()]);
+    }
+
+    public function testGetCastsCacheIsInvalidatedBySetIncrementing()
+    {
+        $model = new ModelStub;
+
+        $with = $model->getCasts();
+        $this->assertArrayHasKey('id', $with);
+
+        $model->setIncrementing(false);
+
+        $without = $model->getCasts();
+        $this->assertArrayNotHasKey('id', $without);
+    }
+
+    public function testGetCastsForNonIncrementingModelReturnsCastsDirectly()
+    {
+        $model = new ModelStub;
+        $model->setIncrementing(false);
+        $model->mergeCasts(['foo' => 'int']);
+
+        $casts = $model->getCasts();
+
+        $this->assertArrayNotHasKey($model->getKeyName(), $casts);
+        $this->assertArrayHasKey('foo', $casts);
+        $this->assertSame('int', $casts['foo']);
+    }
+
+    public function testGetCastsIsIsolatedPerInstance()
+    {
+        $a = new ModelStub;
+        $b = new ModelStub;
+
+        $b->mergeCasts(['extra' => 'int']);
+
+        $this->assertArrayNotHasKey('extra', $a->getCasts());
+        $this->assertArrayHasKey('extra', $b->getCasts());
+    }
+
+    public function testGetCastsOnNewInstanceIsNotSharedWithSource()
+    {
+        $source = new ModelStub;
+        $source->mergeCasts(['a' => 'int']);
+        $source->getCasts();
+
+        $clone = $source->newInstance();
+        $clone->mergeCasts(['b' => 'string']);
+
+        $this->assertArrayHasKey('b', $clone->getCasts());
+        $this->assertArrayNotHasKey('b', $source->getCasts());
+    }
+
+    public function testGetCastsCacheIsInvalidatedDuringInitializeHasAttributes()
+    {
+        Model::clearBootedModels();
+
+        Model::setEventDispatcher($dispatcher = new EventDispatcher);
+
+        try {
+            $dispatcher->listen(
+                'eloquent.booting: ' . GetCastsBootingStub::class,
+                function (GetCastsBootingStub $model) {
+                    $model->getCasts();
+                }
+            );
+
+            $instance = new GetCastsBootingStub;
+
+            $casts = $instance->getCasts();
+
+            $this->assertArrayHasKey('foo', $casts);
+            $this->assertSame('integer', $casts['foo']);
+        } finally {
+            GetCastsBootingStub::flushEventListeners();
+            Model::clearBootedModels();
+            Model::unsetEventDispatcher();
+        }
+    }
+
+    public function testGetCastsCacheIsInvalidatedDuringInitializeSoftDeletes()
+    {
+        Model::clearBootedModels();
+
+        Model::setEventDispatcher($dispatcher = new EventDispatcher);
+
+        try {
+            $dispatcher->listen(
+                'eloquent.booting: ' . GetCastsSoftDeletingBootingStub::class,
+                function (GetCastsSoftDeletingBootingStub $model) {
+                    $model->getCasts();
+                }
+            );
+
+            $instance = new GetCastsSoftDeletingBootingStub;
+
+            $casts = $instance->getCasts();
+
+            $this->assertArrayHasKey('deleted_at', $casts);
+            $this->assertSame('datetime', $casts['deleted_at']);
+        } finally {
+            GetCastsSoftDeletingBootingStub::flushEventListeners();
+            Model::clearBootedModels();
+            Model::unsetEventDispatcher();
+        }
+    }
+
     public function testMergeCastsMergesCastsUsingArrays()
     {
         $model = new CastingStub;
@@ -4468,6 +4615,23 @@ class StringableCastBuilder implements NativeStringable
     {
         return $this->cast;
     }
+}
+
+class GetCastsBootingStub extends Model
+{
+    protected array $guarded = [];
+
+    protected function casts(): array
+    {
+        return ['foo' => 'integer'];
+    }
+}
+
+class GetCastsSoftDeletingBootingStub extends Model
+{
+    use SoftDeletes;
+
+    protected array $guarded = [];
 }
 
 enum ConnectionName

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -83,7 +83,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $like = LikeWithSingleWith::first();
 
         $this->assertTrue($like->relationLoaded('likeable'));
-        $this->assertEquals(Comment::first(), $like->likeable);
+        $this->assertTrue($like->likeable->is(Comment::first()));
     }
 
     public function testItLoadsChainedRelationshipsAutomatically()
@@ -93,7 +93,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $like = LikeWithSingleWith::first();
 
         $this->assertTrue($like->likeable->relationLoaded('commentable'));
-        $this->assertEquals(Post::first(), $like->likeable->commentable);
+        $this->assertTrue($like->likeable->commentable->is(Post::first()));
     }
 
     public function testItLoadsNestedRelationshipsAutomatically()
@@ -105,7 +105,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertTrue($like->relationLoaded('likeable'));
         $this->assertTrue($like->likeable->relationLoaded('owner'));
 
-        $this->assertEquals(User::first(), $like->likeable->owner);
+        $this->assertTrue($like->likeable->owner->is(User::first()));
     }
 
     public function testItLoadsNestedRelationshipsOnDemand()
@@ -117,7 +117,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertTrue($like->relationLoaded('likeable'));
         $this->assertTrue($like->likeable->relationLoaded('owner'));
 
-        $this->assertEquals(User::first(), $like->likeable->owner);
+        $this->assertTrue($like->likeable->owner->is(User::first()));
     }
 
     public function testItLoadsNestedMorphRelationshipsOnDemand()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -407,7 +407,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $userModel->delete();
         $this->assertEquals($now->toDateTimeString(), $userModel->getOriginal('deleted_at'));
         $this->assertNull(User::find(2));
-        $this->assertEquals($userModel, User::withTrashed()->find(2));
+        $this->assertTrue($userModel->is(User::withTrashed()->find(2)));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database;
 
+use Carbon\CarbonInterface;
 use Hypervel\Database\Capsule\Manager as DB;
 use Hypervel\Database\Eloquent\MissingAttributeException;
 use Hypervel\Database\Eloquent\Model;
@@ -78,6 +79,18 @@ class DatabaseEloquentWithCastsTest extends TestCase
             ->createOrFirst(['time' => '07:30']);
 
         $this->assertSame($time1->id, $time2->id);
+    }
+
+    public function testWithCastsDoesNotLeakAcrossQueries()
+    {
+        Time::query()->insert(['time' => '07:30']);
+
+        $scoped = Time::query()->withCasts(['time' => 'string'])->first();
+        $this->assertIsString($scoped->time);
+        $this->assertSame('07:30', $scoped->time);
+
+        $default = Time::query()->first();
+        $this->assertInstanceOf(CarbonInterface::class, $default->time);
     }
 
     public function testThrowsExceptionIfCastableAttributeWasNotRetrievedAndPreventMissingAttributesIsEnabled()


### PR DESCRIPTION
`Model::getCasts()` calls `array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts)` on every invocation when the model is incrementing (which is the default). It gets called from `hasCast`, `castAttribute`, `originalIsEquivalent`, `addCastAttributesToArray`, `getCastType`, `isEnumCastable`, and several other other hot paths.

This PR adds a `?array $mergedCastsCache` instance property on the `HasAttributes` trait to cache the merged result on first access. The cache is cleared everywhere `$this->casts`, `$this->primaryKey`, `$this->keyType`, or `$this->incrementing` can change:

- `mergeCasts()`, which also covers `Builder::withCasts()` since that calls `mergeCasts` internally
- `setKeyName()`, `setKeyType()`, `setIncrementing()`
- `initializeHasAttributes()` and `initializeSoftDeletes()` - the trait initialisers that mutate `$this->casts` during construction, to cover the case where a `booting` event listener calls `getCasts()` before those initialisers run
- `Model::__sleep()`, alongside the existing `$classCastCache` and `$attributeCastCache` clears, so serialised payloads don't carry derived state

The cache lives on the instance because `withCasts()`, `mergeCasts()`, and `newInstance()` can all produce two instances of the same class with different casts. Anything class-level either serves stale data or has to re-check the cast array on every call, which defeats the point. The instance property also matches the existing `$classCastCache` and `$attributeCastCache` pattern.

This is a win in normal request lifecycles too: the same model instance can hit `getCasts()` repeatedly during attribute reads, writes, dirty checks, and array / JSON serialisation.

## Test changes

The new tests cover the runtime invalidation paths: `mergeCasts()`, `setKeyName()`, `setKeyType()`, `setIncrementing()`, and the `booting` event edge case against `initializeHasAttributes` / `initializeSoftDeletes`. The per-instance and `newInstance()` tests guard against naive class-level leakage. A `withCasts()` regression test in `DatabaseEloquentWithCastsTest` exercises the full builder-to-hydration-to-attribute-access path to catch the same type of leak through real query behaviour, not just the trait in isolation. `Model::__sleep()` is also updated to clear the new derived cache alongside the existing cast caches so serialised payloads don't carry memoised state.

Several existing assertions changed from `assertEquals($modelA, $modelB)` to `$modelA->is($modelB)`. `assertEquals` on full model objects compares the internal property bag, which breaks as soon as any per-instance memoisation is added - the cache populates on one side of the comparison but not the other.
