### PR TITLE
Add database read/write suffix routing

### DIFF
--- a/docs/plans/2026-06-30-database-read-write-routing-and-pool-config.md
+++ b/docs/plans/2026-06-30-database-read-write-routing-and-pool-config.md
@@ -1,0 +1,850 @@
+# Database Read / Write Routing and Pool Config Plan
+
+## Goal
+
+Bring Hypervel's database read / write public API closer to current Laravel while keeping the internals native to Hypervel's long-lived Swoole workers, coroutine context, and database connection pools.
+
+This plan does four things:
+
+1. Keeps the current automatic read / write routing design because it is the right default for Hypervel.
+2. Adds safe `::read` / `::write` connection suffix support without copying Laravel's unsafe shared-connection mutation.
+3. Fixes pooled connection URL parsing and the `db --read` / `db --write` config merge path.
+4. Documents the operational sizing behavior of read / write pooled connections.
+
+Churn and backwards compatibility do not matter. The final codebase should read as if Hypervel was designed this way from the start.
+
+## References Checked
+
+Hypervel source:
+
+- `src/database/src/ConnectionResolver.php`
+- `src/database/src/DatabaseManager.php`
+- `src/database/src/Connectors/ConnectionFactory.php`
+- `src/database/src/Connection.php`
+- `src/database/src/Pool/PoolFactory.php`
+- `src/database/src/Pool/DbPool.php`
+- `src/database/src/Pool/PooledConnection.php`
+- `src/database/src/DatabaseTransactionsManager.php`
+- `src/database/src/Migrations/Migrator.php`
+- `src/database/src/Console/DbCommand.php`
+- `src/boost/docs/database.md`
+- `tests/Database/DatabaseConnectionTest.php`
+- `tests/Database/DatabaseConnectionFactoryTest.php`
+- `tests/Database/DatabaseManagerTest.php`
+- `tests/Database/PoolFactoryTest.php`
+- `tests/Integration/Database/DatabaseConnectionsTest.php`
+- `tests/Integration/Database/ConnectionCoroutineSafetyTest.php`
+- `tests/Integration/Database/PooledConnectionTest.php`
+
+Laravel source:
+
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/src/Illuminate/Database/DatabaseManager.php`
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/src/Illuminate/Database/Connection.php`
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/src/Illuminate/Database/Connectors/ConnectionFactory.php`
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/src/Illuminate/Database/Console/DbCommand.php`
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/tests/Integration/Database/DatabaseConnectionsTest.php`
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/tests/Database/DatabaseManagerTest.php`
+- `/home/binaryfire/workspace/monorepo/examples/laravel/framework/tests/Database/DatabaseConnectionFactoryTest.php`
+
+Hypervel history:
+
+- PR #370 added first-class Postgres external pooler support through a separately configured pooled connection plus `migrations_connection`.
+- Commit `7f71c7f0f` removed Laravel's `::read` / `::write` implementation because Laravel mutates the shared `Connection` object's PDO routing, which does not fit Hypervel's pooled Swoole runtime.
+
+## Current Hypervel Behavior
+
+`ConnectionResolver::connection()` resolves a connection name, borrows a `PooledConnection` from `PoolFactory`, stores the concrete `ConnectionInterface` in `CoroutineContext`, and schedules release with `Coroutine::defer()`. The context key is currently:
+
+```php
+sprintf('__database.connection.%s', $name)
+```
+
+`DbPool` creates one `DbPool` per configured connection name. Each pool slot contains a `PooledConnection`, and each `PooledConnection` wraps one `Connection`.
+
+`ConnectionFactory::make()` creates either:
+
+- a single connection when no `read` config exists; or
+- one write connection with a lazy read PDO closure when `read` config exists.
+
+`Connection::getReadPdo()` already routes correctly:
+
+```php
+if ($this->transactions > 0) {
+    return $this->getPdo();
+}
+
+if ($this->readOnWriteConnection
+    || ($this->recordsModified && $this->getConfig('sticky'))) {
+    return $this->getPdo();
+}
+
+$this->latestPdoTypeRetrieved = 'read';
+
+if ($this->readPdo instanceof Closure) {
+    return $this->readPdo = call_user_func($this->readPdo);
+}
+
+return $this->readPdo ?: $this->getPdo();
+```
+
+`Connection::resetForPool()` clears request/coroutine state, including:
+
+- query callbacks
+- query log state
+- duration handlers
+- `readOnWriteConnection`
+- pretend mode
+- `recordsModified`
+
+This means sticky read routing and forced write-read routing do not leak to another coroutine after pool release.
+
+## Current Laravel Behavior
+
+Laravel parses `::read`, `::write`, and `::direct` in `DatabaseManager::parseConnectionName()`:
+
+```php
+protected function parseConnectionName($name)
+{
+    return Str::endsWith($name, ['::read', '::write', '::direct'])
+        ? explode('::', $name, 2)
+        : [$name, null];
+}
+```
+
+Laravel then mutates the connection in `setPdoForType()`:
+
+```php
+if ($type === 'read') {
+    $connection->setPdo($connection->getReadPdo());
+} elseif ($type === 'write') {
+    $connection->setReadPdo($connection->getPdo());
+} elseif ($type === 'direct') {
+    $connection->setPdo($connection->getDirectPdo())
+        ->setReadPdo($connection->getDirectPdo());
+}
+```
+
+This mutation is safe enough in Laravel's lifecycle, but it is not safe to copy into Hypervel because Hypervel reuses pooled connection objects across coroutines.
+
+Laravel's recent Postgres external pooler PR also added `::direct` and `--pooled`, but Hypervel already has a cleaner native model: configure a separate pooled connection and use `migrations_connection` for migration/schema paths.
+
+## Design Decisions
+
+### Keep Automatic Routing As-Is
+
+Do not replace Hypervel's automatic read / write routing with a deep role-aware pool wrapper.
+
+Reason:
+
+- The current design is lazy: actual PDO sockets open only when first used.
+- The current design is coroutine-safe: request routing state is reset on pool release.
+- The current design preserves one coherent `Connection` object with query log, events, query duration handlers, grammars, processors, transaction state, and transaction manager hooks.
+- A deep automatic role-aware wrapper would need to keep all of that state coherent across separate physical pools. That adds complexity and risk for limited gain.
+
+The main operational tradeoff is that a single pool slot can lazily hold both one write PDO and one read PDO. This must be documented.
+
+### Add Safe `::read` / `::write`
+
+Add `DB::connection('name::read')` and `DB::connection('name::write')` because they are Laravel public API and useful for explicit diagnostics or code that accepts only a connection name.
+
+Do not port Laravel's mutation implementation.
+
+Hypervel behavior:
+
+- `name::read` uses a derived read config and a separate read pool when the base connection has a non-null `read` config, using the same `isset($config['read'])` gate as `ConnectionFactory::make()`. An empty `read` array still counts and merges back to the base config; `read => null` does not.
+- `name::write` uses the base pool under a suffixed coroutine context key and calls `useWriteConnectionWhenReading(true)` on that borrowed connection.
+- A connection with no read / write split treats `name::read` and `name::write` as physical aliases of the base connection and never errors.
+- `::direct` remains unsupported because Hypervel uses `migrations_connection` plus separate configured connections instead.
+
+Unsplit suffixes are compatibility aliases only. They should not synthesize a fake read role because there is no configured read side, and doing so would require a mutable per-borrow read marker that Hypervel does not otherwise need.
+
+### Fix Pooled URL Parsing
+
+`DatabaseManager::configuration()` parses `url`, but `DbPool::__construct()` currently reads the raw config and `ConnectionFactory::parseConfig()` does not parse URLs. In pooled Swoole runtime, `DB_URL` / `DB_POOLED_URL` can be ignored.
+
+Fix URL parsing in both:
+
+- `DbPool::__construct()`, so pool-level decisions such as `pool` options and in-memory SQLite detection see parsed config.
+- `ConnectionFactory::parseConfig()`, so every connection creation path has one authoritative parse point.
+
+The parser is idempotent when `url` is absent, so parsing in both places is safe.
+
+### Fix `db --read` / `db --write`
+
+`DbCommand::getConnection()` currently assumes nested config is shaped as `['host' => ...]` and indexes `$connection['read']['host']` directly.
+
+Current Laravel's `mergeConnectionConfiguration()` handles:
+
+- empty nested config
+- list-of-configs
+- host arrays
+- stripping nested `read` / `write` config after merge
+
+Hypervel should adapt that helper without Laravel's `direct` / `pooled` CLI behavior.
+
+### Do Not Add `::direct`
+
+`::direct` should stay omitted. Hypervel's external-pooler model is better as normal named connections:
+
+```php
+'pgsql' => [
+    // direct database connection
+],
+
+'pgsql-pooled' => [
+    // PgBouncer / PgDog connection
+    'migrations_connection' => 'pgsql',
+],
+```
+
+Future ports need to see this is intentional, so implementation must record the omission in:
+
+1. `src/database/README.md` under `Differences From Laravel`.
+2. A concise source comment near suffix parsing.
+3. A `REMOVED:` comment near the corresponding upstream `::direct` tests that are intentionally not ported.
+
+### Do Not Restore `getNameWithReadWriteType()`
+
+Do not restore Laravel's `Connection::getNameWithReadWriteType()`.
+
+Reason:
+
+- Hypervel currently has no consumers.
+- `::write` will use the efficient `useWriteConnectionWhenReading(true)` path and will not carry a forced config marker.
+- Restoring the method would produce an asymmetric identity surface: `name::read` could report a suffix from config, while `name::write` would not unless a new mutable marker was added.
+- Query event and exception behavior is already carried through `latestReadWriteTypeUsed()`.
+
+Keep `Connection::getName()` as the base connection name. This keeps transaction manager keying aligned with Laravel's base-name behavior and avoids splitting transaction callback state by suffix.
+
+## Implementation Plan
+
+### 1. Add a Parsed Connection Name Helper
+
+Add a small final readonly value object in the database package, for example `Hypervel\Database\ConnectionName`.
+
+Purpose:
+
+- parse one string format in one place;
+- reject `::direct` with a clear exception and source comment;
+- expose the requested name, base name, and nullable role.
+
+Sketch:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database;
+
+use InvalidArgumentException;
+
+final readonly class ConnectionName
+{
+    public const READ = 'read';
+
+    public const WRITE = 'write';
+
+    public function __construct(
+        public string $requested,
+        public string $base,
+        public ?string $role = null,
+    ) {
+    }
+
+    public static function parse(string $name): self
+    {
+        foreach ([self::READ, self::WRITE] as $role) {
+            $suffix = '::' . $role;
+
+            if (str_ends_with($name, $suffix)) {
+                return new self($name, substr($name, 0, -strlen($suffix)), $role);
+            }
+        }
+
+        // Laravel's ::direct suffix is intentionally omitted. Hypervel uses
+        // normal named connections plus migrations_connection for pooler paths.
+        if (str_ends_with($name, '::direct')) {
+            throw new InvalidArgumentException(
+                'Database connection suffix [::direct] is not supported. Configure a direct connection and use migrations_connection instead.'
+            );
+        }
+
+        return new self($name, $name);
+    }
+
+    public function isRead(): bool
+    {
+        return $this->role === self::READ;
+    }
+
+    public function isWrite(): bool
+    {
+        return $this->role === self::WRITE;
+    }
+}
+```
+
+`::direct` rejection is intentionally explicit. A silent "connection not configured" error would make the known Laravel difference harder to diagnose.
+
+### 2. Add Role Config Derivation to `ConnectionFactory`
+
+Keep read/write config merging inside `ConnectionFactory`, because it already owns `getReadConfig()`, `getWriteConfig()`, `getReadWriteConfig()`, and `mergeReadWriteConfig()`.
+
+Make `parseConfig()` public so pooled and non-pooled setup can share the same authoritative parsing path without adding a redundant passthrough method. Keep the Laravel-aligned method name, and update callers inside `ConnectionFactory` normally.
+
+Add read helper methods that do not expose mutable connection state:
+
+```php
+public function hasReadConfig(array $config): bool
+{
+    return isset($config[ConnectionName::READ]);
+}
+
+public function configForRead(array $config): array
+{
+    $config = $this->parseConfig($config, $config['name'] ?? null);
+
+    return Arr::add(
+        $this->getReadConfig($config),
+        Connection::READ_WRITE_TYPE_CONFIG_KEY,
+        ConnectionName::READ,
+    );
+}
+```
+
+`parseConfig()` should become public and parse URL config before adding defaults:
+
+```php
+public function parseConfig(array $config, ?string $name): array
+{
+    $config = (new ConfigurationUrlParser)->parseConfiguration($config);
+
+    return Arr::add(Arr::add($config, 'prefix', ''), 'name', $name);
+}
+```
+
+Use `Hypervel\Database\ConfigurationUrlParser`, not `Hypervel\Support\ConfigurationUrlParser`, inside the database package.
+
+`configForRead()` must only be called after `hasReadConfig()` returns true. Use `isset($config['read'])` to match `ConnectionFactory::make()`: an empty array still counts as a read split, while `read => null` is treated as no split and avoids a typed `getReadWriteConfig()` failure.
+
+### 3. Cache Forced Read/Write Type on `Connection`
+
+Add a nullable property initialized from the parsed config once in the constructor. Do not read config on every query.
+
+Place the constant and property beside the existing read/write routing state (`recordsModified`, `readOnWriteConnection`, and `latestPdoTypeRetrieved`) so related state stays grouped.
+
+Sketch:
+
+```php
+public const READ_WRITE_TYPE_CONFIG_KEY = 'read_write_type';
+
+/**
+ * The configured read / write type for derived single-role connections.
+ */
+protected ?string $readWriteType = null;
+
+public function __construct(PDO|Closure $pdo, string $database = '', string $tablePrefix = '', array $config = [])
+{
+    $this->pdo = $pdo;
+    $this->database = $database;
+    $this->tablePrefix = $tablePrefix;
+    $this->config = $config;
+    $this->readWriteType = $config[self::READ_WRITE_TYPE_CONFIG_KEY] ?? null;
+
+    $this->useDefaultQueryGrammar();
+    $this->useDefaultPostProcessor();
+}
+
+protected function latestReadWriteTypeUsed(): ?string
+{
+    return $this->readWriteType ?? $this->latestPdoTypeRetrieved;
+}
+```
+
+This is worker-safe because it is immutable per `Connection` instance. Derived `::read` pools are separate pools. Normal connections have `null`, preserving current behavior.
+
+Do not add a public setter.
+
+### 4. Fix `getConnectionDetails()`
+
+`getConnectionDetails()` currently assumes any latest `read` type means read/write split mode:
+
+```php
+$config = $this->latestReadWriteTypeUsed() === 'read'
+    ? $this->readPdoConfig
+    : $this->config;
+```
+
+For a derived `name::read` single connection, the real target config lives in `$this->config`, and `readPdoConfig` is empty.
+
+Change it to only use `readPdoConfig` when a read/write split config exists:
+
+```php
+$config = $this->latestReadWriteTypeUsed() === 'read' && $this->readPdoConfig !== []
+    ? $this->readPdoConfig
+    : $this->config;
+```
+
+This keeps existing read/write split exception details correct and fixes derived read exception details.
+
+### 5. Make `DbPool` Suffix and URL Aware
+
+`DbPool` must parse URLs before it inspects config.
+
+Sketch:
+
+```php
+public function __construct(Container $container, string $name)
+{
+    $connectionName = ConnectionName::parse($name);
+    $configService = $container->make('config');
+    $key = sprintf('database.connections.%s', $connectionName->base);
+
+    if (! $configService->has($key)) {
+        throw new InvalidArgumentException(sprintf('Database connection [%s] not configured.', $connectionName->base));
+    }
+
+    $factory = $container->make('db.factory');
+    $config = $factory->parseConfig($configService->get($key), $connectionName->base);
+
+    if ($connectionName->isRead() && $factory->hasReadConfig($config)) {
+        $config = $factory->configForRead($config);
+        $this->ensureNotDerivedInMemorySqlitePool($connectionName, $config);
+    }
+
+    $this->config = $config;
+    $poolOptions = Arr::get($this->config, 'pool', []);
+
+    // existing constructor flow...
+}
+```
+
+Do not create a `name::write` pool. `::write` uses the base pool.
+
+This means pooled URL parsing intentionally runs more than once when a pooled connection is first created: twice for a base connection, and three times for a derived `::read` connection because `configForRead()` also parses before deriving the read config. This is idempotent and happens at connection creation time, not per query.
+
+Add an in-memory SQLite guard for derived read pools:
+
+```php
+protected function ensureNotDerivedInMemorySqlitePool(ConnectionName $name, array $config): void
+{
+    if (($config['driver'] ?? null) !== 'sqlite') {
+        return;
+    }
+
+    $database = $config['database'] ?? '';
+
+    if ($database === ':memory:' || str_contains($database, '?mode=memory') || str_contains($database, '&mode=memory')) {
+        throw new InvalidArgumentException(
+            "Database connection [{$name->requested}] cannot use a derived read pool for in-memory SQLite."
+        );
+    }
+}
+```
+
+Reason: a separate read pool for in-memory SQLite would create a second empty in-memory database. File-backed SQLite read/write tests remain supported.
+
+### 6. Make `PoolFactory` Resolve Pool Keys
+
+Add role-aware pool keying:
+
+- base `name` => pool key `name`
+- `name::read` with non-null `read` config, including an empty array => pool key `name::read`
+- `name::read` without `read` config, or with `read => null` => pool key `name`
+- `name::write` => pool key `name`
+
+Sketch:
+
+```php
+public function getPool(string $name): DbPool
+{
+    $poolName = $this->getPoolName($name);
+
+    if (isset($this->pools[$poolName])) {
+        return $this->pools[$poolName];
+    }
+
+    $pool = $this->container->make(DbPool::class, ['name' => $poolName]);
+
+    return $this->pools[$poolName] = $pool;
+}
+
+public function flushPoolsForConnection(string $name): void
+{
+    $base = ConnectionName::parse($name)->base;
+
+    foreach (array_keys($this->pools) as $poolName) {
+        if ($poolName === $base || str_starts_with($poolName, $base . '::')) {
+            $this->flushPool($poolName);
+        }
+    }
+}
+```
+
+`getPoolName()` should read config only to determine whether `::read` passes the same `isset($config['read'])` gate as `ConnectionFactory::make()`. It should not build a connection.
+
+This adds a config read to `PoolFactory`, but only at pool selection / creation time. The hot query path continues to use an already borrowed connection.
+
+### 7. Make `ConnectionResolver` Role Aware
+
+Keep the coroutine context key as the requested name so `name`, `name::read`, and `name::write` are isolated within the same coroutine.
+
+Sketch:
+
+```php
+public function connection(UnitEnum|string|null $name = null): ConnectionInterface
+{
+    $connectionName = ConnectionName::parse(enum_value($name) ?: $this->getDefaultConnection());
+    $contextKey = $this->getContextKey($connectionName->requested);
+
+    if (CoroutineContext::has($contextKey)) {
+        $connection = CoroutineContext::get($contextKey);
+
+        if ($connection instanceof ConnectionInterface) {
+            return $connection;
+        }
+    }
+
+    $pool = $this->factory->getPool($connectionName->requested);
+    $pooledConnection = $pool->get();
+
+    try {
+        $connection = $pooledConnection->getConnection();
+
+        if ($connectionName->isWrite() && $connection instanceof Connection) {
+            $connection->useWriteConnectionWhenReading();
+        }
+
+        CoroutineContext::set($contextKey, $connection);
+    } finally {
+        if (Coroutine::inCoroutine()) {
+            Coroutine::defer(function () use ($pooledConnection, $contextKey) {
+                CoroutineContext::set($contextKey, null);
+                $pooledConnection->release();
+            });
+        }
+    }
+
+    return $connection;
+}
+```
+
+This is safe because:
+
+- `name::write` gets its own context entry.
+- It may borrow a separate base-pool slot if `name` is also used in the same coroutine.
+- `resetForPool()` clears `readOnWriteConnection` on release.
+- No separate write pool is created.
+
+### 8. Make `DatabaseManager` Role Aware
+
+Direct/non-pooled resolution must match pooled resolution so Capsule/tests do not behave differently.
+
+Change `resolveConnectionDirectly()` to cache by requested name but build using the base name/config.
+
+Sketch:
+
+```php
+public function resolveConnectionDirectly(string $name): ConnectionInterface
+{
+    $connectionName = ConnectionName::parse($name);
+
+    if (! isset($this->connections[$connectionName->requested])) {
+        $connection = $this->configure(
+            $this->makeConnection($connectionName)
+        );
+
+        if ($connectionName->isWrite()) {
+            $connection->useWriteConnectionWhenReading();
+        }
+
+        $this->connections[$connectionName->requested] = $connection;
+        $this->dispatchConnectionEstablishedEvent($connection);
+    }
+
+    return $this->connections[$connectionName->requested];
+}
+```
+
+Change `makeConnection()` and `configuration()` to accept `ConnectionName|string`:
+
+```php
+protected function makeConnection(ConnectionName|string $name): Connection
+{
+    $connectionName = is_string($name) ? ConnectionName::parse($name) : $name;
+    $config = $this->configuration($connectionName);
+
+    return $this->factory->make($config, $connectionName->base);
+}
+```
+
+`configuration()` should:
+
+- look up `database.connections.<base>`;
+- parse URL config through the database parser;
+- derive read config only for `::read` when the base config passes the same `isset($config['read'])` gate as `ConnectionFactory::make()`;
+- leave `::write` as base config because write forcing is handled by `useWriteConnectionWhenReading()`;
+- leave unsplit `::read` / `::write` as base config.
+
+`configuration()` should call `$this->factory->hasReadConfig()` and `$this->factory->configForRead()` for read derivation, the same helper path `DbPool` uses. This keeps pooled and non-pooled resolution on one derivation source.
+
+While touching this class, replace existing `$this->app['events']` reads with `$this->app->make('events')` to match Hypervel's container convention.
+
+### 9. Update Manager Cleanup Paths
+
+`purge()`, `disconnect()`, and `reconnect()` must account for base and role variants.
+
+Add helpers:
+
+```php
+protected function connectionNameVariants(UnitEnum|string|null $name): array
+{
+    $base = ConnectionName::parse(enum_value($name) ?: $this->getDefaultConnection())->base;
+
+    return [$base, $base . '::read', $base . '::write'];
+}
+```
+
+Use variants for:
+
+- `CoroutineContext` keys
+- non-pooled `$connections` cache
+- resolver flush calls when the configured resolver implements `FlushableConnectionResolver`
+- pool flushing
+
+`purge()` should forget all variants and call `PoolFactory::flushPoolsForConnection($base)`.
+
+`disconnect()` should disconnect current-coroutine connections for all variants and non-pooled cached connections for all variants, but it should not clear context, matching current behavior.
+
+`reconnect()` should keep the current shape but use the requested context key after `disconnect()`. For `name::write`, reconnecting the suffixed context connection should reconnect that borrowed base-pool slot and preserve the forced-write flag for the current borrow.
+
+### 10. Keep Migration Routing on `migrations_connection`
+
+Do not add `::direct`.
+
+Do not route `db:show` or `db:table` through `migrations_connection`. They inspect the selected app connection. Schema and migration commands already route through `migrations_connection` where needed.
+
+### 11. Fix `DbCommand` Merge Logic
+
+Switch the import to the database parser:
+
+```php
+use Hypervel\Database\ConfigurationUrlParser;
+use Hypervel\Support\Arr;
+```
+
+Add an adapted merge helper:
+
+```php
+protected function mergeConnectionConfiguration(array $connection, string $type): array
+{
+    if (empty($connection[$type])) {
+        return $connection;
+    }
+
+    $merge = $connection[$type];
+
+    if (isset($merge[0]) && is_array($merge[0])) {
+        $merge = $merge[0];
+    }
+
+    if (is_array($merge['host'] ?? null)) {
+        $merge['host'] = $merge['host'][0];
+    }
+
+    $connection = array_merge($connection, $merge);
+
+    if (is_array($connection['host'] ?? null)) {
+        $connection['host'] = $connection['host'][0];
+    }
+
+    return Arr::except($connection, ['read', 'write']);
+}
+```
+
+Use it for `--read` and `--write`.
+
+While touching this command, read config through the config repository resolved with `$this->hypervel->make('config')` instead of container array access.
+
+### 12. Update Docs
+
+Update `src/boost/docs/database.md`.
+
+Add `::read` / `::write` to the read/write section:
+
+```md
+You may also resolve a specific side of a configured read / write connection by appending `::read` or `::write` to the connection name:
+
+```php
+$users = DB::connection('mysql::read')->select('select * from users');
+$count = DB::connection('mysql::write')->table('users')->count();
+```
+
+Use these suffixes when you need to explicitly inspect a replica or force reads through the write connection. Normal application queries do not need them; Hypervel routes reads, writes, transactions, and sticky reads automatically.
+```
+
+Add pool sizing guidance to the connection pooling section:
+
+```md
+For a connection with separate read and write hosts, each base pool slot may lazily open one write PDO and one read PDO. It does not open one PDO per configured host. If `max_connections` is `10`, a worker may therefore hold up to roughly 20 server-side database connections for that configured connection once both sides have been used. Size your database server, PgBouncer, PgDog, or other pooler capacity with that in mind. Increase `max_connections` for more concurrent database work per worker, not simply because you configured more read hosts.
+
+Explicit `::read` connections use a separate read-only pool with the same top-level `pool` settings as the base connection. Explicit `::write` connections do not create a separate pool, but a coroutine that uses both `mysql` and `mysql::write` at the same time may borrow two slots from the base pool. Most applications do not need these suffixes in normal query paths because Hypervel already routes reads, writes, transactions, and sticky reads automatically.
+```
+
+Update the external pooler note to make the Hypervel equivalent of Laravel `::direct` clear without making `::direct` sound supported:
+
+```md
+When you need a direct connection for migrations or schema operations, configure it as a normal connection and reference it with `migrations_connection`. Hypervel does not use Laravel's `::direct` connection suffix.
+```
+
+Update the database CLI section to state that `--read` and `--write` understand list-style nested read/write configs and host arrays.
+
+Update `src/database/README.md` with a concise `Differences From Laravel` section:
+
+```md
+## Differences From Laravel
+
+- Laravel's external database pooler support uses a `::direct` connection suffix. Hypervel instead uses normal named connections for each endpoint and `migrations_connection` for schema and migration paths. This keeps direct and pooled endpoints as normal configured connections with their own pool settings, so Hypervel does not support Laravel's `::direct` suffix.
+```
+
+### 13. Remove Stale Comments and Add Only Useful Comments
+
+Remove or update any old comments that imply `::read` / `::write` are unsupported.
+
+Add one concise source comment near `::direct` rejection. Do not annotate ordinary adapted code.
+
+Do not add `Boot-only.` or similar warnings to `flushState()` docblocks.
+
+## Testing Plan
+
+Run targeted tests immediately after updating each touched test file.
+
+### Unit Tests
+
+Update or add tests in `tests/Database/DatabaseConnectionTest.php`:
+
+- Keep/refine the already added sticky tests:
+  - `testStickyReadConnectionsUseWritePdoAfterRecordsModified()`
+  - `testNonStickyReadConnectionsKeepUsingReadPdoAfterRecordsModified()`
+  - `testResetForPoolClearsStickyReadRoutingState()`
+- Add a test proving a derived `::read` single connection's `QueryException` uses `$this->config`, not empty `readPdoConfig`.
+- Keep existing read/write split exception detail tests green.
+
+Update or add tests in `tests/Database/DatabaseConnectionFactoryTest.php`:
+
+- pooled/non-pooled URL parsing uses `Hypervel\Database\ConfigurationUrlParser` consistently.
+- read role config derivation:
+  - strips nested `read` / `write`;
+  - merges base config;
+  - preserves base `name`;
+  - adds forced read role marker only for derived read config.
+  - treats `read => null` as no read split.
+- the new public factory read helpers do not expose or derive write-role config because `::write` uses the base pool and `useWriteConnectionWhenReading()`.
+
+Add tests for `ConnectionName`:
+
+- `ConnectionName::parse('default')` returns the base name with no role.
+- `ConnectionName::parse('default::read')` and `ConnectionName::parse('default::write')` split requested/base/role correctly.
+- `ConnectionName::parse('default::direct')` throws `InvalidArgumentException` with the documented message.
+
+Update or add tests in `tests/Database/PoolFactoryTest.php`:
+
+- `getPool('default')` returns base pool.
+- `getPool('default::write')` returns the base pool.
+- `getPool('default::read')` returns a separate pool when the base config has non-null `read` config.
+- `getPool('default::read')` returns the base pool when the base config does not have non-null `read` config.
+- `flushPoolsForConnection('default')` flushes base and derived read pools.
+
+Update or add tests in `tests/Database/DatabaseManagerTest.php`:
+
+- non-pooled `connection('default::read')` works.
+- non-pooled `connection('default::write')` works and uses write routing for reads.
+- non-pooled `connection('default::direct')` throws the documented `InvalidArgumentException`.
+- unsplit `connection('default::read')` and `connection('default::write')` do not throw and do not create role-specific pools.
+- `purge('default')`, `disconnect('default')`, and `reconnect('default')` handle base and role variants.
+- touched `DatabaseManager` event dispatch code uses `$this->app->make('events')` instead of container array access.
+
+Update or add tests for `DbCommand`:
+
+- `--read` handles list-of-configs.
+- `--write` handles list-of-configs.
+- host arrays are reduced to the first host for CLI commands.
+- empty nested read/write config returns base config.
+- merged CLI config strips `read` / `write`.
+- command config reads use the container's config repository instead of container array access.
+
+### Integration Tests
+
+Update `tests/Integration/Database/DatabaseConnectionsTest.php`:
+
+- port/adapt Laravel's `readWriteExpectations` coverage for:
+  - base split connection: write/read/write/read
+  - `::read`: read/read/read/read
+  - `::write`: write/write/write/write
+- query logs include the same expected `readWriteType` values.
+- query exceptions carry expected `readWriteType` for `::read` and `::write`.
+- `::read` and `::write` on unsplit connection do not throw and behave as base-connection compatibility aliases.
+- unsplit/base connections never carry the forced-read config marker; their read/write type continues to come only from the latest PDO used.
+- `DB::connection('default::direct')` throws the documented `InvalidArgumentException`.
+
+Add coroutine isolation tests in `tests/Integration/Database/ConnectionCoroutineSafetyTest.php`:
+
+- one coroutine using `default::write` does not force another coroutine's `default` reads onto the write connection.
+- within the same coroutine, `default` and `default::write` use separate context entries, so forcing write reads on the suffixed connection does not affect the plain connection.
+- `default::read` and `default` are separately cached in coroutine context when a read split exists.
+
+Add pool/integration tests in `tests/Integration/Database/PooledConnectionTest.php` or a focused new integration file if clearer:
+
+- pooled config using only `url` creates the correct driver/database config.
+- pooled `pgsql-pooled`-style URL config is parsed before pool setup.
+- derived read pool for in-memory SQLite throws the explicit exception.
+- file-backed SQLite read/write split still works with `::read`.
+
+Add transaction manager coverage in an integration test:
+
+- `getName()` remains the base name for suffixed connections.
+- after-commit callbacks registered while using `default` still execute correctly if the coroutine also touches `default::read`.
+- rollback callbacks do not leak or split by suffixed name.
+
+### Documentation Review Tests
+
+No docs-specific automated test is needed, but after editing docs:
+
+- read the full edited `src/boost/docs/database.md` section around read/write and pooling;
+- verify wording focuses on functionality (`per connection`, `read`, `write`, `pool slots`) rather than internal implementation details;
+- verify it does not claim each host gets its own PDO;
+- verify it explains `max_connections` sizing without telling users to increase pool size just because more hosts exist.
+
+### Command Run Order
+
+After implementation:
+
+```bash
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseConnectionTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseConnectionFactoryTest.php
+./vendor/bin/phpunit --no-progress tests/Database/PoolFactoryTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseManagerTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/DatabaseConnectionsTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/ConnectionCoroutineSafetyTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/PooledConnectionTest.php
+composer fix
+```
+
+`composer fix` runs cs-fixer, phpstan, and the full parallel test suite.
+
+## Self-Review Checklist
+
+Before requesting code review after implementation:
+
+- Trace `DB::connection('name')` through `DatabaseManager`, `ConnectionResolver`, `PoolFactory`, `DbPool`, `PooledConnection`, and `ConnectionFactory`.
+- Trace `DB::connection('name::read')` through the same path and confirm it uses a separate read pool only when the base config passes the same `isset($config['read'])` gate as `ConnectionFactory::make()`.
+- Trace `DB::connection('name::write')` and confirm it uses the base pool, suffixed context key, and `useWriteConnectionWhenReading(true)`.
+- Confirm `resetForPool()` clears every mutable per-borrow state added or touched by this work.
+- Confirm normal unsuffixed query execution has no per-query overhead beyond the existing `latestReadWriteTypeUsed()` property read.
+- Confirm URL parsing is not skipped on pooled runtime connections.
+- Confirm `DbCommand` still works for sqlite and connections without host.
+- Confirm `migrations_connection` behavior is unchanged.
+- Confirm `db:show` and `db:table` behavior is unchanged.
+- Search for `::read`, `::write`, `::direct`, `getNameWithReadWriteType`, and stale comments to make sure no old unsupported-state text remains.
+- Re-read `src/boost/docs/database.md` and `src/database/README.md` after edits.

--- a/src/boost/docs/database.md
+++ b/src/boost/docs/database.md
@@ -124,6 +124,15 @@ Note that three keys have been added to the configuration array: `read`, `write`
 
 You only need to place items in the `read` and `write` arrays if you wish to override the values from the main `mysql` array. So, in this case, `192.168.1.1` will be used as the host for the "read" connection, while `192.168.1.3` will be used for the "write" connection. The database credentials, prefix, character set, pool configuration, and all other options in the main `mysql` array will be shared across both connections. When multiple values exist in the `host` configuration array, a database host will be randomly chosen when a new connection is established.
 
+You may also resolve a specific side of a configured read / write connection by appending `::read` or `::write` to the connection name:
+
+```php
+$users = DB::connection('mysql::read')->select('select * from users');
+$count = DB::connection('mysql::write')->table('users')->count();
+```
+
+Use these suffixes when you need to explicitly inspect a replica or force reads through the write connection. Normal application queries do not need them; Hypervel routes reads, writes, transactions, and sticky reads automatically.
+
 <a name="the-sticky-option"></a>
 #### The `sticky` Option
 
@@ -155,11 +164,17 @@ Each connection may define its own `pool` configuration:
 
 The `min_connections` option determines the minimum number of connections kept warm in the pool, while the `max_connections` option determines the maximum number of connections that may be opened for the worker. The `connect_timeout` option controls how long Hypervel will wait while opening a new database connection. The `wait_timeout` option controls how long a coroutine may wait for an available connection when the pool is exhausted. The `heartbeat` option controls how often Hypervel validates idle connections in the worker pool; set this value to `-1` to disable heartbeats. When heartbeats are enabled, Hypervel keeps the minimum idle connection set alive with a raw `SELECT 1` ping that does not fire query events, query logs, or query duration handlers. The `heartbeat_timeout` option controls how long a heartbeat ping may run before the connection is discarded. The `max_idle_time` option controls how long idle connections above the minimum pool size may remain in the pool before they are closed. The `max_lifetime` option controls the upper bound for how long a pooled connection generation may live before it is recycled while idle or before it is reused; Hypervel assigns each generation an effective lifetime between 90-100% of this value to avoid synchronized reconnects. Set this value to `-1` to disable lifetime recycling.
 
+For a connection with separate read and write hosts, each base pool slot may lazily open one write PDO and one read PDO. It does not open one PDO per configured host. If `max_connections` is `10`, a worker may therefore hold up to roughly 20 server-side database connections for that configured connection once both sides have been used. Size your database server, PgBouncer, PgDog, or other pooler capacity with that in mind. Increase `max_connections` for more concurrent database work per worker, not simply because you configured more read hosts.
+
+Explicit `::read` connections use a separate read-side pool built from the merged read configuration, including the base `pool` settings unless the read configuration overrides them. Explicit `::write` connections do not create a separate pool, but a coroutine that uses both `mysql` and `mysql::write` at the same time may borrow two slots from the base pool. Most applications do not need these suffixes in normal query paths because Hypervel already routes reads, writes, transactions, and sticky reads automatically.
+
 Heartbeat and max lifetime recycling apply to Hypervel's worker pool whether the connection points directly at the database or through a proxy / pooler. They help long-running workers avoid stale sockets and rotate old idle connection generations before those connections are used by a request.
 
 Hypervel's default database configuration also includes a `pgsql-pooled` connection. This connection is intended for PostgreSQL transaction poolers such as PgBouncer and uses separate `DB_POOLED_*` environment variables. It also sets `migrations_connection` to `pgsql`, allowing your application to use the pooled connection at runtime while migration commands use the direct PostgreSQL connection.
 
 You may use `migrations_connection` on any database connection to instruct migration commands to run against another configured connection. This is useful when a runtime connection points at a database pooler that does not support every operation required by migrations.
+
+When you need a direct connection for migrations or schema operations, configure it as a normal connection and reference it with `migrations_connection`. Hypervel does not use Laravel's `::direct` connection suffix.
 
 <a name="running-queries"></a>
 ## Running SQL Queries
@@ -477,6 +492,8 @@ If the connection has separate read and write hosts, you may connect to either h
 ```shell
 php artisan db mysql --read
 ```
+
+The `--read` and `--write` options understand list-style read / write configuration and host arrays. When a side contains multiple hosts, the command connects to the first configured host for that side.
 
 <a name="inspecting-your-databases"></a>
 ## Inspecting Your Databases

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -2,3 +2,7 @@ Database for Hypervel
 ===
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hypervel/database)
+
+## Differences From Laravel
+
+- Laravel's external database pooler support uses a `::direct` connection suffix. Hypervel instead uses normal named connections for each endpoint and `migrations_connection` for schema and migration paths. This keeps direct and pooled endpoints as normal configured connections with their own pool settings, so Hypervel does not support Laravel's `::direct` suffix.

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -117,6 +117,8 @@ class Connection implements ConnectionInterface
      */
     protected ?DatabaseTransactionsManager $transactionsManager = null;
 
+    public const READ_WRITE_TYPE_CONFIG_KEY = 'read_write_type';
+
     /**
      * Indicates if changes have been made to the database.
      */
@@ -126,6 +128,20 @@ class Connection implements ConnectionInterface
      * Indicates if the connection should use the "write" PDO connection.
      */
     protected bool $readOnWriteConnection = false;
+
+    /**
+     * The configured read / write type for derived single-role connections.
+     *
+     * @var null|'read'|'write'
+     */
+    protected ?string $readWriteType = null;
+
+    /**
+     * The last retrieved PDO read / write type.
+     *
+     * @var null|'read'|'write'
+     */
+    protected ?string $latestPdoTypeRetrieved = null;
 
     /**
      * All of the queries run against the connection.
@@ -185,13 +201,6 @@ class Connection implements ConnectionInterface
     protected static array $resolvers = [];
 
     /**
-     * The last retrieved PDO read / write type.
-     *
-     * @var null|'read'|'write'
-     */
-    protected ?string $latestPdoTypeRetrieved = null;
-
-    /**
      * Create a new database connection instance.
      */
     public function __construct(PDO|Closure $pdo, string $database = '', string $tablePrefix = '', array $config = [])
@@ -206,6 +215,8 @@ class Connection implements ConnectionInterface
         $this->tablePrefix = $tablePrefix;
 
         $this->config = $config;
+
+        $this->readWriteType = $config[self::READ_WRITE_TYPE_CONFIG_KEY] ?? null;
 
         // We need to initialize a query grammar and the query post processors
         // which are both very important parts of the database abstractions
@@ -1270,7 +1281,7 @@ class Connection implements ConnectionInterface
      */
     protected function getConnectionDetails(): array
     {
-        $config = $this->latestReadWriteTypeUsed() === 'read'
+        $config = $this->latestReadWriteTypeUsed() === 'read' && $this->readPdoConfig !== []
             ? $this->readPdoConfig
             : $this->config;
 
@@ -1503,7 +1514,7 @@ class Connection implements ConnectionInterface
      */
     protected function latestReadWriteTypeUsed(): ?string
     {
-        return $this->latestPdoTypeRetrieved;
+        return $this->readWriteType ?? $this->latestPdoTypeRetrieved;
     }
 
     /**

--- a/src/database/src/ConnectionName.php
+++ b/src/database/src/ConnectionName.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database;
+
+use InvalidArgumentException;
+
+final readonly class ConnectionName
+{
+    public const READ = 'read';
+
+    public const WRITE = 'write';
+
+    /**
+     * Create a new parsed connection name instance.
+     */
+    public function __construct(
+        public string $requested,
+        public string $base,
+        public ?string $role = null
+    ) {
+    }
+
+    /**
+     * Parse a database connection name.
+     */
+    public static function parse(string $name): self
+    {
+        foreach ([self::READ, self::WRITE] as $role) {
+            $suffix = '::' . $role;
+
+            if (str_ends_with($name, $suffix)) {
+                return new self($name, substr($name, 0, -strlen($suffix)), $role);
+            }
+        }
+
+        // Laravel's ::direct suffix is intentionally omitted. Hypervel uses
+        // normal named connections plus migrations_connection for pooler paths.
+        if (str_ends_with($name, '::direct')) {
+            throw new InvalidArgumentException(
+                'Database connection suffix [::direct] is not supported. Configure a direct connection and use migrations_connection instead.'
+            );
+        }
+
+        return new self($name, $name);
+    }
+
+    /**
+     * Determine if the parsed name requests the read side.
+     */
+    public function isRead(): bool
+    {
+        return $this->role === self::READ;
+    }
+
+    /**
+     * Determine if the parsed name requests the write side.
+     */
+    public function isWrite(): bool
+    {
+        return $this->role === self::WRITE;
+    }
+}

--- a/src/database/src/ConnectionResolver.php
+++ b/src/database/src/ConnectionResolver.php
@@ -57,8 +57,8 @@ class ConnectionResolver implements ConnectionResolverInterface
      */
     public function connection(UnitEnum|string|null $name = null): ConnectionInterface
     {
-        $name = enum_value($name) ?: $this->getDefaultConnection();
-        $contextKey = $this->getContextKey($name);
+        $connectionName = ConnectionName::parse(enum_value($name) ?: $this->getDefaultConnection());
+        $contextKey = $this->getContextKey($connectionName->requested);
 
         // Check if this coroutine already has a connection
         if (CoroutineContext::has($contextKey)) {
@@ -69,7 +69,7 @@ class ConnectionResolver implements ConnectionResolverInterface
         }
 
         // Get a pooled connection wrapper from the pool
-        $pool = $this->factory->getPool($name);
+        $pool = $this->factory->getPool($connectionName->requested);
 
         /** @var PooledConnection $pooledConnection */
         $pooledConnection = $pool->get();
@@ -77,6 +77,10 @@ class ConnectionResolver implements ConnectionResolverInterface
         try {
             // Get the actual database connection from the wrapper
             $connection = $pooledConnection->getConnection();
+
+            if ($connectionName->isWrite() && $connection instanceof Connection) {
+                $connection->useWriteConnectionWhenReading();
+            }
 
             // Store in context for this coroutine
             CoroutineContext::set($contextKey, $connection);

--- a/src/database/src/Connectors/ConnectionFactory.php
+++ b/src/database/src/Connectors/ConnectionFactory.php
@@ -6,7 +6,9 @@ namespace Hypervel\Database\Connectors;
 
 use Closure;
 use Hypervel\Contracts\Container\Container;
+use Hypervel\Database\ConfigurationUrlParser;
 use Hypervel\Database\Connection;
+use Hypervel\Database\ConnectionName;
 use Hypervel\Database\MariaDbConnection;
 use Hypervel\Database\MySqlConnection;
 use Hypervel\Database\PostgresConnection;
@@ -118,9 +120,33 @@ class ConnectionFactory
     /**
      * Parse and prepare the database configuration.
      */
-    protected function parseConfig(array $config, ?string $name): array
+    public function parseConfig(array $config, ?string $name): array
     {
+        $config = (new ConfigurationUrlParser)->parseConfiguration($config);
+
         return Arr::add(Arr::add($config, 'prefix', ''), 'name', $name);
+    }
+
+    /**
+     * Determine if the configuration has a read side.
+     */
+    public function hasReadConfig(array $config): bool
+    {
+        return isset($config[ConnectionName::READ]);
+    }
+
+    /**
+     * Get the single-role read configuration for a read / write connection.
+     */
+    public function configForRead(array $config): array
+    {
+        $config = $this->parseConfig($config, $config['name'] ?? null);
+
+        return Arr::add(
+            $this->getReadConfig($config),
+            Connection::READ_WRITE_TYPE_CONFIG_KEY,
+            ConnectionName::READ
+        );
     }
 
     /**

--- a/src/database/src/Connectors/ConnectionFactory.php
+++ b/src/database/src/Connectors/ConnectionFactory.php
@@ -140,10 +140,12 @@ class ConnectionFactory
      */
     public function configForRead(array $config): array
     {
-        $config = $this->parseConfig($config, $config['name'] ?? null);
+        $name = $config['name'] ?? null;
+        $config = $this->parseConfig($config, $name);
+        $readConfig = $this->parseConfig($this->getReadConfig($config), $name);
 
         return Arr::add(
-            $this->getReadConfig($config),
+            $readConfig,
             Connection::READ_WRITE_TYPE_CONFIG_KEY,
             ConnectionName::READ
         );

--- a/src/database/src/Console/DbCommand.php
+++ b/src/database/src/Console/DbCommand.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Hypervel\Database\Console;
 
 use Hypervel\Console\Command;
-use Hypervel\Support\ConfigurationUrlParser;
+use Hypervel\Database\ConfigurationUrlParser;
+use Hypervel\Support\Arr;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -67,12 +68,12 @@ class DbCommand extends Command
      */
     public function getConnection(): array
     {
-        $connection = $this->hypervel['config']['database.connections.'
-            . (($db = $this->argument('connection')) ?? $this->hypervel['config']['database.default'])
-        ];
+        $config = $this->hypervel->make('config');
+        $connectionName = $this->argument('connection') ?? $config->string('database.default', 'default');
+        $connection = $config->array("database.connections.{$connectionName}", []);
 
         if (empty($connection)) {
-            throw new UnexpectedValueException("Invalid database connection [{$db}].");
+            throw new UnexpectedValueException("Invalid database connection [{$connectionName}].");
         }
 
         if (! empty($connection['url'])) {
@@ -80,20 +81,40 @@ class DbCommand extends Command
         }
 
         if ($this->option('read')) {
-            if (is_array($connection['read']['host'])) {
-                $connection['read']['host'] = $connection['read']['host'][0];
-            }
-
-            $connection = array_merge($connection, $connection['read']);
+            $connection = $this->mergeConnectionConfiguration($connection, 'read');
         } elseif ($this->option('write')) {
-            if (is_array($connection['write']['host'])) {
-                $connection['write']['host'] = $connection['write']['host'][0];
-            }
-
-            $connection = array_merge($connection, $connection['write']);
+            $connection = $this->mergeConnectionConfiguration($connection, 'write');
         }
 
         return $connection;
+    }
+
+    /**
+     * Merge a read / write connection configuration for the CLI client.
+     */
+    protected function mergeConnectionConfiguration(array $connection, string $type): array
+    {
+        if (empty($connection[$type])) {
+            return Arr::except($connection, ['read', 'write']);
+        }
+
+        $merge = $connection[$type];
+
+        if (isset($merge[0]) && is_array($merge[0])) {
+            $merge = $merge[0];
+        }
+
+        if (is_array($merge['host'] ?? null)) {
+            $merge['host'] = $merge['host'][0];
+        }
+
+        $connection = array_merge($connection, $merge);
+
+        if (is_array($connection['host'] ?? null)) {
+            $connection['host'] = $connection['host'][0];
+        }
+
+        return Arr::except($connection, ['read', 'write']);
     }
 
     /**

--- a/src/database/src/DatabaseManager.php
+++ b/src/database/src/DatabaseManager.php
@@ -110,15 +110,23 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function resolveConnectionDirectly(string $name): ConnectionInterface
     {
-        if (! isset($this->connections[$name])) {
-            $this->connections[$name] = $this->configure(
-                $this->makeConnection($name)
+        $connectionName = ConnectionName::parse($name);
+
+        if (! isset($this->connections[$connectionName->requested])) {
+            $connection = $this->configure(
+                $this->makeConnection($connectionName)
             );
 
-            $this->dispatchConnectionEstablishedEvent($this->connections[$name]);
+            if ($connectionName->isWrite()) {
+                $connection->useWriteConnectionWhenReading();
+            }
+
+            $this->connections[$connectionName->requested] = $connection;
+
+            $this->dispatchConnectionEstablishedEvent($connection);
         }
 
-        return $this->connections[$name];
+        return $this->connections[$connectionName->requested];
     }
 
     /**
@@ -150,11 +158,12 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Make the database connection instance.
      */
-    protected function makeConnection(string $name): Connection
+    protected function makeConnection(ConnectionName|string $name): Connection
     {
-        $config = $this->configuration($name);
+        $connectionName = is_string($name) ? ConnectionName::parse($name) : $name;
+        $config = $this->configuration($connectionName);
 
-        return $this->factory->make($config, $name);
+        return $this->factory->make($config, $connectionName->base);
     }
 
     /**
@@ -162,19 +171,26 @@ class DatabaseManager implements ConnectionResolverInterface
      *
      * @throws InvalidArgumentException
      */
-    protected function configuration(string $name): array
+    protected function configuration(ConnectionName|string $name): array
     {
+        $connectionName = is_string($name) ? ConnectionName::parse($name) : $name;
+
         /** @var array<string, array> $connections */
         $connections = $this->configValue('database.connections', []);
 
-        $config = Arr::get($connections, $name);
+        $config = Arr::get($connections, $connectionName->base);
 
         if (is_null($config)) {
-            throw new InvalidArgumentException("Database connection [{$name}] not configured.");
+            throw new InvalidArgumentException("Database connection [{$connectionName->base}] not configured.");
         }
 
-        return (new ConfigurationUrlParser)
-            ->parseConfiguration($config);
+        $config = $this->factory->parseConfig($config, $connectionName->base);
+
+        if ($connectionName->isRead() && $this->factory->hasReadConfig($config)) {
+            return $this->factory->configForRead($config);
+        }
+
+        return $config;
     }
 
     /**
@@ -184,7 +200,7 @@ class DatabaseManager implements ConnectionResolverInterface
     {
         // Set the event dispatcher if available.
         if ($this->app->bound('events')) {
-            $connection->setEventDispatcher($this->app['events']);
+            $connection->setEventDispatcher($this->app->make('events'));
         }
 
         if ($this->app->bound('db.transactions')) {
@@ -207,7 +223,7 @@ class DatabaseManager implements ConnectionResolverInterface
             return;
         }
 
-        $this->app['events']->dispatch(
+        $this->app->make('events')->dispatch(
             new ConnectionEstablished($connection)
         );
     }
@@ -227,27 +243,34 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function purge(UnitEnum|string|null $name = null): void
     {
-        $name = enum_value($name) ?: $this->getDefaultConnection();
+        $requestedName = enum_value($name) ?: $this->getDefaultConnection();
+        $connectionName = ConnectionName::parse($requestedName);
+        $variants = $this->connectionNameVariants($requestedName);
 
-        // Disconnect current connection if any
-        $this->disconnect($name);
+        foreach ($variants as $variant) {
+            // Disconnect current connection if any
+            $this->disconnect($variant);
+        }
 
-        // Clear context so next connection() gets a fresh pooled connection
-        $contextKey = $this->getConnectionContextKey($name);
-        CoroutineContext::forget($contextKey);
+        foreach ($variants as $variant) {
+            // Clear context so next connection() gets a fresh pooled connection
+            CoroutineContext::forget($this->getConnectionContextKey($variant));
 
-        // Clear cached connection for SimpleConnectionResolver (non-pooled mode)
-        unset($this->connections[$name]);
+            // Clear cached connection for SimpleConnectionResolver (non-pooled mode)
+            unset($this->connections[$variant]);
+        }
 
         // Clear resolver-level caching (e.g., DatabaseConnectionResolver's static cache)
         $resolver = $this->app->make('db.resolver');
         if ($resolver instanceof FlushableConnectionResolver) {
-            $resolver->flush($name);
+            foreach ($variants as $variant) {
+                $resolver->flush($variant);
+            }
         }
 
         // Flush the pool to honor config changes
         if ($this->app->has(PoolFactory::class)) {
-            $this->app->make(PoolFactory::class)->flushPool($name);
+            $this->app->make(PoolFactory::class)->flushPoolsForConnection($connectionName->base);
         }
     }
 
@@ -263,18 +286,18 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function disconnect(UnitEnum|string|null $name = null): void
     {
-        $name = enum_value($name) ?: $this->getDefaultConnection();
-        $contextKey = $this->getConnectionContextKey($name);
+        $requestedName = enum_value($name) ?: $this->getDefaultConnection();
+        $connectionName = ConnectionName::parse($requestedName);
 
         // Pooled mode: disconnect the current coroutine's connection
-        $connection = CoroutineContext::get($contextKey);
+        $connection = CoroutineContext::get($this->getConnectionContextKey($connectionName->requested));
         if ($connection instanceof Connection) {
             $connection->disconnect();
         }
 
         // Non-pooled mode (SimpleConnectionResolver): disconnect from $connections array
-        if (isset($this->connections[$name])) {
-            $this->connections[$name]->disconnect();
+        if (isset($this->connections[$connectionName->requested])) {
+            $this->connections[$connectionName->requested]->disconnect();
         }
     }
 
@@ -450,6 +473,18 @@ class DatabaseManager implements ConnectionResolverInterface
     protected function getConnectionContextKey(string $name): string
     {
         return sprintf('__database.connection.%s', $name);
+    }
+
+    /**
+     * Get all coroutine/cache variants for a connection name.
+     *
+     * @return string[]
+     */
+    protected function connectionNameVariants(UnitEnum|string|null $name): array
+    {
+        $base = ConnectionName::parse(enum_value($name) ?: $this->getDefaultConnection())->base;
+
+        return [$base, $base . '::read', $base . '::write'];
     }
 
     /**

--- a/src/database/src/DatabaseManager.php
+++ b/src/database/src/DatabaseManager.php
@@ -79,9 +79,15 @@ class DatabaseManager implements ConnectionResolverInterface
         protected ContainerContract $app,
         protected ConnectionFactory $factory
     ) {
-        $this->reconnector = function ($connection) {
+        $this->reconnector = function (Connection $connection) {
+            $name = $connection->getName();
+
+            if ($name !== null && $connection->getConfig(Connection::READ_WRITE_TYPE_CONFIG_KEY) === ConnectionName::READ) {
+                $name .= '::' . ConnectionName::READ;
+            }
+
             $connection->setPdo(
-                $this->reconnect($connection->getName())->getRawPdo()
+                $this->reconnect($name)->getRawPdo()
             );
         };
     }

--- a/src/database/src/Pool/DbPool.php
+++ b/src/database/src/Pool/DbPool.php
@@ -8,6 +8,8 @@ use Hypervel\Contracts\Container\Container;
 use Hypervel\Contracts\Log\StdoutLoggerInterface;
 use Hypervel\Contracts\Pool\ConnectionInterface;
 use Hypervel\Coordinator\Timer;
+use Hypervel\Database\ConnectionName;
+use Hypervel\Database\Connectors\ConnectionFactory;
 use Hypervel\Pool\Frequency;
 use Hypervel\Pool\Pool;
 use Hypervel\Support\Arr;
@@ -44,16 +46,27 @@ class DbPool extends Pool
 
     public function __construct(Container $container, string $name)
     {
+        $connectionName = ConnectionName::parse($name);
         $configService = $container->make('config');
-        $key = sprintf('database.connections.%s', $name);
+        $key = sprintf('database.connections.%s', $connectionName->base);
 
         if (! $configService->has($key)) {
-            throw new InvalidArgumentException(sprintf('Database connection [%s] not configured.', $name));
+            throw new InvalidArgumentException(sprintf('Database connection [%s] not configured.', $connectionName->base));
         }
 
-        // Include the connection name in the config
-        $this->config = $configService->get($key);
-        $this->config['name'] = $name;
+        /** @var array<string, mixed> $config */
+        $config = $configService->get($key);
+
+        /** @var ConnectionFactory $factory */
+        $factory = $container->make('db.factory');
+        $config = $factory->parseConfig($config, $connectionName->base);
+
+        if ($connectionName->isRead() && $factory->hasReadConfig($config)) {
+            $config = $factory->configForRead($config);
+            $this->ensureNotDerivedInMemorySqlitePool($connectionName, $config);
+        }
+
+        $this->config = $config;
 
         // Extract pool options
         $poolOptions = Arr::get($this->config, 'pool', []);
@@ -126,6 +139,24 @@ class DbPool extends Pool
         return $database === ':memory:'
             || str_contains($database, '?mode=memory')
             || str_contains($database, '&mode=memory');
+    }
+
+    /**
+     * Ensure a derived read pool does not point at an in-memory SQLite database.
+     */
+    protected function ensureNotDerivedInMemorySqlitePool(ConnectionName $name, array $config): void
+    {
+        if (($config['driver'] ?? null) !== 'sqlite') {
+            return;
+        }
+
+        $database = $config['database'] ?? '';
+
+        if ($database === ':memory:' || str_contains($database, '?mode=memory') || str_contains($database, '&mode=memory')) {
+            throw new InvalidArgumentException(
+                "Database connection [{$name->requested}] cannot use a derived read pool for in-memory SQLite."
+            );
+        }
     }
 
     /**

--- a/src/database/src/Pool/PoolFactory.php
+++ b/src/database/src/Pool/PoolFactory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Hypervel\Database\Pool;
 
 use Hypervel\Contracts\Container\Container;
+use Hypervel\Database\ConnectionName;
+use Hypervel\Database\Connectors\ConnectionFactory;
 
 /**
  * Factory for creating and caching database connection pools.
@@ -32,9 +34,44 @@ class PoolFactory
             return $this->pools[$name];
         }
 
-        $pool = $this->container->make(DbPool::class, ['name' => $name]);
+        $poolName = $this->getPoolName($name);
 
-        return $this->pools[$name] = $pool;
+        if (isset($this->pools[$poolName])) {
+            return $this->pools[$poolName];
+        }
+
+        $pool = $this->container->make(DbPool::class, ['name' => $poolName]);
+
+        return $this->pools[$poolName] = $pool;
+    }
+
+    /**
+     * Resolve the physical pool name for a requested connection name.
+     */
+    protected function getPoolName(string $name): string
+    {
+        $connectionName = ConnectionName::parse($name);
+
+        if (! $connectionName->isRead()) {
+            return $connectionName->base;
+        }
+
+        $configService = $this->container->make('config');
+        $key = sprintf('database.connections.%s', $connectionName->base);
+
+        if (! $configService->has($key)) {
+            return $connectionName->base;
+        }
+
+        /** @var array<string, mixed> $config */
+        $config = $configService->get($key);
+
+        /** @var ConnectionFactory $factory */
+        $factory = $this->container->make('db.factory');
+
+        return $factory->hasReadConfig($config)
+            ? $connectionName->requested
+            : $connectionName->base;
     }
 
     /**
@@ -42,7 +79,7 @@ class PoolFactory
      */
     public function hasPool(string $name): bool
     {
-        return isset($this->pools[$name]);
+        return isset($this->pools[$this->getExistingPoolName($name)]);
     }
 
     /**
@@ -50,9 +87,38 @@ class PoolFactory
      */
     public function flushPool(string $name): void
     {
-        if (isset($this->pools[$name])) {
-            $this->pools[$name]->flushAll();
-            unset($this->pools[$name]);
+        $poolName = $this->getExistingPoolName($name);
+
+        if (isset($this->pools[$poolName])) {
+            $this->pools[$poolName]->flushAll();
+            unset($this->pools[$poolName]);
+        }
+    }
+
+    /**
+     * Resolve an existing pool key for a requested connection name.
+     */
+    protected function getExistingPoolName(string $name): string
+    {
+        return isset($this->pools[$name])
+            ? $name
+            : $this->getPoolName($name);
+    }
+
+    /**
+     * Flush all pool variants for a configured connection.
+     *
+     * Boot or tests only. This closes shared worker pools and affects every
+     * coroutine that later resolves the same configured connection.
+     */
+    public function flushPoolsForConnection(string $name): void
+    {
+        $base = ConnectionName::parse($name)->base;
+
+        foreach (array_keys($this->pools) as $poolName) {
+            if ($poolName === $base || str_starts_with($poolName, $base . '::')) {
+                $this->flushPool($poolName);
+            }
         }
     }
 

--- a/src/foundation/src/Testing/DatabaseConnectionResolver.php
+++ b/src/foundation/src/Testing/DatabaseConnectionResolver.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Hypervel\Foundation\Testing;
 
 use Hypervel\Container\Container;
+use Hypervel\Contracts\Config\Repository as ConfigRepository;
 use Hypervel\Contracts\Container\Container as ContainerContract;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Database\Connection;
 use Hypervel\Database\ConnectionInterface;
+use Hypervel\Database\ConnectionName;
 use Hypervel\Database\ConnectionResolver;
 use Hypervel\Database\FlushableConnectionResolver;
 use UnitEnum;
@@ -22,10 +24,10 @@ use function Hypervel\Support\enum_value;
  * pool infrastructure (same factory, config, and connection path as production)
  * but cached statically instead of using the pool's checkout/release cycle.
  *
- * This is intentional — tests don't run in coroutines with defer(), so the
- * normal pool lifecycle (checkout → defer release → coroutine ends) doesn't
- * apply. Instead, connections are cached per-name and reused across test
- * methods within the same worker process.
+ * This is intentional — Testbench needs stable bare connections across its
+ * setup, transaction, and assertion helpers, while production's defer-based
+ * pool lifecycle releases borrowed wrappers at coroutine end. Instead,
+ * connections are cached per-name and reset between tests.
  *
  * The PooledConnection wrapper is discarded after extracting the bare
  * Connection. This means pool release() never runs on the wrapper, but
@@ -148,25 +150,36 @@ class DatabaseConnectionResolver extends ConnectionResolver implements Flushable
      */
     public function connection(UnitEnum|string|null $name = null): ConnectionInterface
     {
-        $name = enum_value($name) ?: $this->getDefaultConnection();
+        $connectionName = ConnectionName::parse(enum_value($name) ?: $this->getDefaultConnection());
 
         // If the pool is enabled, we should use the default connection resolver.
-        $poolEnabled = $this->container
-            ->get('config')
-            ->get("database.connections.{$name}.pool.testing_enabled", false);
+        /** @var ConfigRepository $config */
+        $config = $this->container->make('config');
+        $poolEnabled = $config->boolean("database.connections.{$connectionName->base}.pool.testing_enabled", false);
         if ($poolEnabled) {
-            return parent::connection($name);
+            return parent::connection($connectionName->requested);
         }
 
-        if ($connection = static::$connections[$name] ?? null) {
+        if ($connection = static::$connections[$connectionName->requested] ?? null) {
+            if ($connectionName->isWrite() && $connection instanceof Connection) {
+                // flushCachedConnections() runs resetForPool() between tests and clears this flag.
+                $connection->useWriteConnectionWhenReading();
+            }
+
             return $connection;
         }
 
         // Check out from pool, extract bare Connection, discard the wrapper.
         // The wrapper's release() is not needed — see class docblock.
-        return static::$connections[$name] = $this->factory
-            ->getPool($name)
+        $connection = $this->factory
+            ->getPool($connectionName->requested)
             ->get()
             ->getConnection();
+
+        if ($connectionName->isWrite()) {
+            $connection->useWriteConnectionWhenReading();
+        }
+
+        return static::$connections[$connectionName->requested] = $connection;
     }
 }

--- a/src/prompts/src/Concerns/TypedValue.php
+++ b/src/prompts/src/Concerns/TypedValue.php
@@ -183,8 +183,8 @@ trait TypedValue
      */
     protected function findLastWordStartByLettersAndNumbers(string $before): int
     {
-        if (preg_match_all('/((?:\p{L}\p{M}*|\p{N})+)/u', $before, $m, PREG_OFFSET_CAPTURE) && $m[1] !== []) {
-            $last = end($m[1]);
+        if (preg_match_all('/((?:\p{L}\p{M}*|\p{N})+)/u', $before, $matches, PREG_OFFSET_CAPTURE)) {
+            $last = $matches[1][count($matches[1]) - 1];
 
             return mb_strlen(substr($before, 0, $last[1]), 'UTF-8');
         }

--- a/tests/Database/ConnectionNameTest.php
+++ b/tests/Database/ConnectionNameTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Database\ConnectionName;
+use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
+
+class ConnectionNameTest extends TestCase
+{
+    public function testParsePlainConnectionName(): void
+    {
+        $name = ConnectionName::parse('default');
+
+        $this->assertSame('default', $name->requested);
+        $this->assertSame('default', $name->base);
+        $this->assertNull($name->role);
+        $this->assertFalse($name->isRead());
+        $this->assertFalse($name->isWrite());
+    }
+
+    public function testParseReadConnectionName(): void
+    {
+        $name = ConnectionName::parse('default::read');
+
+        $this->assertSame('default::read', $name->requested);
+        $this->assertSame('default', $name->base);
+        $this->assertSame(ConnectionName::READ, $name->role);
+        $this->assertTrue($name->isRead());
+        $this->assertFalse($name->isWrite());
+    }
+
+    public function testParseWriteConnectionName(): void
+    {
+        $name = ConnectionName::parse('default::write');
+
+        $this->assertSame('default::write', $name->requested);
+        $this->assertSame('default', $name->base);
+        $this->assertSame(ConnectionName::WRITE, $name->role);
+        $this->assertFalse($name->isRead());
+        $this->assertTrue($name->isWrite());
+    }
+
+    public function testParseRejectsDirectConnectionName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Database connection suffix [::direct] is not supported. Configure a direct connection and use migrations_connection instead.'
+        );
+
+        ConnectionName::parse('default::direct');
+    }
+}

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -6,6 +6,8 @@ namespace Hypervel\Tests\Database;
 
 use Hypervel\Container\Container;
 use Hypervel\Database\Capsule\Manager as DB;
+use Hypervel\Database\Connection;
+use Hypervel\Database\ConnectionName;
 use Hypervel\Database\Connectors\ConnectionFactory;
 use Hypervel\Database\SQLiteConnection;
 use Hypervel\Tests\TestCase;
@@ -82,6 +84,87 @@ class DatabaseConnectionFactoryTest extends TestCase
             'strict' => true,
             'engine' => null,
         ], $this->db->getConnection('url-config')->getConfig());
+    }
+
+    public function testParseConfigParsesUrlAndAddsDefaults(): void
+    {
+        $factory = new ConnectionFactory(new Container);
+
+        $config = $factory->parseConfig([
+            'url' => 'mysql://root:pass@db/local?strict=true',
+            'prefix_indexes' => true,
+        ], 'url-config');
+
+        $this->assertSame('url-config', $config['name']);
+        $this->assertSame('mysql', $config['driver']);
+        $this->assertSame('local', $config['database']);
+        $this->assertSame('db', $config['host']);
+        $this->assertSame('root', $config['username']);
+        $this->assertSame('pass', $config['password']);
+        $this->assertSame('', $config['prefix']);
+        $this->assertTrue($config['strict']);
+        $this->assertTrue($config['prefix_indexes']);
+    }
+
+    public function testHasReadConfigRequiresNonNullReadConfig(): void
+    {
+        $factory = new ConnectionFactory(new Container);
+
+        $this->assertTrue($factory->hasReadConfig(['read' => []]));
+        $this->assertFalse($factory->hasReadConfig(['read' => null]));
+        $this->assertFalse($factory->hasReadConfig([]));
+    }
+
+    public function testConfigForReadDerivesSingleRoleReadConfig(): void
+    {
+        $factory = new ConnectionFactory(new Container);
+
+        $config = $factory->configForRead([
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'database' => 'app',
+            'host' => 'write-host',
+            'username' => 'root',
+            'password' => '',
+            'prefix' => 'app_',
+            'read' => [
+                'host' => ['read-one', 'read-two'],
+                'username' => 'reader',
+            ],
+            'write' => [
+                'host' => 'write-host',
+            ],
+        ]);
+
+        $this->assertSame('mysql', $config['name']);
+        $this->assertSame('mysql', $config['driver']);
+        $this->assertSame('app', $config['database']);
+        $this->assertSame('reader', $config['username']);
+        $this->assertSame(['read-one', 'read-two'], $config['host']);
+        $this->assertSame('app_', $config['prefix']);
+        $this->assertSame(ConnectionName::READ, $config[Connection::READ_WRITE_TYPE_CONFIG_KEY]);
+        $this->assertArrayNotHasKey('read', $config);
+        $this->assertArrayNotHasKey('write', $config);
+    }
+
+    public function testConfigForReadTreatsEmptyReadConfigAsBaseConfigWithReadRole(): void
+    {
+        $factory = new ConnectionFactory(new Container);
+
+        $config = $factory->configForRead([
+            'driver' => 'sqlite',
+            'name' => 'default',
+            'database' => 'database.sqlite',
+            'read' => [],
+        ]);
+
+        $this->assertSame('default', $config['name']);
+        $this->assertSame('sqlite', $config['driver']);
+        $this->assertSame('database.sqlite', $config['database']);
+        $this->assertSame('', $config['prefix']);
+        $this->assertSame(ConnectionName::READ, $config[Connection::READ_WRITE_TYPE_CONFIG_KEY]);
+        $this->assertArrayNotHasKey('read', $config);
+        $this->assertArrayNotHasKey('write', $config);
     }
 
     public function testSingleConnectionNotCreatedUntilNeeded()

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -147,6 +147,39 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertArrayNotHasKey('write', $config);
     }
 
+    public function testConfigForReadParsesNestedReadUrl(): void
+    {
+        $factory = new ConnectionFactory(new Container);
+
+        $config = $factory->configForRead([
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'database' => 'write_database',
+            'host' => 'write-host',
+            'username' => 'writer',
+            'password' => '',
+            'read' => [
+                'url' => 'mysql://reader:secret@read-host/read_database?strict=true',
+            ],
+            'write' => [
+                'host' => 'write-host',
+            ],
+        ]);
+
+        $this->assertSame('mysql', $config['name']);
+        $this->assertSame('mysql', $config['driver']);
+        $this->assertSame('read_database', $config['database']);
+        $this->assertSame('read-host', $config['host']);
+        $this->assertSame('reader', $config['username']);
+        $this->assertSame('secret', $config['password']);
+        $this->assertSame('', $config['prefix']);
+        $this->assertTrue($config['strict']);
+        $this->assertSame(ConnectionName::READ, $config[Connection::READ_WRITE_TYPE_CONFIG_KEY]);
+        $this->assertArrayNotHasKey('url', $config);
+        $this->assertArrayNotHasKey('read', $config);
+        $this->assertArrayNotHasKey('write', $config);
+    }
+
     public function testConfigForReadTreatsEmptyReadConfigAsBaseConfigWithReadRole(): void
     {
         $factory = new ConnectionFactory(new Container);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -577,6 +577,43 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(1.23, $log[0]['time']);
     }
 
+    public function testStickyReadConnectionsUseWritePdoAfterRecordsModified(): void
+    {
+        [$connection, $writePdo, $readPdo] = $this->getReadWriteConnection(sticky: true);
+
+        $this->assertSame($readPdo, $connection->getReadPdo());
+
+        $connection->recordsHaveBeenModified();
+
+        $this->assertSame($writePdo, $connection->getReadPdo());
+    }
+
+    public function testNonStickyReadConnectionsKeepUsingReadPdoAfterRecordsModified(): void
+    {
+        [$connection, $writePdo, $readPdo] = $this->getReadWriteConnection(sticky: false);
+
+        $this->assertSame($readPdo, $connection->getReadPdo());
+
+        $connection->recordsHaveBeenModified();
+
+        $actualReadPdo = $connection->getReadPdo();
+
+        $this->assertSame($readPdo, $actualReadPdo);
+        $this->assertNotSame($writePdo, $actualReadPdo);
+    }
+
+    public function testResetForPoolClearsStickyReadRoutingState(): void
+    {
+        [$connection, $writePdo, $readPdo] = $this->getReadWriteConnection(sticky: true);
+
+        $connection->recordsHaveBeenModified();
+        $this->assertSame($writePdo, $connection->getReadPdo());
+
+        $connection->resetForPool();
+
+        $this->assertSame($readPdo, $connection->getReadPdo());
+    }
+
     public function testQueryExceptionContainsReadConnectionDetailsWhenUsingReadPdo()
     {
         // Create write PDO mock that will NOT be used for this query
@@ -681,6 +718,39 @@ class DatabaseConnectionTest extends TestCase
         }
     }
 
+    public function testQueryExceptionContainsDerivedReadConnectionDetails(): void
+    {
+        $pdo = $this->getMockBuilder(PDOStub::class)
+            ->onlyMethods(['prepare'])
+            ->getMock();
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->willThrowException(new PDOException('Connection refused'));
+
+        $connection = new Connection($pdo, 'read_db', '', [
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'host' => '192.168.1.20',
+            'port' => '3307',
+            'database' => 'read_db',
+            Connection::READ_WRITE_TYPE_CONFIG_KEY => 'read',
+        ]);
+        $connection->useDefaultQueryGrammar();
+        $connection->useDefaultPostProcessor();
+
+        try {
+            $connection->select('SELECT * FROM users', useReadPdo: true);
+            $this->fail('Expected QueryException was not thrown');
+        } catch (QueryException $e) {
+            $this->assertSame('read', $e->readWriteType);
+
+            $connectionDetails = $e->getConnectionDetails();
+            $this->assertSame('192.168.1.20', $connectionDetails['host']);
+            $this->assertSame('3307', $connectionDetails['port']);
+            $this->assertSame('read_db', $connectionDetails['database']);
+        }
+    }
+
     public function testQueryExceptionContainsWriteConnectionDetailsWhenUsingWritePdo()
     {
         // Create write PDO mock that throws an exception
@@ -775,6 +845,26 @@ class DatabaseConnectionTest extends TestCase
             $this->assertSame('3306', $connectionDetails['port']);
             $this->assertSame('write_db', $connectionDetails['database']);
         }
+    }
+
+    /**
+     * Create a read / write connection for sticky routing assertions.
+     *
+     * @return array{0: Connection, 1: PDOStub, 2: PDOStub}
+     */
+    protected function getReadWriteConnection(bool $sticky): array
+    {
+        $writePdo = new PDOStub;
+        $readPdo = new PDOStub;
+
+        $connection = new Connection($writePdo, 'test_db', '', [
+            'name' => 'test',
+            'driver' => 'mysql',
+            'sticky' => $sticky,
+        ]);
+        $connection->setReadPdo($readPdo);
+
+        return [$connection, $writePdo, $readPdo];
     }
 
     protected function getMockConnection($methods = [], $pdo = null)

--- a/tests/Database/DatabaseDbCommandTest.php
+++ b/tests/Database/DatabaseDbCommandTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Config\Repository;
+use Hypervel\Contracts\Foundation\Application;
+use Hypervel\Database\Console\DbCommand;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+
+class DatabaseDbCommandTest extends TestCase
+{
+    public function testReadOptionMergesFirstListConfigAndStripsReadWriteConfig(): void
+    {
+        $connection = $this->getConnection([
+            'mysql' => $this->mysqlConfig([
+                'read' => [
+                    ['host' => 'read-one', 'username' => 'reader-one'],
+                    ['host' => 'read-two', 'username' => 'reader-two'],
+                ],
+                'write' => [
+                    ['host' => 'write-one'],
+                ],
+            ]),
+        ], [
+            'connection' => 'mysql',
+            '--read' => true,
+        ]);
+
+        $this->assertSame('read-one', $connection['host']);
+        $this->assertSame('reader-one', $connection['username']);
+        $this->assertArrayNotHasKey('read', $connection);
+        $this->assertArrayNotHasKey('write', $connection);
+    }
+
+    public function testWriteOptionMergesFirstListConfigAndStripsReadWriteConfig(): void
+    {
+        $connection = $this->getConnection([
+            'mysql' => $this->mysqlConfig([
+                'read' => [
+                    ['host' => 'read-one'],
+                ],
+                'write' => [
+                    ['host' => 'write-one', 'username' => 'writer-one'],
+                    ['host' => 'write-two', 'username' => 'writer-two'],
+                ],
+            ]),
+        ], [
+            'connection' => 'mysql',
+            '--write' => true,
+        ]);
+
+        $this->assertSame('write-one', $connection['host']);
+        $this->assertSame('writer-one', $connection['username']);
+        $this->assertArrayNotHasKey('read', $connection);
+        $this->assertArrayNotHasKey('write', $connection);
+    }
+
+    public function testReadOptionUsesFirstHostFromHostArray(): void
+    {
+        $connection = $this->getConnection([
+            'mysql' => $this->mysqlConfig([
+                'read' => [
+                    'host' => ['read-one', 'read-two'],
+                ],
+            ]),
+        ], [
+            'connection' => 'mysql',
+            '--read' => true,
+        ]);
+
+        $this->assertSame('read-one', $connection['host']);
+        $this->assertArrayNotHasKey('read', $connection);
+        $this->assertArrayNotHasKey('write', $connection);
+    }
+
+    public function testEmptyReadConfigReturnsBaseConfigWithoutReadWriteConfig(): void
+    {
+        $connection = $this->getConnection([
+            'mysql' => $this->mysqlConfig([
+                'read' => [],
+                'write' => [
+                    'host' => 'write-one',
+                ],
+            ]),
+        ], [
+            'connection' => 'mysql',
+            '--read' => true,
+        ]);
+
+        $this->assertSame('write-host', $connection['host']);
+        $this->assertArrayNotHasKey('read', $connection);
+        $this->assertArrayNotHasKey('write', $connection);
+    }
+
+    public function testDefaultConnectionIsReadFromConfigRepository(): void
+    {
+        $connection = $this->getConnection([
+            'mysql' => $this->mysqlConfig(),
+        ]);
+
+        $this->assertSame('write-host', $connection['host']);
+    }
+
+    public function testUrlConfigIsParsedBeforeReadWriteMerge(): void
+    {
+        $connection = $this->getConnection([
+            'mysql' => [
+                'url' => 'mysql://root:secret@write-host/app?strict=true',
+                'read' => [
+                    'host' => ['read-one', 'read-two'],
+                ],
+            ],
+        ], [
+            'connection' => 'mysql',
+            '--read' => true,
+        ]);
+
+        $this->assertSame('mysql', $connection['driver']);
+        $this->assertSame('app', $connection['database']);
+        $this->assertSame('read-one', $connection['host']);
+        $this->assertSame('root', $connection['username']);
+        $this->assertSame('secret', $connection['password']);
+        $this->assertTrue($connection['strict']);
+        $this->assertArrayNotHasKey('read', $connection);
+        $this->assertArrayNotHasKey('write', $connection);
+    }
+
+    private function getConnection(array $connections, array $input = []): array
+    {
+        $command = new TestableDbCommand;
+        $command->setHypervel($this->applicationWithConfig($connections));
+        $command->setInput($this->inputFor($command, $input));
+
+        return $command->getConnection();
+    }
+
+    private function applicationWithConfig(array $connections): Application|m\MockInterface
+    {
+        $application = m::mock(Application::class);
+        $application->shouldReceive('make')
+            ->once()
+            ->with('config')
+            ->andReturn(new Repository([
+                'database' => [
+                    'default' => 'mysql',
+                    'connections' => $connections,
+                ],
+            ]));
+
+        return $application;
+    }
+
+    private function inputFor(DbCommand $command, array $input): InputInterface
+    {
+        $arrayInput = new ArrayInput($input);
+        $arrayInput->bind($command->getDefinition());
+
+        return $arrayInput;
+    }
+
+    private function mysqlConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'driver' => 'mysql',
+            'host' => 'write-host',
+            'port' => 3306,
+            'database' => 'app',
+            'username' => 'root',
+            'password' => '',
+            'read' => [
+                'host' => 'read-host',
+            ],
+            'write' => [
+                'host' => 'write-host',
+            ],
+        ], $overrides);
+    }
+}
+
+class TestableDbCommand extends DbCommand
+{
+    public function setInput(InputInterface $input): void
+    {
+        $this->input = $input;
+    }
+}

--- a/tests/Database/DatabaseManagerTest.php
+++ b/tests/Database/DatabaseManagerTest.php
@@ -8,6 +8,8 @@ use Hypervel\Database\Capsule\Manager as DB;
 use Hypervel\Database\Connection;
 use Hypervel\Database\DatabaseManager;
 use Hypervel\Database\SQLiteConnection;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Testing\ParallelTesting;
 use Hypervel\Tests\TestCase;
 use InvalidArgumentException;
 use PDO;
@@ -176,6 +178,88 @@ class DatabaseManagerTest extends TestCase
         $this->assertNotNull($connection->getPdo());
     }
 
+    public function testNonPooledReadConnectionReconnectsUsingReadSuffix(): void
+    {
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('DatabaseManagerTest-read-reconnect');
+        $filesystem->ensureDirectoryExists($directory);
+
+        $readPath = $directory . '/read.sqlite';
+        $writePath = $directory . '/write.sqlite';
+        $connection = null;
+
+        try {
+            $this->createSqliteUsersDatabase($readPath, 'Read Side');
+            $this->createSqliteUsersDatabase($writePath, 'Write Side');
+
+            $this->db->addConnection([
+                'driver' => 'sqlite',
+                'database' => $writePath,
+                'read' => [
+                    'database' => $readPath,
+                ],
+                'write' => [
+                    'database' => $writePath,
+                ],
+            ], 'split-reconnect');
+
+            $connection = $this->db->getDatabaseManager()->connection('split-reconnect::read');
+            $this->assertSame('Read Side', $connection->selectOne('select name from users')->name);
+
+            $connection->setPdo(null);
+            $connection->reconnectIfMissingConnection();
+
+            $this->assertSame('Read Side', $connection->selectOne('select name from users')->name);
+        } finally {
+            if ($connection instanceof Connection) {
+                $connection->disconnect();
+            }
+
+            $filesystem->deleteDirectory($directory);
+        }
+    }
+
+    public function testNonPooledWriteConnectionReconnectsUsingWriteSide(): void
+    {
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('DatabaseManagerTest-write-reconnect');
+        $filesystem->ensureDirectoryExists($directory);
+
+        $readPath = $directory . '/read.sqlite';
+        $writePath = $directory . '/write.sqlite';
+        $connection = null;
+
+        try {
+            $this->createSqliteUsersDatabase($readPath, 'Read Side');
+            $this->createSqliteUsersDatabase($writePath, 'Write Side');
+
+            $this->db->addConnection([
+                'driver' => 'sqlite',
+                'database' => $writePath,
+                'read' => [
+                    'database' => $readPath,
+                ],
+                'write' => [
+                    'database' => $writePath,
+                ],
+            ], 'split-write-reconnect');
+
+            $connection = $this->db->getDatabaseManager()->connection('split-write-reconnect::write');
+            $this->assertSame('Write Side', $connection->selectOne('select name from users')->name);
+
+            $connection->setPdo(null);
+            $connection->reconnectIfMissingConnection();
+
+            $this->assertSame('Write Side', $connection->selectOne('select name from users')->name);
+        } finally {
+            if ($connection instanceof Connection) {
+                $connection->disconnect();
+            }
+
+            $filesystem->deleteDirectory($directory);
+        }
+    }
+
     public function testNonPooledWriteConnectionForcesReadsThroughWritePdo(): void
     {
         $this->db->addConnection([
@@ -274,5 +358,13 @@ class DatabaseManagerTest extends TestCase
         $this->assertNotSame($default, $manager->connection('default'));
         $this->assertNotSame($read, $manager->connection('default::read'));
         $this->assertNotSame($write, $manager->connection('default::write'));
+    }
+
+    protected function createSqliteUsersDatabase(string $path, string $name): void
+    {
+        $pdo = new PDO('sqlite:' . $path);
+        $pdo->exec('create table users (id integer primary key, name varchar)');
+        $statement = $pdo->prepare('insert into users (name) values (?)');
+        $statement->execute([$name]);
     }
 }

--- a/tests/Database/DatabaseManagerTest.php
+++ b/tests/Database/DatabaseManagerTest.php
@@ -9,6 +9,7 @@ use Hypervel\Database\Connection;
 use Hypervel\Database\DatabaseManager;
 use Hypervel\Database\SQLiteConnection;
 use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
 use PDO;
 
 class DatabaseManagerTest extends TestCase
@@ -155,5 +156,123 @@ class DatabaseManagerTest extends TestCase
         $result = $manager->connection('forget-test');
         $this->assertNotSame($custom, $result);
         $this->assertInstanceOf(Connection::class, $result);
+    }
+
+    public function testNonPooledReadConnectionCanBeResolvedFromSplitConfig(): void
+    {
+        $this->db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'read' => [
+                'database' => ':memory:',
+            ],
+        ], 'split');
+
+        $connection = $this->db->getDatabaseManager()->connection('split::read');
+
+        $this->assertInstanceOf(Connection::class, $connection);
+        $this->assertSame('split', $connection->getName());
+        $this->assertSame('read', $connection->getConfig(Connection::READ_WRITE_TYPE_CONFIG_KEY));
+        $this->assertNotNull($connection->getPdo());
+    }
+
+    public function testNonPooledWriteConnectionForcesReadsThroughWritePdo(): void
+    {
+        $this->db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'read' => [
+                'database' => ':memory:',
+            ],
+            'write' => [
+                'database' => ':memory:',
+            ],
+        ], 'split');
+
+        $connection = $this->db->getDatabaseManager()->connection('split::write');
+        $connection->statement('create table users (id integer primary key, name varchar)');
+        $connection->insert('insert into users (name) values (?)', ['Taylor']);
+
+        $this->assertSame('split', $connection->getName());
+        $this->assertNull($connection->getConfig(Connection::READ_WRITE_TYPE_CONFIG_KEY));
+        $this->assertSame('Taylor', $connection->selectOne('select name from users')->name);
+    }
+
+    public function testReadAndWriteSuffixesAreCompatibilityAliasesForUnsplitConnections(): void
+    {
+        $manager = $this->db->getDatabaseManager();
+
+        $read = $manager->connection('default::read');
+        $write = $manager->connection('default::write');
+
+        $this->assertInstanceOf(Connection::class, $read);
+        $this->assertInstanceOf(Connection::class, $write);
+        $this->assertSame('default', $read->getName());
+        $this->assertSame('default', $write->getName());
+        $this->assertNull($read->getConfig(Connection::READ_WRITE_TYPE_CONFIG_KEY));
+        $this->assertNull($write->getConfig(Connection::READ_WRITE_TYPE_CONFIG_KEY));
+    }
+
+    public function testDirectConnectionSuffixIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Database connection suffix [::direct] is not supported. Configure a direct connection and use migrations_connection instead.'
+        );
+
+        $this->db->getDatabaseManager()->connection('default::direct');
+    }
+
+    public function testDisconnectOnlyDisconnectsRequestedNonPooledConnectionVariant(): void
+    {
+        $manager = $this->db->getDatabaseManager();
+
+        $default = $manager->connection('default');
+        $read = $manager->connection('default::read');
+        $write = $manager->connection('default::write');
+
+        $this->assertNotNull($default->getPdo());
+        $this->assertNotNull($read->getPdo());
+        $this->assertNotNull($write->getPdo());
+
+        $manager->disconnect('default');
+
+        $this->assertNull($default->getRawPdo());
+        $this->assertNotNull($read->getRawPdo());
+        $this->assertNotNull($write->getRawPdo());
+    }
+
+    public function testDisconnectCanTargetSuffixedNonPooledConnectionVariant(): void
+    {
+        $manager = $this->db->getDatabaseManager();
+
+        $default = $manager->connection('default');
+        $read = $manager->connection('default::read');
+        $write = $manager->connection('default::write');
+
+        $this->assertNotNull($default->getPdo());
+        $this->assertNotNull($read->getPdo());
+        $this->assertNotNull($write->getPdo());
+
+        $manager->disconnect('default::read');
+
+        $this->assertNotNull($default->getRawPdo());
+        $this->assertNull($read->getRawPdo());
+        $this->assertNotNull($write->getRawPdo());
+    }
+
+    public function testPurgeClearsNonPooledConnectionVariants(): void
+    {
+        $manager = $this->db->getDatabaseManager();
+
+        $default = $manager->connection('default');
+        $read = $manager->connection('default::read');
+        $write = $manager->connection('default::write');
+
+        $manager->purge('default');
+
+        $this->assertNotSame($default, $manager->connection('default'));
+        $this->assertNotSame($read, $manager->connection('default::read'));
+        $this->assertNotSame($write, $manager->connection('default::write'));
     }
 }

--- a/tests/Database/PoolFactoryTest.php
+++ b/tests/Database/PoolFactoryTest.php
@@ -8,6 +8,7 @@ use Hypervel\Config\Repository;
 use Hypervel\Contracts\Container\Container as ContainerContract;
 use Hypervel\Contracts\Log\StdoutLoggerInterface;
 use Hypervel\Contracts\Pool\ConnectionInterface;
+use Hypervel\Database\Connectors\ConnectionFactory;
 use Hypervel\Database\Pool\DbPool;
 use Hypervel\Database\Pool\PoolFactory;
 use Hypervel\Pool\Connection;
@@ -132,9 +133,133 @@ class PoolFactoryTest extends TestCase
         $this->assertNotSame($defaultPool, $freshDefaultPool);
     }
 
-    private function mockContainerWithPools(): m\MockInterface|ContainerContract
+    public function testWriteConnectionUsesBasePool(): void
     {
-        $connectionConfig = [
+        $container = $this->mockContainerWithPools();
+
+        $factory = new PoolFactory($container);
+        $pool = $factory->getPool('default::write');
+
+        $this->assertSame(
+            $factory->getPool('default'),
+            $pool
+        );
+        $this->assertTrue($factory->hasPool('default::write'));
+    }
+
+    public function testReadConnectionUsesSeparatePoolWhenReadConfigExists(): void
+    {
+        $container = $this->mockContainerWithPools([
+            'default' => $this->connectionConfig([
+                'read' => [
+                    'host' => '127.0.0.2',
+                ],
+            ]),
+        ]);
+
+        $factory = new PoolFactory($container);
+
+        $this->assertNotSame(
+            $factory->getPool('default'),
+            $factory->getPool('default::read')
+        );
+        $this->assertTrue($factory->hasPool('default'));
+        $this->assertTrue($factory->hasPool('default::read'));
+    }
+
+    public function testReadConnectionUsesBasePoolWhenReadConfigIsMissingOrNull(): void
+    {
+        $container = $this->mockContainerWithPools([
+            'default' => $this->connectionConfig([
+                'read' => null,
+            ]),
+        ]);
+
+        $factory = new PoolFactory($container);
+
+        $this->assertSame(
+            $factory->getPool('default'),
+            $factory->getPool('default::read')
+        );
+        $this->assertTrue($factory->hasPool('default::read'));
+    }
+
+    public function testFlushPoolResolvesWriteAliasToBasePool(): void
+    {
+        $container = $this->mockContainerWithPools();
+
+        $factory = new PoolFactory($container);
+
+        $pool = $factory->getPool('default::write');
+        $pool->release($pool->get());
+
+        $factory->flushPool('default::write');
+
+        $this->assertSame(0, $pool->getConnectionsInChannel());
+        $this->assertNotSame($pool, $factory->getPool('default'));
+    }
+
+    public function testFlushPoolsForConnectionFlushesBaseAndRolePools(): void
+    {
+        $container = $this->mockContainerWithPools([
+            'default' => $this->connectionConfig([
+                'read' => [
+                    'host' => '127.0.0.2',
+                ],
+            ]),
+            'cache' => $this->connectionConfig(),
+        ]);
+
+        $factory = new PoolFactory($container);
+
+        $defaultPool = $factory->getPool('default');
+        $readPool = $factory->getPool('default::read');
+        $cachePool = $factory->getPool('cache');
+
+        $defaultPool->release($defaultPool->get());
+        $readPool->release($readPool->get());
+        $cachePool->release($cachePool->get());
+
+        $factory->flushPoolsForConnection('default::read');
+
+        $this->assertSame(0, $defaultPool->getConnectionsInChannel());
+        $this->assertSame(0, $readPool->getConnectionsInChannel());
+        $this->assertSame(1, $cachePool->getConnectionsInChannel());
+        $this->assertNotSame($defaultPool, $factory->getPool('default'));
+        $this->assertNotSame($readPool, $factory->getPool('default::read'));
+        $this->assertSame($cachePool, $factory->getPool('cache'));
+    }
+
+    private function mockContainerWithPools(?array $connections = null): m\MockInterface|ContainerContract
+    {
+        $connections ??= [
+            'default' => $this->connectionConfig(),
+            'cache' => $this->connectionConfig(),
+        ];
+
+        $config = new Repository([
+            'database' => [
+                'connections' => $connections,
+            ],
+        ]);
+
+        $container = m::mock(ContainerContract::class);
+        $factory = new ConnectionFactory($container);
+
+        $container->shouldReceive('make')->with('config')->andReturn($config);
+        $container->shouldReceive('make')->with('db.factory')->andReturn($factory);
+        $container->shouldReceive('has')->with(StdoutLoggerInterface::class)->andReturn(false);
+        $container->shouldReceive('bound')->with('events')->andReturn(false);
+        $container->shouldReceive('make')->with(DbPool::class, m::any())->andReturnUsing(
+            fn ($class, $args) => new PoolFactoryTestPool($container, $args['name'])
+        );
+
+        return $container;
+    }
+
+    private function connectionConfig(array $overrides = []): array
+    {
+        return array_merge([
             'driver' => 'mysql',
             'host' => '127.0.0.1',
             'port' => 3306,
@@ -147,26 +272,7 @@ class PoolFactoryTest extends TestCase
                 'heartbeat' => -1,
                 'max_idle_time' => 60.0,
             ],
-        ];
-
-        $config = new Repository([
-            'database' => [
-                'connections' => [
-                    'default' => $connectionConfig,
-                    'cache' => $connectionConfig,
-                ],
-            ],
-        ]);
-
-        $container = m::mock(ContainerContract::class);
-        $container->shouldReceive('make')->with('config')->andReturn($config);
-        $container->shouldReceive('has')->with(StdoutLoggerInterface::class)->andReturn(false);
-        $container->shouldReceive('bound')->with('events')->andReturn(false);
-        $container->shouldReceive('make')->with(DbPool::class, m::any())->andReturnUsing(
-            fn ($class, $args) => new PoolFactoryTestPool($container, $args['name'])
-        );
-
-        return $container;
+        ], $overrides);
     }
 }
 

--- a/tests/Foundation/Testing/DatabaseConnectionResolverTest.php
+++ b/tests/Foundation/Testing/DatabaseConnectionResolverTest.php
@@ -49,4 +49,32 @@ class DatabaseConnectionResolverTest extends TestCase
         // Restore original container
         \Hypervel\Container\Container::setInstance($this->app);
     }
+
+    public function testCachedWriteConnectionReappliesWriteReadRoutingAfterReset(): void
+    {
+        $this->app->make('config')->set('database.connections.testing_readwrite_suffix', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'read' => [
+                'database' => ':memory:',
+            ],
+            'write' => [
+                'database' => ':memory:',
+            ],
+        ]);
+
+        $resolver = $this->app->make(DatabaseConnectionResolver::class);
+        $connection = $resolver->connection('testing_readwrite_suffix::write');
+
+        $connection->statement('create table users (id integer primary key, name varchar)');
+        $connection->insert('insert into users (name) values (?)', ['Taylor']);
+        $this->assertSame('Taylor', $connection->selectOne('select name from users')->name);
+
+        DatabaseConnectionResolver::flushCachedConnections();
+
+        $cachedConnection = $resolver->connection('testing_readwrite_suffix::write');
+
+        $this->assertSame($connection, $cachedConnection);
+        $this->assertSame('Taylor', $cachedConnection->selectOne('select name from users')->name);
+    }
 }

--- a/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
+++ b/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
@@ -17,6 +17,7 @@ use RuntimeException;
 use Throwable;
 
 use function Hypervel\Coroutine\go;
+use function Hypervel\Coroutine\parallel;
 
 /**
  * Tests coroutine safety of database components.
@@ -26,6 +27,48 @@ use function Hypervel\Coroutine\go;
  */
 class ConnectionCoroutineSafetyTest extends DatabaseTestCase
 {
+    protected static string $readPath;
+
+    protected static string $writePath;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        static::$readPath = sys_get_temp_dir() . '/hypervel_coroutine_read_' . uniqid() . '.sqlite';
+        static::$writePath = sys_get_temp_dir() . '/hypervel_coroutine_write_' . uniqid() . '.sqlite';
+        touch(static::$readPath);
+        touch(static::$writePath);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        @unlink(static::$readPath);
+        @unlink(static::$writePath);
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app->make('config')->set('database.connections.sqlite_readwrite_pool', [
+            'driver' => 'sqlite',
+            'read' => [
+                'database' => static::$readPath,
+            ],
+            'write' => [
+                'database' => static::$writePath,
+            ],
+            'pool' => [
+                'testing_enabled' => true,
+                'max_connections' => 5,
+                'heartbeat' => -1,
+            ],
+        ]);
+    }
+
     protected function afterRefreshingDatabase(): void
     {
         Schema::create('tmp_users', function (Blueprint $table) {
@@ -338,6 +381,71 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
 
         $manager = $connection->getTransactionManager();
         $this->assertNotNull($manager, 'Pooled connection should have transaction manager configured');
+    }
+
+    public function testWriteSuffixDoesNotForcePlainConnectionReadsInAnotherCoroutine(): void
+    {
+        $this->seedReadWritePoolMarkers();
+
+        [$writeValue, $plainValue] = parallel([
+            function () {
+                $value = DB::connection('sqlite_readwrite_pool::write')
+                    ->selectOne('select value from markers')
+                    ->value;
+
+                usleep(5000);
+
+                return $value;
+            },
+            function () {
+                usleep(1000);
+
+                return DB::connection('sqlite_readwrite_pool')
+                    ->selectOne('select value from markers')
+                    ->value;
+            },
+        ]);
+
+        $this->assertSame('write', $writeValue);
+        $this->assertSame('read', $plainValue);
+    }
+
+    public function testWriteSuffixAndPlainConnectionUseSeparateCoroutineContextEntries(): void
+    {
+        $this->seedReadWritePoolMarkers();
+
+        $write = DB::connection('sqlite_readwrite_pool::write');
+        $plain = DB::connection('sqlite_readwrite_pool');
+
+        $this->assertNotSame($write, $plain);
+        $this->assertSame($write, DB::connection('sqlite_readwrite_pool::write'));
+        $this->assertSame($plain, DB::connection('sqlite_readwrite_pool'));
+        $this->assertSame('write', $write->selectOne('select value from markers')->value);
+        $this->assertSame('read', $plain->selectOne('select value from markers')->value);
+    }
+
+    public function testReadSuffixAndPlainConnectionUseSeparateCoroutineContextEntries(): void
+    {
+        $this->seedReadWritePoolMarkers();
+
+        $read = DB::connection('sqlite_readwrite_pool::read');
+        $plain = DB::connection('sqlite_readwrite_pool');
+
+        $this->assertNotSame($read, $plain);
+        $this->assertSame($read, DB::connection('sqlite_readwrite_pool::read'));
+        $this->assertSame($plain, DB::connection('sqlite_readwrite_pool'));
+        $this->assertSame('read', $read->selectOne('select value from markers')->value);
+        $this->assertSame('read', $plain->selectOne('select value from markers')->value);
+    }
+
+    protected function seedReadWritePoolMarkers(): void
+    {
+        foreach (['sqlite_readwrite_pool::read' => 'read', 'sqlite_readwrite_pool::write' => 'write'] as $connectionName => $value) {
+            $connection = DB::connection($connectionName);
+            $connection->statement('drop table if exists markers');
+            $connection->statement('create table markers (value varchar not null)');
+            $connection->insert('insert into markers (value) values (?)', [$value]);
+        }
     }
 }
 

--- a/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
+++ b/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
@@ -11,8 +11,10 @@ use Hypervel\Database\DatabaseManager;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Schema\Blueprint;
 use Hypervel\Engine\Channel;
+use Hypervel\Filesystem\Filesystem;
 use Hypervel\Support\Facades\DB;
 use Hypervel\Support\Facades\Schema;
+use Hypervel\Testing\ParallelTesting;
 use RuntimeException;
 use Throwable;
 
@@ -27,6 +29,8 @@ use function Hypervel\Coroutine\parallel;
  */
 class ConnectionCoroutineSafetyTest extends DatabaseTestCase
 {
+    protected static string $databaseDirectory;
+
     protected static string $readPath;
 
     protected static string $writePath;
@@ -35,16 +39,19 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        static::$readPath = sys_get_temp_dir() . '/hypervel_coroutine_read_' . uniqid() . '.sqlite';
-        static::$writePath = sys_get_temp_dir() . '/hypervel_coroutine_write_' . uniqid() . '.sqlite';
+        $filesystem = new Filesystem;
+        static::$databaseDirectory = ParallelTesting::tempDir('ConnectionCoroutineSafetyTest');
+        $filesystem->ensureDirectoryExists(static::$databaseDirectory);
+
+        static::$readPath = static::$databaseDirectory . '/read.sqlite';
+        static::$writePath = static::$databaseDirectory . '/write.sqlite';
         touch(static::$readPath);
         touch(static::$writePath);
     }
 
     public static function tearDownAfterClass(): void
     {
-        @unlink(static::$readPath);
-        @unlink(static::$writePath);
+        (new Filesystem)->deleteDirectory(static::$databaseDirectory);
 
         parent::tearDownAfterClass();
     }

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Integration\Database;
 use Hypervel\Database\QueryException;
 use Hypervel\Support\Arr;
 use Hypervel\Support\Facades\DB;
+use InvalidArgumentException;
 
 class DatabaseConnectionsTest extends DatabaseTestCase
 {
@@ -65,6 +66,8 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
     // REMOVED: testEstablishingAConnectionWillDispatchAnEvent - Uses connectUsing() which is incompatible with Swoole connection pooling
 
+    // REMOVED: testDirectDatabaseConnection - Laravel's ::direct suffix is replaced by Hypervel's migrations_connection setting.
+
     public function testTablePrefix(): void
     {
         DB::setTablePrefix('prefix_');
@@ -86,54 +89,57 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
     public function testReadWriteTypeIsProvidedInQueryExecutedEventAndQueryLog(): void
     {
-        $connection = DB::connection('sqlite_readwrite');
+        $this->assertQueryReadWriteTypes('sqlite_readwrite', ['write', 'read', 'write', 'read']);
+        $this->assertQueryReadWriteTypes('sqlite_readwrite::read', ['read', 'read', 'read', 'read']);
+        $this->assertQueryReadWriteTypes('sqlite_readwrite::write', ['write', 'write', 'write', 'write']);
+    }
+
+    public function testConnectionsWithoutReadWriteConfigurationAlwaysShowAsWrite(): void
+    {
+        $this->assertQueryReadWriteTypes('sqlite', ['write', 'write', 'write', 'write']);
+        $this->assertQueryReadWriteTypes('sqlite::read', ['write', 'write', 'write', 'write']);
+        $this->assertQueryReadWriteTypes('sqlite::write', ['write', 'write', 'write', 'write']);
+    }
+
+    public function testDirectConnectionSuffixIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Database connection suffix [::direct] is not supported. Configure a direct connection and use migrations_connection instead.'
+        );
+
+        DB::connection('default::direct');
+    }
+
+    protected function assertQueryReadWriteTypes(string $connectionName, array $expected): void
+    {
+        $connection = DB::connection($connectionName);
 
         $events = collect();
         $connection->listen($events->push(...));
         $connection->enableQueryLog();
 
         $connection->statement('select 1');
-        $this->assertSame('write', $events->shift()->readWriteType);
+        $this->assertSame($expected[0], $events->shift()->readWriteType);
 
         $connection->select('select 1');
-        $this->assertSame('read', $events->shift()->readWriteType);
+        $this->assertSame($expected[1], $events->shift()->readWriteType);
 
         $connection->statement('select 1');
-        $this->assertSame('write', $events->shift()->readWriteType);
+        $this->assertSame($expected[2], $events->shift()->readWriteType);
 
         $connection->select('select 1');
-        $this->assertSame('read', $events->shift()->readWriteType);
+        $this->assertSame($expected[3], $events->shift()->readWriteType);
 
         $this->assertEmpty($events);
         $this->assertSame([
-            ['query' => 'select 1', 'readWriteType' => 'write'],
-            ['query' => 'select 1', 'readWriteType' => 'read'],
-            ['query' => 'select 1', 'readWriteType' => 'write'],
-            ['query' => 'select 1', 'readWriteType' => 'read'],
+            ['query' => 'select 1', 'readWriteType' => $expected[0]],
+            ['query' => 'select 1', 'readWriteType' => $expected[1]],
+            ['query' => 'select 1', 'readWriteType' => $expected[2]],
+            ['query' => 'select 1', 'readWriteType' => $expected[3]],
         ], Arr::select($connection->getQueryLog(), [
             'query', 'readWriteType',
         ]));
-    }
-
-    public function testConnectionsWithoutReadWriteConfigurationAlwaysShowAsWrite(): void
-    {
-        // Default sqlite connection has no read/write splitting
-        $connection = DB::connection('sqlite');
-
-        $events = collect();
-        $connection->listen($events->push(...));
-
-        $connection->statement('select 1');
-        $this->assertSame('write', $events->shift()->readWriteType);
-
-        $connection->select('select 1');
-        $this->assertSame('write', $events->shift()->readWriteType);
-
-        $connection->statement('select 1');
-        $this->assertSame('write', $events->shift()->readWriteType);
-
-        $connection->select('select 1');
-        $this->assertSame('write', $events->shift()->readWriteType);
     }
 
     public function testQueryExceptionsProvideReadWriteType(): void
@@ -147,6 +153,20 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
         try {
             DB::connection('sqlite_readwrite')->select('xxxx', useReadPdo: false);
+            $this->fail();
+        } catch (QueryException $exception) {
+            $this->assertSame('write', $exception->readWriteType);
+        }
+
+        try {
+            DB::connection('sqlite_readwrite::read')->select('xxxx', useReadPdo: false);
+            $this->fail();
+        } catch (QueryException $exception) {
+            $this->assertSame('read', $exception->readWriteType);
+        }
+
+        try {
+            DB::connection('sqlite_readwrite::write')->select('xxxx', useReadPdo: true);
             $this->fail();
         } catch (QueryException $exception) {
             $this->assertSame('write', $exception->readWriteType);

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\Database;
 
 use Hypervel\Database\QueryException;
+use Hypervel\Filesystem\Filesystem;
 use Hypervel\Support\Arr;
 use Hypervel\Support\Facades\DB;
+use Hypervel\Testing\ParallelTesting;
 use InvalidArgumentException;
 
 class DatabaseConnectionsTest extends DatabaseTestCase
 {
+    protected static string $databaseDirectory;
+
     protected static string $readPath;
 
     protected static string $writePath;
@@ -19,33 +23,37 @@ class DatabaseConnectionsTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        // Create temp SQLite files for read/write splitting tests
-        static::$readPath = sys_get_temp_dir() . '/hypervel_test_read_' . uniqid() . '.sqlite';
-        static::$writePath = sys_get_temp_dir() . '/hypervel_test_write_' . uniqid() . '.sqlite';
+        $filesystem = new Filesystem;
+        static::$databaseDirectory = ParallelTesting::tempDir('DatabaseConnectionsTest');
+        $filesystem->ensureDirectoryExists(static::$databaseDirectory);
+
+        static::$readPath = static::$databaseDirectory . '/read.sqlite';
+        static::$writePath = static::$databaseDirectory . '/write.sqlite';
         touch(static::$readPath);
         touch(static::$writePath);
     }
 
     public static function tearDownAfterClass(): void
     {
-        @unlink(static::$readPath);
-        @unlink(static::$writePath);
+        (new Filesystem)->deleteDirectory(static::$databaseDirectory);
 
         parent::tearDownAfterClass();
     }
 
     protected function defineEnvironment($app): void
     {
+        $config = $app->make('config');
+
         // Configure a basic sqlite connection for testConnectionsWithoutReadWriteConfigurationAlwaysShowAsWrite
         // (When running with Postgres, DB_DATABASE=testing would be used, causing SQLite to fail)
-        $app['config']->set('database.connections.sqlite', [
+        $config->set('database.connections.sqlite', [
             'driver' => 'sqlite',
             'database' => ':memory:',
             'prefix' => '',
         ]);
 
         // Configure a read/write split connection for tests
-        $app['config']->set('database.connections.sqlite_readwrite', [
+        $config->set('database.connections.sqlite_readwrite', [
             'driver' => 'sqlite',
             'read' => [
                 'database' => static::$readPath,

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -11,6 +11,28 @@ use RuntimeException;
 
 class DatabaseTransactionsTest extends DatabaseTestCase
 {
+    protected static string $readPath;
+
+    protected static string $writePath;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        static::$readPath = sys_get_temp_dir() . '/hypervel_transactions_read_' . uniqid() . '.sqlite';
+        static::$writePath = sys_get_temp_dir() . '/hypervel_transactions_write_' . uniqid() . '.sqlite';
+        touch(static::$readPath);
+        touch(static::$writePath);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        @unlink(static::$readPath);
+        @unlink(static::$writePath);
+
+        parent::tearDownAfterClass();
+    }
+
     protected function defineEnvironment(Application $app): void
     {
         parent::defineEnvironment($app);
@@ -19,6 +41,15 @@ class DatabaseTransactionsTest extends DatabaseTestCase
             'database.connections.second_connection' => [
                 'driver' => 'sqlite',
                 'database' => ':memory:',
+            ],
+            'database.connections.transaction_readwrite' => [
+                'driver' => 'sqlite',
+                'read' => [
+                    'database' => static::$readPath,
+                ],
+                'write' => [
+                    'database' => static::$writePath,
+                ],
             ],
         ]);
     }
@@ -110,6 +141,26 @@ class DatabaseTransactionsTest extends DatabaseTestCase
         $this->assertFalse($thirdObject->ran);
     }
 
+    public function testSuffixedConnectionsUseBaseNameForTransactionCallbacks(): void
+    {
+        $afterCommitRan = false;
+        $write = DB::connection('transaction_readwrite::write');
+        $read = DB::connection('transaction_readwrite::read');
+
+        $this->assertSame('transaction_readwrite', $write->getName());
+        $this->assertSame('transaction_readwrite', $read->getName());
+
+        $write->transaction(function () use ($write, &$afterCommitRan) {
+            DB::connection('transaction_readwrite::read')->select('select 1');
+
+            $write->afterCommit(function () use (&$afterCommitRan) {
+                $afterCommitRan = true;
+            });
+        });
+
+        $this->assertTrue($afterCommitRan);
+    }
+
     public function testAfterRollbackCallbacksAreExecuted()
     {
         $afterCommitRan = false;
@@ -122,6 +173,33 @@ class DatabaseTransactionsTest extends DatabaseTestCase
                 });
 
                 DB::afterRollBack(function () use (&$afterRollbackRan) {
+                    $afterRollbackRan = true;
+                });
+
+                throw new RuntimeException('rollback');
+            });
+        } catch (RuntimeException) {
+            // Ignore the expected rollback exception.
+        }
+
+        $this->assertFalse($afterCommitRan);
+        $this->assertTrue($afterRollbackRan);
+    }
+
+    public function testSuffixedConnectionsUseBaseNameForRollbackCallbacks(): void
+    {
+        $afterCommitRan = false;
+        $afterRollbackRan = false;
+        $write = DB::connection('transaction_readwrite::write');
+
+        try {
+            $write->transaction(function () use ($write, &$afterCommitRan, &$afterRollbackRan) {
+                DB::connection('transaction_readwrite::read')->select('select 1');
+
+                $write->afterCommit(function () use (&$afterCommitRan) {
+                    $afterCommitRan = true;
+                });
+                $write->afterRollBack(function () use (&$afterRollbackRan) {
                     $afterRollbackRan = true;
                 });
 

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -6,11 +6,15 @@ namespace Hypervel\Tests\Integration\Database;
 
 use Exception;
 use Hypervel\Contracts\Foundation\Application;
+use Hypervel\Filesystem\Filesystem;
 use Hypervel\Support\Facades\DB;
+use Hypervel\Testing\ParallelTesting;
 use RuntimeException;
 
 class DatabaseTransactionsTest extends DatabaseTestCase
 {
+    protected static string $databaseDirectory;
+
     protected static string $readPath;
 
     protected static string $writePath;
@@ -19,16 +23,19 @@ class DatabaseTransactionsTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        static::$readPath = sys_get_temp_dir() . '/hypervel_transactions_read_' . uniqid() . '.sqlite';
-        static::$writePath = sys_get_temp_dir() . '/hypervel_transactions_write_' . uniqid() . '.sqlite';
+        $filesystem = new Filesystem;
+        static::$databaseDirectory = ParallelTesting::tempDir('DatabaseTransactionsTest');
+        $filesystem->ensureDirectoryExists(static::$databaseDirectory);
+
+        static::$readPath = static::$databaseDirectory . '/read.sqlite';
+        static::$writePath = static::$databaseDirectory . '/write.sqlite';
         touch(static::$readPath);
         touch(static::$writePath);
     }
 
     public static function tearDownAfterClass(): void
     {
-        @unlink(static::$readPath);
-        @unlink(static::$writePath);
+        (new Filesystem)->deleteDirectory(static::$databaseDirectory);
 
         parent::tearDownAfterClass();
     }
@@ -37,7 +44,7 @@ class DatabaseTransactionsTest extends DatabaseTestCase
     {
         parent::defineEnvironment($app);
 
-        $app['config']->set([
+        $app->make('config')->set([
             'database.connections.second_connection' => [
                 'driver' => 'sqlite',
                 'database' => ':memory:',

--- a/tests/Integration/Database/PooledConnectionTest.php
+++ b/tests/Integration/Database/PooledConnectionTest.php
@@ -12,8 +12,10 @@ use Hypervel\Database\Events\ConnectionEstablished;
 use Hypervel\Database\Pool\DbPool;
 use Hypervel\Database\Pool\PooledConnection;
 use Hypervel\Database\SQLiteConnection;
+use Hypervel\Filesystem\Filesystem;
 use Hypervel\Pool\Events\ReleaseConnection;
 use Hypervel\Pool\PoolOption;
+use Hypervel\Testing\ParallelTesting;
 use InvalidArgumentException;
 use PDO;
 use ReflectionProperty;
@@ -93,7 +95,11 @@ class PooledConnectionTest extends DatabaseTestCase
 
     public function testPoolParsesUrlConfigurationBeforeCreatingConnection(): void
     {
-        $databasePath = sys_get_temp_dir() . '/hypervel_url_pool_test_' . uniqid() . '.sqlite';
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('PooledConnectionTest-url');
+        $filesystem->ensureDirectoryExists($directory);
+
+        $databasePath = $directory . '/database.sqlite';
         touch($databasePath);
 
         try {
@@ -117,7 +123,7 @@ class PooledConnectionTest extends DatabaseTestCase
 
             $pooledConnection->release();
         } finally {
-            @unlink($databasePath);
+            $filesystem->deleteDirectory($directory);
         }
     }
 
@@ -144,10 +150,48 @@ class PooledConnectionTest extends DatabaseTestCase
         new DbPool($this->app, 'memory_read_pool_test::read');
     }
 
+    public function testDerivedReadPoolForInMemorySqliteReadUrlIsRejected(): void
+    {
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('PooledConnectionTest-read-url-memory');
+        $filesystem->ensureDirectoryExists($directory);
+
+        $writePath = $directory . '/write.sqlite';
+        touch($writePath);
+
+        try {
+            $this->app->make('config')->set('database.connections.memory_read_url_pool_test', [
+                'driver' => 'sqlite',
+                'database' => $writePath,
+                'read' => [
+                    'url' => 'sqlite:///:memory:',
+                ],
+                'pool' => [
+                    'min_connections' => 1,
+                    'max_connections' => 1,
+                    'heartbeat' => -1,
+                ],
+            ]);
+
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage(
+                'Database connection [memory_read_url_pool_test::read] cannot use a derived read pool for in-memory SQLite.'
+            );
+
+            new DbPool($this->app, 'memory_read_url_pool_test::read');
+        } finally {
+            $filesystem->deleteDirectory($directory);
+        }
+    }
+
     public function testDerivedReadPoolForFileBackedSqliteUsesReadConfig(): void
     {
-        $readPath = sys_get_temp_dir() . '/hypervel_read_pool_test_' . uniqid() . '.sqlite';
-        $writePath = sys_get_temp_dir() . '/hypervel_write_pool_test_' . uniqid() . '.sqlite';
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('PooledConnectionTest-file-read');
+        $filesystem->ensureDirectoryExists($directory);
+
+        $readPath = $directory . '/read.sqlite';
+        $writePath = $directory . '/write.sqlite';
         touch($readPath);
         touch($writePath);
 
@@ -179,8 +223,7 @@ class PooledConnectionTest extends DatabaseTestCase
 
             $pooledConnection->release();
         } finally {
-            @unlink($readPath);
-            @unlink($writePath);
+            $filesystem->deleteDirectory($directory);
         }
     }
 
@@ -608,7 +651,11 @@ class PooledConnectionTest extends DatabaseTestCase
         // Use a file-based SQLite connection so reconnect() takes the
         // factory->make() path (not the makeSqliteFromSharedPdo() path
         // that in-memory SQLite uses).
-        $databasePath = sys_get_temp_dir() . '/hypervel_extension_pool_test.db';
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('PooledConnectionTest-extension');
+        $filesystem->ensureDirectoryExists($directory);
+
+        $databasePath = $directory . '/extension.sqlite';
         touch($databasePath);
 
         try {
@@ -643,7 +690,7 @@ class PooledConnectionTest extends DatabaseTestCase
             // reconnect() calls factory->make() which should consult the extension
             $this->assertSame($custom, $pooledConnection->getConnection());
         } finally {
-            @unlink($databasePath);
+            $filesystem->deleteDirectory($directory);
         }
     }
 

--- a/tests/Integration/Database/PooledConnectionTest.php
+++ b/tests/Integration/Database/PooledConnectionTest.php
@@ -14,6 +14,7 @@ use Hypervel\Database\Pool\PooledConnection;
 use Hypervel\Database\SQLiteConnection;
 use Hypervel\Pool\Events\ReleaseConnection;
 use Hypervel\Pool\PoolOption;
+use InvalidArgumentException;
 use PDO;
 use ReflectionProperty;
 
@@ -88,6 +89,99 @@ class PooledConnectionTest extends DatabaseTestCase
         $connection = $pooledConnection->getConnection();
 
         $this->assertInstanceOf(Connection::class, $connection);
+    }
+
+    public function testPoolParsesUrlConfigurationBeforeCreatingConnection(): void
+    {
+        $databasePath = sys_get_temp_dir() . '/hypervel_url_pool_test_' . uniqid() . '.sqlite';
+        touch($databasePath);
+
+        try {
+            $this->app->make('config')->set('database.connections.url_pool_test', [
+                'url' => 'sqlite:///' . $databasePath,
+                'pool' => [
+                    'min_connections' => 1,
+                    'max_connections' => 1,
+                    'heartbeat' => -1,
+                ],
+            ]);
+
+            $pool = new DbPool($this->app, 'url_pool_test');
+
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $connection = $pooledConnection->getConnection();
+
+            $this->assertSame('sqlite', $connection->getConfig('driver'));
+            $this->assertSame($databasePath, $connection->getConfig('database'));
+
+            $pooledConnection->release();
+        } finally {
+            @unlink($databasePath);
+        }
+    }
+
+    public function testDerivedReadPoolForInMemorySqliteIsRejected(): void
+    {
+        $this->app->make('config')->set('database.connections.memory_read_pool_test', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'read' => [
+                'database' => ':memory:',
+            ],
+            'pool' => [
+                'min_connections' => 1,
+                'max_connections' => 1,
+                'heartbeat' => -1,
+            ],
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Database connection [memory_read_pool_test::read] cannot use a derived read pool for in-memory SQLite.'
+        );
+
+        new DbPool($this->app, 'memory_read_pool_test::read');
+    }
+
+    public function testDerivedReadPoolForFileBackedSqliteUsesReadConfig(): void
+    {
+        $readPath = sys_get_temp_dir() . '/hypervel_read_pool_test_' . uniqid() . '.sqlite';
+        $writePath = sys_get_temp_dir() . '/hypervel_write_pool_test_' . uniqid() . '.sqlite';
+        touch($readPath);
+        touch($writePath);
+
+        try {
+            $this->app->make('config')->set('database.connections.file_read_pool_test', [
+                'driver' => 'sqlite',
+                'read' => [
+                    'database' => $readPath,
+                ],
+                'write' => [
+                    'database' => $writePath,
+                ],
+                'pool' => [
+                    'min_connections' => 1,
+                    'max_connections' => 1,
+                    'heartbeat' => -1,
+                ],
+            ]);
+
+            $pool = new DbPool($this->app, 'file_read_pool_test::read');
+
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $connection = $pooledConnection->getConnection();
+
+            $this->assertSame('file_read_pool_test', $connection->getName());
+            $this->assertSame($readPath, $connection->getConfig('database'));
+            $this->assertSame('read', $connection->getConfig(Connection::READ_WRITE_TYPE_CONFIG_KEY));
+
+            $pooledConnection->release();
+        } finally {
+            @unlink($readPath);
+            @unlink($writePath);
+        }
     }
 
     public function testGetConnectionReturnsSameInstanceWhileValid(): void


### PR DESCRIPTION
## Summary

For more details, see: docs/plans/2026-06-30-database-read-write-routing-and-pool-config.md

This adds Hypervel-native support for Laravel-style explicit database read/write connection suffixes: `DB::connection('name::read')` and `DB::connection('name::write')`. Normal application queries still use Hypervel's existing automatic read/write routing; the suffixes are for explicit inspection, diagnostics, and code paths that need a connection name for a specific side.

The implementation intentionally does not port Laravel's `::direct` suffix. Hypervel's external-pooler model uses normal named connections plus `migrations_connection`, which keeps direct and pooled endpoints explicit and avoids mutating shared connection objects in a long-lived Swoole worker.

## Details

- Added a shared `ConnectionName` parser for database connection suffixes, including an explicit `::direct` rejection with Hypervel guidance.
- Added read-side config derivation helpers to `ConnectionFactory`, including URL parsing through the database parser.
- Added immutable read/write role metadata to derived connections so query logs and exceptions report the right side without per-query config reads.
- Made database pools suffix-aware:
  - `name::read` uses a separate read pool when the base connection has read config.
  - `name::write` uses the base pool and forces reads through the write connection for that borrow.
  - unsplit `::read` and `::write` names remain compatibility aliases of the base connection.
- Made pooled coroutine resolution cache each requested suffix separately in `CoroutineContext`.
- Made non-pooled `DatabaseManager` resolution, disconnect, purge, and reconnect suffix-aware.
- Made the Testbench database resolver preserve suffix behavior during testing resets.
- Fixed `db --read` / `db --write` config merging for list-style configs, host arrays, empty nested configs, and stripped nested branches.
- Documented suffix usage, pool sizing implications, and the Hypervel alternative to Laravel's `::direct` suffix.

## Performance And Coroutine Safety

The hot query path keeps the existing automatic routing model. Suffix parsing and config derivation happen when resolving or creating connections and pools, not per query.

For pooled connections, suffix state is scoped to the requested coroutine context key. Forced write routing for `name::write` is applied only to the borrowed connection and is cleared by the existing pool reset path before the connection is reused.

The read pool is created only when a configured read side exists. `name::write` does not create another physical pool; it borrows from the base pool and uses the existing write-read routing flag.

## Testing

- Added focused unit coverage for `ConnectionName`, factory read config derivation, connection metadata, pool keying, manager cleanup, Testbench resolver behavior, and db command config merging.
- Added integration coverage for read/write suffix query routing, query logs, query exceptions, transaction base-name handling, coroutine isolation, pooled URL parsing, and derived SQLite guard behavior.
- Ran `composer fix` successfully before committing this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added explicit `::read` / `::write` connection suffix routing for database operations.
  * Enhanced connection pooling to support separate read/write pools when configured.
  * Improved CLI `--read`/`--write` handling for nested settings and host arrays.

* **Bug Fixes**
  * Fixed routing, caching, disconnect/purge, and reconnect behavior for derived read/write variants.
  * Improved validation and error details, including rejecting `::direct` and derived in-memory SQLite read pools.

* **Documentation**
  * Updated database docs with read/write routing and pooling behavior, including migration connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->