### PR TITLE
fix: Sanctum middleware config mutation

### DIFF
--- a/src/boost/docs/session.md
+++ b/src/boost/docs/session.md
@@ -11,6 +11,7 @@
     - [Regenerating the Session ID](#regenerating-the-session-id)
 - [Session Cache](#session-cache)
 - [Session Blocking](#session-blocking)
+- [Configuring the Session Cookie](#configuring-the-session-cookie)
 - [Adding Custom Session Drivers](#adding-custom-session-drivers)
     - [Implementing the Driver](#implementing-the-driver)
     - [Registering the Driver](#registering-the-driver)
@@ -328,6 +329,42 @@ Route::post('/profile', function () {
     // ...
 })->block();
 ```
+
+<a name="configuring-the-session-cookie"></a>
+## Configuring the Session Cookie
+
+Session cookie attributes are normally configured using your application's `config/session.php` configuration file. If you need to determine session cookie attributes dynamically for each request, you may register a callback using the `configureSessionCookieUsing` method on the `StartSession` middleware.
+
+This method should typically be called from the `boot` method of a [service provider](/docs/{{version}}/providers):
+
+```php
+<?php
+
+namespace App\Providers;
+
+use Hypervel\Http\Request;
+use Hypervel\Session\Middleware\StartSession;
+use Hypervel\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            return array_replace($cookie, [
+                'domain' => tenant()->sessionCookieDomain(),
+            ]);
+        });
+    }
+}
+```
+
+The callback receives the current request and the session cookie configuration, and should return the modified cookie configuration. This is useful when cookie attributes, such as the cookie domain, depend on the current request. In this example, `tenant()` represents an application-specific helper that returns the current tenant.
+
+If multiple callbacks are registered, they will be executed in the order they were registered. Each callback receives the cookie configuration returned by the previous callback.
 
 <a name="adding-custom-session-drivers"></a>
 ## Adding Custom Session Drivers

--- a/src/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -19,8 +19,6 @@ class EnsureFrontendRequestsAreStateful
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $this->configureSecureCookieSessions();
-
         return (new Pipeline(app()))->send($request)->through(
             static::fromFrontend($request) ? $this->frontendMiddleware() : []
         )->then(function ($request) use ($next) {
@@ -84,16 +82,5 @@ class EnsureFrontendRequestsAreStateful
     public static function statefulDomains(): array
     {
         return config('sanctum.stateful', []);
-    }
-
-    /**
-     * Configure secure cookie sessions.
-     */
-    protected function configureSecureCookieSessions(): void
-    {
-        config([
-            'session.http_only' => true,
-            'session.same_site' => 'lax',
-        ]);
     }
 }

--- a/src/sanctum/src/SanctumGuard.php
+++ b/src/sanctum/src/SanctumGuard.php
@@ -275,4 +275,14 @@ class SanctumGuard implements GuardContract
 
         return "__auth.guards.{$this->name}.user." . md5($token);
     }
+
+    /**
+     * Flush all static state back to defaults.
+     *
+     * Boot or tests only. Resets registered macros on the guard class.
+     */
+    public static function flushState(): void
+    {
+        static::flushMacros();
+    }
 }

--- a/src/sanctum/src/SanctumServiceProvider.php
+++ b/src/sanctum/src/SanctumServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Hypervel\Sanctum;
 
 use Hypervel\Auth\AuthManager;
+use Hypervel\Http\Request;
 use Hypervel\Sanctum\Console\Commands\PruneExpired;
+use Hypervel\Session\Middleware\StartSession;
 use Hypervel\Support\Facades\Route;
 use Hypervel\Support\ServiceProvider;
 
@@ -28,6 +30,8 @@ class SanctumServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerSanctumGuard();
+        $this->configureSessionCookies();
+
         if ($this->app->runningInConsole()) {
             $this->registerPublishing();
             $this->registerCommands();
@@ -51,6 +55,23 @@ class SanctumServiceProvider extends ServiceProvider
                     expiration: $app['config']->get('sanctum.expiration'),
                 );
             });
+        });
+    }
+
+    /**
+     * Configure session cookies for stateful frontend requests.
+     */
+    protected function configureSessionCookies(): void
+    {
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            if (! $request->attributes->get('sanctum')) {
+                return $cookie;
+            }
+
+            return array_replace($cookie, [
+                'http_only' => true,
+                'same_site' => 'lax',
+            ]);
         });
     }
 

--- a/src/session/src/Middleware/StartSession.php
+++ b/src/session/src/Middleware/StartSession.php
@@ -24,6 +24,13 @@ use Throwable;
 class StartSession
 {
     /**
+     * The callbacks used to configure the session cookie attributes.
+     *
+     * @var array<int, Closure>
+     */
+    protected static array $sessionCookieCallbacks = [];
+
+    /**
      * Create a new session middleware.
      */
     public function __construct(
@@ -106,7 +113,7 @@ class StartSession
 
             $this->storeCurrentUrl($request, $session);
 
-            $this->addCookieToResponse($response, $session);
+            $this->addCookieToResponse($request, $response, $session);
 
             // Again, if the session has been configured we will need to close out the session
             // so that the attributes may be persisted to some storage medium. We will also
@@ -189,10 +196,10 @@ class StartSession
     /**
      * Add the session cookie to the application response.
      */
-    protected function addCookieToResponse(Response $response, Session $session): void
+    protected function addCookieToResponse(Request $request, Response $response, Session $session): void
     {
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
-            $cookieConfig = $this->getSessionCookieConfig($config);
+            $cookieConfig = $this->resolveSessionCookieConfig($request, $config);
 
             $response->headers->setCookie(new Cookie(
                 $session->getName(),
@@ -212,14 +219,11 @@ class StartSession
     /**
      * Get the session cookie configuration.
      *
-     * Extracted as an extension point so subclasses can provide dynamic
-     * cookie settings without duplicating the rest of addCookieToResponse.
-     *
      * @return array{path: string, domain: string, secure: ?bool, http_only: bool, same_site: ?string, partitioned: bool}
      */
-    protected function getSessionCookieConfig(array $config): array
+    protected function resolveSessionCookieConfig(Request $request, array $config): array
     {
-        return [
+        $cookieConfig = [
             'path' => $config['path'] ?? '/',
             'domain' => $config['domain'] ?? '',
             'secure' => $config['secure'] ?? null,
@@ -227,6 +231,27 @@ class StartSession
             'same_site' => $config['same_site'] ?? null,
             'partitioned' => $config['partitioned'] ?? false,
         ];
+
+        foreach (static::$sessionCookieCallbacks as $callback) {
+            $cookieConfig = $callback($request, $cookieConfig);
+        }
+
+        return $cookieConfig;
+    }
+
+    /**
+     * Register a callback to configure the session cookie attributes.
+     *
+     * Boot-only. The callback persists in a static property for the worker
+     * lifetime and runs on every session cookie write across all coroutines.
+     * Callbacks run in registration order; later callbacks receive the values
+     * returned by earlier callbacks and may overwrite them.
+     *
+     * @param Closure(Request, array): array $callback
+     */
+    public static function configureSessionCookieUsing(Closure $callback): void
+    {
+        static::$sessionCookieCallbacks[] = $callback;
     }
 
     /**
@@ -275,5 +300,15 @@ class StartSession
         $config = $config ?: $this->manager->getSessionConfig();
 
         return ! is_null($config['driver'] ?? null);
+    }
+
+    /**
+     * Flush all static state back to defaults.
+     *
+     * Boot or tests only. Resets the registered cookie configuration callbacks.
+     */
+    public static function flushState(): void
+    {
+        static::$sessionCookieCallbacks = [];
     }
 }

--- a/tests/AfterEachTestSubscriber.php
+++ b/tests/AfterEachTestSubscriber.php
@@ -143,12 +143,14 @@ final class AfterEachTestSubscriber implements FinishedSubscriber
         \Hypervel\Routing\SortedMiddleware::flushCache();
         \Hypervel\Routing\UrlGenerator::flushState();
         \Hypervel\Sanctum\Sanctum::flushState();
+        \Hypervel\Sanctum\SanctumGuard::flushState();
         \Hypervel\Scout\Builder::flushState();
         \Hypervel\Scout\Scout::flushState();
         \Hypervel\Server\ServerManager::flushState();
         \Hypervel\ServerProcess\ProcessCollector::flushState();
         \Hypervel\ServerProcess\ProcessManager::flushState();
         \Hypervel\Session\Middleware\AuthenticateSession::flushState();
+        \Hypervel\Session\Middleware\StartSession::flushState();
         \Hypervel\Session\Store::flushState();
         \Hypervel\Support\Arr::flushState();
         \Hypervel\Support\BinaryCodec::flushState();

--- a/tests/Routing/RoutingStaticStateTest.php
+++ b/tests/Routing/RoutingStaticStateTest.php
@@ -12,8 +12,8 @@ use Hypervel\Routing\Redirector;
 use Hypervel\Routing\ResponseFactory;
 use Hypervel\Routing\Route;
 use Hypervel\Routing\RouteCollection;
-use Hypervel\Routing\RouteRegistrar;
 use Hypervel\Routing\Router;
+use Hypervel\Routing\RouteRegistrar;
 use Hypervel\Routing\UrlGenerator;
 use Hypervel\Tests\Routing\RoutingTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -36,12 +36,24 @@ class RoutingStaticStateTest extends RoutingTestCase
         $this->assertFalse($class::hasMacro('routingFlushProbe'));
     }
 
+    public static function macroableRoutingClasses(): array
+    {
+        return [
+            [PendingResourceRegistration::class],
+            [PendingSingletonResourceRegistration::class],
+            [Redirector::class],
+            [ResponseFactory::class],
+            [RouteRegistrar::class],
+            [Router::class],
+        ];
+    }
+
     public function testRouteFlushStateClearsEnumCache(): void
     {
         $enumCache = new ReflectionProperty(Route::class, 'enumCache');
-        $enumCache->setValue(null, ['Some\\Enum' => true]);
+        $enumCache->setValue(null, ['Some\Enum' => true]);
 
-        $this->assertSame(['Some\\Enum' => true], $enumCache->getValue());
+        $this->assertSame(['Some\Enum' => true], $enumCache->getValue());
 
         Route::flushState();
 
@@ -78,17 +90,5 @@ class RoutingStaticStateTest extends RoutingTestCase
         ThrottleRequests::flushState();
 
         $this->assertTrue($shouldHashKeys->getValue());
-    }
-
-    public static function macroableRoutingClasses(): array
-    {
-        return [
-            [PendingResourceRegistration::class],
-            [PendingSingletonResourceRegistration::class],
-            [Redirector::class],
-            [ResponseFactory::class],
-            [RouteRegistrar::class],
-            [Router::class],
-        ];
     }
 }

--- a/tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php
@@ -82,7 +82,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
 
         $request = Request::create('http://localhost', server: ['HTTP_ORIGIN' => 'https://wrong.com']);
 
-        (new EnsureFrontendRequestsAreStateful())->handle($request, fn () => new Response('ok'));
+        (new EnsureFrontendRequestsAreStateful)->handle($request, fn () => new Response('ok'));
 
         $this->assertFalse($this->app->make('config')->get('session.http_only'));
         $this->assertSame('strict', $this->app->make('config')->get('session.same_site'));

--- a/tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Sanctum;
 
 use Hypervel\Http\Request;
+use Hypervel\Http\Response;
 use Hypervel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use Hypervel\Testbench\TestCase;
 
@@ -70,6 +71,21 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
 
         // Custom middleware with overridden statefulDomains SHOULD match
         $this->assertTrue(CustomStatefulMiddleware::fromFrontend($request));
+    }
+
+    public function testMiddlewareDoesNotMutateSessionConfig(): void
+    {
+        $this->app->make('config')->set([
+            'session.http_only' => false,
+            'session.same_site' => 'strict',
+        ]);
+
+        $request = Request::create('http://localhost', server: ['HTTP_ORIGIN' => 'https://wrong.com']);
+
+        (new EnsureFrontendRequestsAreStateful())->handle($request, fn () => new Response('ok'));
+
+        $this->assertFalse($this->app->make('config')->get('session.http_only'));
+        $this->assertSame('strict', $this->app->make('config')->get('session.same_site'));
     }
 }
 

--- a/tests/Sanctum/FrontendCookieHardeningTest.php
+++ b/tests/Sanctum/FrontendCookieHardeningTest.php
@@ -74,7 +74,7 @@ class FrontendCookieHardeningTest extends TestCase
             'HTTP_ORIGIN' => 'https://test.com',
         ]);
 
-        return (new EnsureFrontendRequestsAreStateful())
+        return (new EnsureFrontendRequestsAreStateful)
             ->handle($request, fn () => new Response('ok'));
     }
 

--- a/tests/Sanctum/FrontendCookieHardeningTest.php
+++ b/tests/Sanctum/FrontendCookieHardeningTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Sanctum;
+
+use Hypervel\Http\Request;
+use Hypervel\Http\Response;
+use Hypervel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Hypervel\Sanctum\SanctumServiceProvider;
+use Hypervel\Session\Middleware\StartSession;
+use Hypervel\Testbench\TestCase;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class FrontendCookieHardeningTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make('config')->set([
+            'session.driver' => 'array',
+            'session.http_only' => false,
+            'session.same_site' => 'strict',
+            'sanctum.stateful' => ['test.com'],
+        ]);
+
+        $provider = $this->app->make(SanctumServiceProvider::class);
+        $provider->register();
+        $provider->boot();
+    }
+
+    public function testStatefulFrontendRequestForcesSecureSessionCookieAttributes(): void
+    {
+        $cookie = $this->sessionCookie($this->handleStatefulFrontendRequest());
+
+        $this->assertTrue($cookie->isHttpOnly());
+        $this->assertSame('lax', $cookie->getSameSite());
+        $this->assertFalse($this->app->make('config')->get('session.http_only'));
+        $this->assertSame('strict', $this->app->make('config')->get('session.same_site'));
+    }
+
+    public function testSanctumSessionCookieHonorsApplicationCookieCallbacks(): void
+    {
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            $cookie['domain'] = '.example.com';
+
+            return $cookie;
+        });
+
+        $cookie = $this->sessionCookie($this->handleStatefulFrontendRequest());
+
+        $this->assertSame('.example.com', $cookie->getDomain());
+        $this->assertTrue($cookie->isHttpOnly());
+        $this->assertSame('lax', $cookie->getSameSite());
+    }
+
+    public function testNonSanctumSessionCookieDoesNotReceiveSanctumHardening(): void
+    {
+        $request = Request::create('http://localhost/normal', 'GET');
+
+        $response = $this->app->make(StartSession::class)
+            ->handle($request, fn () => new Response('ok'));
+
+        $cookie = $this->sessionCookie($response);
+
+        $this->assertFalse($cookie->isHttpOnly());
+        $this->assertSame('strict', $cookie->getSameSite());
+    }
+
+    protected function handleStatefulFrontendRequest(): Response
+    {
+        $request = Request::create('http://localhost/probe', 'GET', server: [
+            'HTTP_ORIGIN' => 'https://test.com',
+        ]);
+
+        return (new EnsureFrontendRequestsAreStateful())
+            ->handle($request, fn () => new Response('ok'));
+    }
+
+    protected function sessionCookie(Response $response): Cookie
+    {
+        $sessionCookieName = $this->app->make('config')->get('session.cookie');
+
+        foreach ($response->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === $sessionCookieName) {
+                return $cookie;
+            }
+        }
+
+        $this->fail("Session cookie [{$sessionCookieName}] was not set.");
+    }
+}

--- a/tests/Sanctum/SanctumGuardStaticStateTest.php
+++ b/tests/Sanctum/SanctumGuardStaticStateTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Sanctum;
+
+use Hypervel\Sanctum\SanctumGuard;
+use Hypervel\Tests\TestCase;
+
+class SanctumGuardStaticStateTest extends TestCase
+{
+    public function testFlushStateClearsSanctumGuardMacros(): void
+    {
+        SanctumGuard::macro('staticStateProbe', static fn (): string => 'ok');
+
+        $this->assertTrue(SanctumGuard::hasMacro('staticStateProbe'));
+
+        SanctumGuard::flushState();
+
+        $this->assertFalse(SanctumGuard::hasMacro('staticStateProbe'));
+    }
+}

--- a/tests/Session/Middleware/StartSessionTest.php
+++ b/tests/Session/Middleware/StartSessionTest.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Session\Middleware;
 
+use Hypervel\Http\Request;
 use Hypervel\Session\Middleware\StartSession;
-use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
+use Hypervel\Support\ClassInvoker;
+use Hypervel\Tests\TestCase;
 
 class StartSessionTest extends TestCase
 {
-    public function testGetSessionCookieConfigReturnsDefaults(): void
+    public function testResolveSessionCookieConfigReturnsDefaults(): void
     {
         $middleware = $this->createStartSessionMock();
 
-        $config = $this->invokeGetSessionCookieConfig($middleware, []);
+        $config = $this->invokeResolveSessionCookieConfig($middleware, Request::create('/'), []);
 
         $this->assertSame('/', $config['path']);
         $this->assertSame('', $config['domain']);
@@ -24,11 +25,11 @@ class StartSessionTest extends TestCase
         $this->assertFalse($config['partitioned']);
     }
 
-    public function testGetSessionCookieConfigReturnsConfiguredValues(): void
+    public function testResolveSessionCookieConfigReturnsConfiguredValues(): void
     {
         $middleware = $this->createStartSessionMock();
 
-        $config = $this->invokeGetSessionCookieConfig($middleware, [
+        $config = $this->invokeResolveSessionCookieConfig($middleware, Request::create('/'), [
             'path' => '/app',
             'domain' => '.example.com',
             'secure' => true,
@@ -45,19 +46,84 @@ class StartSessionTest extends TestCase
         $this->assertTrue($config['partitioned']);
     }
 
-    public function testGetSessionCookieConfigCanBeOverridden(): void
+    public function testSessionCookieConfigCanBeConfiguredUsingCallback(): void
     {
-        $middleware = new CustomStartSession;
+        $middleware = $this->createStartSessionMock();
 
-        $config = $this->invokeGetSessionCookieConfig($middleware, [
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            $cookie['domain'] = '.custom.example.com';
+
+            return $cookie;
+        });
+
+        $config = $this->invokeResolveSessionCookieConfig($middleware, Request::create('/'), [
             'path' => '/',
             'domain' => '.example.com',
         ]);
 
-        // Custom middleware overrides domain
         $this->assertSame('.custom.example.com', $config['domain']);
-        // Other values come from config
         $this->assertSame('/', $config['path']);
+    }
+
+    public function testSessionCookieConfigCallbacksReceiveRequest(): void
+    {
+        $middleware = $this->createStartSessionMock();
+
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            $cookie['domain'] = '.' . $request->getHost();
+
+            return $cookie;
+        });
+
+        $config = $this->invokeResolveSessionCookieConfig(
+            $middleware,
+            Request::create('https://tenant.example.com'),
+            []
+        );
+
+        $this->assertSame('.tenant.example.com', $config['domain']);
+    }
+
+    public function testSessionCookieConfigCallbacksComposeInRegistrationOrder(): void
+    {
+        $middleware = $this->createStartSessionMock();
+
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            $cookie['same_site'] = 'strict';
+            $cookie['domain'] = '.first.example.com';
+
+            return $cookie;
+        });
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            $cookie['same_site'] = 'lax';
+
+            return $cookie;
+        });
+
+        $config = $this->invokeResolveSessionCookieConfig($middleware, Request::create('/'), []);
+
+        $this->assertSame('.first.example.com', $config['domain']);
+        $this->assertSame('lax', $config['same_site']);
+    }
+
+    public function testFlushStateClearsSessionCookieCallbacks(): void
+    {
+        $middleware = $this->createStartSessionMock();
+
+        StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
+            $cookie['domain'] = '.custom.example.com';
+
+            return $cookie;
+        });
+
+        $this->assertSame(
+            '.custom.example.com',
+            $this->invokeResolveSessionCookieConfig($middleware, Request::create('/'), [])['domain']
+        );
+
+        StartSession::flushState();
+
+        $this->assertSame('', $this->invokeResolveSessionCookieConfig($middleware, Request::create('/'), [])['domain']);
     }
 
     private function createStartSessionMock(): StartSession
@@ -65,33 +131,9 @@ class StartSessionTest extends TestCase
         return new TestStartSession;
     }
 
-    private function invokeGetSessionCookieConfig(StartSession $middleware, array $config): array
+    private function invokeResolveSessionCookieConfig(StartSession $middleware, Request $request, array $config): array
     {
-        $method = new ReflectionMethod($middleware, 'getSessionCookieConfig');
-        $method->setAccessible(true);
-
-        return $method->invoke($middleware, $config);
-    }
-}
-
-/**
- * Custom middleware for testing getSessionCookieConfig override.
- */
-class CustomStartSession extends StartSession
-{
-    public function __construct()
-    {
-        // Skip parent constructor for testing
-    }
-
-    protected function getSessionCookieConfig(array $config): array
-    {
-        $cookieConfig = parent::getSessionCookieConfig($config);
-
-        // Override domain
-        $cookieConfig['domain'] = '.custom.example.com';
-
-        return $cookieConfig;
+        return (new ClassInvoker($middleware))->resolveSessionCookieConfig($request, $config);
     }
 }
 


### PR DESCRIPTION
This PR cleans up Sanctum so it no longer mutate's configuration per-request. It also refactor's the previous extension point we added to a static method so it can be set in a service provider.

## Summary

- Add `StartSession::configureSessionCookieUsing()` so session cookie attributes can be customized per request from a service provider, without subclassing the session middleware.
- Move Sanctum's stateful frontend cookie hardening onto that hook instead of mutating the global config repository during request handling.
- Add static-state cleanup for the new session callback registry and `SanctumGuard` macros, with regression coverage for cookie hardening, callback composition, and test isolation.

## Details

Sanctum previously called `config()` from `EnsureFrontendRequestsAreStateful::handle()` to force `session.http_only = true` and `session.same_site = lax`. That is safe in Laravel's request model, but not in Hypervel workers: the config repository is process-global, so request-time writes can leak into other requests handled by the same worker. Technically it wasn't causing problems but it's a worthwhile correctness cleanup.

This PR keeps Sanctum's behavior without the global mutation. `StartSession` now supports boot-time registration of request-aware cookie configuration callbacks:

```php
StartSession::configureSessionCookieUsing(function (Request $request, array $cookie): array {
    return array_replace($cookie, [
        'domain' => tenant()->sessionCookieDomain(),
    ]);
});
```

Callbacks run when the session cookie is written, receive the current request and current cookie configuration, and compose in registration order. Sanctum registers one of these callbacks during provider boot and only applies its `http_only` / `same_site` hardening when the existing Sanctum request attribute is present.

This also replaces the older protected-method extension point. Customizing session cookie attributes no longer requires creating a child middleware class and swapping it into the middleware stack; apps can now configure the behavior directly from a service provider, which is closer to Laravel's `...Using()` extension style and easier to use for multi-tenant cookie settings.

## Tests

- `./vendor/bin/phpunit tests/Session/Middleware/StartSessionTest.php`
- `./vendor/bin/phpunit tests/Session`
- `./vendor/bin/phpunit tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php tests/Sanctum/FrontendCookieHardeningTest.php tests/Sanctum/SanctumGuardStaticStateTest.php`
- `./vendor/bin/phpunit tests/Sanctum`
- `./vendor/bin/phpunit tests/Session tests/Sanctum`
- `./vendor/bin/phpstan analyse src/session/src src/sanctum/src tests/Session/Middleware/StartSessionTest.php tests/Sanctum tests/AfterEachTestSubscriber.php`
