### PR TITLE
fix: flush global state in queue's createPayloadCallbacks

### DIFF
--- a/src/foundation/src/Testing/TestCase.php
+++ b/src/foundation/src/Testing/TestCase.php
@@ -15,6 +15,7 @@ use Hypervel\Foundation\Testing\Concerns\InteractsWithSession;
 use Hypervel\Foundation\Testing\Concerns\InteractsWithTime;
 use Hypervel\Foundation\Testing\Concerns\MakesHttpRequests;
 use Hypervel\Foundation\Testing\Concerns\MocksApplicationServices;
+use Hypervel\Queue\Queue;
 use Hypervel\Support\Facades\Facade;
 use Mockery;
 use Throwable;
@@ -123,6 +124,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $this->flushApplication();
             /* @phpstan-ignore-next-line */
             Coroutine::flushAfterCreated();
+            Queue::createPayloadUsing(null);
         }
 
         $this->afterApplicationCreatedCallbacks = [];


### PR DESCRIPTION
This PR fixes a potential memory leak in queue's `createPayloadCallbacks` state in testing.