### PR TITLE
Add database pool max-lifetime recycling

### DIFF
--- a/src/boost/docs/database.md
+++ b/src/boost/docs/database.md
@@ -112,9 +112,10 @@ To see how read / write connections should be configured, let's look at this exa
         'max_connections' => (int) env('DB_MAX_CONNECTIONS', 10),
         'connect_timeout' => 10.0,
         'wait_timeout' => 3.0,
-        'heartbeat' => -1,
-        'heartbeat_timeout' => 1.0,
+        'heartbeat' => (float) env('DB_HEARTBEAT', -1),
+        'heartbeat_timeout' => (float) env('DB_HEARTBEAT_TIMEOUT', 1.0),
         'max_idle_time' => (float) env('DB_MAX_IDLE_TIME', 60),
+        'max_lifetime' => (float) env('DB_MAX_LIFETIME', -1),
     ],
 ],
 ```
@@ -144,14 +145,17 @@ Each connection may define its own `pool` configuration:
         'max_connections' => (int) env('DB_MAX_CONNECTIONS', 10),
         'connect_timeout' => 10.0,
         'wait_timeout' => 3.0,
-        'heartbeat' => -1,
-        'heartbeat_timeout' => 1.0,
+        'heartbeat' => (float) env('DB_HEARTBEAT', -1),
+        'heartbeat_timeout' => (float) env('DB_HEARTBEAT_TIMEOUT', 1.0),
         'max_idle_time' => (float) env('DB_MAX_IDLE_TIME', 60),
+        'max_lifetime' => (float) env('DB_MAX_LIFETIME', -1),
     ],
 ],
 ```
 
-The `min_connections` option determines the minimum number of connections kept warm in the pool, while the `max_connections` option determines the maximum number of connections that may be opened for the worker. The `connect_timeout` option controls how long Hypervel will wait while opening a new database connection. The `wait_timeout` option controls how long a coroutine may wait for an available connection when the pool is exhausted. The `heartbeat` option controls how often Hypervel validates idle pooled connections; set this value to `-1` to disable heartbeats. When heartbeats are enabled, Hypervel keeps the minimum idle connection set alive with a raw `SELECT 1` ping that does not fire query events, query logs, or query duration handlers. The `heartbeat_timeout` option controls how long a heartbeat ping may run before the connection is discarded. The `max_idle_time` option controls how long idle connections above the minimum pool size may remain in the pool before they are closed.
+The `min_connections` option determines the minimum number of connections kept warm in the pool, while the `max_connections` option determines the maximum number of connections that may be opened for the worker. The `connect_timeout` option controls how long Hypervel will wait while opening a new database connection. The `wait_timeout` option controls how long a coroutine may wait for an available connection when the pool is exhausted. The `heartbeat` option controls how often Hypervel validates idle connections in the worker pool; set this value to `-1` to disable heartbeats. When heartbeats are enabled, Hypervel keeps the minimum idle connection set alive with a raw `SELECT 1` ping that does not fire query events, query logs, or query duration handlers. The `heartbeat_timeout` option controls how long a heartbeat ping may run before the connection is discarded. The `max_idle_time` option controls how long idle connections above the minimum pool size may remain in the pool before they are closed. The `max_lifetime` option controls how long a pooled connection generation may live before it is recycled while idle or before it is reused; set this value to `-1` to disable lifetime recycling.
+
+Heartbeat and max lifetime recycling apply to Hypervel's worker pool whether the connection points directly at the database or through a proxy / pooler. They help long-running workers avoid stale sockets and rotate old idle connection generations before those connections are used by a request.
 
 Hypervel's default database configuration also includes a `pgsql-pooled` connection. This connection is intended for PostgreSQL transaction poolers such as PgBouncer and uses separate `DB_POOLED_*` environment variables. It also sets `migrations_connection` to `pgsql`, allowing your application to use the pooled connection at runtime while migration commands use the direct PostgreSQL connection.
 

