### PR TITLE
Harden permission forbidden assignments

### DIFF
--- a/docs/plans/2026-07-02-permission-forbidden-single-state-hardening.md
+++ b/docs/plans/2026-07-02-permission-forbidden-single-state-hardening.md
@@ -1,0 +1,1696 @@
+# Permission Forbidden Single-State Hardening Plan
+
+## Objective
+
+Fix the permission package so forbidden permissions are modeled as a single state on each assignment edge, not as a second row that can coexist beside an allowed row.
+
+The final package must read as if it was designed this way from the start:
+
+- one database row per subject / permission / team edge
+- `is_forbidden` is the effect stored on that edge
+- write methods flip the edge effect instead of creating competing rows
+- read methods treat forbidden as deny and never depend on relation order
+- query scopes use the same effective permission semantics as `hasPermissionTo()`
+- allowed permission accessors do not return forbidden rows
+- assignment cache invalidation uses a fresh namespace token instead of numeric increments
+- README and Boost docs describe the final behavior without stale dual-row wording
+
+This PR is for Hypervel 0.4. Churn and backwards compatibility do not matter here; the target is the best final codebase.
+
+## Current Bug And Root Cause
+
+Greptile flagged order-dependent reads in:
+
+- `src/permission/src/Traits/HasPermissions.php::hasDirectPermission()`
+- `src/permission/src/Models/Role.php::hasPermissionTo()`
+
+The real root cause is schema and write behavior, not only those readers.
+
+Current migrations include `is_forbidden` in the primary key:
+
+```php
+$table->primary(
+    [$pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'],
+    'model_has_permissions_permission_model_type_primary',
+);
+
+$table->primary(
+    [$pivotPermission, $pivotRole, 'is_forbidden'],
+    'role_has_permissions_permission_id_role_id_primary',
+);
+```
+
+That allows two rows for the same edge:
+
+```text
+model_id=1, permission_id=5, is_forbidden=false
+model_id=1, permission_id=5, is_forbidden=true
+```
+
+Then reads that call `first()` can return whichever row the relation gives first. Even when a caller checks forbidden before allowed, the data model is still contradictory and has to be defended in too many places.
+
+The correct model is one row per edge:
+
+```text
+model_id=1, permission_id=5, is_forbidden=true
+```
+
+Assigning allow or deny for the same edge updates that row's effect.
+
+During implementation, `scopePermission()` was also found to ignore forbidden
+effects. A model where `hasPermissionTo()` returns `false` could still match
+`User::permission()` because the scope counted forbidden direct pivots and
+forbidden role-permission pivots as grants. That is the same class of
+forbidden-correctness bug and must be fixed in this plan.
+
+## Agreed Decisions
+
+1. Keep forbidden permissions as a Hypervel improvement.
+
+   Explicit deny is useful in role/permission systems. A forbidden assignment must win over a direct allow, a role allow, or another role's allow.
+
+2. Store forbidden as an effect, not an identity field.
+
+   `is_forbidden` stays as a boolean column on `model_has_permissions` and `role_has_permissions`, but it must not be part of the primary key.
+
+3. Make write paths enforce single-state.
+
+   `givePermissionTo()` and `giveForbiddenTo()` must insert missing edges and update existing edges to the requested effect. They must not rely on duplicate rows.
+
+4. Keep defensive read hardening.
+
+   Once schema and writes are fixed, duplicates cannot be created through public APIs. Readers still handle bad manual data by making forbidden win deterministically.
+
+5. Exclude forbidden rows from allowed permission accessors.
+
+   `getDirectPermissions()` and `getPermissionNames()` are allow-oriented APIs. They must not return explicit denies.
+
+6. Make permission query scopes match effective permission semantics.
+
+   `permission($permissions)` must return models that effectively have at
+   least one requested permission. For each requested permission, an allow from
+   a direct assignment or a role assignment counts only when there is no direct
+   or role deny for that same permission. `withoutPermission($permissions)` must
+   be the exact negation of `permission($permissions)`.
+
+7. Replace numeric assignment cache versions with unique namespace tokens.
+
+   The current numeric `increment()` path is not needed. A fresh ULID token is simpler and avoids store-specific increment behavior. This is not a hot permission-check path; it runs when assignment cache namespaces are invalidated.
+
+8. Update docs to describe the final model only.
+
+   Documentation must not mention the old dual-row shape or leave wording that suggests allow and forbid rows can coexist for the same edge.
+
+## Files To Change
+
+### Schema Definitions
+
+All three schema definitions must change together:
+
+- `src/permission/database/migrations/2025_07_02_000000_create_permission_tables.php`
+- `src/permission/database/migrations/add_teams_fields.php.stub`
+- `tests/Permission/TestCase.php`
+
+The cache key config also changes as part of the token rename:
+
+- `src/permission/config/permission.php`
+
+Current primary keys:
+
+```php
+// Base migration, teams enabled.
+$table->primary(
+    [$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'],
+    'model_has_permissions_permission_model_type_primary',
+);
+
+// Base migration, teams disabled.
+$table->primary(
+    [$pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'],
+    'model_has_permissions_permission_model_type_primary',
+);
+
+// Base migration, role permissions.
+$table->primary(
+    [$pivotPermission, $pivotRole, 'is_forbidden'],
+    'role_has_permissions_permission_id_role_id_primary',
+);
+```
+
+Target primary keys:
+
+```php
+// Base migration, teams enabled.
+$table->primary(
+    [$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type'],
+    'model_has_permissions_permission_model_type_primary',
+);
+
+// Base migration, teams disabled.
+$table->primary(
+    [$pivotPermission, $modelMorphKey, 'model_type'],
+    'model_has_permissions_permission_model_type_primary',
+);
+
+// Base migration, role permissions.
+$table->primary(
+    [$pivotPermission, $pivotRole],
+    'role_has_permissions_permission_id_role_id_primary',
+);
+```
+
+The teams upgrade stub target changes only the `primary()` column list:
+
+```php
+$table->primary(
+    [$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type'],
+    'model_has_permissions_permission_model_type_primary',
+);
+```
+
+Keep the surrounding `dropForeign()`, `dropPrimary()`, and re-add `foreign()` scaffolding exactly as the stub has it today.
+
+The custom-primary-key test schema must match the same shape:
+
+```php
+$table->primary(
+    [$pivotPermission, $modelMorphKey, 'model_type'],
+    'model_has_permissions_permission_model_type_primary',
+);
+
+$table->primary(
+    [$pivotPermission, $pivotRole],
+    'role_has_permissions_permission_id_role_id_primary',
+);
+```
+
+Keep:
+
+```php
+$table->boolean('is_forbidden')->default(false);
+```
+
+### Assignment Writes
+
+File:
+
+- `src/permission/src/Traits/HasPermissions.php`
+
+Current write path:
+
+```php
+private function attachPermissions(array $permissions, bool $isForbidden): static
+{
+    $permissions = $this->collectPermissions($permissions);
+    $model = $this;
+    $registrar = $this->permissionRegistrar();
+    $teamPivot = $registrar->teams && ! $this instanceof Role
+        ? [$registrar->teamsKey => getPermissionsTeamId()] : [];
+    $pivot = $teamPivot + ['is_forbidden' => $isForbidden];
+
+    if ($model->exists) {
+        $currentPermissions = $this->relationCollection($this->loadMissing('permissions'), 'permissions')
+            ->filter(fn (Model $permission): bool => $this->pivotIsForbidden($permission) === $isForbidden)
+            ->map(fn (Model $permission) => $permission->getKey())
+            ->toArray();
+
+        $this->permissions()->attach(array_diff($permissions, $currentPermissions), $pivot);
+        $model->unsetRelation('permissions');
+    } else {
+        $this->queuePermissionAssignments($permissions, $pivot);
+    }
+
+    // cache/event cleanup...
+}
+```
+
+Target behavior:
+
+- collect permission ids
+- build the team pivot once
+- for persisted models, find existing related permission ids regardless of effect
+- attach missing ids with the requested `is_forbidden` value
+- update existing ids whose pivot effect differs
+- do not keep same-flag dedup logic
+- unset the relation after mutation
+- keep existing cache, event, and wildcard invalidation behavior
+
+Target shape:
+
+```php
+private function attachPermissions(array $permissions, bool $isForbidden): static
+{
+    $permissions = $this->collectPermissions($permissions);
+    $model = $this;
+    $registrar = $this->permissionRegistrar();
+    $pivot = $this->permissionAssignmentPivot($isForbidden);
+
+    if ($model->exists) {
+        $this->upsertPermissionAssignments($permissions, $pivot);
+        $model->unsetRelation('permissions');
+    } else {
+        $this->queuePermissionAssignments($permissions, $pivot);
+    }
+
+    if ($this instanceof Role) {
+        $this->forgetCachedPermissions();
+    } elseif ($model->exists) {
+        $registrar->forgetModelPermissionCache($model);
+    }
+
+    $this->dispatchPermissionAttachedEvent($permissions);
+    $this->forgetWildcardPermissionIndex();
+
+    return $this;
+}
+```
+
+Add a helper for the pivot data so direct and queued paths share the same source:
+
+```php
+/**
+ * Build permission assignment pivot attributes.
+ *
+ * @return array<string, mixed>
+ */
+private function permissionAssignmentPivot(bool $isForbidden): array
+{
+    $registrar = $this->permissionRegistrar();
+
+    $teamPivot = $registrar->teams && ! $this instanceof Role
+        ? [$registrar->teamsKey => getPermissionsTeamId()] : [];
+
+    return $teamPivot + ['is_forbidden' => $isForbidden];
+}
+```
+
+Add a helper that flips existing rows and inserts only missing rows:
+
+```php
+/**
+ * Insert missing permission assignments and update existing effects.
+ *
+ * @param array<int, int|string> $permissions
+ * @param array<string, mixed> $pivot
+ */
+private function upsertPermissionAssignments(array $permissions, array $pivot): void
+{
+    if ($permissions === []) {
+        return;
+    }
+
+    $relation = $this->permissions();
+    $currentPermissions = $relation->get()
+        ->keyBy(fn (Model $permission): string => (string) $permission->getKey());
+    $effect = ['is_forbidden' => (bool) $pivot['is_forbidden']];
+
+    $attach = [];
+    $updated = false;
+
+    foreach ($permissions as $permission) {
+        $key = (string) $permission;
+        $currentPermission = $currentPermissions->get($key);
+
+        if (! $currentPermission instanceof Model) {
+            $attach[] = $permission;
+            continue;
+        }
+
+        if ($this->pivotIsForbidden($currentPermission) !== $effect['is_forbidden']) {
+            $updated = $relation->updateExistingPivot($permission, $effect, false) > 0 || $updated;
+        }
+    }
+
+    if ($attach !== []) {
+        $relation->attach($attach, $pivot, false);
+        $updated = true;
+    }
+
+    if ($updated) {
+        $relation->touchIfTouching();
+    }
+}
+```
+
+Upsert notes:
+
+- `permissions()` already scopes model permissions by team through `wherePivot($teamsKey, getPermissionsTeamId())`, so `updateExistingPivot()` and `attach()` operate in the current team context for user/model assignments.
+- For model assignments, pass the full pivot data to `attach()` so new rows get the team id, but pass only `['is_forbidden' => ...]` to `updateExistingPivot()`. The relation already scopes the update to the current team, so setting the team column again is noise.
+- Role permission assignments have no team pivot by design, so the same helper works for `Role`.
+- The helper queries the relation fresh instead of using `loadMissing()`. This matters because callers may already have a stale `permissions` relation loaded, and queued assignments can process allow/deny calls back-to-back after save.
+- `touchIfTouching()` is called once after a changed batch so flipping multiple rows does not touch repeatedly, and no-op calls do not touch related models.
+
+Add a helper for assignment sets that are known to have no existing rows:
+
+```php
+/**
+ * Insert permission assignments into an empty assignment set.
+ *
+ * @param array<int, int|string> $permissions
+ * @param array<string, mixed> $pivot
+ */
+private function attachPermissionAssignments(array $permissions, array $pivot): void
+{
+    if ($permissions === []) {
+        return;
+    }
+
+    $relation = $this->permissions();
+
+    $relation->attach($permissions, $pivot, false);
+    $relation->touchIfTouching();
+}
+```
+
+This helper is only for paths that have already proved the assignment set is
+empty for the target `(model, permission, team)` identity. Do not replace the
+normal persisted `givePermissionTo()` / `giveForbiddenTo()` path with it.
+Known-empty paths use `attachPermissionAssignments()` to avoid the read that
+`upsertPermissionAssignments()` needs for possibly-existing rows.
+
+Place `permissionAssignmentPivot()`, `upsertPermissionAssignments()`, and
+`attachPermissionAssignments()` next to `attachPermissions()` and the `give*`
+methods, not at the end of the trait.
+
+### Queued Assignments For Unsaved Models
+
+Current queued path:
+
+```php
+protected function attachQueuedPermissionAssignments(): void
+{
+    if ($this->queuedPermissionAssignments === []) {
+        return;
+    }
+
+    $registrar = $this->permissionRegistrar();
+
+    foreach ($this->queuedPermissionAssignments as $assignment) {
+        $this->permissions()->attach($assignment['permissions'], $assignment['pivot']);
+    }
+
+    $this->queuedPermissionAssignments = [];
+    $this->unsetRelation('permissions');
+
+    // cache cleanup...
+}
+```
+
+This will hit primary-key conflicts under the new schema if an unsaved model receives both allow and forbid for the same permission before it is saved.
+
+Target:
+
+```php
+protected function attachQueuedPermissionAssignments(): void
+{
+    if ($this->queuedPermissionAssignments === []) {
+        return;
+    }
+
+    $registrar = $this->permissionRegistrar();
+    $assignments = $this->collapseQueuedPermissionAssignments();
+
+    foreach ($assignments as $assignment) {
+        $this->attachPermissionAssignments(
+            $assignment['permissions'],
+            $assignment['pivot'],
+        );
+    }
+
+    $this->queuedPermissionAssignments = [];
+    $this->unsetRelation('permissions');
+
+    if ($this instanceof Role) {
+        $this->forgetCachedPermissions();
+    } else {
+        $registrar->forgetModelPermissionCache($this);
+    }
+
+    $this->forgetWildcardPermissionIndex();
+}
+```
+
+Add helpers for collapsing and batching queued assignments:
+
+```php
+/**
+ * Collapse queued permission assignments to their final edge state.
+ *
+ * @return array<int, array{permissions: array<int, int|string>, pivot: array<string, mixed>}>
+ */
+private function collapseQueuedPermissionAssignments(): array
+{
+    $collapsed = [];
+
+    foreach ($this->queuedPermissionAssignments as $assignment) {
+        foreach ($assignment['permissions'] as $permission) {
+            $key = $permission . '|' . $this->queuedPermissionAssignmentTeamKey($assignment['pivot']);
+
+            $collapsed[$key] = [
+                'permission' => $permission,
+                'pivot' => $assignment['pivot'],
+            ];
+        }
+    }
+
+    $batches = [];
+
+    foreach ($collapsed as $assignment) {
+        $pivot = $assignment['pivot'];
+        $batchKey = $this->queuedPermissionAssignmentTeamKey($pivot) . '|'
+            . ((bool) $pivot['is_forbidden'] ? 'forbidden' : 'allowed');
+
+        $batches[$batchKey] ??= [
+            'permissions' => [],
+            'pivot' => $pivot,
+        ];
+        $batches[$batchKey]['permissions'][] = $assignment['permission'];
+    }
+
+    return array_values($batches);
+}
+
+/**
+ * Build the queued assignment team key.
+ *
+ * @param array<string, mixed> $pivot
+ */
+private function queuedPermissionAssignmentTeamKey(array $pivot): string
+{
+    $registrar = $this->permissionRegistrar();
+
+    if (! $registrar->teams || $this instanceof Role) {
+        return 'none';
+    }
+
+    return (string) ($pivot[$registrar->teamsKey] ?? 'global');
+}
+```
+
+This keeps queued calls ordered per assignment edge. For example:
+
+```php
+$user = new User;
+$user->givePermissionTo('edit articles');
+$user->giveForbiddenTo('edit articles');
+$user->save();
+```
+
+The saved row must be forbidden. Reversing the calls must save an allowed row.
+The collapse key is permission id plus team identity, not permission id alone:
+
+```php
+$user = new User;
+setPermissionsTeamId(1);
+$user->givePermissionTo('edit articles');
+setPermissionsTeamId(2);
+$user->givePermissionTo('edit articles');
+$user->save();
+```
+
+This must create one row for team 1 and one row for team 2. Only repeated queued
+assignments for the same permission and same team collapse, with the last effect
+winning.
+
+Do not dispatch `PermissionAttachedEvent` from `attachQueuedPermissionAssignments()`.
+The existing API dispatches at `givePermissionTo()` / `giveForbiddenTo()` call
+time, including unsaved-model queued calls. The queued flush must only persist
+rows and invalidate caches/wildcard indexes, or queued calls would double-fire
+events.
+
+### Sync Behavior
+
+`syncPermissionsWithForbidden()` already builds one `$syncData[$permissionId]` entry per permission id:
+
+```php
+foreach ($allowedIds as $permissionId) {
+    $syncData[$permissionId] = $teamPivot + ['is_forbidden' => false];
+}
+
+foreach ($forbiddenIds as $permissionId) {
+    $syncData[$permissionId] = $teamPivot + ['is_forbidden' => true];
+}
+
+$changes = $this->permissions()->sync($syncData);
+```
+
+Because `sync()` updates existing pivot attributes for existing ids, this method is already aligned with the target single-state model.
+
+Still verify these paths with tests:
+
+- allow to forbid returns the changed permission id under `updated`
+- forbid to allow returns the changed permission id under `updated`
+- permission present in both `allowed` and `forbidden` ends forbidden
+- custom primary key tests still pass
+
+`syncPermissions()` should collect ids once, detach existing rows, then use the
+known-empty insert helper. Do not call `givePermissionTo()` after detaching: it
+would re-collect string inputs and route through the upsert helper, adding a
+read that is unnecessary after the set has been emptied.
+
+```php
+public function syncPermissions(...$permissions): static
+{
+    $permissions = $this->collectPermissions($permissions);
+    $model = $this;
+
+    if ($this->exists) {
+        $this->permissions()->detach();
+        $this->attachPermissionAssignments(
+            $permissions,
+            $this->permissionAssignmentPivot(false),
+        );
+        $model->unsetRelation('permissions');
+    } else {
+        $this->queuePermissionAssignments(
+            $permissions,
+            $this->permissionAssignmentPivot(false),
+        );
+    }
+
+    if ($this instanceof Role) {
+        $this->forgetCachedPermissions();
+    } elseif ($model->exists) {
+        $this->permissionRegistrar()->forgetModelPermissionCache($model);
+    }
+
+    $this->dispatchPermissionAttachedEvent($permissions);
+    $this->forgetWildcardPermissionIndex();
+
+    return $this;
+}
+```
+
+This preserves the existing public event timing: `syncPermissions()` dispatches
+the attach event once, while queued unsaved-model flushes do not dispatch again.
+
+### Revoke Behavior
+
+`revokePermissionTo()` detaches the one edge regardless of current effect:
+
+```php
+public function revokePermissionTo($permission): static
+{
+    $storedPermission = $this->getStoredPermission($permission);
+
+    $this->permissions()->detach($storedPermission);
+
+    // cache/event cleanup...
+}
+```
+
+No source change is expected here, but add coverage proving a direct deny can be revoked:
+
+```php
+$user->giveForbiddenTo('edit articles');
+$user->revokePermissionTo('edit articles');
+
+$this->assertFalse($user->hasForbiddenPermission('edit articles'));
+$this->assertFalse($user->hasPermissionTo('edit articles'));
+$this->assertSame([], $user->getDirectPermissions()->all());
+```
+
+### Read Hardening
+
+File:
+
+- `src/permission/src/Traits/HasPermissions.php`
+
+Current:
+
+```php
+public function hasDirectPermission($permission): bool
+{
+    $permission = $this->filterPermission($permission);
+
+    $matchedPermission = $this->getCachedDirectPermissions()
+        ->first(fn (Model $directPermission): bool => $directPermission->getKey() === $permission->getKey());
+
+    return $matchedPermission !== null
+        && ! $this->pivotIsForbidden($matchedPermission);
+}
+```
+
+Target:
+
+```php
+public function hasDirectPermission($permission): bool
+{
+    $permission = $this->filterPermission($permission);
+
+    $matches = $this->getCachedDirectPermissions()
+        ->filter(fn (Model $directPermission): bool => $directPermission->getKey() === $permission->getKey());
+
+    return $matches->isNotEmpty()
+        && ! $matches->contains(fn (Model $directPermission): bool => $this->pivotIsForbidden($directPermission));
+}
+```
+
+This is defense against bad/manual data. With the new schema and write path, public APIs do not create duplicates.
+
+File:
+
+- `src/permission/src/Models/Role.php`
+
+Current:
+
+```php
+$matchedPermission = $this->loadMissing('permissions')
+    ->getRelation('permissions')
+    ->first(fn (Model $rolePermission): bool => $rolePermission->getKey() === $permission->getKey());
+$pivot = $matchedPermission?->getRelation('pivot');
+
+return $matchedPermission !== null
+    && (! $pivot instanceof Pivot || ! (bool) $pivot->getAttribute('is_forbidden'));
+```
+
+Target:
+
+```php
+$matches = $this->loadMissing('permissions')
+    ->getRelation('permissions')
+    ->filter(fn (Model $rolePermission): bool => $rolePermission->getKey() === $permission->getKey());
+
+return $matches->isNotEmpty()
+    && ! $matches->contains(fn (Model $rolePermission): bool => $this->pivotIsForbidden($rolePermission));
+```
+
+This removes the last direct `Pivot` class reference in `Role.php`. Remove the `use Hypervel\Database\Eloquent\Relations\Pivot;` import.
+
+### Effective Permission Query Scopes
+
+File:
+
+- `src/permission/src/Traits/HasPermissions.php`
+
+`scopePermission()` currently counts direct and role permission rows without
+checking the forbidden effect:
+
+```php
+return $query->where(
+    fn (Builder $query) => $query
+        ->{! $without ? 'whereHas' : 'whereDoesntHave'}(
+            'permissions',
+            fn (Builder $subQuery) => $subQuery
+                ->whereIn(Config::permissionsTable() . ".{$permissionKey}", array_column($permissions, $permissionKey))
+        )
+        ->when(
+            count($roleIdsWithPermissions),
+            fn ($whenQuery) => $whenQuery
+                ->{! $without ? 'orWhereHas' : 'whereDoesntHave'}(
+                    'roles',
+                    fn (Builder $subQuery) => $subQuery
+                        ->whereIn(Config::rolesTable() . ".{$roleKey}", $roleIdsWithPermissions)
+                )
+        )
+);
+```
+
+This is wrong for forbidden permissions:
+
+- direct forbidden rows match `permission()` as if they were allows
+- role forbidden rows match `permission()` as if they were allows
+- `withoutPermission()` is not a true inverse once deny semantics are involved
+
+Target semantics for one model `M` and permission `p`:
+
+```text
+directAllow(M, p) = direct edge for p with is_forbidden=false
+directDeny(M, p)  = direct edge for p with is_forbidden=true
+roleAllow(M, p)   = assigned role edge for p with is_forbidden=false
+roleDeny(M, p)    = assigned role edge for p with is_forbidden=true
+
+effective(M, p) = (directAllow(M, p) OR roleAllow(M, p))
+                  AND NOT (directDeny(M, p) OR roleDeny(M, p))
+```
+
+For a set of requested permissions:
+
+```text
+permission([p1, p2]) = effective(M, p1) OR effective(M, p2)
+withoutPermission([p1, p2]) = NOT permission([p1, p2])
+```
+
+The deny check must be correlated to the same permission. A model with allow
+`P1` and deny `P2` must still match `permission([P1, P2])` through `P1`.
+
+Do not keep the current precomputed `$roleIdsWithPermissions` path. It is built
+from hydrated permission-role relations and cannot express the role-permission
+pivot effect cleanly. Use relation existence queries so SQL checks the actual
+assignment edges.
+
+Target shape:
+
+```php
+public function scopePermission(Builder $query, $permissions, bool $without = false): Builder
+{
+    $permissions = $this->convertToPermissionModels($permissions);
+    $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
+    $permissionIds = array_column($permissions, $permissionKey);
+
+    $effectivePermission = fn (Builder $query): Builder => $this->whereEffectivePermission(
+        $query,
+        $permissionIds,
+    );
+
+    return $without
+        ? $query->whereNot($effectivePermission)
+        : $query->where($effectivePermission);
+}
+```
+
+Add helpers near `scopePermission()`:
+
+```php
+/**
+ * Add an effective permission predicate for the given permission ids.
+ *
+ * @param array<int, int|string> $permissionIds
+ */
+protected function whereEffectivePermission(Builder $query, array $permissionIds): Builder
+{
+    if ($permissionIds === []) {
+        return $query->whereRaw('1 = 0');
+    }
+
+    foreach ($permissionIds as $index => $permissionId) {
+        $method = $index === 0 ? 'where' : 'orWhere';
+
+        $query->{$method}(fn (Builder $query) => $query
+            ->where(fn (Builder $query) => $this->wherePermissionEffect($query, $permissionId, false))
+            ->whereNot(fn (Builder $query) => $this->wherePermissionEffect($query, $permissionId, true))
+        );
+    }
+
+    return $query;
+}
+
+/**
+ * Add a permission-effect predicate for direct and role-granted permissions.
+ */
+protected function wherePermissionEffect(Builder $query, int|string $permissionId, bool $forbidden): Builder
+{
+    $query->whereHas(
+        'permissions',
+        fn (Builder $query) => $this->whereDirectPermissionEffect($query, $permissionId, $forbidden),
+    );
+
+    if (! $this instanceof Role) {
+        $query->orWhereHas(
+            'roles.permissions',
+            fn (Builder $query) => $this->whereRolePermissionEffect($query, $permissionId, $forbidden),
+        );
+    }
+
+    return $query;
+}
+
+/**
+ * Add a direct permission-effect predicate.
+ */
+protected function whereDirectPermissionEffect(Builder $query, int|string $permissionId, bool $forbidden): Builder
+{
+    $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
+    $pivotTable = $this instanceof Role
+        ? Config::roleHasPermissionsTable()
+        : Config::modelHasPermissionsTable();
+
+    return $query
+        ->where(Config::permissionsTable() . ".{$permissionKey}", $permissionId)
+        ->where("{$pivotTable}.is_forbidden", $forbidden);
+}
+
+/**
+ * Add a role permission-effect predicate.
+ */
+protected function whereRolePermissionEffect(Builder $query, int|string $permissionId, bool $forbidden): Builder
+{
+    $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
+
+    return $query
+        ->where(Config::permissionsTable() . ".{$permissionKey}", $permissionId)
+        ->where(Config::roleHasPermissionsTable() . '.is_forbidden', $forbidden);
+}
+```
+
+Important implementation constraints:
+
+- The direct branch must be wrapped in `whereHas('permissions', ...)`. The
+  `permissions` table and the permission pivot table are not joined into the
+  outer model query; direct-effect predicates are valid only inside the
+  relationship existence subquery.
+- Use qualified pivot table columns inside `whereHas()` callbacks. The callback
+  receives an Eloquent builder, not the `BelongsToMany` relation object, so
+  `wherePivot()` is not available there.
+- Preserve the `Role` subject behavior. `Role::permission()` must check only
+  the role's own `role_has_permissions` edge and must not traverse
+  `roles.permissions`.
+- Do not change `scopeRole()` or `scopeWithoutRole()`. Role assignment has no
+  forbidden effect column; it is pure membership.
+- The direct branch inherits team scoping from `permissions()` for models. The
+  nested role branch inherits team scoping from `roles()`, while
+  `role_has_permissions` remains unscoped by team by design.
+- Query scopes evaluate concrete stored permission grants. They cannot expand
+  wildcard permission grammar in SQL; document this boundary in README and Boost
+  docs.
+
+Leave `scopeWithoutPermission()` as the one-line delegate:
+
+```php
+public function scopeWithoutPermission(Builder $query, $permissions): Builder
+{
+    return $this->scopePermission($query, $permissions, true);
+}
+```
+
+Do not duplicate complement logic in `scopeWithoutPermission()`. `scopePermission()`
+is the single source of truth and handles `$without` by negating the effective
+permission predicate.
+
+### Allowed Permission Accessors
+
+Files:
+
+- `src/permission/src/Traits/HasRoles.php`
+- `src/permission/src/Traits/HasPermissions.php`
+
+Current:
+
+```php
+public function getDirectPermissions(): Collection
+{
+    return $this->getCachedDirectPermissions();
+}
+
+public function getPermissionNames(): Collection
+{
+    return $this->getCachedDirectPermissions()->pluck('name');
+}
+```
+
+Target:
+
+```php
+/**
+ * Return allowed direct permissions.
+ */
+protected function allowedDirectPermissions(): Collection
+{
+    return $this->getCachedDirectPermissions()
+        ->reject(fn (Model $permission): bool => $this->pivotIsForbidden($permission))
+        ->values();
+}
+
+public function getPermissionNames(): Collection
+{
+    return $this->allowedDirectPermissions()->pluck('name');
+}
+
+public function getDirectPermissions(): Collection
+{
+    return $this->allowedDirectPermissions();
+}
+```
+
+Place `allowedDirectPermissions()` in `HasPermissions` near `getCachedDirectPermissions()` / other direct-permission helpers. `getPermissionNames()` also lives in `HasPermissions`, and `Role` uses `HasPermissions` without `HasRoles`, so `getPermissionNames()` must not call `getDirectPermissions()`. Keep `getDirectPermissions()` in `HasRoles` as the public user-model API, but make it delegate to the shared helper.
+
+### Global Catalog Cache Payload
+
+File:
+
+- `src/permission/src/PermissionRegistrar.php`
+
+The global catalog payload already carries role-permission pivot effects:
+
+```php
+'roles' => $this->relationCollection($permission, 'roles')
+    ->map(fn (Model $role): array => [
+        'pivot' => [
+            $this->pivotPermission => $permission->getKey(),
+            $this->pivotRole => $role->getKey(),
+            'is_forbidden' => $this->pivotIsForbidden($role),
+        ],
+    ])
+    ->values()
+    ->all(),
+```
+
+Hydration already reattaches the pivot:
+
+```php
+$role->setRelation('pivot', Pivot::fromRawAttributes(
+    $permission,
+    (array) $item['pivot'],
+    $this->config->string('permission.table_names.role_has_permissions'),
+    true,
+));
+```
+
+During implementation, verify this still passes after single-state writes and schema changes. Keep tests around:
+
+- payload includes `is_forbidden=false` for allowed role permissions
+- payload includes `is_forbidden=true` for forbidden role permissions
+- hydrated cache preserves forbidden role behavior after clearing coroutine-local catalog state
+
+### Assignment Cache Namespace Token
+
+File:
+
+- `src/permission/src/PermissionRegistrar.php`
+
+Current:
+
+```php
+public function modelAssignmentCacheVersion(): int
+{
+    return $this->cacheRepository()->rememberForever(
+        $this->scopedCacheKey($this->modelCacheVersionKey),
+        fn () => 1,
+    );
+}
+
+public function bumpModelAssignmentCacheVersion(): int
+{
+    $cache = $this->cacheRepository();
+    $key = $this->scopedCacheKey($this->modelCacheVersionKey);
+    $cache->add($key, 1);
+
+    $version = $cache->increment($key);
+
+    if (is_int($version)) {
+        return $version;
+    }
+
+    $version = ((int) $cache->get($key, 1)) + 1;
+    $cache->forever($key, $version);
+
+    return $version;
+}
+```
+
+Target:
+
+```php
+use Hypervel\Support\Str;
+
+public function modelAssignmentCacheToken(): string
+{
+    return $this->cacheRepository()->rememberForever(
+        $this->scopedCacheKey($this->modelCacheTokenKey),
+        fn (): string => $this->newModelAssignmentCacheToken(),
+    );
+}
+
+public function bumpModelAssignmentCacheToken(): string
+{
+    $token = $this->newModelAssignmentCacheToken();
+
+    $this->cacheRepository()->forever(
+        $this->scopedCacheKey($this->modelCacheTokenKey),
+        $token,
+    );
+
+    return $token;
+}
+
+/**
+ * Create a new model assignment cache namespace token.
+ */
+protected function newModelAssignmentCacheToken(): string
+{
+    return (string) Str::ulid();
+}
+```
+
+Rename the concept everywhere:
+
+```php
+public const MODEL_CACHE_TOKEN_KEY = 'hypervel.permission.cache.model.token';
+
+protected string $modelCacheTokenKey;
+```
+
+Use config key `permission.cache.keys.model_token` with default `self::MODEL_CACHE_TOKEN_KEY`.
+
+Update `src/permission/config/permission.php`:
+
+```php
+'cache' => [
+    'expiration_seconds' => 86400,
+    'store' => env('PERMISSION_CACHE_STORE', 'default'),
+    'keys' => [
+        'roles' => 'hypervel.permission.cache.roles',
+        'model_roles' => 'hypervel.permission.cache.model.roles',
+        'model_permissions' => 'hypervel.permission.cache.model.permissions',
+        'model_token' => 'hypervel.permission.cache.model.token',
+    ],
+    'column_names_except' => ['created_at', 'updated_at', 'deleted_at'],
+],
+```
+
+Update all source callers:
+
+```php
+$registrar->bumpModelAssignmentCacheToken();
+```
+
+Place `newModelAssignmentCacheToken()` next to `modelAssignmentCacheToken()` and `bumpModelAssignmentCacheToken()`.
+
+Why ULID:
+
+- `Hypervel\Support\Str::ulid()` exists and returns a unique 26-character token.
+- The token is not security material; it only namespaces cache keys.
+- `xxh128` is excellent for hashing existing input into a stable key, but it is not an ID generator. Using it here would still require unique input and would make the code less direct.
+- The method runs only when assignment cache namespaces are seeded or bumped, not on every permission check.
+
+Two concurrent first-ever reads of `modelAssignmentCacheToken()` can generate different ULIDs and briefly disagree before the cache store settles. That causes a one-off cache miss and recompute from the database, not stale authorization data, because both keys point to independently recomputed assignment data. This is an acceptable trade for removing store-specific increment behavior from invalidation.
+
+Replace tests that assume numeric ordering. For example, rename `testPermissionCacheResetBumpsModelAssignmentCacheVersion()` to `testPermissionCacheResetChangesModelAssignmentCacheToken()` and replace `assertGreaterThan()` with `assertNotSame()`:
+
+```php
+$firstToken = $registrar->modelAssignmentCacheToken();
+
+$registrar->forgetCachedPermissions();
+
+$this->assertNotSame($firstToken, $registrar->modelAssignmentCacheToken());
+```
+
+Keep `modelCacheKey()` and `wildcardPermissionIndexKey()` logic intact except for calling `modelAssignmentCacheToken()`; both already interpolate the namespace value as a string segment. `tests/Permission/WildcardPermissionTest.php` calls the bump method for its side effect only, so update the method name to `bumpModelAssignmentCacheToken()` but no assertion change is needed.
+
+### Docs
+
+Files:
+
+- `src/permission/README.md`
+- `src/boost/docs/permission.md`
+
+Update docs to say:
+
+- `is_forbidden` is an effect column on permission assignment tables.
+- Each assignment edge has one row.
+- Calling `givePermissionTo()` after `giveForbiddenTo()` flips that edge back to allowed.
+- Calling `giveForbiddenTo()` after `givePermissionTo()` flips that edge to forbidden.
+- `revokePermissionTo()` removes the edge regardless of whether it is allowed or forbidden.
+- `getDirectPermissions()` and `getPermissionNames()` return allowed direct permissions, not explicit denies.
+- `permission()` and `withoutPermission()` query scopes use effective concrete
+  permission semantics: an allow counts only when the same permission is not
+  denied directly or through a role.
+- wildcard permission checks still happen through runtime permission checks; SQL
+  query scopes evaluate stored concrete permission grants and do not expand the
+  wildcard grammar.
+- Permission assignment caches use namespace tokens; resetting permission cache makes old model assignment keys unreachable until TTL cleanup.
+- Update the existing Boost docs prose that says "assignment-cache version" to "assignment-cache token", including the current text around `src/boost/docs/permission.md:1081` and `src/boost/docs/permission.md:1178`.
+
+Suggested Boost docs replacement around forbidden permissions:
+
+```md
+Forbidden permissions explicitly deny access. The permission assignment tables store
+`is_forbidden` as the effect for the assignment edge, so a model or role has one
+row for a given permission in the current team context.
+
+Calling `giveForbiddenTo` for an allowed permission flips that assignment to a
+deny. Calling `givePermissionTo` for a forbidden permission flips it back to an
+allow.
+```
+
+Suggested retrieval note:
+
+```md
+`getDirectPermissions`, `getPermissionsViaRoles`, `getAllPermissions`, and
+`getPermissionNames` return allowed permissions. Explicitly forbidden permissions
+are checked through `hasForbiddenPermission` and
+`hasForbiddenPermissionViaRoles`.
+```
+
+Suggested query-scope note:
+
+```md
+The `permission` and `withoutPermission` query scopes filter by effective stored
+permissions. Direct and role-granted denies override allows for the same
+permission. Wildcard permission strings are evaluated by runtime permission
+checks such as `hasPermissionTo`; query scopes match stored concrete permission
+records.
+```
+
+Suggested cache note:
+
+```md
+Model role and direct-permission assignment cache keys include a namespace token.
+When roles, permissions, or assignment-wide state changes, the package writes a
+new token so older per-model cache keys are bypassed and expire naturally through
+the configured cache TTL.
+```
+
+Update README differences:
+
+```md
+- Hypervel adds forbidden permissions. A forbidden permission explicitly denies
+  an ability and wins over direct or role-granted allows. The deny flag is stored
+  as the effect on the assignment row, so assigning allow or deny for the same
+  model/role and permission updates the existing edge.
+- Hypervel's cache config uses `expiration_seconds` and separate named cache keys
+  so role, model-role, model-permission, and assignment-token caches can be
+  invalidated independently.
+```
+
+Remove or rewrite any wording that implies an allowed and forbidden row can both exist for the same assignment edge.
+
+## Testing Plan
+
+Run tests after each changed test file.
+
+### Focused Tests To Add Or Update
+
+File:
+
+- `tests/Permission/ForbiddenPermissionTest.php`
+
+Add imports as needed:
+
+```php
+use Hypervel\Database\Eloquent\Relations\Pivot;
+use Hypervel\Permission\PermissionRegistrar;
+use Hypervel\Permission\Support\Config;
+```
+
+Add/update coverage:
+
+```php
+public function testDirectForbiddenPermissionFlipsExistingAllowedPermission(): void
+{
+    $this->testUser->givePermissionTo('edit-articles');
+    $this->testUser->giveForbiddenTo('edit-articles');
+
+    $this->testUser->refresh();
+
+    $this->assertSame(1, $this->testUser->permissions()->count());
+    $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+    $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+    $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    $this->assertSame([], $this->testUser->getPermissionNames()->all());
+}
+
+public function testDirectAllowedPermissionFlipsExistingForbiddenPermission(): void
+{
+    $this->testUser->giveForbiddenTo('edit-articles');
+    $this->testUser->givePermissionTo('edit-articles');
+
+    $this->testUser->refresh();
+
+    $this->assertSame(1, $this->testUser->permissions()->count());
+    $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+    $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
+    $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+    $this->assertSame(['edit-articles'], $this->testUser->getPermissionNames()->all());
+}
+```
+
+Role edge flips:
+
+```php
+public function testRoleForbiddenPermissionFlipsExistingAllowedPermission(): void
+{
+    $this->testUserRole->givePermissionTo('edit-articles');
+    $this->testUserRole->giveForbiddenTo('edit-articles');
+
+    $this->testUserRole->refresh();
+
+    $this->assertSame(1, $this->testUserRole->permissions()->count());
+    $this->assertTrue($this->testUserRole->hasForbiddenPermission('edit-articles'));
+    $this->assertFalse($this->testUserRole->hasPermissionTo('edit-articles'));
+}
+
+public function testRoleAllowedPermissionFlipsExistingForbiddenPermission(): void
+{
+    $this->testUserRole->giveForbiddenTo('edit-articles');
+    $this->testUserRole->givePermissionTo('edit-articles');
+
+    $this->testUserRole->refresh();
+
+    $this->assertSame(1, $this->testUserRole->permissions()->count());
+    $this->assertFalse($this->testUserRole->hasForbiddenPermission('edit-articles'));
+    $this->assertTrue($this->testUserRole->hasPermissionTo('edit-articles'));
+}
+```
+
+Queued unsaved-model flips:
+
+```php
+public function testQueuedDirectForbiddenPermissionFlipsExistingQueuedAllowedPermission(): void
+{
+    $user = new User(['email' => 'queued@example.com']);
+
+    $user->givePermissionTo('edit-articles');
+    $user->giveForbiddenTo('edit-articles');
+    $user->save();
+
+    $user->refresh();
+
+    $this->assertSame(1, $user->permissions()->count());
+    $this->assertTrue($user->hasForbiddenPermission('edit-articles'));
+    $this->assertFalse($user->hasPermissionTo('edit-articles'));
+}
+
+public function testQueuedDirectAllowedPermissionFlipsExistingQueuedForbiddenPermission(): void
+{
+    $user = new User(['email' => 'queued@example.com']);
+
+    $user->giveForbiddenTo('edit-articles');
+    $user->givePermissionTo('edit-articles');
+    $user->save();
+
+    $user->refresh();
+
+    $this->assertSame(1, $user->permissions()->count());
+    $this->assertFalse($user->hasForbiddenPermission('edit-articles'));
+    $this->assertTrue($user->hasPermissionTo('edit-articles'));
+}
+```
+
+Add a team-aware queued assignment test in `TeamHasPermissionsTest`:
+
+```php
+public function testQueuedPermissionAssignmentsKeepSeparateTeamEdges(): void
+{
+    $user = new User(['email' => 'queued-teams@example.com']);
+
+    setPermissionsTeamId(1);
+    $user->givePermissionTo('edit-articles');
+
+    setPermissionsTeamId(2);
+    $user->givePermissionTo('edit-articles');
+
+    $user->save();
+
+    setPermissionsTeamId(1);
+    $this->assertTrue($user->hasPermissionTo('edit-articles'));
+    $this->assertSame(1, $user->permissions()->count());
+
+    setPermissionsTeamId(2);
+    $user->unsetRelation('permissions');
+    $this->assertTrue($user->hasPermissionTo('edit-articles'));
+    $this->assertSame(1, $user->permissions()->count());
+}
+```
+
+Keep these existing query-count tests at two queries:
+
+- `testItDoesNotRunUnnecessarySqlWhenAssigningNewPermissions`
+- `testItDoesNotLetQueuedGivePermissionToInterfereWithOtherObjects`
+- `testItDoesNotLetQueuedSyncPermissionsInterfereWithOtherObjects`
+
+They verify that `syncPermissions()` and queued unsaved-model flushes use the
+known-empty path instead of reading current pivots before attaching.
+
+Revoke deny:
+
+```php
+public function testRevokePermissionRemovesDirectForbiddenPermission(): void
+{
+    $this->testUser->giveForbiddenTo('edit-articles');
+    $this->testUser->revokePermissionTo('edit-articles');
+
+    $this->testUser->refresh();
+
+    $this->assertSame(0, $this->testUser->permissions()->count());
+    $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+    $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+}
+```
+
+Layered reveal:
+
+```php
+public function testRemovingDirectForbiddenPermissionRevealsRoleAllowedPermission(): void
+{
+    $this->testUserRole->givePermissionTo('edit-articles');
+    $this->testUser->assignRole($this->testUserRole);
+    $this->testUser->giveForbiddenTo('edit-articles');
+
+    $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+
+    $this->testUser->revokePermissionTo('edit-articles');
+
+    $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+}
+```
+
+Bad/manual data defense for direct permissions:
+
+```php
+public function testDirectPermissionChecksDenyWhenRelationContainsDuplicateEffects(): void
+{
+    $permission = $this->app->make(PermissionContract::class)::findByName('edit-articles');
+    $allowed = clone $permission;
+    $forbidden = clone $permission;
+
+    $allowed->setRelation('pivot', Pivot::fromRawAttributes(
+        $this->testUser,
+        [
+            $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+            Config::morphKey() => $this->testUser->getKey(),
+            'model_type' => $this->testUser->getMorphClass(),
+            'is_forbidden' => false,
+        ],
+        Config::modelHasPermissionsTable(),
+        true,
+    ));
+
+    $forbidden->setRelation('pivot', Pivot::fromRawAttributes(
+        $this->testUser,
+        [
+            $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+            Config::morphKey() => $this->testUser->getKey(),
+            'model_type' => $this->testUser->getMorphClass(),
+            'is_forbidden' => true,
+        ],
+        Config::modelHasPermissionsTable(),
+        true,
+    ));
+
+    $this->testUser->setRelation('permissions', collect([$allowed, $forbidden]));
+
+    $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+}
+```
+
+This does not weaken the final schema. It proves the defensive read path with an in-memory relation containing bad duplicate data.
+
+Bad/manual data defense for role permissions:
+
+```php
+public function testRolePermissionChecksDenyWhenRelationContainsDuplicateEffects(): void
+{
+    $permission = $this->app->make(PermissionContract::class)::findByName('edit-articles');
+    $allowed = clone $permission;
+    $forbidden = clone $permission;
+
+    $allowed->setRelation('pivot', Pivot::fromRawAttributes(
+        $this->testUserRole,
+        [
+            $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+            $this->app->make(PermissionRegistrar::class)->pivotRole => $this->testUserRole->getKey(),
+            'is_forbidden' => false,
+        ],
+        Config::roleHasPermissionsTable(),
+        true,
+    ));
+
+    $forbidden->setRelation('pivot', Pivot::fromRawAttributes(
+        $this->testUserRole,
+        [
+            $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+            $this->app->make(PermissionRegistrar::class)->pivotRole => $this->testUserRole->getKey(),
+            'is_forbidden' => true,
+        ],
+        Config::roleHasPermissionsTable(),
+        true,
+    ));
+
+    $this->testUserRole->setRelation('permissions', collect([$allowed, $forbidden]));
+
+    $this->assertFalse($this->testUserRole->hasDirectPermission('edit-articles'));
+    $this->assertFalse($this->testUserRole->hasPermissionTo('edit-articles'));
+}
+```
+
+The `hasDirectPermission()` assertion exercises the hardened duplicate-match filter. `Role::hasPermissionTo()` first calls `hasForbiddenPermission()`, so its assertion confirms the public role permission check still denies, but it does not by itself prove the rewritten `$matches` block in `Role::hasPermissionTo()` is reached.
+
+### Query Scopes
+
+Files:
+
+- `tests/Permission/Traits/HasPermissionsTest.php`
+- `tests/Permission/Traits/TeamHasPermissionsTest.php`
+- `tests/Permission/ForbiddenPermissionTest.php`
+
+Add coverage for effective permission query scopes:
+
+```php
+public function testPermissionScopeExcludesDirectForbiddenPermission(): void
+{
+    $this->testUser->giveForbiddenTo('edit-articles');
+
+    $this->assertFalse(User::permission('edit-articles')->get()->contains($this->testUser));
+    $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains($this->testUser));
+}
+
+public function testPermissionScopeExcludesRoleForbiddenPermission(): void
+{
+    $this->testUserRole->giveForbiddenTo('edit-articles');
+    $this->testUser->assignRole($this->testUserRole);
+
+    $this->assertFalse(User::permission('edit-articles')->get()->contains($this->testUser));
+    $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains($this->testUser));
+}
+
+public function testPermissionScopeLetsDirectDenyOverrideRoleAllow(): void
+{
+    $this->testUserRole->givePermissionTo('edit-articles');
+    $this->testUser->assignRole($this->testUserRole);
+    $this->testUser->giveForbiddenTo('edit-articles');
+
+    $this->assertFalse(User::permission('edit-articles')->get()->contains($this->testUser));
+    $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains($this->testUser));
+}
+
+public function testPermissionScopeLetsRoleDenyOverrideDirectAllow(): void
+{
+    $this->testUserRole->giveForbiddenTo('edit-articles');
+    $this->testUser->assignRole($this->testUserRole);
+    $this->testUser->givePermissionTo('edit-articles');
+
+    $this->assertFalse(User::permission('edit-articles')->get()->contains($this->testUser));
+    $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains($this->testUser));
+}
+```
+
+Add tests that catch per-permission correlation bugs:
+
+```php
+public function testPermissionScopeMatchesAllowedPermissionWhenDifferentRequestedPermissionIsDenied(): void
+{
+    $this->testUser->givePermissionTo('edit-articles');
+    $this->testUser->giveForbiddenTo('edit-news');
+
+    $this->assertTrue(User::permission(['edit-articles', 'edit-news'])->get()->contains($this->testUser));
+}
+
+public function testPermissionScopeMatchesSecondAllowedPermissionWhenFirstRequestedPermissionIsDenied(): void
+{
+    $this->testUserRole->giveForbiddenTo('edit-articles');
+    $this->testUser->assignRole($this->testUserRole);
+    $this->testUser->givePermissionTo('edit-articles');
+    $this->testUser->givePermissionTo('edit-news');
+
+    $this->assertTrue(User::permission(['edit-articles', 'edit-news'])->get()->contains($this->testUser));
+}
+```
+
+Add empty-set complement coverage:
+
+```php
+public function testPermissionScopeWithNoPermissionsMatchesNoModels(): void
+{
+    $this->assertFalse(User::permission([])->get()->contains($this->testUser));
+}
+
+public function testWithoutPermissionScopeWithNoPermissionsMatchesAllModels(): void
+{
+    $this->assertTrue(User::withoutPermission([])->get()->contains($this->testUser));
+}
+```
+
+Add role-subject coverage:
+
+```php
+public function testRolePermissionScopeExcludesForbiddenRolePermissionEdges(): void
+{
+    $this->testUserRole->giveForbiddenTo('edit-articles');
+
+    $this->assertFalse($this->app->make(RoleContract::class)::permission('edit-articles')->get()->contains($this->testUserRole));
+}
+```
+
+Keep the existing allow-only scope tests green. They prove the reworked scope
+preserves the public "any requested permission" behavior.
+
+### Teams
+
+File:
+
+- `tests/Permission/Traits/TeamHasPermissionsTest.php`
+
+Add or update coverage:
+
+- allow then forbid in team 1 leaves one row in team 1 and does not affect team 2
+- forbid then allow in team 1 leaves one allowed row in team 1
+- `getPermissionNames()` excludes forbidden direct permissions in the active team
+- `revokePermissionTo()` removes a forbidden row in the active team only
+- `permission()` respects direct allow/deny effects in the active team
+- role-granted permissions match in a team where the role is assigned and do not
+  match in a team where the role is not assigned
+
+### Cache
+
+File:
+
+- `tests/Permission/CacheTest.php`
+
+Replace the existing numeric version test:
+
+```php
+public function testPermissionCacheResetChangesModelAssignmentCacheToken(): void
+{
+    $this->testUser->assignRole('testRole');
+    $registrar = $this->app->make(PermissionRegistrar::class);
+
+    $this->assertTrue($this->testUser->hasRole('testRole'));
+
+    $firstToken = $registrar->modelAssignmentCacheToken();
+
+    $registrar->forgetCachedPermissions();
+
+    $this->assertNotSame($firstToken, $registrar->modelAssignmentCacheToken());
+    $this->assertTrue($this->testUser->hasRole('testRole'));
+}
+```
+
+Add token shape check:
+
+```php
+$this->assertMatchesRegularExpression('/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/', $registrar->modelAssignmentCacheToken());
+```
+
+`Str::ulid()` currently returns Symfony's ULID string format, which is uppercase Crockford base32.
+
+Keep scoped cache resolver tests and adjust names from "version" to "token" where relevant:
+
+- global permission catalog scope
+- model assignment token scope
+- model role assignment cache scope
+- model direct-permission assignment cache scope
+- wildcard index scope
+
+In `tests/Permission/CacheTest.php`, the scoped-resolver test currently asserts exact old key strings. Update them:
+
+```php
+$this->assertContains('hypervel.permission.cache.model.token:tenant-a', $keys);
+$this->assertContains('hypervel.permission.cache.model.token:tenant-b', $keys);
+```
+
+### Schema
+
+Files:
+
+- `tests/Permission/SchemaConfigTest.php`
+- `tests/Permission/CustomSchemaConfigTest.php`
+
+Add assertions for primary key shape where the schema inspection API supports it. If index introspection is too driver-specific, assert behavior instead:
+
+```php
+$this->testUser->givePermissionTo('edit-articles');
+$this->testUser->giveForbiddenTo('edit-articles');
+
+$this->assertSame(1, $this->testUser->permissions()->count());
+```
+
+Run the custom model test path too, because `tests/Permission/TestCase.php` has its own schema with UUID pivot keys.
+
+### Commands To Run
+
+After each changed test file:
+
+```sh
+./vendor/bin/phpunit --no-progress tests/Permission/ForbiddenPermissionTest.php
+./vendor/bin/phpunit --no-progress tests/Permission/Traits/HasPermissionsTest.php
+./vendor/bin/phpunit --no-progress tests/Permission/Traits/TeamHasPermissionsTest.php
+./vendor/bin/phpunit --no-progress tests/Permission/CacheTest.php
+./vendor/bin/phpunit --no-progress tests/Permission/SchemaConfigTest.php
+./vendor/bin/phpunit --no-progress tests/Permission/CustomSchemaConfigTest.php
+```
+
+After implementation:
+
+```sh
+composer fix
+```
+
+`composer fix` runs php-cs-fixer, PHPStan, and the parallel test suite.
+
+## Implementation Checklist
+
+1. Change all schema primary keys to remove `is_forbidden` from identity while keeping the column.
+2. Add permission assignment pivot/upsert/known-empty attach helpers in `HasPermissions`.
+3. Update `attachPermissions()` to call the upsert helper for persisted models.
+4. Update `attachQueuedPermissionAssignments()` to collapse queued assignments by permission and team, then attach with the known-empty helper after save.
+5. Remove same-flag dedup logic that only existed for dual-row schema.
+6. Update `syncPermissions()` to collect ids once and attach through the known-empty helper after detach.
+7. Preserve permission attach event timing: dispatch from give/sync methods, not from queued flushes.
+8. Harden `hasDirectPermission()` and `Role::hasPermissionTo()` to deny if any matching pivot is forbidden.
+9. Rework `scopePermission()` around the effective permission predicate, and keep `scopeWithoutPermission()` as a delegate to `scopePermission(..., true)`.
+10. Add `allowedDirectPermissions()` in `HasPermissions`, make `getPermissionNames()` use it, and make `HasRoles::getDirectPermissions()` delegate to it.
+11. Verify and keep global catalog serialization/hydration of `is_forbidden`.
+12. Rename numeric model assignment cache versions to ULID namespace tokens across source, config, tests, README, and Boost docs.
+13. Update tests for forbidden flips, queued flips, query-count preservation, revoke deny, effective scopes, teams, cache token, and accessors.
+14. Update README and Boost docs, including the concrete-grant query-scope boundary for wildcard permissions.
+15. Run focused tests after each changed test file.
+16. Run `composer fix`.
+17. Remove the dead `Pivot` import from `Role.php`.
+18. Self-review for stale imports, dead helpers, stale docs, stale comments, and old "version" names/wording where the concept is now a token.
+
+## Self-Review Checklist After Implementation
+
+Check all of these before asking for review:
+
+- `grep -R "is_forbidden.*primary\|primary.*is_forbidden" -n src/permission tests/Permission` returns nothing outside archived material.
+- No public write path can create two rows for the same edge.
+- `givePermissionTo()` after `giveForbiddenTo()` flips deny to allow.
+- `giveForbiddenTo()` after `givePermissionTo()` flips allow to deny.
+- queued unsaved model calls preserve call order and end with one row.
+- queued unsaved model calls for the same permission in different teams create
+  separate team edges.
+- queued unsaved model flushes do not dispatch a second attach event.
+- `syncPermissions()` collects ids once and does not read current pivots after
+  detaching.
+- `syncPermissionsWithForbidden()` still reports `attached`, `detached`, and `updated` correctly.
+- existing query-count tests for new permissions and queued unsaved-model
+  assignments still expect two queries and pass.
+- `revokePermissionTo()` removes a direct deny.
+- direct deny hides role allow, and removing the direct deny reveals the role allow.
+- role deny hides direct allow.
+- role deny hides another role's allow.
+- `permission()` uses effective permission semantics and does not include models
+  denied directly or through roles for the same permission.
+- `withoutPermission()` is the exact complement of `permission()`.
+- deny checks in query scopes are correlated to the same requested permission,
+  so allow `P1` plus deny `P2` still matches `permission([P1, P2])`.
+- `permission([])` matches no models and `withoutPermission([])` matches all
+  models.
+- `Role::permission()` checks only `role_has_permissions` and does not traverse
+  `roles.permissions`.
+- wildcard docs state that permission query scopes filter concrete stored grants
+  and do not expand wildcard grammar.
+- allowed accessors exclude forbidden rows.
+- global catalog cache payload contains `is_forbidden` and hydration preserves it.
+- model assignment cache keys include a ULID token.
+- tests no longer compare assignment cache namespace values numerically.
+- `grep -R "assertGreaterThan.*modelAssignmentCache\\|modelAssignmentCache.*assertGreaterThan" -n tests/Permission` returns nothing.
+- `grep -R "modelAssignmentCacheVersion\|bumpModelAssignmentCacheVersion\|modelCacheVersion\|model_version\|MODEL_CACHE_VERSION\|cache\\.model\\.version\|model\\.version" -n src/permission tests/Permission src/boost/docs/permission.md src/permission/README.md` returns nothing.
+- `grep -R "assignment-cache version\|cache version" -n src/permission tests/Permission src/boost/docs/permission.md src/permission/README.md` returns nothing.
+- permission cache docs and comments describe the assignment cache namespace as a token, not a numeric version.
+- `grep -R "use Hypervel\\\\Database\\\\Eloquent\\\\Relations\\\\Pivot;" -n src/permission/src/Models/Role.php` returns nothing.
+- docs no longer imply dual allow/forbid rows can coexist for one edge.
+- all changed files have no unused imports, dead code, stale comments, or stale wording.
+
+## Expected Commit Split After Everything Is Green
+
+The final split can be decided after implementation. The expected clean split is:
+
+1. schema and write/read behavior for single-state forbidden permissions
+2. effective permission query-scope behavior
+3. regression tests for forbidden single-state and effective-scope behavior
+4. assignment cache namespace token cleanup
+5. permission docs/README updates
+
+This remains one PR.

