### PR TITLE
feat: support enum value resolution in data object

### DIFF
--- a/src/support/src/DataObject.php
+++ b/src/support/src/DataObject.php
@@ -291,7 +291,7 @@ abstract class DataObject implements ArrayAccess, JsonSerializable
                 : $property->getName();
             if (enum_exists($typeName)) {
                 $result[$dataKey] = [
-                    'handler' => [$typeName, 'from'],
+                    'handler' => fn ($value) => $value instanceof $typeName ? $value : $typeName::from($value),
                     'nullable' => $allowsNull,
                     'children' => [],
                 ];

--- a/src/support/src/DataObject.php
+++ b/src/support/src/DataObject.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Support;
 
 use ArrayAccess;
+use BackedEnum;
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonInterface;
 use DateTime;
@@ -289,7 +290,7 @@ abstract class DataObject implements ArrayAccess, JsonSerializable
             $dataKey = static::isAutoCasting()
                 ? static::convertPropertyToDataKey($property->getName())
                 : $property->getName();
-            if (enum_exists($typeName)) {
+            if (enum_exists($typeName) && is_subclass_of($typeName, BackedEnum::class, true)) {
                 $result[$dataKey] = [
                     'handler' => fn ($value) => $value instanceof $typeName ? $value : $typeName::from($value),
                     'nullable' => $allowsNull,


### PR DESCRIPTION
## Summary

This PR improves `Hypervel\Support\DataObject` auto-resolution for enum-typed properties.

Data objects can now safely receive either a backed enum instance or its scalar backing value when auto-resolving dependencies. The enum resolver also now only applies to `BackedEnum` types, avoiding invalid `from()` calls on pure enums.

## Changes

- Adds `BackedEnum` detection to `DataObject` dependency resolution.
- Converts scalar values into backed enum cases via `EnumClass::from($value)`.
- Preserves existing enum instances instead of re-resolving them.
- Skips pure enums during automatic enum conversion.

## Why

Previously, enum resolution assumed enum values should always be passed through `from()`. That works for scalar-backed values, but fails when the provided data already contains an enum instance. It also risks calling `from()` on pure enums, which do not support backed-value resolution.

This makes `DataObject::make(..., autoResolve: true)` more flexible and safer for backed enum properties.