--- a/src/boost/todo.md
+++ b/src/boost/todo.md
@@ -25,7 +25,7 @@
 
 ## Database
 
-- Add max-lifetime recycling support for pooled database connections. Heartbeat keeps minimum idle connections validated for the worker lifetime, but rotating database poolers and managed proxies may still benefit from periodically replacing otherwise healthy long-lived sockets. Correct fix: add an opt-in pool option that recycles idle pooled DB connections older than the configured lifetime without affecting borrowed connections or normal query execution.
+- Consider built-in early jitter for DB pool `max_lifetime`. Exact max-lifetime recycling can make a burst-created cohort of idle connections expire in the same heartbeat tick, causing synchronized reconnects. A clean design would avoid an extra config knob and assign each connection an effective lifetime between 90-100% of `max_lifetime`, so the configured value remains the upper bound while reconnects are spread out.
 
 ## Foundation
 
@@ -52,6 +52,7 @@
 ## Pool
 
 - Make `Hypervel\Pool\KeepaliveConnection` honor disabled heartbeat configuration. `PoolOption` documents `heartbeat => -1` as disabled, but `KeepaliveConnection::getHeartbeatSeconds()` currently turns any non-positive heartbeat into a 10-second interval and `addHeartbeat()` always creates a timer. Correct fix: only create the heartbeat timer when `PoolOption::getHeartbeat() > 0`; when heartbeat is `<= 0`, do not start a timer or run heartbeat work. Keep `max_idle_time` behavior separate from heartbeat.
+- Add Redis pool heartbeat and max-lifetime support. Redis pools expose a `heartbeat` config key today, but `Hypervel\Redis\RedisPool` extends the base pool and no Redis code consumes `PoolOption::getHeartbeat()` or starts a heartbeat timer. Correct fix: add opt-in Redis heartbeat and max-lifetime recycling for idle pooled Redis connections, keep both disabled by default, and test that borrowed connections are never recycled.
 
 ## Routing
 

--- a/src/contracts/src/Pool/PoolOptionInterface.php
+++ b/src/contracts/src/Pool/PoolOptionInterface.php
@@ -42,6 +42,11 @@ interface PoolOptionInterface
     public function getMaxIdleTime(): float;
 
     /**
+     * Get the maximum lifetime in seconds before a connection is recycled.
+     */
+    public function getMaxLifetime(): float;
+
+    /**
      * Get the events to trigger on connection lifecycle.
      */
     public function getEvents(): array;