--- a/docs/plans/2026-07-02-permission-forbidden-single-state-hardening.md
+++ b/docs/plans/2026-07-02-permission-forbidden-single-state-hardening.md
@@ -258,8 +258,8 @@ private function attachPermissions(array $permissions, bool $isForbidden): stati
         $registrar->forgetModelPermissionCache($model);
     }
 
-    $this->dispatchPermissionAttachedEvent($permissions);
     $this->forgetWildcardPermissionIndex();
+    $this->dispatchPermissionAttachedEvent($permissions);
 
     return $this;
 }
@@ -518,6 +518,13 @@ time, including unsaved-model queued calls. The queued flush must only persist
 rows and invalidate caches/wildcard indexes, or queued calls would double-fire
 events.
 
+Queued replace-style APIs must replace only the current assignment scope. For
+teams, that means the current team. For roles and non-team mode, that means the
+whole pending permission queue. Use `queuedPermissionAssignmentTeamKey()` as the
+scope discriminator so unsaved-model behavior matches the saved-model
+`permissions()->detach()` path, which is already scoped by the `permissions()`
+relation.
+
 ### Sync Behavior
 
 `syncPermissionsWithForbidden()` already builds one `$syncData[$permissionId]` entry per permission id:
@@ -556,15 +563,22 @@ public function syncPermissions(...$permissions): static
 
     if ($this->exists) {
         $this->permissions()->detach();
+        $pivot = $this->permissionAssignmentPivot(false);
         $this->attachPermissionAssignments(
             $permissions,
-            $this->permissionAssignmentPivot(false),
+            $pivot,
         );
         $model->unsetRelation('permissions');
     } else {
-        $this->queuePermissionAssignments(
-            $permissions,
-            $this->permissionAssignmentPivot(false),
+        $pivot = $this->permissionAssignmentPivot(false);
+        $this->replaceQueuedPermissionAssignments(
+            [
+                [
+                    'permissions' => $permissions,
+                    'pivot' => $pivot,
+                ],
+            ],
+            $pivot,
         );
     }
 
@@ -574,8 +588,8 @@ public function syncPermissions(...$permissions): static
         $this->permissionRegistrar()->forgetModelPermissionCache($model);
     }
 
