### PR TITLE
feat: Socialite OIDC JWKS refresh

### DIFF
--- a/src/socialite/src/Two/OpenIdProvider.php
+++ b/src/socialite/src/Two/OpenIdProvider.php
@@ -6,6 +6,7 @@ namespace Hypervel\Socialite\Two;
 
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
+use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\RequestOptions;
 use Hypervel\Http\RedirectResponse;
 use Hypervel\Socialite\Two\Exceptions\ConfigurationFetchingException;
@@ -15,6 +16,7 @@ use Hypervel\Socialite\Two\Exceptions\InvalidNonceException;
 use Hypervel\Socialite\Two\Exceptions\InvalidUserInfoUrlException;
 use Hypervel\Support\Str;
 use Throwable;
+use UnexpectedValueException;
 
 abstract class OpenIdProvider extends AbstractProvider
 {
@@ -33,6 +35,16 @@ abstract class OpenIdProvider extends AbstractProvider
      * This is used to verify the JWT tokens.
      */
     protected ?array $jwks = null;
+
+    /**
+     * The timestamp of the last forced JWKS refresh attempt.
+     */
+    protected ?int $jwksRefreshAttemptedAt = null;
+
+    /**
+     * The minimum seconds between forced JWKS refreshes.
+     */
+    protected int $jwksRefreshCooldownSeconds = 10;
 
     /**
      * Get the base URL for the OIDC provider.
@@ -101,9 +113,9 @@ abstract class OpenIdProvider extends AbstractProvider
     /**
      * Get the jwks URI for the provider.
      */
-    protected function getJwksUri(): string
+    protected function getJwksUri(bool $refresh = false): string
     {
-        return $this->getOpenIdConfig()['jwks_uri'];
+        return $this->getOpenIdConfig($refresh)['jwks_uri'];
     }
 
     /**
@@ -153,9 +165,9 @@ abstract class OpenIdProvider extends AbstractProvider
     /**
      * @throws ConfigurationFetchingException
      */
-    protected function getOpenIdConfig(): array
+    protected function getOpenIdConfig(bool $refresh = false): array
     {
-        if ($this->openidConfig) {
+        if ($this->openidConfig && ! $refresh) {
             return $this->openidConfig;
         }
 
@@ -182,18 +194,36 @@ abstract class OpenIdProvider extends AbstractProvider
     /**
      * Get the JSON Web Key Set (JWKS) for the provider.
      */
-    protected function getJwks(): array
+    protected function getJwks(bool $refresh = false): array
     {
-        if ($this->jwks) {
+        if ($this->jwks && ! $refresh) {
             return $this->jwks;
         }
 
+        if ($this->jwks && ! $this->canRefreshJwks($refresh)) {
+            return $this->jwks;
+        }
+
+        if ($refresh) {
+            $this->jwksRefreshAttemptedAt = time();
+        }
+
         $response = $this->getHttpClient()
-            ->get($this->getJwksUri());
+            ->get($this->getJwksUri($refresh));
 
         return $this->jwks = JWK::parseKeySet(
             json_decode((string) $response->getBody(), true)
         );
+    }
+
+    /**
+     * Determine if the JWKS can be force-refreshed.
+     */
+    protected function canRefreshJwks(bool $refresh): bool
+    {
+        return ! $refresh
+            || $this->jwksRefreshAttemptedAt === null
+            || (time() - $this->jwksRefreshAttemptedAt) >= $this->jwksRefreshCooldownSeconds;
     }
 
     /**
@@ -243,9 +273,20 @@ abstract class OpenIdProvider extends AbstractProvider
      */
     protected function getUserByOIDCToken(string $token): ?array
     {
-        $this->validateOIDCPayload(
-            $data = (array) JWT::decode($token, $this->getJwks())
-        );
+        try {
+            $data = (array) JWT::decode($token, $this->getJwks());
+        } catch (SignatureInvalidException) {
+            // Some providers briefly replace key material under an existing kid.
+            $data = (array) JWT::decode($token, $this->getJwks(refresh: true));
+        } catch (UnexpectedValueException $e) {
+            if (! str_contains($e->getMessage(), '"kid" invalid')) {
+                throw $e;
+            }
+
+            $data = (array) JWT::decode($token, $this->getJwks(refresh: true));
+        }
+
+        $this->validateOIDCPayload($data);
 
         return $data;
     }

--- a/tests/Socialite/Fixtures/VerifyingOpenIdTestProviderStub.php
+++ b/tests/Socialite/Fixtures/VerifyingOpenIdTestProviderStub.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Socialite\Fixtures;
+
+use GuzzleHttp\Client;
+use Hypervel\Socialite\Two\OpenIdProvider;
+use Hypervel\Socialite\Two\User;
+use Mockery as m;
+
+class VerifyingOpenIdTestProviderStub extends OpenIdProvider
+{
+    /**
+     * @var \GuzzleHttp\Client|\Mockery\MockInterface
+     */
+    public $http;
+
+    public function verifyToken(string $token): ?array
+    {
+        return $this->getUserByOIDCToken($token);
+    }
+
+    public function setJwksRefreshCooldownSeconds(int $seconds): void
+    {
+        $this->jwksRefreshCooldownSeconds = $seconds;
+    }
+
+    protected function getBaseUrl(): string
+    {
+        return 'http://base.url';
+    }
+
+    protected function getAuthUrl(?string $state, ?string $nonce = null): string
+    {
+        return $this->buildAuthUrlFromBase('http://auth.url', $state, $nonce);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return 'http://token.url';
+    }
+
+    protected function getUserByToken(string $token): array
+    {
+        return ['id' => 'foo'];
+    }
+
+    protected function mapUserToObject(array $user): User
+    {
+        return (new User)->map(['id' => $user['sub']]);
+    }
+
+    /**
+     * Get a fresh instance of the Guzzle HTTP client.
+     *
+     * @return \GuzzleHttp\Client|\Mockery\MockInterface
+     */
+    protected function getHttpClient(): Client
+    {
+        if ($this->http) {
+            return $this->http;
+        }
+
+        return $this->http = m::mock(Client::class);
+    }
+}

--- a/tests/Socialite/OpenIdProviderTest.php
+++ b/tests/Socialite/OpenIdProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Socialite;
 
+use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Hypervel\Contracts\Session\Session as SessionContract;
@@ -12,11 +13,13 @@ use Hypervel\Http\Request;
 use Hypervel\Socialite\Two\Exceptions\InvalidAudienceException;
 use Hypervel\Socialite\Two\User;
 use Hypervel\Tests\Socialite\Fixtures\OpenIdTestProviderStub;
+use Hypervel\Tests\Socialite\Fixtures\VerifyingOpenIdTestProviderStub;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use ReflectionMethod;
+use UnexpectedValueException;
 
 class OpenIdProviderTest extends TestCase
 {
@@ -172,5 +175,198 @@ class OpenIdProviderTest extends TestCase
             'aud' => 'original_id',
             'iss' => 'http://base.url',
         ]);
+    }
+
+    public function testOidcJwksRefreshesWhenTokenKidIsMissingFromCachedKeys()
+    {
+        $oldKey = $this->createRsaKeyPair('old-key');
+        $newKey = $this->createRsaKeyPair('new-key');
+        $provider = $this->createVerifyingProvider();
+
+        $this->expectOpenIdConfigRequests($provider->http, 2);
+        $this->expectJwksRequests($provider->http, [
+            $this->jwks($oldKey),
+            $this->jwks($newKey),
+        ]);
+
+        $user = $provider->verifyToken($this->createSignedToken($newKey));
+
+        $this->assertSame('foo', $user['sub']);
+    }
+
+    public function testOidcJwksRemainCachedWhenTokenKidIsPresent()
+    {
+        $key = $this->createRsaKeyPair('current-key');
+        $provider = $this->createVerifyingProvider();
+
+        $this->expectOpenIdConfigRequests($provider->http, 1);
+        $this->expectJwksRequests($provider->http, [
+            $this->jwks($key),
+        ]);
+
+        $firstUser = $provider->verifyToken($this->createSignedToken($key));
+        $secondUser = $provider->verifyToken($this->createSignedToken($key));
+
+        $this->assertSame('foo', $firstUser['sub']);
+        $this->assertSame('foo', $secondUser['sub']);
+    }
+
+    public function testOidcJwksDoesNotRefreshForTokenWithoutKid()
+    {
+        $key = $this->createRsaKeyPair('current-key');
+        $provider = $this->createVerifyingProvider();
+
+        $this->expectOpenIdConfigRequests($provider->http, 1);
+        $this->expectJwksRequests($provider->http, [
+            $this->jwks($key),
+        ]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('"kid" empty');
+
+        $provider->verifyToken($this->createSignedToken($key, includeKid: false));
+    }
+
+    public function testOidcJwksRefreshCooldownPreventsRepeatedUnknownKidFetches()
+    {
+        $oldKey = $this->createRsaKeyPair('old-key');
+        $newKey = $this->createRsaKeyPair('new-key');
+        $provider = $this->createVerifyingProvider();
+        $provider->setJwksRefreshCooldownSeconds(60);
+
+        $this->expectOpenIdConfigRequests($provider->http, 2);
+        $this->expectJwksRequests($provider->http, [
+            $this->jwks($oldKey),
+            $this->jwks($oldKey),
+        ]);
+
+        $failures = 0;
+        $token = $this->createSignedToken($newKey);
+
+        for ($i = 0; $i < 2; ++$i) {
+            try {
+                $provider->verifyToken($token);
+            } catch (UnexpectedValueException $e) {
+                $this->assertStringContainsString('"kid" invalid', $e->getMessage());
+                ++$failures;
+            }
+        }
+
+        $this->assertSame(2, $failures);
+    }
+
+    public function testOidcJwksRefreshesWhenCachedKeyMaterialIsStale()
+    {
+        $oldKey = $this->createRsaKeyPair('shared-key');
+        $newKey = $this->createRsaKeyPair('shared-key');
+        $provider = $this->createVerifyingProvider();
+
+        $this->expectOpenIdConfigRequests($provider->http, 2);
+        $this->expectJwksRequests($provider->http, [
+            $this->jwks($oldKey),
+            $this->jwks($newKey),
+        ]);
+
+        $user = $provider->verifyToken($this->createSignedToken($newKey));
+
+        $this->assertSame('foo', $user['sub']);
+    }
+
+    private function createVerifyingProvider(): VerifyingOpenIdTestProviderStub
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('session')
+            ->andReturn($session = m::mock(SessionContract::class));
+        $session->allows('has')->with('nonce')->andReturns(true);
+        $session->allows('get')->with('nonce')->andReturns('nonce');
+
+        $provider = new VerifyingOpenIdTestProviderStub(
+            $request,
+            'client_id',
+            'client_secret',
+            'redirect'
+        );
+        $provider->http = m::mock(Client::class);
+
+        return $provider;
+    }
+
+    private function expectOpenIdConfigRequests(Client $http, int $times): void
+    {
+        $http->shouldReceive('get')
+            ->with('http://base.url/.well-known/openid-configuration')
+            ->times($times)
+            ->andReturn(new Response(
+                body: json_encode([
+                    'issuer' => 'http://base.url',
+                    'token_endpoint' => 'http://token.url',
+                    'jwks_uri' => 'http://jwks.url',
+                ])
+            ));
+    }
+
+    private function expectJwksRequests(Client $http, array $jwksResponses): void
+    {
+        $http->shouldReceive('get')
+            ->with('http://jwks.url')
+            ->times(count($jwksResponses))
+            ->andReturn(...array_map(
+                fn (array $jwks): Response => new Response(body: json_encode($jwks)),
+                $jwksResponses
+            ));
+    }
+
+    private function createSignedToken(array $key, bool $includeKid = true): string
+    {
+        return JWT::encode([
+            'iss' => 'http://base.url',
+            'sub' => 'foo',
+            'aud' => 'client_id',
+            'nonce' => 'nonce',
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ], $key['private'], 'RS256', $includeKid ? $key['kid'] : null);
+    }
+
+    private function createRsaKeyPair(string $kid): array
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        if ($key === false) {
+            $this->fail('Unable to generate RSA key pair for OIDC test.');
+        }
+
+        openssl_pkey_export($key, $privateKey);
+        $details = openssl_pkey_get_details($key);
+
+        return [
+            'kid' => $kid,
+            'private' => $privateKey,
+            'jwk' => [
+                'kid' => $kid,
+                'kty' => 'RSA',
+                'use' => 'sig',
+                'alg' => 'RS256',
+                'n' => $this->base64UrlEncode($details['rsa']['n']),
+                'e' => $this->base64UrlEncode($details['rsa']['e']),
+            ],
+        ];
+    }
+
+    private function jwks(array $key): array
+    {
+        return [
+            'keys' => [
+                $key['jwk'],
+            ],
+        ];
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
     }
 }