--- a/src/database/src/Pool/DbPool.php
+++ b/src/database/src/Pool/DbPool.php
@@ -201,7 +201,15 @@ class DbPool extends Pool
     protected function heartbeatConnection(PooledConnection $connection): void
     {
         try {
-            if ($connection->isIdleExpired() && $this->currentConnections > $this->option->getMinConnections()) {
+            $now = microtime(true);
+
+            if ($connection->isLifetimeExpired($now)) {
+                $this->discardHeartbeatConnection($connection);
+
+                return;
+            }
+
+            if ($connection->isIdleExpired($now) && $this->currentConnections > $this->option->getMinConnections()) {
                 $this->discardHeartbeatConnection($connection);
 
                 return;

--- a/src/database/src/Pool/PooledConnection.php
+++ b/src/database/src/Pool/PooledConnection.php
@@ -47,6 +47,8 @@ class PooledConnection implements PoolConnectionInterface
 
     protected float $createdAt = 0.0;
 
+    protected bool $availableForReuse = false;
+
     protected bool $invalid = false;
 
     protected ?Dispatcher $dispatcher = null;
@@ -80,6 +82,8 @@ class PooledConnection implements PoolConnectionInterface
     public function getActiveConnection(): Connection
     {
         if ($this->check()) {
+            $this->availableForReuse = false;
+
             return $this->connection;
         }
 
@@ -138,6 +142,7 @@ class PooledConnection implements PoolConnectionInterface
         $now = microtime(true);
         $this->lastUseTime = $now;
         $this->createdAt = $now;
+        $this->availableForReuse = false;
         $this->markValid();
 
         return true;
@@ -158,17 +163,21 @@ class PooledConnection implements PoolConnectionInterface
 
         $now = microtime(true);
 
-        if ($this->isLifetimeExpired($now)) {
-            return false;
+        if ($this->availableForReuse) {
+            // Time-based recycling is a reuse rule; it must not replace a connection
+            // while the borrowed wrapper may still hold transaction state.
+            if ($this->isLifetimeExpired($now)) {
+                return false;
+            }
+
+            $maxIdleTime = $this->pool->getOption()->getMaxIdleTime();
+
+            if ($now > $maxIdleTime + max($this->lastReleaseTime, $this->lastUseTime)) {
+                return false;
+            }
+
+            $this->lastUseTime = $now;
         }
-
-        $maxIdleTime = $this->pool->getOption()->getMaxIdleTime();
-
-        if ($now > $maxIdleTime + max($this->lastReleaseTime, $this->lastUseTime)) {
-            return false;
-        }
-
-        $this->lastUseTime = $now;
 
         return true;
     }
@@ -279,6 +288,7 @@ class PooledConnection implements PoolConnectionInterface
             // Mark as stale so it will be recreated
             $this->markInvalid();
         } finally {
+            $this->availableForReuse = true;
             $this->pool->release($this);
         }
     }

--- a/src/database/src/Pool/PooledConnection.php
+++ b/src/database/src/Pool/PooledConnection.php
@@ -45,6 +45,8 @@ class PooledConnection implements PoolConnectionInterface
 
     protected float $lastReleaseTime = 0.0;
 
+    protected float $createdAt = 0.0;
+
     protected bool $invalid = false;
 
     protected ?Dispatcher $dispatcher = null;
@@ -133,7 +135,9 @@ class PooledConnection implements PoolConnectionInterface
             );
         }
 
-        $this->lastUseTime = microtime(true);
+        $now = microtime(true);
+        $this->lastUseTime = $now;
+        $this->createdAt = $now;
         $this->markValid();
 
         return true;
@@ -152,8 +156,13 @@ class PooledConnection implements PoolConnectionInterface
             return false;
         }
 
-        $maxIdleTime = $this->pool->getOption()->getMaxIdleTime();
         $now = microtime(true);
+
+        if ($this->isLifetimeExpired($now)) {
+            return false;
+        }
+
+        $maxIdleTime = $this->pool->getOption()->getMaxIdleTime();
 
         if ($now > $maxIdleTime + max($this->lastReleaseTime, $this->lastUseTime)) {
             return false;
@@ -291,6 +300,28 @@ class PooledConnection implements PoolConnectionInterface
     }
 
     /**
+     * Get the connection generation creation time.
+     */
+    public function getCreatedAt(): float
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Determine if this connection generation has reached its maximum lifetime.
+     */
+    public function isLifetimeExpired(?float $now = null): bool
+    {
+        $maxLifetime = $this->pool->getOption()->getMaxLifetime();
+
+        if ($maxLifetime <= 0) {
+            return false;
+        }
+
+        return ($now ?? microtime(true)) >= $this->createdAt + $maxLifetime;
+    }
+
+    /**
      * Determine if the underlying connection has an open transaction.
      */
     public function hasOpenTransaction(): bool
@@ -399,5 +430,7 @@ class PooledConnection implements PoolConnectionInterface
                 new ConnectionEstablished($connection)
             );
         }
+
+        $this->createdAt = microtime(true);
     }
 }

--- a/src/foundation/config/database.php
+++ b/src/foundation/config/database.php
@@ -25,8 +25,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Database connections may define a "pool" array for long-lived workers.
-    | Heartbeats are disabled with -1; positive values keep the minimum
-    | idle connections validated without firing query events or logs.
+    | Heartbeats validate idle connections, while max lifetime recycling
+    | rotates old idle connection generations before they are reused.
     |
     */
 