-    $this->dispatchPermissionAttachedEvent($permissions);
     $this->forgetWildcardPermissionIndex();
+    $this->dispatchPermissionAttachedEvent($permissions);
 
     return $this;
 }
@@ -583,6 +597,21 @@ public function syncPermissions(...$permissions): static
 
 This preserves the existing public event timing: `syncPermissions()` dispatches
 the attach event once, while queued unsaved-model flushes do not dispatch again.
+Invalidate the wildcard permission index before dispatching so synchronous
+listeners rebuild from current assignment state instead of reading a stale
+wildcard index.
+
+`syncPermissionsWithForbidden()` must support unsaved models with the same
+scope-aware queued replacement. Its return value remains the database sync
+change set. For unsaved models, no rows are changed until the model is saved, so
+it returns an empty change set after queueing the future allowed and forbidden
+assignments. Apply the existing allowed-minus-forbidden filtering before
+queueing so a permission present in both arrays still ends forbidden.
+
+`syncPermissionsWithForbidden()` also dispatches `PermissionAttachedEvent` once
+with the desired allowed and forbidden ids, matching `syncPermissions()` event
+timing. For unsaved models, the event fires when the sync method is called; the
+queued flush on save must not dispatch it again.
 
 ### Revoke Behavior
 
@@ -1608,6 +1637,7 @@ After each changed test file:
 ./vendor/bin/phpunit --no-progress tests/Permission/CacheTest.php
 ./vendor/bin/phpunit --no-progress tests/Permission/SchemaConfigTest.php
 ./vendor/bin/phpunit --no-progress tests/Permission/CustomSchemaConfigTest.php
