### PR TITLE
feat: enable/disable service providers

### DIFF
--- a/src/boost/docs/providers.md
+++ b/src/boost/docs/providers.md
@@ -3,8 +3,11 @@
 - [Introduction](#introduction)
 - [Writing Service Providers](#writing-service-providers)
     - [The Register Method](#the-register-method)
+    - [Merging Configuration](#merging-configuration)
     - [The Boot Method](#the-boot-method)
+    - [Conditionally Loading Providers](#conditionally-loading-providers)
 - [Registering Providers](#registering-providers)
+    - [Provider Priority](#provider-priority)
 - [Deferred Providers](#deferred-providers)
 
 <a name="introduction"></a>
@@ -104,6 +107,39 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
+<a name="merging-configuration"></a>
+#### Merging Configuration
+
+Package service providers may merge their default configuration into the application's configuration using the `mergeConfigFrom` method. This is typically done within the `register` method:
+
+```php
+/**
+ * Register any application services.
+ */
+public function register(): void
+{
+    $this->mergeConfigFrom(
+        __DIR__.'/../config/riak.php', 'riak'
+    );
+}
+```
+
+By default, configuration is merged at the top level. If your configuration contains arrays that should allow applications to add new entries without replacing the entire array, override the `mergeableOptions` method:
+
+```php
+/**
+ * Get the options within the configuration that should be merged.
+ *
+ * @return array<int, string>
+ */
+protected function mergeableOptions(string $name): array
+{
+    return $name === 'riak' ? ['connections'] : [];
+}
+```
+
+In this example, the application's `riak.connections` entries will be merged with the package's default connections. Entries with the same key will still be replaced by the application's configuration.
+
 <a name="the-boot-method"></a>
 ### The Boot Method
 
@@ -150,6 +186,23 @@ public function boot(ResponseFactory $response): void
 }
 ```
 
+<a name="conditionally-loading-providers"></a>
+### Conditionally Loading Providers
+
+You may prevent a service provider from being registered or booted by overriding the `isEnabled` method. This is useful for packages that are installed in many applications but should only load in some of them:
+
+```php
+/**
+ * Determine whether this provider should be registered and booted.
+ */
+public function isEnabled(): bool
+{
+    return (bool) config('modules.riak.enabled');
+}
+```
+
+When this method returns `false`, the provider's `register` and `boot` methods will not be called, its `bindings` and `singletons` properties will not be processed, and the provider will not be marked as loaded.
+
 <a name="registering-providers"></a>
 ## Registering Providers
 
@@ -173,6 +226,25 @@ return [
     App\Providers\ComposerServiceProvider::class, // [tl! add]
 ];
 ```
+
+<a name="provider-priority"></a>
+### Provider Priority
+
+Auto-discovered package providers may define a `priority` property to control their registration order relative to other discovered package providers. Providers with a higher priority are registered first:
+
+```php
+use Hypervel\Support\ServiceProvider;
+
+class RiakServiceProvider extends ServiceProvider
+{
+    /**
+     * The registration priority for this provider.
+     */
+    public int $priority = 10;
+}
+```
+
+Provider priority only applies to auto-discovered package providers. Framework providers are always registered before discovered package providers, and application providers are registered after them.
 
 <a name="deferred-providers"></a>
 ## Deferred Providers

--- a/src/foundation/src/Application.php
+++ b/src/foundation/src/Application.php
@@ -950,6 +950,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $provider = $this->resolveProvider($provider);
         }
 
+        // Hypervel-specific: providers may opt out of registration via isEnabled()
+        // returning false (e.g. gated on runtime config/env). A disabled provider
+        // is instantiated but never registered or booted, its bindings/singletons
+        // properties are skipped, and it is not tracked as a registered provider.
+        if (! $provider->isEnabled()) {
+            return $provider;
+        }
+
         $provider->register();
 
         // If there are bindings / singletons set as properties on the provider we

--- a/src/support/src/ServiceProvider.php
+++ b/src/support/src/ServiceProvider.php
@@ -83,6 +83,20 @@ abstract class ServiceProvider
     }
 
     /**
+     * Determine whether this provider should be registered and booted.
+     *
+     * Hypervel-specific extension (not in Laravel). Override on a subclass to
+     * gate registration on runtime config / env / feature flags. When this
+     * returns false the provider is instantiated but neither register() nor
+     * boot() is called, its bindings/singletons properties are not processed,
+     * and it is not tracked in the application's provider list.
+     */
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
+    /**
      * Register any application services.
      */
     public function register(): void

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -14,6 +14,7 @@ use Hypervel\Foundation\Events\LocaleUpdated;
 use Hypervel\Support\ServiceProvider;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
+use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -63,6 +64,7 @@ class FoundationApplicationTest extends TestCase
     {
         $provider = m::mock(ApplicationBasicServiceProviderStub::class);
         $class = get_class($provider);
+        $provider->shouldReceive('isEnabled')->andReturn(true);
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
@@ -114,6 +116,7 @@ class FoundationApplicationTest extends TestCase
     {
         $provider = m::mock(ServiceProvider::class);
         $class = get_class($provider);
+        $provider->shouldReceive('isEnabled')->andReturn(true);
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
@@ -125,12 +128,70 @@ class FoundationApplicationTest extends TestCase
     {
         $provider = m::mock(ServiceProvider::class);
         $class = get_class($provider);
+        $provider->shouldReceive('isEnabled')->andReturn(true);
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
 
         $this->assertTrue($app->providerIsLoaded($class));
         $this->assertFalse($app->providerIsLoaded(ApplicationBasicServiceProviderStub::class));
+    }
+
+    public function testDisabledServiceProviderIsNotRegisteredOrTracked()
+    {
+        $app = new Application;
+        $app->register($provider = new ApplicationDisabledServiceProviderStub($app));
+
+        $this->assertArrayNotHasKey(get_class($provider), $app->getLoadedProviders());
+        $this->assertFalse($app->providerIsLoaded(get_class($provider)));
+        $this->assertNull($app->getProvider(get_class($provider)));
+        $this->assertSame([], $app->getProviders(get_class($provider)));
+    }
+
+    public function testDisabledServiceProviderBindingsArrayIsSkipped()
+    {
+        $app = new Application;
+        $app->register(new class($app) extends ServiceProvider {
+            public $bindings = [
+                AbstractClass::class => ConcreteClass::class,
+            ];
+
+            public function isEnabled(): bool
+            {
+                return false;
+            }
+        });
+
+        $this->assertFalse($app->bound(AbstractClass::class));
+    }
+
+    public function testDisabledServiceProviderSingletonsArrayIsSkipped()
+    {
+        $app = new Application;
+        $app->register(new class($app) extends ServiceProvider {
+            public $singletons = [
+                AbstractClass::class => ConcreteClass::class,
+            ];
+
+            public function isEnabled(): bool
+            {
+                return false;
+            }
+        });
+
+        $this->assertFalse($app->bound(AbstractClass::class));
+    }
+
+    public function testDisabledServiceProviderIsNotBootedWhenAppAlreadyBooted()
+    {
+        $app = new Application;
+        $app->boot();
+
+        // boot() throws if called — passing the late-register branch without
+        // the isEnabled() check would call bootProvider() and trigger it.
+        $app->register(new ApplicationDisabledServiceProviderStub($app));
+
+        $this->assertTrue($app->isBooted());
     }
 
     public function testEnvironment()
@@ -666,6 +727,24 @@ class ApplicationBasicServiceProviderStub extends ServiceProvider
 
     public function register(): void
     {
+    }
+}
+
+class ApplicationDisabledServiceProviderStub extends ServiceProvider
+{
+    public function isEnabled(): bool
+    {
+        return false;
+    }
+
+    public function register(): void
+    {
+        throw new RuntimeException('register() must not be called on a disabled provider');
+    }
+
+    public function boot(): void
+    {
+        throw new RuntimeException('boot() must not be called on a disabled provider');
     }
 }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -7,8 +7,8 @@ namespace Hypervel\Tests\Support;
 use Hypervel\Config\Repository as ConfigRepository;
 use Hypervel\Foundation\Application;
 use Hypervel\Support\ServiceProvider;
+use Hypervel\Tests\TestCase;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
 
 class SupportServiceProviderTest extends TestCase
 {
@@ -16,6 +16,8 @@ class SupportServiceProviderTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->app = $app = m::mock(Application::class)->makePartial();
 
         $config = new ConfigRepository([
@@ -27,6 +29,33 @@ class SupportServiceProviderTest extends TestCase
         $one->boot();
         $two = new ServiceProviderForTestingTwo($app);
         $two->boot();
+    }
+
+    public function testIsEnabledReturnsTrueByDefault()
+    {
+        $provider = new ServiceProviderForTestingOne($this->app);
+
+        $this->assertTrue($provider->isEnabled());
+    }
+
+    public function testIsEnabledCanBeOverriddenToReturnFalse()
+    {
+        $provider = new ServiceProviderForTestingDisabled($this->app);
+
+        $this->assertFalse($provider->isEnabled());
+    }
+
+    public function testIsEnabledCanReadFromContainerAndConfig()
+    {
+        $config = new ConfigRepository(['package' => ['enabled' => true]]);
+        $app = m::mock(Application::class)->makePartial();
+        $app->shouldReceive('make')->with('config')->andReturn($config);
+
+        $provider = new ServiceProviderForTestingConditionallyEnabled($app);
+        $this->assertTrue($provider->isEnabled());
+
+        $config->set('package.enabled', false);
+        $this->assertFalse($provider->isEnabled());
     }
 
     public function testPublishableServiceProviders()
@@ -473,6 +502,22 @@ class ServiceProviderForTestingTwo extends ServiceProvider
         $this->publishes(['source/unmarked/two/c' => 'destination/tagged/two/a']);
         $this->publishes(['source/tagged/two/a' => 'destination/tagged/two/a'], 'some_tag');
         $this->publishes(['source/tagged/two/b' => 'destination/tagged/two/b'], 'some_tag');
+    }
+}
+
+class ServiceProviderForTestingDisabled extends ServiceProvider
+{
+    public function isEnabled(): bool
+    {
+        return false;
+    }
+}
+
+class ServiceProviderForTestingConditionallyEnabled extends ServiceProvider
+{
+    public function isEnabled(): bool
+    {
+        return (bool) $this->app->make('config')->get('package.enabled', false);
     }
 }
 


### PR DESCRIPTION
This PR adds `ServiceProvider::isEnabled()`, giving providers a simple way to opt out of registration and booting.

The default implementation returns `true`, so existing providers keep working exactly as before. Packages that need conditional loading can override it and read from config, env or any other application state available during provider registration:

```php
public function isEnabled(): bool
{
    return (bool) config('modules.billing.enabled');
}
```

When a provider is disabled, Hypervel skips `register()`, skips `boot()`, does not process the provider's `bindings` / `singletons` properties, and does not mark the provider as loaded. This makes it useful for modular codebases where the same package set is installed across multiple apps, but each app enables only the modules it actually uses.

This also pairs nicely with the existing `$priority` property, which allows setting a custom load order. 