### PR TITLE
fix: fix sleep time when no jobs are fetched

### DIFF
--- a/src/queue/src/Worker.php
+++ b/src/queue/src/Worker.php
@@ -182,11 +182,11 @@ class Worker
             if ($job) {
                 ++$jobsProcessed;
                 $concurrent->create(fn () => $this->runJob($job, $connectionName, $options));
-            }
 
-            if ($job && $options->rest > 0) {
-                $this->sleep($options->rest);
-            } elseif (! $job && $jobsProcessed) {
+                if ($options->rest > 0) {
+                    $this->sleep($options->rest);
+                }
+            } else {
                 $this->sleep($options->sleep);
             }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -123,6 +123,22 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->twice();
     }
 
+    public function testDaemonSleepsWhenQueueIsEmptyAtStartup()
+    {
+        // Regression: the idle branch must sleep even when $jobsProcessed is still 0
+        // (i.e. on the very first loop iteration with an empty queue).
+        $workerOptions = new WorkerOptions();
+        $workerOptions->stopWhenEmpty = true;
+        $workerOptions->sleep = 5;
+
+        $worker = $this->getWorker('default', ['queue' => []]);
+
+        $status = $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->assertEquals(5, $worker->sleptFor);
+        $this->assertSame(Worker::EXIT_SUCCESS, $status);
+    }
+
     public function testWorkerStopsWhenMemoryExceeded()
     {
         $workerOptions = new WorkerOptions();


### PR DESCRIPTION
### Problem

The queue worker's sleep behavior was incorrect when no jobs were available. The previous condition `elseif (! $job && $jobsProcessed)` only triggered the sleep when **both** no job was fetched **and** at least one job had already been processed in the current loop. This meant the worker would spin in a tight loop without sleeping during idle periods at startup or after draining the queue — until at least one job had been processed.

### Solution

Simplify the idle-sleep condition to a plain `else` (i.e., whenever no job was fetched). This ensures the configured `sleep` duration is always respected when the queue is empty, regardless of how many jobs have been processed in the session.

Additionally, move the `rest` sleep (post-job delay) inside the `if ($job)` block where it logically belongs, replacing the redundant `$job &&` guard.

### Changes

- `src/queue/src/Worker.php` — Fixed sleep-time logic in the coroutine worker loop

### Before / After

```php
// Before
if ($job && $options->rest > 0) {
    $this->sleep($options->rest);
} elseif (! $job && $jobsProcessed) {   // ← only sleeps if a job was processed before
    $this->sleep($options->sleep);
}

// After
if ($job) {
    if ($options->rest > 0) {
        $this->sleep($options->rest);
    }
} else {                                 // ← always sleeps when queue is empty
    $this->sleep($options->sleep);
}