+./vendor/bin/phpunit --no-progress tests/Permission/Events/EventTest.php
 ```
 
 After implementation:
@@ -1626,18 +1656,20 @@ composer fix
 4. Update `attachQueuedPermissionAssignments()` to collapse queued assignments by permission and team, then attach with the known-empty helper after save.
 5. Remove same-flag dedup logic that only existed for dual-row schema.
 6. Update `syncPermissions()` to collect ids once and attach through the known-empty helper after detach.
-7. Preserve permission attach event timing: dispatch from give/sync methods, not from queued flushes.
-8. Harden `hasDirectPermission()` and `Role::hasPermissionTo()` to deny if any matching pivot is forbidden.
-9. Rework `scopePermission()` around the effective permission predicate, and keep `scopeWithoutPermission()` as a delegate to `scopePermission(..., true)`.
-10. Add `allowedDirectPermissions()` in `HasPermissions`, make `getPermissionNames()` use it, and make `HasRoles::getDirectPermissions()` delegate to it.
-11. Verify and keep global catalog serialization/hydration of `is_forbidden`.
-12. Rename numeric model assignment cache versions to ULID namespace tokens across source, config, tests, README, and Boost docs.
-13. Update tests for forbidden flips, queued flips, query-count preservation, revoke deny, effective scopes, teams, cache token, and accessors.
-14. Update README and Boost docs, including the concrete-grant query-scope boundary for wildcard permissions.
-15. Run focused tests after each changed test file.
-16. Run `composer fix`.
-17. Remove the dead `Pivot` import from `Role.php`.
-18. Self-review for stale imports, dead helpers, stale docs, stale comments, and old "version" names/wording where the concept is now a token.
+7. Update queued replace-style sync paths to replace only the current assignment scope.
+8. Update unsaved `syncPermissionsWithForbidden()` to queue allowed and forbidden assignments, return an empty change set, and preserve forbidden-wins filtering.
+9. Preserve permission attach event timing: dispatch from give/sync methods, including `syncPermissionsWithForbidden()`, not from queued flushes. Invalidate wildcard indexes before dispatch so synchronous listeners see fresh wildcard state.
+10. Harden `hasDirectPermission()` and `Role::hasPermissionTo()` to deny if any matching pivot is forbidden.
+11. Rework `scopePermission()` around the effective permission predicate, and keep `scopeWithoutPermission()` as a delegate to `scopePermission(..., true)`.
+12. Add `allowedDirectPermissions()` in `HasPermissions`, make `getPermissionNames()` use it, and make `HasRoles::getDirectPermissions()` delegate to it.
+13. Verify and keep global catalog serialization/hydration of `is_forbidden`.
+14. Rename numeric model assignment cache versions to ULID namespace tokens across source, config, tests, README, and Boost docs.
+15. Update tests for forbidden flips, queued flips, query-count preservation, revoke deny, effective scopes, teams, cache token, and accessors.
+16. Update README and Boost docs, including the concrete-grant query-scope boundary for wildcard permissions.
+17. Run focused tests after each changed test file.
+18. Run `composer fix`.
+19. Remove the dead `Pivot` import from `Role.php`.
+20. Self-review for stale imports, dead helpers, stale docs, stale comments, and old "version" names/wording where the concept is now a token.
 
 ## Self-Review Checklist After Implementation
 
@@ -1650,7 +1682,16 @@ Check all of these before asking for review:
 - queued unsaved model calls preserve call order and end with one row.
 - queued unsaved model calls for the same permission in different teams create
   separate team edges.
+- unsaved `syncPermissions()` replaces only the current assignment scope in the
+  pending queue.
+- unsaved `syncPermissionsWithForbidden()` replaces only the current assignment
+  scope, queues both effects, applies forbidden-wins filtering, and returns an
+  empty change set because no database rows changed yet.
 - queued unsaved model flushes do not dispatch a second attach event.
+- `syncPermissionsWithForbidden()` dispatches `PermissionAttachedEvent` once for
+  saved and unsaved models.
+- permission attach events fire after wildcard index invalidation, so
+  synchronous listeners see fresh wildcard permission state.
 - `syncPermissions()` collects ids once and does not read current pivots after
   detaching.
 - `syncPermissionsWithForbidden()` still reports `attached`, `detached`, and `updated` correctly.

--- a/src/boost/docs/permission.md
+++ b/src/boost/docs/permission.md
@@ -175,16 +175,19 @@ You may also customize the pivot and morph column names:
 The package caches role and permission data to reduce database queries during permission checks:
 
 ```php