@@ -79,9 +79,10 @@ return [
                 'max_connections' => (int) env('DB_MAX_CONNECTIONS', 10),
                 'connect_timeout' => 10.0,
                 'wait_timeout' => 3.0,
-                'heartbeat' => -1,
-                'heartbeat_timeout' => 1.0,
+                'heartbeat' => (float) env('DB_HEARTBEAT', -1),
+                'heartbeat_timeout' => (float) env('DB_HEARTBEAT_TIMEOUT', 1.0),
                 'max_idle_time' => (float) env('DB_MAX_IDLE_TIME', 60),
+                'max_lifetime' => (float) env('DB_MAX_LIFETIME', -1),
             ],
         ],
 
@@ -108,9 +109,10 @@ return [
                 'max_connections' => (int) env('DB_MAX_CONNECTIONS', 10),
                 'connect_timeout' => 10.0,
                 'wait_timeout' => 3.0,
-                'heartbeat' => -1,
-                'heartbeat_timeout' => 1.0,
+                'heartbeat' => (float) env('DB_HEARTBEAT', -1),
+                'heartbeat_timeout' => (float) env('DB_HEARTBEAT_TIMEOUT', 1.0),
                 'max_idle_time' => (float) env('DB_MAX_IDLE_TIME', 60),
+                'max_lifetime' => (float) env('DB_MAX_LIFETIME', -1),
             ],
         ],
 
@@ -135,9 +137,10 @@ return [
                 'max_connections' => (int) env('DB_MAX_CONNECTIONS', 10),
                 'connect_timeout' => 10.0,
                 'wait_timeout' => 3.0,
-                'heartbeat' => -1,
-                'heartbeat_timeout' => 1.0,
+                'heartbeat' => (float) env('DB_HEARTBEAT', -1),
+                'heartbeat_timeout' => (float) env('DB_HEARTBEAT_TIMEOUT', 1.0),
                 'max_idle_time' => (float) env('DB_MAX_IDLE_TIME', 60),
+                'max_lifetime' => (float) env('DB_MAX_LIFETIME', -1),
             ],
         ],
 
@@ -163,9 +166,10 @@ return [
                 'max_connections' => (int) env('DB_POOLED_MAX_CONNECTIONS', 20),
                 'connect_timeout' => 10.0,
                 'wait_timeout' => 3.0,
-                'heartbeat' => -1,
-                'heartbeat_timeout' => 1.0,
+                'heartbeat' => (float) env('DB_POOLED_HEARTBEAT', -1),
+                'heartbeat_timeout' => (float) env('DB_POOLED_HEARTBEAT_TIMEOUT', 1.0),
                 'max_idle_time' => (float) env('DB_POOLED_MAX_IDLE_TIME', 60),
+                'max_lifetime' => (float) env('DB_POOLED_MAX_LIFETIME', -1),
             ],
         ],
     ],

--- a/src/pool/src/Pool.php
+++ b/src/pool/src/Pool.php
@@ -173,6 +173,7 @@ abstract class Pool implements PoolInterface
             heartbeat: $options['heartbeat'] ?? -1,
             heartbeatTimeout: $options['heartbeat_timeout'] ?? 1.0,
             maxIdleTime: $options['max_idle_time'] ?? 60.0,
+            maxLifetime: $options['max_lifetime'] ?? -1.0,
             events: $options['events'] ?? [],
         );
     }

--- a/src/pool/src/PoolOption.php
+++ b/src/pool/src/PoolOption.php
@@ -19,6 +19,7 @@ class PoolOption implements PoolOptionInterface
      * @param float $heartbeat Heartbeat interval in seconds (-1 to disable)
      * @param float $heartbeatTimeout Heartbeat timeout in seconds
      * @param float $maxIdleTime Maximum idle time in seconds before connection is closed
