### PR TITLE
feat: add support for serialization compatibility with newer Laravel

### DIFF
--- a/src/event/illuminate/CallQueuedListener.php
+++ b/src/event/illuminate/CallQueuedListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Illuminate\Events;
 
+use AllowDynamicProperties;
 use DateInterval;
 use DateTimeInterface;
 use Hyperf\Context\ApplicationContext;
@@ -13,6 +14,7 @@ use Hypervel\Queue\Contracts\ShouldQueue;
 use Hypervel\Queue\InteractsWithQueue;
 use Throwable;
 
+#[AllowDynamicProperties]
 class CallQueuedListener implements ShouldQueue
 {
     use InteractsWithQueue;

--- a/src/event/src/CallQueuedListener.php
+++ b/src/event/src/CallQueuedListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Event;
 
+use AllowDynamicProperties;
 use DateInterval;
 use DateTimeInterface;
 use Hyperf\Context\ApplicationContext;
@@ -13,6 +14,7 @@ use Hypervel\Queue\Contracts\ShouldQueue;
 use Hypervel\Queue\InteractsWithQueue;
 use Throwable;
 
+#[AllowDynamicProperties]
 class CallQueuedListener implements ShouldQueue
 {
     use InteractsWithQueue;

--- a/src/foundation/src/Application.php
+++ b/src/foundation/src/Application.php
@@ -31,7 +31,7 @@ class Application extends Container implements ApplicationContract
      *
      * @var string
      */
-    public const VERSION = '0.3.20';
+    public const VERSION = '0.3.21';
 
     /**
      * The base path for the Hypervel installation.

--- a/src/queue/src/CallQueuedClosure.php
+++ b/src/queue/src/CallQueuedClosure.php
@@ -28,6 +28,11 @@ class CallQueuedClosure implements ShouldQueue
     public array $failureCallbacks = [];
 
     /**
+     * The name assigned to the job.
+     */
+    public ?string $name = null;
+
+    /**
      * Indicate if the job should be deleted when models are missing.
      */
     public bool $deleteWhenMissingModels = true;
@@ -91,6 +96,18 @@ class CallQueuedClosure implements ShouldQueue
     {
         $reflection = new ReflectionFunction($this->closure->getClosure());
 
-        return 'Closure (' . basename($reflection->getFileName()) . ':' . $reflection->getStartLine() . ')';
+        $prefix = is_null($this->name) ? '' : "{$this->name} - ";
+
+        return $prefix . 'Closure (' . basename($reflection->getFileName()) . ':' . $reflection->getStartLine() . ')';
+    }
+
+    /**
+     * Assign a name to the job.
+     */
+    public function name(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
     }
 }

--- a/tests/Event/CallQueuedListenerTest.php
+++ b/tests/Event/CallQueuedListenerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Event;
+
+use Hypervel\Event\CallQueuedListener as HypervelCallQueuedListener;
+use Hypervel\Tests\TestCase;
+use Illuminate\Events\CallQueuedListener as IlluminateCallQueuedListener;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class CallQueuedListenerTest extends TestCase
+{
+    public function testHypervelListenerToleratesUnknownPropertiesOnUnserialization()
+    {
+        $this->assertListenerToleratesUnknownProperties(
+            HypervelCallQueuedListener::class
+        );
+    }
+
+    public function testIlluminateListenerToleratesUnknownPropertiesOnUnserialization()
+    {
+        $this->assertListenerToleratesUnknownProperties(
+            IlluminateCallQueuedListener::class
+        );
+    }
+
+    /**
+     * Simulates cross-version deserialization: a job payload serialized by a
+     * newer Laravel/Hypervel version (which adds extra properties to
+     * CallQueuedListener) is unserialized by an older version that does not
+     * declare those properties. Without #[AllowDynamicProperties], PHP 8.2+
+     * raises an error on the dynamic property assignment during unserialize().
+     */
+    private function assertListenerToleratesUnknownProperties(string $class): void
+    {
+        $listener = new $class('App\Listeners\OrderShipped', 'handle', []);
+        $serialized = serialize($listener);
+
+        // Inject a synthetic property absent from the current class definition.
+        $extra = 's:18:"newPropertyFromV11";s:5:"value";';
+        $serialized = preg_replace_callback(
+            '/^(O:\d+:"[^"]+":)(\d+):/',
+            fn ($m) => $m[1] . ((int) $m[2] + 1) . ':',
+            $serialized
+        );
+        $serialized = substr($serialized, 0, -1) . $extra . '}';
+
+        $result = unserialize($serialized);
+
+        $this->assertInstanceOf($class, $result);
+        $this->assertSame('App\Listeners\OrderShipped', $result->class);
+        $this->assertSame('value', $result->newPropertyFromV11);
+    }
+}


### PR DESCRIPTION
### Background

Newer versions of Laravel added the `#[AllowDynamicProperties]` attribute to `CallQueuedListener`. Without it, PHP 8.2+ emits deprecation notices when dynamic properties are assigned during unserialization, and stricter future PHP versions will throw errors outright.

More critically, this creates a **cross-version serialization breakage**: if a job is serialized (pushed to queue) with a Laravel version where `CallQueuedListener` carries additional properties — then deserialized (popped from queue) by a worker running a different version without the attribute — PHP rejects the unknown properties. The result is a fatal unserialization error that silently kills queued jobs.

### Changes

#### `src/event/src/CallQueuedListener.php` · `src/event/illuminate/CallQueuedListener.php`

Added the `#[AllowDynamicProperties]` attribute to both `Hypervel\Event\CallQueuedListener` and the `Illuminate\Events\CallQueuedListener` shim. This mirrors the upstream Laravel change and ensures dynamic properties set during unserialization are accepted without error, regardless of which version serialized the payload.

#### `src/queue/src/CallQueuedClosure.php`

Ported the `name()` feature from newer Laravel, which allows queued closures to carry a human-readable display name:

- Added `public ?string $name = null;` property
- Added `name(string $name): static` fluent method
- Updated `displayName()` to prefix the output when a name is set: `MyJob - Closure (DispatchesJobs.php:42)`

### Why both `CallQueuedListener` files?

Hypervel ships two variants of `CallQueuedListener`:

- `Hypervel\Event\CallQueuedListener` — the native Hypervel implementation
- `Illuminate\Events\CallQueuedListener` — a shim under the Illuminate namespace for compatibility with packages that dispatch listeners via the standard Laravel namespace

Both must carry the attribute so payloads are interchangeable regardless of which class path was used to serialize them.

### Impact

- Fixes fatal unserialization errors when queue workers and producers run against mismatched `CallQueuedListener` class shapes
- No breaking changes; `$name` defaults to `null` and `displayName()` output is unchanged when no name is set
- PHP 8.1 minimum is preserved (`#[AllowDynamicProperties]` is available since PHP 8.1)