-'cache' => [
-    'expiration_seconds' => 86400,
-    'keys' => [
-        'roles' => 'hypervel.permission.cache.roles',
-        'model_roles' => 'hypervel.permission.cache.model.roles',
-        'model_permissions' => 'hypervel.permission.cache.model.permissions',
-        'model_version' => 'hypervel.permission.cache.model.version',
+return [
+    'cache' => [
+        'expiration_seconds' => 86400,
+        'store' => env('PERMISSION_CACHE_STORE', 'default'),
+        'keys' => [
+            'roles' => 'hypervel.permission.cache.roles',
+            'model_roles' => 'hypervel.permission.cache.model.roles',
+            'model_permissions' => 'hypervel.permission.cache.model.permissions',
+            'model_token' => 'hypervel.permission.cache.model.token',
+        ],
+        'column_names_except' => ['created_at', 'updated_at', 'deleted_at'],
     ],
-    'store' => env('PERMISSION_CACHE_STORE', 'default'),
-],
+];
 ```
 
 When `store` is `default`, the application's default cache store is used.
@@ -508,6 +511,8 @@ $editors = User::permission('edit articles')->get();
 $usersWithoutEditPermission = User::withoutPermission('edit articles')->get();
 ```
 
+The `permission` and `withoutPermission` query scopes filter by effective stored permissions. Direct and role-granted denies override allows for the same permission. Wildcard permission strings are evaluated by runtime permission checks such as `hasPermissionTo`; query scopes match stored concrete permission records.
+
 <a name="gate-and-super-admins"></a>
 ### Gate and Super Admins
 
@@ -534,7 +539,9 @@ Direct package calls such as `hasPermissionTo` do not pass through Gate callback
 <a name="forbidden-permissions"></a>
 ### Forbidden Permissions
 
-Forbidden permissions explicitly deny access. A forbidden permission overrides an allowed permission, including permissions inherited through roles:
+Forbidden permissions explicitly deny access. The permission assignment tables store `is_forbidden` as the effect for the assignment edge, so a model or role has one row for a given permission in the current team context.
+
+Calling `giveForbiddenTo` for an allowed permission flips that assignment to a deny. Calling `givePermissionTo` for a forbidden permission flips it back to an allow. A forbidden permission overrides an allowed permission, including permissions inherited through roles:
 
 ```php
 $user->givePermissionTo('delete articles');
@@ -578,6 +585,8 @@ $user->revokePermissionTo('edit articles');
 $user->revokePermissionTo('edit articles', 'delete articles');
 ```
 
+This removes the assignment edge whether it is currently allowed or forbidden.
+
 <a name="retrieving-permissions"></a>
 ### Retrieving Permissions
 
@@ -593,7 +602,7 @@ To retrieve only permissions inherited through roles, use `getPermissionsViaRole
 $rolePermissions = $user->getPermissionsViaRoles();
 ```
 
-Forbidden permissions are excluded from these result sets.
+`getDirectPermissions`, `getPermissionsViaRoles`, `getAllPermissions`, and `getPermissionNames` return allowed permissions. Explicitly forbidden permissions are checked through `hasForbiddenPermission` and `hasForbiddenPermissionViaRoles`.
 
 <a name="using-enums"></a>
 ## Using Enums
@@ -1078,7 +1087,7 @@ public function boot(): void
 }
 ```
 
-The resolver adds a context segment to the global permission catalog, model assignment caches, assignment-cache version, and wildcard permission indexes. Since the resolver is called during each cache-key build, it can safely read request-specific coroutine context. Teams still scope inside this context, so a multi-tenant app can have independent teams for each tenant.
+The resolver adds a context segment to the global permission catalog, model assignment caches, assignment-cache token, and wildcard permission indexes. Since the resolver is called during each cache-key build, it can safely read request-specific coroutine context. Teams still scope inside this context, so a multi-tenant app can have independent teams for each tenant.
 
 **Why a static callback, not a config closure?** Config files are evaluated once at boot in Swoole. A closure calling `tenantId()` in config would capture the boot-time tenant (likely null), not the per-request tenant. The static resolver callback runs fresh when permission cache keys are built, reading the current coroutine's context.
 
@@ -1175,7 +1184,9 @@ Prefer policies and Gate checks when authorization depends on both the user and 
 <a name="performance"></a>
 ## Performance
 
-Permission checks use cached role and permission data after the first lookup. Model role assignments and direct permission assignments have their own cache keys, and those keys include the model type, model key, active team id when teams are enabled, assignment-cache version, and the custom cache-key scope when one is registered.
+Permission checks use cached role and permission data after the first lookup. Model role assignments and direct permission assignments have their own cache keys, and those keys include the model type, model key, active team id when teams are enabled, assignment-cache token, and the custom cache-key scope when one is registered.
+
+When roles, permissions, or assignment-wide state changes, the package writes a new assignment-cache token so older per-model cache keys are bypassed and expire naturally through the configured cache TTL.
 
 If you need to display a model's roles or permissions, eager load the relationships you will render:
 
@@ -1211,6 +1222,6 @@ $exception->getRequiredPermissions();
 <a name="differences-from-spatie-laravel-permission"></a>
 ## Differences From Spatie Laravel Permission
 
-- Hypervel adds forbidden permissions. A forbidden permission explicitly denies an ability and wins over direct or role-granted allows.
+- Hypervel adds forbidden permissions. A forbidden permission explicitly denies an ability and wins over direct or role-granted allows. The deny flag is stored as the effect on the assignment row, so assigning allow or deny for the same model or role and permission updates the existing edge.
 - Hypervel accepts pure unit enums anywhere enum names are valid role or permission inputs. Backed enums use their values; unit enums use their case names.
-- Hypervel's cache config uses `expiration_seconds` and separate named cache keys so role, model-role, model-permission, and assignment-version caches can be invalidated independently.
+- Hypervel's cache config uses `expiration_seconds` and separate named cache keys so role, model-role, model-permission, and assignment-token caches can be invalidated independently.

--- a/src/boost/docs/permission.md
+++ b/src/boost/docs/permission.md
@@ -574,6 +574,10 @@ $user->syncPermissionsWithForbidden(
 );
 ```
 
+When this method is called before a model is saved, the assignments are queued
+until save and the returned change set is empty because no database rows changed
+yet.
+
 <a name="revoking-permissions"></a>
 ### Revoking Permissions
 

--- a/src/permission/README.md
+++ b/src/permission/README.md
@@ -40,7 +40,7 @@ class User extends Model
 
 ## Differences From Spatie Laravel Permission
 
-- Hypervel adds forbidden permissions. A forbidden permission explicitly denies an ability and wins over direct or role-granted allows. The deny flag is stored as the effect on the assignment row, so assigning allow or deny for the same model or role and permission updates the existing edge.
+- Hypervel adds forbidden permissions. A forbidden permission explicitly denies an ability and wins over direct or role-granted allows. The deny flag is stored as the effect on the assignment row, so assigning allow or deny for the same model or role and permission updates the existing edge. Use `syncPermissionsWithForbidden()` to replace allowed and forbidden assignments together.
 - Hypervel accepts pure unit enums anywhere enum names are valid role or permission inputs. Backed enums use their values; unit enums use their case names.
 - Hypervel's cache config uses `expiration_seconds` and separate named cache keys so role, model-role, model-permission, and assignment-token caches can be invalidated independently.
 - Apps where permission data depends on request context, such as multi-tenant apps with tenant-scoped permission tables, may register a runtime cache key resolver with `PermissionRegistrar::resolveCacheKeyUsing(...)` so cached permission catalogs and assignments are isolated per context.

--- a/src/permission/README.md
+++ b/src/permission/README.md
@@ -40,9 +40,9 @@ class User extends Model
 
 ## Differences From Spatie Laravel Permission
 
-- Hypervel adds forbidden permissions. A forbidden permission explicitly denies an ability and wins over direct or role-granted allows.
+- Hypervel adds forbidden permissions. A forbidden permission explicitly denies an ability and wins over direct or role-granted allows. The deny flag is stored as the effect on the assignment row, so assigning allow or deny for the same model or role and permission updates the existing edge.
 - Hypervel accepts pure unit enums anywhere enum names are valid role or permission inputs. Backed enums use their values; unit enums use their case names.
-- Hypervel's cache config uses `expiration_seconds` and separate named cache keys so role, model-role, model-permission, and assignment-version caches can be invalidated independently.
+- Hypervel's cache config uses `expiration_seconds` and separate named cache keys so role, model-role, model-permission, and assignment-token caches can be invalidated independently.
 - Apps where permission data depends on request context, such as multi-tenant apps with tenant-scoped permission tables, may register a runtime cache key resolver with `PermissionRegistrar::resolveCacheKeyUsing(...)` so cached permission catalogs and assignments are isolated per context.
 
 Full usage docs are available in `src/boost/docs/permission.md`.

--- a/src/permission/config/permission.php
+++ b/src/permission/config/permission.php
@@ -103,7 +103,7 @@ return [
             'roles' => 'hypervel.permission.cache.roles',
             'model_roles' => 'hypervel.permission.cache.model.roles',
             'model_permissions' => 'hypervel.permission.cache.model.permissions',
-            'model_version' => 'hypervel.permission.cache.model.version',
+            'model_token' => 'hypervel.permission.cache.model.token',
         ],
         'column_names_except' => ['created_at', 'updated_at', 'deleted_at'],
     ],