+     * @param float $maxLifetime Maximum lifetime in seconds before connection is recycled (-1 to disable)
      * @param array<int, string> $events Events to trigger on connection lifecycle
      */
     public function __construct(
@@ -29,6 +30,7 @@ class PoolOption implements PoolOptionInterface
         private float $heartbeat = -1,
         private float $heartbeatTimeout = 1.0,
         private float $maxIdleTime = 60.0,
+        private float $maxLifetime = -1.0,
         private array $events = [],
     ) {
     }
@@ -162,6 +164,28 @@ class PoolOption implements PoolOptionInterface
     public function setMaxIdleTime(float $maxIdleTime): static
     {
         $this->maxIdleTime = $maxIdleTime;
+
+        return $this;
+    }
+
+    /**
+     * Get the maximum lifetime in seconds before a connection is recycled.
+     */
+    public function getMaxLifetime(): float
+    {
+        return $this->maxLifetime;
+    }
+
+    /**
+     * Set the maximum lifetime in seconds before a connection is recycled.
+     *
+     * Boot-only. The value persists on the worker-lifetime pool option and is
+     * read by every subsequent pool operation. Per-request use races across
+     * coroutines.
+     */
+    public function setMaxLifetime(float $maxLifetime): static
+    {
+        $this->maxLifetime = $maxLifetime;
 
         return $this;
     }

--- a/tests/Integration/Database/PooledConnectionTest.php
+++ b/tests/Integration/Database/PooledConnectionTest.php
@@ -41,7 +41,9 @@ class PooledConnectionTest extends DatabaseTestCase
                 'connect_timeout' => 10.0,
                 'wait_timeout' => 3.0,
                 'heartbeat' => -1,
+                'heartbeat_timeout' => 1.0,
                 'max_idle_time' => 60.0,
+                'max_lifetime' => -1.0,
             ],
         ]);
     }
@@ -287,6 +289,85 @@ class PooledConnectionTest extends DatabaseTestCase
         $this->assertNotSame($originalConnection, $pooledConnection->getActiveConnection());
     }
 
+    public function testExpiredLifetimeReconnectsBeforeReuseEvenWithoutHeartbeat(): void
+    {
+        $this->app->make('config')->set('database.connections.pool_test.pool.max_lifetime', 1.0);
+
+        $pool = new DbPool($this->app, 'pool_test');
+        $pooledConnection = $this->createPooledConnection($pool);
+        $originalConnection = $pooledConnection->getConnection();
+
+        $this->assertSame(1.0, $pool->getOption()->getMaxLifetime());
+
+        $this->ageConnectionGeneration($pooledConnection);
+
+        $this->assertFalse($pooledConnection->check());
+        $this->assertNotSame($originalConnection, $pooledConnection->getActiveConnection());
+    }
+
+    public function testExpiredLifetimeReconnectsWhenBorrowedFromPoolAgainWithoutHeartbeat(): void
+    {
+        $this->app->make('config')->set('database.connections.pool_test.pool.max_lifetime', 1.0);
+
+        $pool = new DbPool($this->app, 'pool_test');
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+        $originalConnection = $pooledConnection->getConnection();
+        $pooledConnection->release();
+
+        $this->ageConnectionGeneration($pooledConnection);
+
+        /** @var PooledConnection $nextPooledConnection */
+        $nextPooledConnection = $pool->get();
+
+        $this->assertSame($pooledConnection, $nextPooledConnection);
+        $this->assertNotSame($originalConnection, $nextPooledConnection->getConnection());
+
+        $nextPooledConnection->release();
+    }
+
+    public function testDisabledMaxLifetimeDoesNotRecycleAgedConnectionGeneration(): void
+    {
+        $pool = new DbPool($this->app, 'pool_test');
+        $pooledConnection = $this->createPooledConnection($pool);
+        $originalConnection = $pooledConnection->getConnection();
+
+        $this->assertSame(-1.0, $pool->getOption()->getMaxLifetime());
+
+        $this->ageConnectionGeneration($pooledConnection);
+
+        $this->assertFalse($pooledConnection->isLifetimeExpired());
+        $this->assertTrue($pooledConnection->check());
+        $this->assertSame($originalConnection, $pooledConnection->getActiveConnection());
+    }
+
+    public function testPingDoesNotExtendConnectionLifetime(): void
+    {
+        $pool = new DbPool($this->app, 'pool_test');
+        $pooledConnection = $this->createPooledConnection($pool);
+        $pooledConnection->getConnection()->getPdo();
+
+        $createdAt = $pooledConnection->getCreatedAt();
+
+        $this->assertTrue($pooledConnection->ping(1.0));
+        $this->assertSame($createdAt, $pooledConnection->getCreatedAt());
+    }
+
+    public function testConnectionRefreshResetsLifetime(): void
+    {
+        $pool = new DbPool($this->app, 'pool_test');
+        $pooledConnection = $this->createPooledConnection($pool);
+        $connection = $pooledConnection->getConnection();
+
+        $this->ageConnectionGeneration($pooledConnection);
+        $expiredAt = $pooledConnection->getCreatedAt();
+
+        $connection->reconnect();
+
+        $this->assertGreaterThan($expiredAt, $pooledConnection->getCreatedAt());
+    }
+
     public function testReleaseSnapshotsErrorCountBeforeResettingConnection(): void
     {
         $pool = new DbPool($this->app, 'pool_test');
@@ -439,5 +520,10 @@ class PooledConnectionTest extends DatabaseTestCase
         $config['name'] = $name;
 
         return new PooledConnection($this->app, $pool, $config);
+    }
+
+    private function ageConnectionGeneration(PooledConnection $connection): void
+    {
+        (new ReflectionProperty(PooledConnection::class, 'createdAt'))->setValue($connection, microtime(true) - 5.0);
     }
 }