### PR DESCRIPTION
This PR makes Socialite's OpenID Connect token verification resilient to provider JWKS rotation in long-running workers.

Previously, `OpenIdProvider` fetched the provider discovery document and JWKS once, cached the parsed keys on the provider instance, and reused them for the worker lifetime. That is fast, but under Swoole it means a provider key rotation can leave a worker validating ID tokens against stale keys until restart.

The provider now refreshes discovery/JWKS and retries verification when Firebase JWT reports a stale-key-shaped failure:

- an ID token references a new `kid` that is not in the cached JWKS
- an ID token uses an existing `kid` but the cached key material no longer verifies the signature

Malformed tokens, missing `kid`s, invalid claims, nonce failures, issuer failures, and audience failures still fail normally without forcing JWKS refresh.

## Details

- Adds forced-refresh support to `OpenIdProvider::getOpenIdConfig()` and `getJwks()`.
- Retries `JWT::decode()` once after a forced JWKS refresh for unknown `kid` and stale key material cases.
- Adds a small per-provider cooldown for forced JWKS refresh attempts so repeated bad unknown-`kid` tokens cannot turn verification into unlimited JWKS HTTP requests.
- Keeps the normal hot path unchanged: valid tokens continue to use the cached JWKS with no extra HTTP call.

This intentionally avoids adding a PSR-6 cache adapter or switching to Firebase's `CachedKeySet`. The issue is narrow, key rotation is rare, and a local retry/cooldown keeps the fix simple without adding framework-wide cache compatibility surface.

## Tests

Added real Firebase JWT/OpenSSL coverage for:

- refreshing JWKS when the token `kid` is missing from cached keys
- reusing cached JWKS when the token `kid` is already present
- not refreshing for a token with no `kid`
- applying the refresh cooldown to repeated unknown-`kid` failures
- refreshing when key material changes under the same `kid`