--- a/src/permission/database/migrations/2025_07_02_000000_create_permission_tables.php
+++ b/src/permission/database/migrations/2025_07_02_000000_create_permission_tables.php
@@ -77,9 +77,9 @@ return new class extends Migration {
                 $table->unsignedBigInteger($teamForeignKey);
                 $table->index($teamForeignKey, 'model_has_permissions_team_foreign_key_index');
 
-                $table->primary([$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'], 'model_has_permissions_permission_model_type_primary');
+                $table->primary([$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
             } else {
-                $table->primary([$pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'], 'model_has_permissions_permission_model_type_primary');
+                $table->primary([$pivotPermission, $modelMorphKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
             }
         });
 
@@ -119,7 +119,7 @@ return new class extends Migration {
                 ->on($tableNames['roles'])
                 ->cascadeOnDelete();
 
-            $table->primary([$pivotPermission, $pivotRole, 'is_forbidden'], 'role_has_permissions_permission_id_role_id_primary');
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
         });
 
         app('cache')

--- a/src/permission/database/migrations/add_teams_fields.php.stub
+++ b/src/permission/database/migrations/add_teams_fields.php.stub
@@ -59,7 +59,7 @@ return new class extends Migration {
 
                 $table->dropPrimary();
 
-                $table->primary([$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'], 'model_has_permissions_permission_model_type_primary');
+                $table->primary([$teamForeignKey, $pivotPermission, $modelMorphKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
 
                 if (DB::getDriverName() !== 'sqlite') {
                     $table->foreign($pivotPermission)

--- a/src/permission/src/Models/Role.php
+++ b/src/permission/src/Models/Role.php
@@ -9,7 +9,6 @@ use Hypervel\Container\Container;
 use Hypervel\Database\Eloquent\Collection;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\BelongsToMany;
-use Hypervel\Database\Eloquent\Relations\Pivot;
 use Hypervel\Permission\Contracts\Permission as PermissionContract;
 use Hypervel\Permission\Contracts\Role as RoleContract;
 use Hypervel\Permission\Exceptions\GuardDoesNotMatch;
@@ -228,12 +227,11 @@ class Role extends Model implements RoleContract
             throw GuardDoesNotMatch::create($permission->guard_name, $guardName ? collect([$guardName]) : $this->getGuardNames());
         }
 
-        $matchedPermission = $this->loadMissing('permissions')
+        $matches = $this->loadMissing('permissions')
             ->getRelation('permissions')
-            ->first(fn (Model $rolePermission): bool => $rolePermission->getKey() === $permission->getKey());
-        $pivot = $matchedPermission?->getRelation('pivot');
+            ->filter(fn (Model $rolePermission): bool => $rolePermission->getKey() === $permission->getKey());
 
-        return $matchedPermission !== null
-            && (! $pivot instanceof Pivot || ! (bool) $pivot->getAttribute('is_forbidden'));
+        return $matches->isNotEmpty()
+            && ! $matches->contains(fn (Model $rolePermission): bool => $this->pivotIsForbidden($rolePermission));
     }
 }

--- a/src/permission/src/PermissionRegistrar.php
+++ b/src/permission/src/PermissionRegistrar.php
@@ -23,6 +23,7 @@ use Hypervel\Permission\Contracts\Role as RoleContract;
 use Hypervel\Permission\Models\Permission;
 use Hypervel\Permission\Models\Role;
 use Hypervel\Support\Arr;
+use Hypervel\Support\Str;
 use InvalidArgumentException;
 
 class PermissionRegistrar
@@ -31,7 +32,7 @@ class PermissionRegistrar
 
     public const MODEL_PERMISSIONS_CACHE_KEY_PREFIX = 'hypervel.permission.cache.model.permissions';
 
-    public const MODEL_CACHE_VERSION_KEY = 'hypervel.permission.cache.model.version';
+    public const MODEL_CACHE_TOKEN_KEY = 'hypervel.permission.cache.model.token';
 
     public const PERMISSION_CATALOG_CONTEXT_KEY = '__permission.catalog';
 
@@ -66,7 +67,7 @@ class PermissionRegistrar
 
     protected string $modelPermissionsCacheKeyPrefix;
 
-    protected string $modelCacheVersionKey;
+    protected string $modelCacheTokenKey;
 
     protected ?string $cacheStoreName = null;
 
@@ -110,7 +111,7 @@ class PermissionRegistrar
         $this->cacheKey = $this->config->string('permission.cache.keys.roles', 'hypervel.permission.cache.roles');
         $this->modelRolesCacheKeyPrefix = $this->config->string('permission.cache.keys.model_roles', self::MODEL_ROLES_CACHE_KEY_PREFIX);
         $this->modelPermissionsCacheKeyPrefix = $this->config->string('permission.cache.keys.model_permissions', self::MODEL_PERMISSIONS_CACHE_KEY_PREFIX);
-        $this->modelCacheVersionKey = $this->config->string('permission.cache.keys.model_version', self::MODEL_CACHE_VERSION_KEY);
+        $this->modelCacheTokenKey = $this->config->string('permission.cache.keys.model_token', self::MODEL_CACHE_TOKEN_KEY);
 
         $pivotRole = $this->config->get('permission.column_names.role_pivot_key');
         $pivotPermission = $this->config->get('permission.column_names.permission_pivot_key');
@@ -206,7 +207,7 @@ class PermissionRegistrar
     public function forgetCachedPermissions(): bool
     {
         $this->clearPermissionsCollection();
-        $this->bumpModelAssignmentCacheVersion();
+        $this->bumpModelAssignmentCacheToken();
 
         return $this->cacheRepository()->forget($this->getCacheKey());
     }
@@ -281,7 +282,7 @@ class PermissionRegistrar
 
         return implode(':', [
             $this->scopedCacheKey($prefix),
-            $this->modelAssignmentCacheVersion(),
+            $this->modelAssignmentCacheToken(),
             $model->getMorphClass(),
             $model->getKey(),
             $teamId,
@@ -289,32 +290,37 @@ class PermissionRegistrar
     }
 
     /**
-     * Get the current model assignment cache version.
+     * Get the current model assignment cache token.
      */
-    public function modelAssignmentCacheVersion(): int
+    public function modelAssignmentCacheToken(): string
     {
-        return $this->cacheRepository()->rememberForever($this->scopedCacheKey($this->modelCacheVersionKey), fn () => 1);
+        return $this->cacheRepository()->rememberForever(
+            $this->scopedCacheKey($this->modelCacheTokenKey),
+            fn (): string => $this->newModelAssignmentCacheToken(),
+        );
     }
 
     /**
-     * Bump the model assignment cache version.
+     * Bump the model assignment cache token.
      */
-    public function bumpModelAssignmentCacheVersion(): int
+    public function bumpModelAssignmentCacheToken(): string
     {
-        $cache = $this->cacheRepository();
-        $key = $this->scopedCacheKey($this->modelCacheVersionKey);
-        $cache->add($key, 1);
+        $token = $this->newModelAssignmentCacheToken();
 
-        $version = $cache->increment($key);
+        $this->cacheRepository()->forever(
+            $this->scopedCacheKey($this->modelCacheTokenKey),
+            $token,
+        );
 
-        if (is_int($version)) {
-            return $version;
-        }
+        return $token;
+    }
 
-        $version = ((int) $cache->get($key, 1)) + 1;
-        $cache->forever($key, $version);
-
-        return $version;
+    /**
+     * Create a new model assignment cache namespace token.
+     */
+    protected function newModelAssignmentCacheToken(): string
+    {
+        return (string) Str::ulid();
     }
 
     /**
@@ -366,7 +372,7 @@ class PermissionRegistrar
     {
         $teamId = $this->teams ? (string) ($this->getPermissionsTeamId() ?? 'global') : 'none';
         $segments = [
-            $this->modelAssignmentCacheVersion(),
+            $this->modelAssignmentCacheToken(),
             $record->getMorphClass(),
             $record->getKey(),
             $teamId,

--- a/src/permission/src/Traits/HasAssignedModels.php
+++ b/src/permission/src/Traits/HasAssignedModels.php
@@ -38,7 +38,7 @@ trait HasAssignedModels
         }
 
         $this->unsetRelation('users');
-        $registrar->bumpModelAssignmentCacheVersion();
+        $registrar->bumpModelAssignmentCacheToken();
 
         return $this;
     }
@@ -58,7 +58,7 @@ trait HasAssignedModels
         }
 
         $this->unsetRelation('users');
-        $registrar->bumpModelAssignmentCacheVersion();
+        $registrar->bumpModelAssignmentCacheToken();
 
         return $this;
     }
@@ -84,7 +84,7 @@ trait HasAssignedModels
         }
 
         $this->unsetRelation('users');
-        $registrar->bumpModelAssignmentCacheVersion();
+        $registrar->bumpModelAssignmentCacheToken();
 
         return $this;
     }

--- a/src/permission/src/Traits/HasPermissions.php
+++ b/src/permission/src/Traits/HasPermissions.php
@@ -640,9 +640,9 @@ trait HasPermissions
             $registrar->forgetModelPermissionCache($model);
         }
 
-        $this->dispatchPermissionAttachedEvent($permissions);
-
+        // Clear wildcard state before dispatch so synchronous listeners rebuild from current assignments.
         $this->forgetWildcardPermissionIndex();
+        $this->dispatchPermissionAttachedEvent($permissions);
 
         return $this;
     }
@@ -736,6 +736,29 @@ trait HasPermissions
             'permissions' => $permissions,
             'pivot' => $pivot,
         ];
+    }
+
+    /**
+     * Replace queued permission assignments for the given scope.
+     *
+     * @param array<int, array{permissions: array<int, int|string>, pivot: array<string, mixed>}> $assignments
+     * @param array<string, mixed> $scopePivot
+     */
+    private function replaceQueuedPermissionAssignments(array $assignments, array $scopePivot): void
+    {
+        $teamKey = $this->queuedPermissionAssignmentTeamKey($scopePivot);
+        $this->queuedPermissionAssignments = array_values(array_filter(
+            $this->queuedPermissionAssignments,
+            fn (array $assignment): bool => $this->queuedPermissionAssignmentTeamKey($assignment['pivot']) !== $teamKey,
+        ));
+
+        foreach ($assignments as $assignment) {
+            if ($assignment['permissions'] === []) {
+                continue;
+            }
+
+            $this->queuePermissionAssignments($assignment['permissions'], $assignment['pivot']);
+        }
     }
 
     /**
@@ -859,33 +882,48 @@ trait HasPermissions
         $model = $this;
 
         if ($this->exists) {
+            $pivot = $this->permissionAssignmentPivot(false);
+
             $this->permissions()->detach();
             $this->attachPermissionAssignments(
                 $permissions,
-                $this->permissionAssignmentPivot(false),
+                $pivot,
             );
             $model->unsetRelation('permissions');
         } else {
-            $this->queuePermissionAssignments(
-                $permissions,
-                $this->permissionAssignmentPivot(false),
+            $pivot = $this->permissionAssignmentPivot(false);
+
+            $this->replaceQueuedPermissionAssignments(
+                [
+                    [
+                        'permissions' => $permissions,
+                        'pivot' => $pivot,
+                    ],
+                ],
+                $pivot,
             );
         }
 
-        if ($this instanceof Role) {
-            $this->forgetCachedPermissions();
-        } elseif ($model->exists) {
-            $this->permissionRegistrar()->forgetModelPermissionCache($model);
+        if ($model->exists) {
+            if ($this instanceof Role) {
+                $this->forgetCachedPermissions();
+            } else {
+                $this->permissionRegistrar()->forgetModelPermissionCache($model);
+            }
         }
 
-        $this->dispatchPermissionAttachedEvent($permissions);
+        // Clear wildcard state before dispatch so synchronous listeners rebuild from current assignments.
         $this->forgetWildcardPermissionIndex();
+        $this->dispatchPermissionAttachedEvent($permissions);
 
         return $this;
     }
 
     /**
      * Remove all current permissions and set allowed and forbidden permissions.
+     *
+     * For unsaved models, assignments are queued until the model is saved and
+     * the returned change set is empty because no database rows are changed yet.
      *
      * @param array<array-key, mixed>|Collection<array-key, mixed> $allowed
      * @param array<array-key, mixed>|Collection<array-key, mixed> $forbidden
@@ -895,28 +933,46 @@ trait HasPermissions
     {
         $model = $this;
 
-        if (! $model->exists) {
-            return ['attached' => [], 'detached' => [], 'updated' => []];
-        }
-
         $allowedIds = $this->collectPermissions($allowed);
         $forbiddenIds = $this->collectPermissions($forbidden);
         $allowedIds = array_values(array_filter(
             $allowedIds,
             fn (int|string $allowedId): bool => ! in_array($allowedId, $forbiddenIds, true),
         ));
-        $registrar = $this->permissionRegistrar();
-        $teamPivot = $registrar->teams && ! $this instanceof Role
-            ? [$registrar->teamsKey => getPermissionsTeamId()] : [];
+        $permissions = array_merge($allowedIds, $forbiddenIds);
+        $allowedPivot = $this->permissionAssignmentPivot(false);
+        $forbiddenPivot = $this->permissionAssignmentPivot(true);
+
+        if (! $model->exists) {
+            $this->replaceQueuedPermissionAssignments(
+                [
+                    [
+                        'permissions' => $allowedIds,
+                        'pivot' => $allowedPivot,
+                    ],
+                    [
+                        'permissions' => $forbiddenIds,
+                        'pivot' => $forbiddenPivot,
+                    ],
+                ],
+                $allowedPivot,
+            );
+
+            // Clear wildcard state before dispatch so synchronous listeners rebuild from current assignments.
+            $this->forgetWildcardPermissionIndex();
+            $this->dispatchPermissionAttachedEvent($permissions);
+
+            return ['attached' => [], 'detached' => [], 'updated' => []];
+        }
 
         $syncData = [];
 
         foreach ($allowedIds as $permissionId) {
-            $syncData[$permissionId] = $teamPivot + ['is_forbidden' => false];
+            $syncData[$permissionId] = $allowedPivot;
         }
 
         foreach ($forbiddenIds as $permissionId) {
-            $syncData[$permissionId] = $teamPivot + ['is_forbidden' => true];
+            $syncData[$permissionId] = $forbiddenPivot;
         }
 
         /** @var array{attached: array<int, int|string>, detached: array<int, int|string>, updated: array<int, int|string>} $changes */
@@ -930,7 +986,9 @@ trait HasPermissions
             $this->permissionRegistrar()->forgetModelPermissionCache($model);
         }
 
+        // Clear wildcard state before dispatch so synchronous listeners rebuild from current assignments.
         $this->forgetWildcardPermissionIndex();
+        $this->dispatchPermissionAttachedEvent($permissions);
 
         return $changes;
     }

--- a/src/permission/src/Traits/HasPermissions.php
+++ b/src/permission/src/Traits/HasPermissions.php
@@ -87,7 +87,7 @@ trait HasPermissions
                     ->delete();
             }
 
-            Container::getInstance()->make(PermissionRegistrar::class)->bumpModelAssignmentCacheVersion();
+            Container::getInstance()->make(PermissionRegistrar::class)->bumpModelAssignmentCacheToken();
         });
 
         static::saved(function (Model $model): void {
@@ -221,6 +221,16 @@ trait HasPermissions
     }
 
     /**
+     * Return allowed direct permissions.
+     */
+    protected function allowedDirectPermissions(): Collection
+    {
+        return $this->getCachedDirectPermissions()
+            ->reject(fn (Model $permission): bool => $this->pivotIsForbidden($permission))
+            ->values();
+    }
+
+    /**
      * Scope the model query to certain permissions only.
      *
      * @param array|Collection|int|Permission|string|UnitEnum $permissions
@@ -228,40 +238,90 @@ trait HasPermissions
     public function scopePermission(Builder $query, $permissions, bool $without = false): Builder
     {
         $permissions = $this->convertToPermissionModels($permissions);
-
         $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
-        $roleKey = Guard::getModelKeyName($this instanceof Role ? static::class : $this->getRoleClass());
-        $roleIdsWithPermissions = $this instanceof Role ? [] : array_values(array_unique(
-            array_reduce(
-                $permissions,
-                fn (array $result, Model $permission): array => array_merge(
-                    $result,
-                    $this->relationCollection($permission, 'roles')
-                        ->map(fn (Model $role) => $role->getAttribute($roleKey))
-                        ->all(),
-                ),
-                [],
-            ),
-            SORT_REGULAR,
-        ));
-
-        return $query->where(
-            fn (Builder $query) => $query
-                ->{! $without ? 'whereHas' : 'whereDoesntHave'}(
-                    'permissions',
-                    fn (Builder $subQuery) => $subQuery
-                        ->whereIn(Config::permissionsTable() . ".{$permissionKey}", array_column($permissions, $permissionKey))
-                )
-                ->when(
-                    count($roleIdsWithPermissions),
-                    fn ($whenQuery) => $whenQuery
-                        ->{! $without ? 'orWhereHas' : 'whereDoesntHave'}(
-                            'roles',
-                            fn (Builder $subQuery) => $subQuery
-                                ->whereIn(Config::rolesTable() . ".{$roleKey}", $roleIdsWithPermissions)
-                        )
-                )
+        $permissionIds = array_column($permissions, $permissionKey);
+        $effectivePermission = fn (Builder $query): Builder => $this->whereEffectivePermission(
+            $query,
+            $permissionIds,
         );
+
+        return $without
+            ? $query->whereNot($effectivePermission)
+            : $query->where($effectivePermission);
+    }
+
+    /**
+     * Add an effective permission predicate for the given permission ids.
+     *
+     * @param array<int, int|string> $permissionIds
+     */
+    protected function whereEffectivePermission(Builder $query, array $permissionIds): Builder
+    {
+        if ($permissionIds === []) {
+            // No requested permissions means no effective grant; whereNot() turns this into the exact complement.
+            $query->whereRaw('1 = 0');
+
+            return $query;
+        }
+
+        foreach ($permissionIds as $index => $permissionId) {
+            $method = $index === 0 ? 'where' : 'orWhere';
+
+            $query->{$method}(
+                fn (Builder $query) => $query
+                    ->where(fn (Builder $query) => $this->wherePermissionEffect($query, $permissionId, false))
+                    ->whereNot(fn (Builder $query) => $this->wherePermissionEffect($query, $permissionId, true))
+            );
+        }
+
+        return $query;
+    }
+
+    /**
+     * Add a permission-effect predicate for direct and role-granted permissions.
+     */
+    protected function wherePermissionEffect(Builder $query, int|string $permissionId, bool $forbidden): Builder
+    {
+        $query->whereHas(
+            'permissions',
+            fn (Builder $query) => $this->whereDirectPermissionEffect($query, $permissionId, $forbidden),
+        );
+
+        if (! $this instanceof Role) {
+            $query->orWhereHas(
+                'roles.permissions',
+                fn (Builder $query) => $this->whereRolePermissionEffect($query, $permissionId, $forbidden),
+            );
+        }
+
+        return $query;
+    }
+
+    /**
+     * Add a direct permission-effect predicate.
+     */
+    protected function whereDirectPermissionEffect(Builder $query, int|string $permissionId, bool $forbidden): Builder
+    {
+        $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
+        $pivotTable = $this instanceof Role
+            ? Config::roleHasPermissionsTable()
+            : Config::modelHasPermissionsTable();
+
+        return $query
+            ->where(Config::permissionsTable() . ".{$permissionKey}", $permissionId)
+            ->where("{$pivotTable}.is_forbidden", $forbidden);
+    }
+
+    /**
+     * Add a role permission-effect predicate.
+     */
+    protected function whereRolePermissionEffect(Builder $query, int|string $permissionId, bool $forbidden): Builder
+    {
+        $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
+
+        return $query
+            ->where(Config::permissionsTable() . ".{$permissionKey}", $permissionId)
+            ->where(Config::roleHasPermissionsTable() . '.is_forbidden', $forbidden);
     }
 
     /**
@@ -468,11 +528,11 @@ trait HasPermissions
     {
         $permission = $this->filterPermission($permission);
 
-        $matchedPermission = $this->getCachedDirectPermissions()
-            ->first(fn (Model $directPermission): bool => $directPermission->getKey() === $permission->getKey());
+        $matches = $this->getCachedDirectPermissions()
+            ->filter(fn (Model $directPermission): bool => $directPermission->getKey() === $permission->getKey());
 
-        return $matchedPermission !== null
-            && ! $this->pivotIsForbidden($matchedPermission);
+        return $matches->isNotEmpty()
+            && ! $matches->contains(fn (Model $directPermission): bool => $this->pivotIsForbidden($directPermission));
     }
 
     /**
@@ -565,17 +625,10 @@ trait HasPermissions
         $permissions = $this->collectPermissions($permissions);
         $model = $this;
         $registrar = $this->permissionRegistrar();
-        $teamPivot = $registrar->teams && ! $this instanceof Role
-            ? [$registrar->teamsKey => getPermissionsTeamId()] : [];
-        $pivot = $teamPivot + ['is_forbidden' => $isForbidden];
+        $pivot = $this->permissionAssignmentPivot($isForbidden);
 
         if ($model->exists) {
-            $currentPermissions = $this->relationCollection($this->loadMissing('permissions'), 'permissions')
-                ->filter(fn (Model $permission): bool => $this->pivotIsForbidden($permission) === $isForbidden)
-                ->map(fn (Model $permission) => $permission->getKey())
-                ->toArray();
-
-            $this->permissions()->attach(array_diff($permissions, $currentPermissions), $pivot);
+            $this->upsertPermissionAssignments($permissions, $pivot);
             $model->unsetRelation('permissions');
         } else {
             $this->queuePermissionAssignments($permissions, $pivot);
@@ -592,6 +645,83 @@ trait HasPermissions
         $this->forgetWildcardPermissionIndex();
 
         return $this;
+    }
+
+    /**
+     * Build permission assignment pivot attributes.
+     *
+     * @return array<string, mixed>
+     */
+    private function permissionAssignmentPivot(bool $isForbidden): array
+    {
+        $registrar = $this->permissionRegistrar();
+
+        $teamPivot = $registrar->teams && ! $this instanceof Role
+            ? [$registrar->teamsKey => getPermissionsTeamId()] : [];
+
+        return $teamPivot + ['is_forbidden' => $isForbidden];
+    }
+
+    /**
+     * Insert missing permission assignments and update existing effects.
+     *
+     * @param array<int, int|string> $permissions
+     * @param array<string, mixed> $pivot
+     */
+    private function upsertPermissionAssignments(array $permissions, array $pivot): void
+    {
+        if ($permissions === []) {
+            return;
+        }
+
+        $relation = $this->permissions();
+        $currentPermissions = $relation->get()
+            ->keyBy(fn (Model $permission): string => (string) $permission->getKey());
+        $effect = ['is_forbidden' => (bool) $pivot['is_forbidden']];
+
+        $attach = [];
+        $updated = false;
+
+        foreach ($permissions as $permission) {
+            $key = (string) $permission;
+            $currentPermission = $currentPermissions->get($key);
+
+            if (! $currentPermission instanceof Model) {
+                $attach[] = $permission;
+                continue;
+            }
+
+            if ($this->pivotIsForbidden($currentPermission) !== $effect['is_forbidden']) {
+                $updated = $relation->updateExistingPivot($permission, $effect, false) > 0 || $updated;
+            }
+        }
+
+        if ($attach !== []) {
+            $relation->attach($attach, $pivot, false);
+            $updated = true;
+        }
+
+        if ($updated) {
+            $relation->touchIfTouching();
+        }
+    }
+
+    /**
+     * Insert permission assignments into an empty assignment set.
+     *
+     * @param array<int, int|string> $permissions
+     * @param array<string, mixed> $pivot
+     */
+    private function attachPermissionAssignments(array $permissions, array $pivot): void
+    {
+        if ($permissions === []) {
+            return;
+        }
+
+        $relation = $this->permissions();
+
+        $relation->attach($permissions, $pivot, false);
+        $relation->touchIfTouching();
     }
 
     /**
@@ -619,8 +749,11 @@ trait HasPermissions
 
         $registrar = $this->permissionRegistrar();
 
-        foreach ($this->queuedPermissionAssignments as $assignment) {
-            $this->permissions()->attach($assignment['permissions'], $assignment['pivot']);
+        foreach ($this->collapseQueuedPermissionAssignments() as $assignment) {
+            $this->attachPermissionAssignments(
+                $assignment['permissions'],
+                $assignment['pivot'],
+            );
         }
 
         $this->queuedPermissionAssignments = [];
@@ -633,6 +766,61 @@ trait HasPermissions
         }
 
         $this->forgetWildcardPermissionIndex();
+    }
+
+    /**
+     * Collapse queued permission assignments to their final edge state.
+     *
+     * @return array<int, array{permissions: array<int, int|string>, pivot: array<string, mixed>}>
+     */
+    private function collapseQueuedPermissionAssignments(): array
+    {
+        $collapsed = [];
+
+        // Collapse by edge first so the last queued effect wins for each permission and team.
+        foreach ($this->queuedPermissionAssignments as $assignment) {
+            foreach ($assignment['permissions'] as $permission) {
+                $key = $permission . '|' . $this->queuedPermissionAssignmentTeamKey($assignment['pivot']);
+
+                $collapsed[$key] = [
+                    'permission' => $permission,
+                    'pivot' => $assignment['pivot'],
+                ];
+            }
+        }
+
+        $batches = [];
+
+        // Then batch by pivot so each distinct team and effect can be inserted together.
+        foreach ($collapsed as $assignment) {
+            $pivot = $assignment['pivot'];
+            $batchKey = $this->queuedPermissionAssignmentTeamKey($pivot) . '|'
+                . ((bool) $pivot['is_forbidden'] ? 'forbidden' : 'allowed');
+
+            $batches[$batchKey] ??= [
+                'permissions' => [],
+                'pivot' => $pivot,
+            ];
+            $batches[$batchKey]['permissions'][] = $assignment['permission'];
+        }
+
+        return array_values($batches);
+    }
+
+    /**
+     * Build the queued assignment team key.
+     *
+     * @param array<string, mixed> $pivot
+     */
+    private function queuedPermissionAssignmentTeamKey(array $pivot): string
+    {
+        $registrar = $this->permissionRegistrar();
+
+        if (! $registrar->teams || $this instanceof Role) {
+            return 'none';
+        }
+
+        return (string) ($pivot[$registrar->teamsKey] ?? 'global');
     }
 
     /**
@@ -667,13 +855,31 @@ trait HasPermissions
      */
     public function syncPermissions(...$permissions): static
     {
+        $permissions = $this->collectPermissions($permissions);
+        $model = $this;
+
         if ($this->exists) {
-            $this->collectPermissions($permissions);
             $this->permissions()->detach();
-            $this->setRelation('permissions', collect());
+            $this->attachPermissionAssignments(
+                $permissions,
+                $this->permissionAssignmentPivot(false),
+            );
+            $model->unsetRelation('permissions');
+        } else {
+            $this->queuePermissionAssignments(
+                $permissions,
+                $this->permissionAssignmentPivot(false),
+            );
         }
 
-        $this->givePermissionTo($permissions);
+        if ($this instanceof Role) {
+            $this->forgetCachedPermissions();
+        } elseif ($model->exists) {
+            $this->permissionRegistrar()->forgetModelPermissionCache($model);
+        }
+
+        $this->dispatchPermissionAttachedEvent($permissions);
+        $this->forgetWildcardPermissionIndex();
 
         return $this;
     }
@@ -923,7 +1129,7 @@ trait HasPermissions
      */
     public function getPermissionNames(): Collection
     {
-        return $this->getCachedDirectPermissions()->pluck('name');
+        return $this->allowedDirectPermissions()->pluck('name');
     }
 
     /**

--- a/src/permission/src/Traits/HasRoles.php
+++ b/src/permission/src/Traits/HasRoles.php
@@ -63,7 +63,7 @@ trait HasRoles
                     ->delete();
             }
 
-            $registrar->bumpModelAssignmentCacheVersion();
+            $registrar->bumpModelAssignmentCacheToken();
         });
 
         static::saved(function (Model $model): void {
@@ -608,7 +608,7 @@ trait HasRoles
      */
     public function getDirectPermissions(): Collection
     {
-        return $this->getCachedDirectPermissions();
+        return $this->allowedDirectPermissions();
     }
 
     /**

--- a/src/permission/src/Traits/HasRoles.php
+++ b/src/permission/src/Traits/HasRoles.php
@@ -604,7 +604,7 @@ trait HasRoles
     }
 
     /**
-     * Return all permissions directly coupled to the model.
+     * Return allowed permissions directly assigned to the model.
      */
     public function getDirectPermissions(): Collection
     {

--- a/tests/Permission/CacheTest.php
+++ b/tests/Permission/CacheTest.php
@@ -47,18 +47,19 @@ class CacheTest extends TestCase
         $this->assertTrue($this->testUser->hasForbiddenPermissionViaRoles('edit-articles'));
     }
 
-    public function testPermissionCacheResetBumpsModelAssignmentCacheVersion(): void
+    public function testPermissionCacheResetChangesModelAssignmentCacheToken(): void
     {
         $this->testUser->assignRole('testRole');
         $registrar = $this->app->make(PermissionRegistrar::class);
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
-        $firstVersion = $registrar->modelAssignmentCacheVersion();
+        $firstToken = $registrar->modelAssignmentCacheToken();
 
         $registrar->forgetCachedPermissions();
 
-        $this->assertGreaterThan($firstVersion, $registrar->modelAssignmentCacheVersion());
+        $this->assertMatchesRegularExpression('/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/', $firstToken);
+        $this->assertNotSame($firstToken, $registrar->modelAssignmentCacheToken());
         $this->assertTrue($this->testUser->hasRole('testRole'));
     }
 
@@ -194,7 +195,7 @@ class CacheTest extends TestCase
         $this->assertArrayHasKey($registrar->cacheKey . ':tenant-b', $items);
     }
 
-    public function testCustomCacheKeyResolverScopesModelAssignmentAndVersionCaches(): void
+    public function testCustomCacheKeyResolverScopesModelAssignmentAndTokenCaches(): void
     {
         $tenant = 'tenant-a';
         PermissionRegistrar::resolveCacheKeyUsing(function () use (&$tenant): string {
@@ -212,8 +213,8 @@ class CacheTest extends TestCase
 
         $keys = array_keys($store->all());
 
-        $this->assertContains('hypervel.permission.cache.model.version:tenant-a', $keys);
-        $this->assertContains('hypervel.permission.cache.model.version:tenant-b', $keys);
+        $this->assertContains('hypervel.permission.cache.model.token:tenant-a', $keys);
+        $this->assertContains('hypervel.permission.cache.model.token:tenant-b', $keys);
         $this->assertNotEmpty(array_filter(
             $keys,
             fn (string $key): bool => str_starts_with($key, 'hypervel.permission.cache.model.roles:tenant-a:'),

--- a/tests/Permission/CustomSchemaConfigTest.php
+++ b/tests/Permission/CustomSchemaConfigTest.php
@@ -56,4 +56,16 @@ class CustomSchemaConfigTest extends TestCase
         $this->assertTrue($this->app->make(Role::class)::where('name', 'testRole')->exists());
         $this->assertTrue($this->app->make(Permission::class)::where('name', 'edit-articles')->exists());
     }
+
+    public function testForbiddenPermissionUpdatesExistingCustomTableAssignmentEdge(): void
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        $this->testUser->refresh();
+
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
 }

--- a/tests/Permission/Events/EventTest.php
+++ b/tests/Permission/Events/EventTest.php
@@ -11,6 +11,7 @@ use Hypervel\Permission\Events\PermissionDetachedEvent;
 use Hypervel\Permission\Events\RoleAttachedEvent;
 use Hypervel\Permission\Events\RoleDetachedEvent;
 use Hypervel\Support\Facades\Event;
+use Hypervel\Tests\Permission\Fixtures\Models\User;
 use Hypervel\Tests\Permission\TestCase;
 use Mockery as m;
 
@@ -79,6 +80,39 @@ class EventTest extends TestCase
 
         Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event): bool {
             return $event->model->is($this->testUser)
+                && $event->permissionsOrIds === [$this->testUserPermission->getKey()];
+        });
+    }
+
+    public function testSyncPermissionsDispatchesPermissionAttachedEventOnce(): void
+    {
+        $this->app->make('config')->set('permission.events_enabled', true);
+
+        Event::fake([PermissionAttachedEvent::class]);
+
+        $this->testUser->syncPermissions('edit-articles');
+
+        Event::assertDispatchedTimes(PermissionAttachedEvent::class, 1);
+        Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event): bool {
+            return $event->model->is($this->testUser)
+                && $event->permissionsOrIds === [$this->testUserPermission->getKey()];
+        });
+    }
+
+    public function testQueuedPermissionAssignmentDispatchesPermissionAttachedEventOnce(): void
+    {
+        $this->app->make('config')->set('permission.events_enabled', true);
+
+        Event::fake([PermissionAttachedEvent::class]);
+
+        $user = new User(['email' => 'queued-event@example.com']);
+
+        $user->givePermissionTo('edit-articles');
+        $user->save();
+
+        Event::assertDispatchedTimes(PermissionAttachedEvent::class, 1);
+        Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event) use ($user): bool {
+            return $event->model->is($user)
                 && $event->permissionsOrIds === [$this->testUserPermission->getKey()];
         });
     }