--- a/tests/Integration/Database/PooledConnectionTest.php
+++ b/tests/Integration/Database/PooledConnectionTest.php
@@ -264,17 +264,28 @@ class PooledConnectionTest extends DatabaseTestCase
         $this->assertTrue($fired, 'ReleaseConnection event should be dispatched when configured');
     }
 
-    public function testLastUseTimeUpdatedOnCheck(): void
+    public function testLastUseTimeUpdatedOnReuseCheck(): void
     {
         $pool = new DbPool($this->app, 'pool_test');
-        $pooledConnection = $this->createPooledConnection($pool);
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+        $pooledConnection->getConnection();
 
         $initialTime = $pooledConnection->getLastUseTime();
 
-        usleep(10000); // 10ms
-        $pooledConnection->check();
+        $pooledConnection->release();
 
-        $this->assertGreaterThan($initialTime, $pooledConnection->getLastUseTime());
+        usleep(10000); // 10ms
+
+        /** @var PooledConnection $nextPooledConnection */
+        $nextPooledConnection = $pool->get();
+        $nextPooledConnection->getConnection();
+
+        $this->assertSame($pooledConnection, $nextPooledConnection);
+        $this->assertGreaterThan($initialTime, $nextPooledConnection->getLastUseTime());
+
+        $nextPooledConnection->release();
     }
 
     public function testInvalidConnectionReconnectsEvenWithFreshReleaseTime(): void
@@ -289,7 +300,7 @@ class PooledConnectionTest extends DatabaseTestCase
         $this->assertNotSame($originalConnection, $pooledConnection->getActiveConnection());
     }
 
