### PR TITLE
fix: fix latestStartedAt in WorkCommand in coroutines

### DIFF
--- a/src/queue/src/Console/WorkCommand.php
+++ b/src/queue/src/Console/WorkCommand.php
@@ -8,6 +8,7 @@ use Hyperf\Command\Command;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Stringable\Str;
 use Hypervel\Cache\Contracts\Factory as CacheFactory;
+use Hypervel\Context\Context;
 use Hypervel\Queue\Contracts\Job;
 use Hypervel\Queue\Events\JobFailed;
 use Hypervel\Queue\Events\JobProcessed;
@@ -59,11 +60,6 @@ class WorkCommand extends Command
      * The console command description.
      */
     protected string $description = 'Start processing jobs on the queue as a daemon';
-
-    /**
-     * Holds the start time of the last processed job, if any.
-     */
-    protected ?float $latestStartedAt = null;
 
     /**
      * Indicates if the worker's event listeners have been registered.
@@ -216,7 +212,7 @@ class WorkCommand extends Command
         ));
 
         if ($status == 'starting') {
-            $this->latestStartedAt = microtime(true);
+            $this->setLatestStartedAt(microtime(true));
 
             $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
                 $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
@@ -229,7 +225,7 @@ class WorkCommand extends Command
             return;
         }
 
-        $runTime = $this->runTimeForHumans($this->latestStartedAt);
+        $runTime = $this->runTimeForHumans($this->getLatestStartedAt());
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
             $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
@@ -331,6 +327,16 @@ class WorkCommand extends Command
         }
 
         return $this->option('json');
+    }
+
+    protected function getLatestStartedAt(): ?float
+    {
+        return Context::get('__queue.worker.latest_started_at');
+    }
+
+    protected function setLatestStartedAt(?float $latestStartedAt): void
+    {
+        Context::set('__queue.worker.latest_started_at', $latestStartedAt);
     }
 
     /**

--- a/src/queue/src/Console/WorkCommand.php
+++ b/src/queue/src/Console/WorkCommand.php
@@ -268,9 +268,9 @@ class WorkCommand extends Command
         ]);
 
         if ($status === 'starting') {
-            $this->latestStartedAt = microtime(true);
+            $this->setLatestStartedAt(microtime(true));
         } else {
-            $log['duration'] = round(microtime(true) - $this->latestStartedAt, 6);
+            $log['duration'] = round(microtime(true) - $this->getLatestStartedAt(), 6);
         }
 
         $this->output->writeln(json_encode($log));


### PR DESCRIPTION
## Summary

Fixes a coroutine safety issue in `WorkCommand` where `latestStartedAt` was stored as an instance property, causing it to be shared across concurrent coroutines processing different jobs simultaneously.

### Problem

In a coroutine environment, multiple workers can run concurrently within the same object instance. The `$latestStartedAt` property was set when a job started and read when it finished, but because instance properties are shared across coroutines, concurrent jobs would overwrite each other's start time — resulting in incorrect run time calculations displayed in the output.

### Solution

- Remove the `$latestStartedAt` instance property
- Store and retrieve the value via `Context::get/set` using the key `__queue.worker.latest_started_at`, which is coroutine-scoped and isolated per execution context
- Introduce `getLatestStartedAt()` and `setLatestStartedAt()` accessors to encapsulate the context access

## Changes

- **`src/queue/src/Console/WorkCommand.php`**
  - Removed `protected ?float $latestStartedAt` instance property
  - Added `getLatestStartedAt(): ?float` using `Context::get`
  - Added `setLatestStartedAt(?float): void` using `Context::set`
  - Updated `runJob()` to call the new accessors instead of reading/writing the property directly
  - Imported `Hypervel\Context\Context`