--- a/tests/Permission/Events/EventTest.php
+++ b/tests/Permission/Events/EventTest.php
@@ -84,6 +84,27 @@ class EventTest extends TestCase
         });
     }
 
+    public function testPermissionAttachedEventListenerSeesFreshWildcardIndexAfterPermissionAttach(): void
+    {
+        $this->app->make('config')->set('permission.enable_wildcard_permission', true);
+        $this->app->make('config')->set('permission.events_enabled', true);
+        $this->flushPermissionState();
+
+        $this->assertFalse($this->testUser->hasPermissionTo('posts.create'));
+
+        $listenerSawPermission = false;
+        Event::listen(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event) use (&$listenerSawPermission): void {
+            if ($event->model->is($this->testUser)) {
+                $listenerSawPermission = $event->model->hasPermissionTo('posts.create');
+            }
+        });
+
+        $this->app->make(PermissionContract::class)::create(['name' => 'posts.*']);
+        $this->testUser->givePermissionTo('posts.*');
+
+        $this->assertTrue($listenerSawPermission);
+    }
+
     public function testSyncPermissionsDispatchesPermissionAttachedEventOnce(): void
     {
         $this->app->make('config')->set('permission.events_enabled', true);
@@ -96,6 +117,47 @@ class EventTest extends TestCase
         Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event): bool {
             return $event->model->is($this->testUser)
                 && $event->permissionsOrIds === [$this->testUserPermission->getKey()];
+        });
+    }
+
+    public function testPermissionAttachedEventListenerSeesFreshWildcardIndexAfterPermissionSync(): void
+    {
+        $this->app->make('config')->set('permission.enable_wildcard_permission', true);
+        $this->app->make('config')->set('permission.events_enabled', true);
+        $this->flushPermissionState();
+
+        $this->assertFalse($this->testUser->hasPermissionTo('posts.create'));
+
+        $listenerSawPermission = false;
+        Event::listen(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event) use (&$listenerSawPermission): void {
+            if ($event->model->is($this->testUser)) {
+                $listenerSawPermission = $event->model->hasPermissionTo('posts.create');
+            }
+        });
+
+        $this->app->make(PermissionContract::class)::create(['name' => 'posts.*']);
+        $this->testUser->syncPermissions('posts.*');
+
+        $this->assertTrue($listenerSawPermission);
+    }
+
+    public function testSyncPermissionsWithForbiddenDispatchesPermissionAttachedEventOnce(): void
+    {
+        $this->app->make('config')->set('permission.events_enabled', true);
+
+        Event::fake([PermissionAttachedEvent::class]);
+
+        $this->testUser->syncPermissionsWithForbidden(
+            allowed: ['edit-articles'],
+            forbidden: ['edit-news'],
+        );
+
+        $editNewsPermission = $this->app->make(PermissionContract::class)::findByName('edit-news');
+
+        Event::assertDispatchedTimes(PermissionAttachedEvent::class, 1);
+        Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event) use ($editNewsPermission): bool {
+            return $event->model->is($this->testUser)
+                && $event->permissionsOrIds === [$this->testUserPermission->getKey(), $editNewsPermission->getKey()];
         });
     }
 
@@ -114,6 +176,29 @@ class EventTest extends TestCase
         Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event) use ($user): bool {
             return $event->model->is($user)
                 && $event->permissionsOrIds === [$this->testUserPermission->getKey()];
+        });
+    }
+
+    public function testQueuedForbiddenPermissionSyncDispatchesPermissionAttachedEventOnce(): void
+    {
+        $this->app->make('config')->set('permission.events_enabled', true);
+
+        Event::fake([PermissionAttachedEvent::class]);
+
+        $user = new User(['email' => 'queued-forbidden-event@example.com']);
+
+        $user->syncPermissionsWithForbidden(
+            allowed: ['edit-articles'],
+            forbidden: ['edit-news'],
+        );
+        $user->save();
+
+        $editNewsPermission = $this->app->make(PermissionContract::class)::findByName('edit-news');
+
+        Event::assertDispatchedTimes(PermissionAttachedEvent::class, 1);
+        Event::assertDispatched(PermissionAttachedEvent::class, function (PermissionAttachedEvent $event) use ($user, $editNewsPermission): bool {
+            return $event->model->is($user)
+                && $event->permissionsOrIds === [$this->testUserPermission->getKey(), $editNewsPermission->getKey()];
         });
     }
 

--- a/tests/Permission/ForbiddenPermissionTest.php
+++ b/tests/Permission/ForbiddenPermissionTest.php
@@ -182,6 +182,28 @@ class ForbiddenPermissionTest extends TestCase
         $this->assertFalse($this->testUser->hasForbiddenPermission('edit-news'));
     }
 
+    public function testQueuedForbiddenSyncReplacesEarlierQueuedAssignmentsWhenModelIsSaved(): void
+    {
+        $user = new User(['email' => 'queued-forbidden-sync@example.com']);
+
+        $user->givePermissionTo('edit-articles');
+        $changes = $user->syncPermissionsWithForbidden(
+            allowed: ['edit-blog', 'edit-news'],
+            forbidden: ['edit-news'],
+        );
+
+        $this->assertSame(['attached' => [], 'detached' => [], 'updated' => []], $changes);
+
+        $user->save();
+        $user->refresh();
+
+        $this->assertSame(2, $user->permissions()->count());
+        $this->assertFalse($user->hasPermissionTo('edit-articles'));
+        $this->assertTrue($user->hasPermissionTo('edit-blog'));
+        $this->assertFalse($user->hasPermissionTo('edit-news'));
+        $this->assertTrue($user->hasForbiddenPermission('edit-news'));
+    }
+
     public function testQueuedDirectForbiddenPermissionFlipsExistingQueuedAllowedPermission(): void
     {
         $user = new User(['email' => 'queued@example.com']);

--- a/tests/Permission/ForbiddenPermissionTest.php
+++ b/tests/Permission/ForbiddenPermissionTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Permission;
 
+use Hypervel\Database\Eloquent\Relations\Pivot;
 use Hypervel\Permission\Contracts\Permission as PermissionContract;
 use Hypervel\Permission\Contracts\Role as RoleContract;
+use Hypervel\Permission\PermissionRegistrar;
+use Hypervel\Permission\Support\Config;
 use Hypervel\Tests\Permission\Fixtures\Models\Permission;
 use Hypervel\Tests\Permission\Fixtures\Models\Role;
 use Hypervel\Tests\Permission\Fixtures\Models\User;
@@ -20,6 +23,34 @@ class ForbiddenPermissionTest extends TestCase
         $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
         $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
         $this->assertTrue((bool) $this->testUser->permissions->firstWhere('name', 'edit-articles')->pivot->getAttribute('is_forbidden'));
+    }
+
+    public function testDirectForbiddenPermissionFlipsExistingAllowedPermission(): void
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        $this->testUser->refresh();
+
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+        $this->assertSame([], $this->testUser->getPermissionNames()->all());
+    }
+
+    public function testDirectAllowedPermissionFlipsExistingForbiddenPermission(): void
+    {
+        $this->testUser->giveForbiddenTo('edit-articles');
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->testUser->refresh();
+
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+        $this->assertSame(['edit-articles'], $this->testUser->getPermissionNames()->all());
     }
 
     public function testDirectForbiddenPermissionOverridesRolePermission(): void
@@ -46,6 +77,30 @@ class ForbiddenPermissionTest extends TestCase
         $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
         $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
         $this->assertFalse($this->testUser->getAllPermissions()->contains('name', 'edit-articles'));
+    }
+
+    public function testRoleForbiddenPermissionFlipsExistingAllowedPermission(): void
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->testUserRole->giveForbiddenTo('edit-articles');
+
+        $this->testUserRole->refresh();
+
+        $this->assertSame(1, $this->testUserRole->permissions()->count());
+        $this->assertTrue($this->testUserRole->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($this->testUserRole->hasPermissionTo('edit-articles'));
+    }
+
+    public function testRoleAllowedPermissionFlipsExistingForbiddenPermission(): void
+    {
+        $this->testUserRole->giveForbiddenTo('edit-articles');
+        $this->testUserRole->givePermissionTo('edit-articles');
+
+        $this->testUserRole->refresh();
+
+        $this->assertSame(1, $this->testUserRole->permissions()->count());
+        $this->assertFalse($this->testUserRole->hasForbiddenPermission('edit-articles'));
+        $this->assertTrue($this->testUserRole->hasPermissionTo('edit-articles'));
     }
 
     public function testRoleForbiddenPermissionOverridesAllowedRolePermission(): void
@@ -125,6 +180,61 @@ class ForbiddenPermissionTest extends TestCase
         $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
         $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));
         $this->assertFalse($this->testUser->hasForbiddenPermission('edit-news'));