-    public function testExpiredLifetimeReconnectsBeforeReuseEvenWithoutHeartbeat(): void
+    public function testExpiredLifetimeDoesNotReconnectDuringActiveBorrow(): void
     {
         $this->app->make('config')->set('database.connections.pool_test.pool.max_lifetime', 1.0);
 
@@ -299,10 +310,28 @@ class PooledConnectionTest extends DatabaseTestCase
 
         $this->assertSame(1.0, $pool->getOption()->getMaxLifetime());
 
+        $originalConnection->beginTransaction();
         $this->ageConnectionGeneration($pooledConnection);
 
-        $this->assertFalse($pooledConnection->check());
-        $this->assertNotSame($originalConnection, $pooledConnection->getActiveConnection());
+        $this->assertTrue($pooledConnection->check());
+        $this->assertSame($originalConnection, $pooledConnection->getActiveConnection());
+        $this->assertSame(1, $originalConnection->transactionLevel());
+
+        $originalConnection->rollBack();
+    }
+
+    public function testExpiredIdleTimeDoesNotReconnectDuringActiveBorrow(): void
+    {
+        $this->app->make('config')->set('database.connections.pool_test.pool.max_idle_time', 1.0);
+
+        $pool = new DbPool($this->app, 'pool_test');
+        $pooledConnection = $this->createPooledConnection($pool);
+        $originalConnection = $pooledConnection->getConnection();
+
+        $this->ageActiveConnectionUse($pooledConnection);
+
+        $this->assertTrue($pooledConnection->check());
+        $this->assertSame($originalConnection, $pooledConnection->getActiveConnection());
     }
 
     public function testExpiredLifetimeReconnectsWhenBorrowedFromPoolAgainWithoutHeartbeat(): void
@@ -525,5 +554,10 @@ class PooledConnectionTest extends DatabaseTestCase
     private function ageConnectionGeneration(PooledConnection $connection): void
     {
         (new ReflectionProperty(PooledConnection::class, 'createdAt'))->setValue($connection, microtime(true) - 5.0);
+    }
+
+    private function ageActiveConnectionUse(PooledConnection $connection): void
+    {
+        (new ReflectionProperty(PooledConnection::class, 'lastUseTime'))->setValue($connection, microtime(true) - 5.0);
     }
 }

--- a/tests/Integration/Database/Sqlite/DbPoolHeartbeatTest.php
+++ b/tests/Integration/Database/Sqlite/DbPoolHeartbeatTest.php
@@ -146,6 +146,62 @@ class DbPoolHeartbeatTest extends TestCase
         });
     }
 
+    public function testHeartbeatDiscardsLifetimeExpiredIdleConnectionBeforePinging(): void
+    {
+        run(function () {
+            $pool = $this->createPool([
+                'min_connections' => 1,
+                'max_connections' => 1,
+                'heartbeat' => -1,
+                'max_lifetime' => 1.0,
+            ], LifetimeExpiredPingTrackingDbPool::class);
+
+            $pooledConnection = $pool->get();
+            $this->assertInstanceOf(LifetimeExpiredPingTrackingPooledConnection::class, $pooledConnection);
+
+            $connection = $pooledConnection->getConnection();
+            $pooledConnection->release();
+
+            $this->ageConnectionGeneration($pooledConnection);
+
+            $pool->runHeartbeatForTest();
+
+            $this->assertFalse($pooledConnection->pingCalled);
+            $this->assertSame(0, $pool->getCurrentConnections());
+            $this->assertSame(0, $pool->getConnectionsInChannel());
+
+            $nextPooledConnection = $pool->get();
+
+            $this->assertNotSame($connection, $nextPooledConnection->getConnection());
+
+            $nextPooledConnection->release();
+        });
+    }
+
+    public function testHeartbeatDoesNotRecycleBorrowedLifetimeExpiredConnection(): void
+    {
+        run(function () {
+            $pool = $this->createPool([
+                'min_connections' => 1,
+                'max_connections' => 1,
+                'heartbeat' => -1,
+                'max_lifetime' => 1.0,
+            ]);
+
+            $borrowed = $pool->get();
+
+            $this->ageConnectionGeneration($borrowed);
+
+            $pool->runHeartbeatForTest();
+
+            $this->assertSame(1, $borrowed->getConnection()->selectOne('SELECT 1 as result')->result);
+            $this->assertSame(1, $pool->getCurrentConnections());
+            $this->assertSame(0, $pool->getConnectionsInChannel());
+
+            $borrowed->release();
+        });
+    }
+
     public function testHeartbeatDoesNotRealizeLazyPdoClosures(): void
     {
         run(function () {
@@ -353,6 +409,7 @@ class DbPoolHeartbeatTest extends TestCase
                 'heartbeat' => -1,
                 'heartbeat_timeout' => 1.0,
                 'max_idle_time' => 60.0,
+                'max_lifetime' => -1.0,
                 ...$poolOptions,
             ],
         ]);