+    }
+
+    public function testQueuedDirectForbiddenPermissionFlipsExistingQueuedAllowedPermission(): void
+    {
+        $user = new User(['email' => 'queued@example.com']);
+
+        $user->givePermissionTo('edit-articles');
+        $user->giveForbiddenTo('edit-articles');
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertSame(1, $user->permissions()->count());
+        $this->assertTrue($user->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($user->hasPermissionTo('edit-articles'));
+    }
+
+    public function testQueuedDirectAllowedPermissionFlipsExistingQueuedForbiddenPermission(): void
+    {
+        $user = new User(['email' => 'queued@example.com']);
+
+        $user->giveForbiddenTo('edit-articles');
+        $user->givePermissionTo('edit-articles');
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertSame(1, $user->permissions()->count());
+        $this->assertFalse($user->hasForbiddenPermission('edit-articles'));
+        $this->assertTrue($user->hasPermissionTo('edit-articles'));
+    }
+
+    public function testRevokePermissionRemovesDirectForbiddenPermission(): void
+    {
+        $this->testUser->giveForbiddenTo('edit-articles');
+        $this->testUser->revokePermissionTo('edit-articles');
+
+        $this->testUser->refresh();
+
+        $this->assertSame(0, $this->testUser->permissions()->count());
+        $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
+
+    public function testRemovingDirectForbiddenPermissionRevealsRoleAllowedPermission(): void
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->testUser->assignRole($this->testUserRole);
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+
+        $this->testUser->revokePermissionTo('edit-articles');
+
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
     }
 
     public function testRoleForbiddenSyncUsesCustomPermissionPrimaryKeys(): void
@@ -207,5 +317,172 @@ class ForbiddenPermissionTest extends TestCase
 
         $this->assertSame(['edit-articles'], $permissionNames);
         $this->assertTrue($role->hasForbiddenPermission('edit-news'));
+    }
+
+    public function testDirectPermissionChecksDenyWhenRelationContainsDuplicateEffects(): void
+    {
+        $permission = $this->app->make(PermissionContract::class)::findByName('edit-articles');
+        $allowed = clone $permission;
+        $forbidden = clone $permission;
+
+        $allowed->setRelation('pivot', Pivot::fromRawAttributes(
+            $this->testUser,
+            [
+                $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+                Config::morphKey() => $this->testUser->getKey(),
+                'model_type' => $this->testUser->getMorphClass(),
+                'is_forbidden' => false,
+            ],
+            Config::modelHasPermissionsTable(),
+            true,
+        ));
+
+        $forbidden->setRelation('pivot', Pivot::fromRawAttributes(
+            $this->testUser,
+            [
+                $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+                Config::morphKey() => $this->testUser->getKey(),
+                'model_type' => $this->testUser->getMorphClass(),
+                'is_forbidden' => true,
+            ],
+            Config::modelHasPermissionsTable(),
+            true,
+        ));
+
+        $this->testUser->setRelation('permissions', collect([$allowed, $forbidden]));
+
+        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+    }
+
+    public function testRolePermissionChecksDenyWhenRelationContainsDuplicateEffects(): void
+    {
+        $permission = $this->app->make(PermissionContract::class)::findByName('edit-articles');
+        $allowed = clone $permission;
+        $forbidden = clone $permission;
+
+        $allowed->setRelation('pivot', Pivot::fromRawAttributes(
+            $this->testUserRole,
+            [
+                $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+                $this->app->make(PermissionRegistrar::class)->pivotRole => $this->testUserRole->getKey(),
+                'is_forbidden' => false,
+            ],
+            Config::roleHasPermissionsTable(),
+            true,
+        ));
+
+        $forbidden->setRelation('pivot', Pivot::fromRawAttributes(
+            $this->testUserRole,
+            [
+                $this->app->make(PermissionRegistrar::class)->pivotPermission => $permission->getKey(),
+                $this->app->make(PermissionRegistrar::class)->pivotRole => $this->testUserRole->getKey(),
+                'is_forbidden' => true,
+            ],
+            Config::roleHasPermissionsTable(),
+            true,
+        ));
+
+        $this->testUserRole->setRelation('permissions', collect([$allowed, $forbidden]));
+
+        $this->assertFalse($this->testUserRole->hasDirectPermission('edit-articles'));
+        $this->assertFalse($this->testUserRole->hasPermissionTo('edit-articles'));
+    }
+
+    public function testPermissionScopeExcludesDirectForbiddenPermission(): void
+    {
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        $this->assertFalse(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+        $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeExcludesRoleForbiddenPermission(): void
+    {
+        $this->testUserRole->giveForbiddenTo('edit-articles');
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertFalse(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+        $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeLetsDirectDenyOverrideRoleAllow(): void
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->testUser->assignRole($this->testUserRole);
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        $this->assertFalse(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+        $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeLetsRoleDenyOverrideDirectAllow(): void
+    {
+        $this->testUserRole->giveForbiddenTo('edit-articles');
+        $this->testUser->assignRole($this->testUserRole);
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->assertFalse(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+        $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeMatchesAllowedPermissionWhenDifferentRequestedPermissionIsDenied(): void
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->testUser->giveForbiddenTo('edit-news');
+
+        $this->assertTrue(User::permission(['edit-articles', 'edit-news'])->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeMatchesSecondAllowedPermissionWhenFirstRequestedPermissionIsDenied(): void
+    {
+        $this->testUserRole->giveForbiddenTo('edit-articles');
+        $this->testUser->assignRole($this->testUserRole);
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->assertTrue(User::permission(['edit-articles', 'edit-news'])->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeWithNoPermissionsMatchesNoModels(): void
+    {
+        $this->assertFalse(User::permission([])->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testWithoutPermissionScopeWithNoPermissionsMatchesAllModels(): void
+    {
+        $this->assertTrue(User::withoutPermission([])->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testRolePermissionScopeExcludesForbiddenRolePermissionEdges(): void
+    {
+        $this->testUserRole->giveForbiddenTo('edit-articles');
+
+        $this->assertFalse($this->app->make(RoleContract::class)::permission('edit-articles')->get()->contains(
+            fn ($role): bool => $role->is($this->testUserRole),
+        ));
     }
 }

--- a/tests/Permission/SchemaConfigTest.php
+++ b/tests/Permission/SchemaConfigTest.php
@@ -37,4 +37,16 @@ class SchemaConfigTest extends TestCase
             'permission_test_id' => $this->app->make(Permission::class)::findByName('edit-news')->getKey(),
         ]);
     }
+
+    public function testForbiddenPermissionUpdatesExistingCustomKeyAssignmentEdge(): void
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        $this->testUser->refresh();
+
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
 }

--- a/tests/Permission/TestCase.php
+++ b/tests/Permission/TestCase.php
@@ -354,7 +354,7 @@ abstract class TestCase extends TestbenchTestCase
                 ->on($tableNames['permissions'])
                 ->cascadeOnDelete();
 
-            $table->primary([$pivotPermission, $modelMorphKey, 'model_type', 'is_forbidden'], 'model_has_permissions_permission_model_type_primary');
+            $table->primary([$pivotPermission, $modelMorphKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
         });
 
         Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($modelMorphKey, $pivotRole, $tableNames): void {
@@ -386,7 +386,7 @@ abstract class TestCase extends TestbenchTestCase
                 ->on($tableNames['roles'])
                 ->cascadeOnDelete();
 
-            $table->primary([$pivotPermission, $pivotRole, 'is_forbidden'], 'role_has_permissions_permission_id_role_id_primary');
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
         });
     }
 }

--- a/tests/Permission/Traits/HasPermissionsTest.php
+++ b/tests/Permission/Traits/HasPermissionsTest.php
@@ -581,6 +581,36 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-articles'));
     }
 
+    public function testQueuedSyncPermissionsReplacesEarlierQueuedPermissionAssignments(): void
+    {
+        $user = new User(['email' => 'queued-sync@example.com']);
+
+        $user->givePermissionTo('edit-news');
+        $user->syncPermissions('edit-articles');
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertSame(1, $user->permissions()->count());
+        $this->assertTrue($user->hasPermissionTo('edit-articles'));
+        $this->assertFalse($user->hasPermissionTo('edit-news'));
+    }
+
+    public function testQueuedSyncPermissionsReplacesEarlierQueuedForbiddenPermissionAssignment(): void
+    {
+        $user = new User(['email' => 'queued-sync-forbidden@example.com']);
+
+        $user->giveForbiddenTo('edit-articles');
+        $user->syncPermissions('edit-articles');
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertSame(1, $user->permissions()->count());
+        $this->assertTrue($user->hasPermissionTo('edit-articles'));
+        $this->assertFalse($user->hasForbiddenPermission('edit-articles'));
+    }
+
     public function testItDoesNotRunUnnecessarySqlWhenAssigningNewPermissions(): void
     {
         $permission2 = app(Permission::class)->where('name', 'edit-news')->first();

--- a/tests/Permission/Traits/TeamHasPermissionsTest.php
+++ b/tests/Permission/Traits/TeamHasPermissionsTest.php
@@ -104,4 +104,133 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         $this->assertCount(1, User::permission(['edit-articles', 'edit-news'])->get());
         $this->assertCount(0, User::permission('edit-news')->get());
     }
+
+    public function testForbiddenPermissionFlipsExistingAllowedPermissionForCurrentTeamOnly(): void
+    {
+        setPermissionsTeamId(1);
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        setPermissionsTeamId(2);
+        $this->testUser->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $this->testUser->unsetRelation('permissions');
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertSame([], $this->testUser->getPermissionNames()->all());
+
+        setPermissionsTeamId(2);
+        $this->testUser->unsetRelation('permissions');
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+        $this->assertSame(['edit-articles'], $this->testUser->getPermissionNames()->all());
+    }
+
+    public function testAllowedPermissionFlipsExistingForbiddenPermissionForCurrentTeamOnly(): void
+    {
+        setPermissionsTeamId(1);
+        $this->testUser->giveForbiddenTo('edit-articles');
+        $this->testUser->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(2);
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $this->testUser->unsetRelation('permissions');
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+
+        setPermissionsTeamId(2);
+        $this->testUser->unsetRelation('permissions');
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
+
+    public function testQueuedPermissionAssignmentsKeepSeparateTeamEdges(): void
+    {
+        $user = new User(['email' => 'queued-teams@example.com']);
+
+        setPermissionsTeamId(1);
+        $user->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(2);
+        $user->givePermissionTo('edit-articles');
+
+        $user->save();
+
+        setPermissionsTeamId(1);
+        $this->assertTrue($user->hasPermissionTo('edit-articles'));
+        $this->assertSame(1, $user->permissions()->count());
+
+        setPermissionsTeamId(2);
+        $user->unsetRelation('permissions');
+        $this->assertTrue($user->hasPermissionTo('edit-articles'));
+        $this->assertSame(1, $user->permissions()->count());
+    }
+
+    public function testItRevokesForbiddenPermissionsForCurrentTeamOnly(): void
+    {
+        setPermissionsTeamId(1);
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        setPermissionsTeamId(2);
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $this->testUser->revokePermissionTo('edit-articles');
+        $this->testUser->unsetRelation('permissions');
+        $this->assertSame(0, $this->testUser->permissions()->count());
+        $this->assertFalse($this->testUser->hasForbiddenPermission('edit-articles'));
+
+        setPermissionsTeamId(2);
+        $this->testUser->unsetRelation('permissions');
+        $this->assertSame(1, $this->testUser->permissions()->count());
+        $this->assertTrue($this->testUser->hasForbiddenPermission('edit-articles'));
+    }
+
+    public function testPermissionScopeUsesDirectPermissionEffectForCurrentTeamOnly(): void
+    {
+        setPermissionsTeamId(1);
+        $this->testUser->giveForbiddenTo('edit-articles');
+
+        setPermissionsTeamId(2);
+        $this->testUser->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $this->assertFalse(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+        $this->assertTrue(User::withoutPermission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+
+        setPermissionsTeamId(2);
+        $this->assertTrue(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+        $this->assertFalse(User::withoutPermission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
+
+    public function testPermissionScopeUsesRoleAssignmentsForCurrentTeamOnly(): void
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertTrue(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+
+        setPermissionsTeamId(2);
+        $this->assertFalse(User::permission('edit-articles')->get()->contains(
+            fn (User $user): bool => $user->is($this->testUser),
+        ));
+    }
 }

--- a/tests/Permission/Traits/TeamHasPermissionsTest.php
+++ b/tests/Permission/Traits/TeamHasPermissionsTest.php
@@ -172,6 +172,63 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         $this->assertSame(1, $user->permissions()->count());
     }
 
+    public function testQueuedSyncPermissionsReplacesOnlyCurrentTeamPermissionAssignments(): void
+    {
+        $user = new User(['email' => 'queued-team-sync@example.com']);
+
+        setPermissionsTeamId(1);
+        $user->givePermissionTo('edit-news');
+
+        setPermissionsTeamId(2);
+        $user->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $user->syncPermissions('edit-blog');
+
+        $user->save();
+
+        setPermissionsTeamId(1);
+        $user->unsetRelation('permissions');
+        $this->assertSame(['edit-blog'], $user->getPermissionNames()->all());
+        $this->assertFalse($user->hasPermissionTo('edit-news'));
+
+        setPermissionsTeamId(2);
+        $user->unsetRelation('permissions');
+        $this->assertSame(['edit-articles'], $user->getPermissionNames()->all());
+    }
+
+    public function testQueuedForbiddenSyncReplacesOnlyCurrentTeamPermissionAssignments(): void
+    {
+        $user = new User(['email' => 'queued-team-forbidden-sync@example.com']);
+
+        setPermissionsTeamId(1);
+        $user->givePermissionTo('edit-news');
+
+        setPermissionsTeamId(2);
+        $user->givePermissionTo('edit-articles');
+
+        setPermissionsTeamId(1);
+        $changes = $user->syncPermissionsWithForbidden(
+            allowed: ['edit-blog'],
+            forbidden: ['edit-articles'],
+        );
+
+        $this->assertSame(['attached' => [], 'detached' => [], 'updated' => []], $changes);
+
+        $user->save();
+
+        setPermissionsTeamId(1);
+        $user->unsetRelation('permissions');
+        $this->assertSame(['edit-blog'], $user->getPermissionNames()->all());
+        $this->assertTrue($user->hasForbiddenPermission('edit-articles'));
+        $this->assertFalse($user->hasPermissionTo('edit-news'));
+
+        setPermissionsTeamId(2);
+        $user->unsetRelation('permissions');
+        $this->assertSame(['edit-articles'], $user->getPermissionNames()->all());
+        $this->assertFalse($user->hasForbiddenPermission('edit-articles'));
+    }
+
     public function testItRevokesForbiddenPermissionsForCurrentTeamOnly(): void
     {
         setPermissionsTeamId(1);

--- a/tests/Permission/WildcardPermissionTest.php
+++ b/tests/Permission/WildcardPermissionTest.php
@@ -83,7 +83,7 @@ class WildcardPermissionTest extends TestCase
         $this->assertFalse($this->testUser->hasPermissionTo('posts.create'));
     }
 
-    public function testWildcardIndexUsesCurrentAssignmentCacheVersion(): void
+    public function testWildcardIndexUsesCurrentAssignmentCacheToken(): void
     {
         $this->testUser->givePermissionTo(Permission::create(['name' => 'posts.*']));
         $registrar = $this->app->make(PermissionRegistrar::class);
@@ -95,7 +95,7 @@ class WildcardPermissionTest extends TestCase
             ->where(Config::morphKey(), $this->testUser->getKey())
             ->where('model_type', $this->testUser->getMorphClass())
             ->delete();
-        $registrar->bumpModelAssignmentCacheVersion();
+        $registrar->bumpModelAssignmentCacheToken();
 
         $this->assertFalse($this->testUser->hasPermissionTo('posts.create'));
     }


### PR DESCRIPTION
This PR fixes how forbidden permissions are stored and checked.

Before this, a model or role could have two rows for the same permission: one allowed and one forbidden. That made some checks depend on whichever row the database returned first. It also meant query scopes could disagree with normal permission checks.

Now each assignment has one row. `is_forbidden` is the state of that row. Calling `givePermissionTo()` or `giveForbiddenTo()` flips that state, and deny wins consistently for direct permissions, role permissions, and permission query scopes.

This also avoids extra read queries in places where the package already knows the assignment set is empty, such as `syncPermissions()` after detach and queued assignments after the model is first saved. Cache invalidation now uses fresh tokens instead of numeric increments, so it no longer depends on cache stores supporting atomic increment.

For more info, see: docs/plans/2026-07-02-permission-forbidden-single-state-hardening.md

## Permission source

- Removes `is_forbidden` from assignment primary keys while keeping it as the assignment state.
- Updates allow and forbid writes to insert missing edges and flip existing ones.
- Collapses queued unsaved-model permission assignments by permission and team.
- Keeps queued flushes from firing duplicate attach events.
- Makes direct and role permission reads handle bad duplicate data deterministically.
- Returns only allowed direct permissions from allow-oriented accessors.
- Makes `permission()` and `withoutPermission()` use the same deny-wins behavior as runtime checks.
- Replaces assignment cache versions with assignment cache tokens.

## Tests

- Adds coverage for direct and role allow/deny flips.
- Covers queued unsaved-model flips and cross-team queued assignment edges.
- Covers direct deny over role allow, role deny over direct allow, and duplicate-effect defensive reads.
- Covers `permission()` and `withoutPermission()` query scopes, including empty input and mixed allow/deny cases.
- Covers exact-once permission attach events for `syncPermissions()` and queued flushes.
- Updates cache and wildcard tests for assignment cache tokens.
- Adds schema coverage for custom keys and custom table names.

## Docs

- Updates the package README and Boost docs to describe forbidden permissions as a single assignment state.
- Documents query-scope behavior, wildcard query-scope boundaries, allowed-only accessors, revoke behavior, and assignment cache tokens.

## Verification

- `composer fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission handling now treats allow/forbid as a single assignment state, making permission changes update the existing edge instead of creating conflicting entries.
  * Assignment cache invalidation now uses a new token-based mechanism for more reliable refreshes.

* **Bug Fixes**
  * Fixed permission checks and query scopes so forbidden permissions are handled consistently, including team-scoped and role-based cases.
  * Improved wildcard and direct-permission behavior after cache refreshes.

* **Documentation**
  * Updated permission docs to reflect the new forbidden-permission and cache behavior.

* **Tests**
  * Added coverage for permission flips, revokes, scopes, teams, and cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