@@ -370,6 +427,11 @@ class DbPoolHeartbeatTest extends TestCase
 
         $lastReleaseTime->setValue($connection, microtime(true) - 5.0);
         $lastUseTime->setValue($connection, microtime(true) - 5.0);
+    }
+
+    protected function ageConnectionGeneration(PooledConnection $connection): void
+    {
+        (new ReflectionProperty(PooledConnection::class, 'createdAt'))->setValue($connection, microtime(true) - 5.0);
     }
 }
 
@@ -401,6 +463,26 @@ class FailingHeartbeatPooledConnection extends PooledConnection
     public function ping(float $timeout): bool
     {
         return false;
+    }
+}
+
+class LifetimeExpiredPingTrackingDbPool extends InspectableHeartbeatDbPool
+{
+    protected function createConnection(): ConnectionInterface
+    {
+        return new LifetimeExpiredPingTrackingPooledConnection($this->container, $this, $this->config);
+    }
+}
+
+class LifetimeExpiredPingTrackingPooledConnection extends PooledConnection
+{
+    public bool $pingCalled = false;
+
+    public function ping(float $timeout): bool
+    {
+        $this->pingCalled = true;
+
+        return true;
     }
 }
 

--- a/tests/Pool/PoolOptionTest.php
+++ b/tests/Pool/PoolOptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Pool;
+
+use Hypervel\Pool\PoolOption;
+use Hypervel\Tests\TestCase;
+
+class PoolOptionTest extends TestCase
+{
+    public function testMaxLifetimeDefaultsToDisabled(): void
+    {
+        $option = new PoolOption;
+
+        $this->assertSame(-1.0, $option->getMaxLifetime());
+    }
+
+    public function testMaxLifetimeCanBeConfigured(): void
+    {
+        $option = new PoolOption(maxLifetime: 120.0);
+
+        $this->assertSame(120.0, $option->getMaxLifetime());
+    }
+
+    public function testMaxLifetimeCanBeChanged(): void
+    {
+        $option = new PoolOption;
+
+        $this->assertSame($option, $option->setMaxLifetime(30.0));
+        $this->assertSame(30.0, $option->getMaxLifetime());
+    }
+}


### PR DESCRIPTION
## Summary
- add a disabled-by-default pool max_lifetime option
- recycle expired database connection generations before reuse and before heartbeat pinging
- expose database pool heartbeat timeout and max-lifetime env config, including pgsql-pooled settings
- document the behavior and add regression coverage for reuse, heartbeat ordering, disabled defaults, and borrowed connection safety

## Validation
- ./vendor/bin/phpunit tests/Integration/Database/PooledConnectionTest.php
- ./vendor/bin/phpunit tests/Integration/Database/Sqlite/DbPoolHeartbeatTest.php
- ./vendor/bin/phpunit tests/Pool/PoolOptionTest.php
- composer fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum connection lifetime option for database connection pools to enable automatic recycling of aged connections
  * Enhanced connection pool heartbeat with support for max lifetime recycling, even through proxies and connection poolers

* **Configuration**
  * Updated default database configuration to support environment variable-driven pool settings (`DB_HEARTBEAT`, `DB_HEARTBEAT_TIMEOUT`, `DB_MAX_LIFETIME`)

* **Documentation**
  * Expanded documentation to describe connection recycling behavior and max lifetime configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->