### PR TITLE
Add test-state cleanup registrars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -576,7 +576,11 @@ Examples: `tests/Inertia/CoroutineIsolationTest.php`, `tests/Container/Coroutine
 
 When porting source classes that use static properties for caching (e.g., `$booted`, `$globalScopes`, resolved config values, compiled formats):
 1. Add a `public static function flushState(): void` method that resets the static properties to their initial values
-2. Check whether the subscriber (`tests/AfterEachTestSubscriber.php`) should call it — if the cached state could leak between tests and cause failures, add the call
+2. Check whether the subscriber (`src/testing/src/PHPUnit/AfterEachTestSubscriber.php`) should call it — if the cached state could leak between tests and cause failures, add the call
+
+Framework-owned classes go in `AfterEachTestSubscriber`. First-party optional framework packages may stay in grouped optional methods at the bottom of that subscriber. Third-party packages, private packages, and applications should register their cleanup through `extra.hypervel.test-state` and a `TestState` registrar instead of hardcoding their classes into the framework subscriber.
+
+Do not add `Hypervel\Testing\PHPUnit\AfterEachTestCleanup` itself to `AfterEachTestSubscriber`. Its callbacks are suite-level registrations that must persist for the PHPUnit worker lifetime.
 
 Place `flushState()` at the end of the class. The only exception is when the class has trailing magic dispatch/lifecycle methods (`__call`, `__callStatic`, `__get`, `__set`, `__isset`, `__unset`, `__destruct`) at the end; in that case, place `flushState()` immediately before that trailing magic-method block. `__invoke()` is not a placement anchor.
 

--- a/docs/plans/2026-07-04-testing-after-each-cleanup-registrars.md
+++ b/docs/plans/2026-07-04-testing-after-each-cleanup-registrars.md
@@ -1,0 +1,1133 @@
+# Testing After Each Cleanup Registrars Plan
+
+Date: 2026-07-04
+
+Author: Codex
+
+Scope: make Hypervel's after-each test cleanup extensible for apps and packages while keeping framework cleanup centralized, deterministic, and independent of application boot.
+
+## Goal
+
+Build a first-class test cleanup API for Hypervel's long-lived worker model:
+
+- Keep the framework-owned after-each cleanup list centralized in `hypervel/testing`.
+- Let apps register their own worker-lifetime/static cleanup in one obvious generated class.
+- Let packages ship their own cleanup registrars so app developers do not need to know package internals.
+- Make cleanup registration work from the first test in every PHPUnit or Paratest worker, including workers that run only app-less unit tests.
+- Avoid service provider based registration, separate local PHPUnit subscribers, duplicated Composer manifest parsing, stale docs, and any code that suggests cleanup is optional for worker-lifetime state.
+- Fix the app skeleton so generated apps run Hypervel's framework cleanup after every test.
+
+Churn and backwards compatibility do not constrain this plan. The resulting codebase should read as if the testing cleanup API was designed this way from the start.
+
+## Source Material Reviewed
+
+Project instructions:
+
+- `contrib/hypervel/components/AGENTS.md`, read in full on 2026-07-04 before writing this plan.
+
+Hypervel source and docs:
+
+- `src/testing/src/PHPUnit/AfterEachTestExtension.php`
+- `src/testing/src/PHPUnit/AfterEachTestSubscriber.php`
+- `src/testing/composer.json`
+- `src/foundation/src/PackageManifest.php`
+- `src/testbench/src/Foundation/PackageManifest.php`
+- `src/boost/docs/testing.md`
+- `src/boost/docs/packages.md`
+- `phpunit.xml.dist`
+- `tests/Testing/TestingStaticStateTest.php`
+- `tests/Foundation/FoundationPackageManifestTest.php`
+- `tests/Foundation/Fixtures/composer.json`
+- `tests/Foundation/Fixtures/vendor/composer/installed.json`
+
+Application skeleton:
+
+- `../hypervel/phpunit.xml`
+- `../hypervel/composer.json`
+- `../hypervel/tests/TestCase.php`
+- `../hypervel/tests/Feature/ExampleTest.php`
+- `../hypervel/tests/Unit/ExampleTest.php`
+
+Codesonic consensus messages:
+
+- `.codesonic/agents/messages/2026-07-04-235259-codex-to-claude-second-opinion-testing-after-each-cleanup-extension-point-for-apps-and-packages.md`
+- `.codesonic/agents/messages/2026-07-05-000034-claude-to-codex-second-opinion-testing-after-each-cleanup-extension-point-for-apps-and-packages.md`
+- `.codesonic/agents/messages/2026-07-05-001905-claude-to-codex-second-opinion-full-cleanup-api-with-package-owned-automatic-registration.md`
+- `.codesonic/agents/messages/2026-07-05-003017-claude-to-codex-second-opinion-full-cleanup-api-with-package-owned-automatic-registration.md`
+- `.codesonic/agents/messages/2026-07-05-003236-codex-to-claude-second-opinion-full-cleanup-api-with-package-owned-automatic-registration.md`
+- `.codesonic/agents/messages/2026-07-05-003409-claude-to-codex-second-opinion-full-cleanup-api-with-package-owned-automatic-registration.md`
+
+## Current State
+
+### Framework Cleanup
+
+`src/testing/src/PHPUnit/AfterEachTestExtension.php` currently only registers the subscriber:
+
+```php
+class AfterEachTestExtension implements Extension
+{
+    /**
+     * Bootstrap the extension.
+     */
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $facade->registerSubscriber(new AfterEachTestSubscriber);
+    }
+}
+```
+
+`src/testing/src/PHPUnit/AfterEachTestSubscriber.php` has a single large `notify()` method. It runs:
+
+- `Mockery::close()`;
+- Carbon, container, coroutine context, model, routing, view, support, testing, and other framework static cleanup;
+- optional first-party package cleanup methods at the bottom through `callIfExists()`.
+
+The optional first-party cleanup methods are intentionally grouped at the bottom:
+
+```php
+$this->flushFortifyState();
+$this->flushHorizonState();
+$this->flushInertiaState();
+$this->flushNestedSetState();
+$this->flushPasskeysState();
+$this->flushPermissionState();
+$this->flushReverbState();
+$this->flushSanctumState();
+$this->flushScoutState();
+$this->flushSentryState();
+$this->flushTelescopeState();
+$this->flushTestbenchState();
+$this->flushWayfinderState();
+```
+
+This works for framework-owned classes and first-party optional packages that the framework knows about. It does not give third-party packages or apps a clean, automatic place to register their own static cleanup.
+
+### Package Manifest
+
+`src/foundation/src/PackageManifest.php` currently mixes two responsibilities inside `build()`:
+
+1. Scan `vendor/composer/installed.json`, read each package's `extra.hypervel` metadata, merge `dont-discover`, and append package `version`.
+2. Write the resulting manifest to disk.
+
+The scan details currently live only inside `build()`:
+
+```php
+$packages = [];
+
+if ($this->files->exists($path = $this->vendorPath . '/composer/installed.json')) {
+    $installed = json_decode($this->files->get($path), true);
+
+    $packages = $installed['packages'] ?? $installed;
+}
+
+$ignore = $this->packagesToIgnore();
+
+$manifest = (new Collection($packages))->mapWithKeys(function (array $package) {
+    return [$this->format($package['name']) => [
+        ...($package['extra']['hypervel'] ?? []),
+        'version' => $package['version'] ?? null,
+    ]];
+})->each(function (array $configuration) use (&$ignore) {
+    $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
+})->reject(function (array $configuration, string $package) use ($ignore) {
+    return in_array($package, $ignore, true);
+})->filter()->all();
+```
+
+The testing package needs the scan result at PHPUnit extension bootstrap, but it must not call `build()` because `build()` writes to `bootstrap/cache`. Package test repos and partial installs may not have that directory or may not want writes during extension bootstrap.
+
+### Application Skeleton
+
+`contrib/hypervel/hypervel/phpunit.xml` currently has:
+
+```xml
+bootstrap="vendor/autoload.php"
+```
+
+It has no `<extensions>` block and does not register `Hypervel\Testing\PHPUnit\AfterEachTestExtension`. Apps generated from the skeleton therefore run zero framework static-state cleanup between tests. Framework statics such as the container instance, coroutine context, Carbon test time, model caches, macros, and facade resolved instances can leak across an app test suite.
+
+The components repo and the private package repos already register `AfterEachTestExtension` in `phpunit.xml.dist`. The missing artifact is the app skeleton.
+
+### Documentation
+
+`src/boost/docs/testing.md` currently tells users to manually flush `Collection` macros in `tearDown()`:
+
+```php
+protected function tearDown(): void
+{
+    Collection::flushMacros();
+
+    parent::tearDown();
+}
+```
+
+That advice is stale for framework classes. `Hypervel\Support\Collection::flushState()` already clears macros and proxies, and `AfterEachTestSubscriber` already calls `\Hypervel\Support\Collection::flushState()`. The docs should instead explain:
+
+- framework cleanup is automatic when the testing extension is registered;
+- app-owned or package-owned macroable/static state should be registered through the new cleanup API;
+- app developers should not duplicate cleanup for framework classes already handled by Hypervel.
+
+## Decisions
+
+### Use A Registry For After-Each Cleanup Callbacks
+
+Add `Hypervel\Testing\PHPUnit\AfterEachTestCleanup`.
+
+The registry owns callbacks that run after every test. Registrations are process-local and persist for the PHPUnit worker lifetime. It is a test bootstrap API, not application runtime API.
+
+Proposed shape:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Testing\PHPUnit;
+
+use Closure;
+use Throwable;
+
+class AfterEachTestCleanup
+{
+    /**
+     * The registered after-each cleanup callbacks.
+     *
+     * @var array<string, Closure(): void>
+     */
+    protected static array $callbacks = [];
+
+    /**
+     * Register a callback to flush test state after every test.
+     *
+     * Boot or tests only. The callback persists in static state for the
+     * PHPUnit worker lifetime and runs after every subsequent test.
+     */
+    public static function flushUsing(string $name, callable $callback): void
+    {
+        static::$callbacks[$name] = Closure::fromCallable($callback);
+    }
+
+    /**
+     * Run registered callbacks.
+     *
+     * @throws Throwable
+     */
+    public static function runCallbacks(): void
+    {
+        /** @var Throwable|null $exception */
+        $exception = null;
+
+        foreach (static::$callbacks as $callback) {
+            try {
+                $callback();
+            } catch (Throwable $throwable) {
+                $exception ??= $throwable;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Forget all registered callbacks.
+     *
+     * Boot or tests only. This removes process-local cleanup registrations
+     * for the current PHPUnit worker, including callbacks discovered from
+     * app and package metadata.
+     */
+    public static function forgetCallbacks(): void
+    {
+        static::$callbacks = [];
+    }
+}
+```
+
+Important details:
+
+- The name is required. This makes registration idempotent by construction and avoids append-only growth if a registrar runs more than once.
+- Package-owned names should be Composer package names such as `vendor/package`.
+- App-owned names may use `app`.
+- Last registration for a name wins.
+- Unique root app callbacks register after package callbacks, so they run after package callbacks and before framework cleanup.
+- `runCallbacks()` continues through all callbacks if one throws, then rethrows the first exception. This prevents one broken package cleanup callback from suppressing another package's cleanup.
+- Do not add `AfterEachTestCleanup` to the framework subscriber's flush list. Calling `forgetCallbacks()` after every test would erase suite-level registrations and silently disable app/package cleanup after the first test. Add a short class-level comment explaining that this class intentionally does not expose `flushState()` and should not be included in `AfterEachTestSubscriber`.
+
+### Run Custom Cleanup Before Framework Cleanup
+
+Refactor `AfterEachTestSubscriber` so `notify()` delegates to a method that can be tested directly:
+
+```php
+/**
+ * Clean up static state after a test finishes.
+ */
+public function notify(Finished $event): void
+{
+    $this->flushStateAfterTest();
+}
+
+/**
+ * Flush all test state after a test finishes.
+ */
+public function flushStateAfterTest(): void
+{
+    try {
+        AfterEachTestCleanup::runCallbacks();
+    } finally {
+        $this->flushFrameworkState();
+    }
+}
+
+/**
+ * Flush framework-owned static state.
+ */
+protected function flushFrameworkState(): void
+{
+    // Existing notify() body moves here.
+}
+```
+
+Custom callbacks run before framework cleanup because app/package cleanup may need framework services, facades, the container, context, or other framework state while cleaning itself up. The framework cleanup then gets the last pass.
+
+If a custom callback throws and framework cleanup also throws inside the `finally`, PHP will surface the framework cleanup exception. That double-fault behavior is acceptable because framework cleanup must still be attempted, and a framework cleanup failure is itself a suite-level failure that needs fixing.
+
+Keep the optional first-party package cleanup methods together at the bottom of `flushFrameworkState()`, preserving the current layout.
+
+### Discover Package And App Registrars At PHPUnit Extension Bootstrap
+
+Do not register package cleanup from service providers.
+
+Provider-based registration fails in normal Paratest scenarios:
+
+- `Hypervel\Tests\TestCase` unit tests do not boot an application.
+- A Paratest worker can receive only app-less unit test files.
+- In that worker, package providers never run.
+- Any provider-registered cleanup would be missing until an app-booting test happens to run in the same worker.
+
+Package cleanup must be discovered and registered by `AfterEachTestExtension::bootstrap()` because the PHPUnit extension runs at worker bootstrap before the first test, independent of application boot.
+
+Add a small discoverer class in the testing package, for example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Testing\PHPUnit;
+
+use Composer\InstalledVersions;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Foundation\PackageManifest;
+use Hypervel\Support\Env;
+use RuntimeException;
+
+class TestStateRegistrars
+{
+    /**
+     * The filesystem instance.
+     */
+    protected Filesystem $files;
+
+    /**
+     * Create a test-state registrar discoverer.
+     */
+    public function __construct(
+        protected string $basePath,
+        protected string $vendorPath,
+        ?Filesystem $files = null
+    ) {
+        $this->files = $files ?? new Filesystem;
+    }
+
+    /**
+     * Create a discoverer for the current Composer root install.
+     */
+    public static function forRootInstall(): static
+    {
+        $basePath = static::installedRootPath();
+
+        return new static(
+            $basePath,
+            Env::get('COMPOSER_VENDOR_DIR') ?: $basePath . '/vendor'
+        );
+    }
+
+    /**
+     * Register discovered test-state registrars.
+     */
+    public function register(): void
+    {
+        foreach ($this->registrars() as $source => $classes) {
+            foreach ((array) $classes as $class) {
+                $this->registerClass($source, $class);
+            }
+        }
+    }
+
+    /**
+     * Get root test-state registrar classes.
+     *
+     * @return array<int, class-string>
+     */
+    protected function rootRegistrars(): array
+    {
+        $path = $this->basePath . '/composer.json';
+
+        if (! $this->files->isFile($path)) {
+            return [];
+        }
+
+        $composer = json_decode(
+            $this->files->get($path),
+            true
+        );
+
+        if (! is_array($composer)) {
+            return [];
+        }
+
+        return (array) ($composer['extra']['hypervel']['test-state'] ?? []);
+    }
+
+    /**
+     * Get registrar classes keyed by their source package.
+     *
+     * @return array<string, array<int, class-string>>
+     */
+    protected function registrars(): array
+    {
+        $registrars = [];
+        $baseIgnore = PackageManifest::packagesToIgnoreFromComposer($this->files, $this->basePath);
+
+        foreach (PackageManifest::discoverInstalledPackages($this->files, $this->vendorPath, $baseIgnore) as $package => $configuration) {
+            if (isset($configuration['test-state'])) {
+                $registrars[$package] = (array) $configuration['test-state'];
+            }
+        }
+
+        $rootRegistrars = $this->rootRegistrars();
+
+        if ($rootRegistrars !== []) {
+            $registrars['root'] = $rootRegistrars;
+        }
+
+        return $registrars;
+    }
+
+    /**
+     * Register one registrar class.
+     */
+    protected function registerClass(string $source, string $class): void
+    {
+        if (! class_exists($class)) {
+            throw new RuntimeException(
+                "Test-state registrar [{$class}] declared by [{$source}] does not exist. Check that it is in normal autoload, not dependency autoload-dev."
+            );
+        }
+
+        if (! method_exists($class, 'register')) {
+            throw new RuntimeException(
+                "Test-state registrar [{$class}] declared by [{$source}] must define a register method."
+            );
+        }
+
+        $class::register();
+    }
+}
+```
+
+The implementation should include the needed root path helper. The vendor path must be computed the same way as `Hypervel\Foundation\PackageManifest`, honoring `COMPOSER_VENDOR_DIR` before falling back to `$basePath . '/vendor'`; do not derive a separate vendor path by reflecting Composer internals.
+
+```php
+/**
+ * Get the Composer root package path.
+ */
+protected static function installedRootPath(): string
+{
+    $rootPackage = InstalledVersions::getRootPackage();
+    $basePath = $rootPackage['install_path'] ?? getcwd();
+
+    if (! is_string($basePath) || $basePath === '') {
+        $currentPath = getcwd();
+        $basePath = $currentPath === false ? '.' : $currentPath;
+    }
+
+    $realPath = realpath($basePath);
+
+    return $realPath === false ? $basePath : $realPath;
+}
+```
+
+The implementation must satisfy static analysis. If a value has already been proven locally but phpstan cannot infer it, use clear local structure or a local `@var` assertion rather than defensive runtime clutter.
+
+Register the discoverer from the extension:
+
+```php
+public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+{
+    TestStateRegistrars::forRootInstall()->register();
+
+    $facade->registerSubscriber(new AfterEachTestSubscriber);
+}
+```
+
+Discovery order is stable:
+
+1. Package registrars in the order returned by Composer's `installed.json` after `dont-discover` filtering.
+2. Root app/package registrars from root `composer.json` last.
+
+Callbacks registered by root app registrars therefore run after package callbacks when they use unique names. Duplicate callback names are last-wins; use package-scoped names to avoid accidental replacement.
+
+### Use `extra.hypervel.test-state`
+
+Packages declare registrar classes in their normal package `composer.json` metadata:
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "Vendor\\Package\\": "src/"
+        }
+    },
+    "extra": {
+        "hypervel": {
+            "providers": [
+                "Vendor\\Package\\PackageServiceProvider"
+            ],
+            "test-state": [
+                "Vendor\\Package\\Testing\\TestState"
+            ]
+        }
+    }
+}
+```
+
+Package registrars must live in the package's normal source autoload, not `autoload-dev`, because consuming apps do not load dependency dev autoloaders.
+
+A package registrar should aggregate that package's cleanup:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\Package\Testing;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+use Vendor\Package\Support\InvoiceNumbers;
+use Vendor\Package\Support\ReceiptMacros;
+use Vendor\Package\Support\TaxRates;
+
+class TestState
+{
+    /**
+     * Register package test-state cleanup.
+     */
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('vendor/package', fn () => static::flushState());
+    }
+
+    /**
+     * Flush package static state.
+     */
+    public static function flushState(): void
+    {
+        InvoiceNumbers::flushState();
+        TaxRates::flushState();
+        ReceiptMacros::flushState();
+    }
+}
+```
+
+For monopackages with many internal sub-packages, use one registrar class and one Composer metadata entry. The registrar may internally group optional cleanup:
+
+```php
+public static function flushState(): void
+{
+    static::flushCoreState();
+    static::flushAuthState();
+    static::flushBillingState();
+}
+
+protected static function flushBillingState(): void
+{
+    static::callIfExists(BillingManager::class, 'flushState');
+}
+```
+
+Optional checks belong inside the owning registrar. The discovery layer only validates the declared registrar class itself.
+
+Root apps and root package repos declare their own registrars in root `composer.json`:
+
+```json
+"extra": {
+    "hypervel": {
+        "dont-discover": [],
+        "test-state": [
+            "Tests\\Support\\TestState"
+        ]
+    }
+}
+```
+
+The root class may live under root `autoload-dev` because the root dev autoload is loaded during tests:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+
+class TestState
+{
+    /**
+     * Register application test-state cleanup.
+     */
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('app', fn () => static::flushState());
+    }
+
+    /**
+     * Flush application static state.
+     */
+    public static function flushState(): void
+    {
+        //
+    }
+}
+```
+
+### Declare Direct Testing Package Dependencies
+
+Update `src/testing/composer.json` to require `hypervel/filesystem` directly.
+
+The testing package already imports filesystem classes indirectly through existing cleanup calls, and the registrar discoverer will use `Hypervel\Filesystem\Filesystem` directly. `hypervel/testing` currently receives filesystem transitively through `hypervel/foundation`; the final package metadata should declare its direct imports instead of relying on transitive resolution.
+
+The monorepo root `composer.json` already replaces `hypervel/filesystem` and `hypervel/testing`, so the split package composer file is the important dependency surface for this change.
+
+### Fail Fast Only For Declared Broken Registrars
+
+The discovery layer should distinguish missing metadata files from broken declared metadata:
+
+- Missing root `composer.json` or missing `vendor/composer/installed.json`: degrade to framework cleanup only.
+- Malformed root `composer.json` or malformed `vendor/composer/installed.json`: degrade to framework cleanup only without emitting PHP warnings from chained array access.
+- A value named in `extra.hypervel.test-state` that is not a class name string: throw at PHPUnit bootstrap with the source package.
+- A class named in `extra.hypervel.test-state` that does not exist: throw at PHPUnit bootstrap with the class and source package.
+- A class named in `extra.hypervel.test-state` that lacks `register()`: throw at PHPUnit bootstrap with the class and source package.
+- A non-static `register()` method may fail naturally when called statically. Reflection is not required unless the implementation chooses to improve the error message without adding clutter.
+
+This keeps partial package repos and CI states resilient while making real package/app metadata bugs obvious.
+
+### Extract No-Write Package Discovery From `PackageManifest`
+
+Add a pure helper to `Hypervel\Foundation\PackageManifest`:
+
+```php
+/**
+ * Discover installed Hypervel package metadata.
+ *
+ * @param array<int, string> $baseIgnore
+ */
+public static function discoverInstalledPackages(Filesystem $files, string $vendorPath, array $baseIgnore): array
+{
+    $packages = [];
+
+    if ($files->exists($path = $vendorPath . '/composer/installed.json')) {
+        $installed = json_decode($files->get($path), true);
+
+        if (is_array($installed)) {
+            $packages = $installed['packages'] ?? $installed;
+        }
+    }
+
+    $ignore = $baseIgnore;
+
+    return (new Collection($packages))->mapWithKeys(function (array $package) use ($vendorPath) {
+        return [static::formatPackageName($package['name'], $vendorPath) => [
+            ...($package['extra']['hypervel'] ?? []),
+            'version' => $package['version'] ?? null,
+        ]];
+    })->each(function (array $configuration) use (&$ignore) {
+        $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
+    })->reject(function (array $configuration, string $package) use ($ignore) {
+        return in_array($package, $ignore, true);
+    })->filter()->all();
+}
+```
+
+Then make `build()` a write-through caller:
+
+```php
+/**
+ * Build the manifest and write it to disk.
+ */
+public function build(): void
+{
+    $manifest = static::discoverInstalledPackages(
+        $this->files,
+        $this->vendorPath,
+        $this->packagesToIgnore()
+    );
+
+    $this->write($manifest);
+
+    $this->manifest = $manifest;
+    $this->rawManifest = $manifest;
+}
+```
+
+The helper must keep `build()` output byte-identical for existing fixtures:
+
+- same `vendor/composer/installed.json` handling;
+- same `$installed['packages'] ?? $installed`;
+- same root `extra.hypervel.dont-discover`;
+- same per-package `dont-discover` merge before filtering;
+- same package name formatting;
+- same `version` key appended to every package configuration;
+- same inclusion of version-only packages unless they are ignored.
+- same virtual `packagesToIgnore()` dispatch from `build()`.
+- malformed JSON handled without PHP warnings.
+
+The static helper must take the initial ignore list as an argument. Do not make it read root `composer.json` directly. `Hypervel\Testbench\Foundation\PackageManifest` overrides `packagesToIgnore()` to return `[]` during build so testbench can manage package ignores at read time. `build()` must keep calling `$this->packagesToIgnore()` and pass that result into the static helper, preserving testbench's override.
+
+Add helper methods only where they remove real duplication:
+
+```php
+/**
+ * Format the given package name.
+ */
+protected static function formatPackageName(string $package, string $vendorPath): string
+{
+    return str_replace($vendorPath . '/', '', $package);
+}
+
+/**
+ * Get the package names ignored by root composer metadata.
+ *
+ * @return array<int, string>
+ */
+public static function packagesToIgnoreFromComposer(Filesystem $files, string $basePath): array
+{
+    if (! $files->isFile($basePath . '/composer.json')) {
+        return [];
+    }
+
+    $composer = json_decode($files->get(
+        $basePath . '/composer.json'
+    ), true);
+
+    if (! is_array($composer)) {
+        return [];
+    }
+
+    return $composer['extra']['hypervel']['dont-discover'] ?? [];
+}
+```
+
+Keep the existing `format()` instance method because `Hypervel\Testbench\Foundation\PackageManifest::providersFromRoot()` calls it. Update `format()` to delegate to `static::formatPackageName($package, $this->vendorPath)` if useful, but do not remove it.
+
+Keep the existing `packagesToIgnore()` instance method as the virtual seam that `build()` calls. It may delegate to `static::packagesToIgnoreFromComposer($this->files, $this->basePath)`, but it must remain overridable so testbench's override keeps working.
+
+### Update The Application Skeleton
+
+Update `contrib/hypervel/hypervel/phpunit.xml` to register the after-each cleanup extension:
+
+```xml
+<extensions>
+    <bootstrap class="Hypervel\Testing\PHPUnit\AfterEachTestExtension" />
+</extensions>
+```
+
+Do not replace `bootstrap="vendor/autoload.php"` with a custom `tests/bootstrap.php`. Composer root metadata discovery means apps do not need another bootstrap file just to register cleanup.
+
+Update `contrib/hypervel/hypervel/composer.json`:
+
+```json
+"extra": {
+    "hypervel": {
+        "dont-discover": [],
+        "test-state": [
+            "Tests\\Support\\TestState"
+        ]
+    }
+}
+```
+
+Add `contrib/hypervel/hypervel/tests/Support/TestState.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+
+class TestState
+{
+    /**
+     * Register application test-state cleanup.
+     */
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('app', fn () => static::flushState());
+    }
+
+    /**
+     * Flush application static state.
+     */
+    public static function flushState(): void
+    {
+        //
+    }
+}
+```
+
+This class is intentionally empty in the skeleton. It gives app developers a wired place to add cleanup without exposing PHPUnit extension internals.
+
+The app skeleton currently also does not enable `SlowTestExtension`. That is a separate skeleton policy decision, not part of state cleanup correctness. During implementation, surface that decision to the owner before making any slow-test skeleton change.
+
+### Update Documentation
+
+Update `src/boost/docs/testing.md`.
+
+Add a "Test State Cleanup" section near "Running Tests in Coroutines" and before "Macro State":
+
+~~~md
+<a name="test-state-cleanup"></a>
+### Test State Cleanup
+
+Hypervel applications keep framework objects, static caches, macros, and manager state in memory for the life of the PHP process. During tests, Hypervel's PHPUnit extension flushes framework-owned state after every test method.
+
+If your application has its own worker-lifetime state, add its cleanup to `tests/Support/TestState.php`. Use this class as one application-level entry point that aggregates the cleanup for any stateful classes your app owns:
+
+```php
+namespace Tests\Support;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+
+class TestState
+{
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('app', fn () => static::flushState());
+    }
+
+    public static function flushState(): void
+    {
+        InvoiceNumbers::flushState();
+        TaxRates::flushState();
+        ReceiptMacros::flushState();
+    }
+}
+```
+
+Callbacks registered by your app run after package cleanup callbacks and before Hypervel flushes framework state. This means framework services are still available while your callback runs, then Hypervel tears them down immediately after.
+
+Do not call `AfterEachTestCleanup::forgetCallbacks()` from ordinary application tests. That method clears all registered callbacks for the current PHPUnit worker, including callbacks discovered from application and package metadata.
+~~~
+
+Document package authors in `src/boost/docs/packages.md` because `extra.hypervel.test-state` is package metadata. Place this as a `### Test State Cleanup` section near package discovery metadata and add it to the page's section list.
+
+~~~md
+<a name="test-state-cleanup"></a>
+### Test State Cleanup
+
+Packages that keep worker-lifetime state for tests may declare a test-state registrar:
+
+```json
+"extra": {
+    "hypervel": {
+        "test-state": [
+            "Vendor\\Package\\Testing\\TestState"
+        ]
+    }
+}
+```
+
+The registrar must be autoloadable from the package's normal `autoload` section and must define `register()`. Use the registrar as one package-level entry point that aggregates the cleanup for any stateful classes your package owns:
+
+```php
+namespace Vendor\Package\Testing;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+
+class TestState
+{
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('vendor/package', fn () => static::flushState());
+    }
+
+    public static function flushState(): void
+    {
+        InvoiceNumbers::flushState();
+        TaxRates::flushState();
+        ReceiptMacros::flushState();
+    }
+}
+```
+
+Use your Composer package name as the callback name. Registrar classes are discovered during PHPUnit extension bootstrap, so package cleanup runs even in workers that only execute unit tests and never boot a Hypervel application.
+~~~
+
+Replace the current `Collection::flushMacros()` example in "Macro State" with app-owned macroable guidance:
+
+```md
+Hypervel already flushes framework macroable classes such as `Collection`, `ResponseFactory`, `View\Factory`, and testing helpers after every test. Do not add teardown cleanup for framework classes already handled by Hypervel.
+
+If your application or package defines its own macroable class and registers temporary macros inside a test, add that class to your test-state cleanup.
+```
+
+Also update the table of contents.
+
+### Update AGENTS.md If Implementation Changes The Pattern
+
+After implementation, update `contrib/hypervel/components/AGENTS.md` only where its current guidance becomes stale.
+
+The current "Static State and Test Cleanup" section says:
+
+- `AfterEachTestSubscriber` handles global cleanup.
+- When porting source classes that use static properties, add `flushState()`.
+- Check whether the subscriber should call it.
+
+After the new API exists, keep the framework guidance but add package/app guidance:
+
+- framework-owned classes still go in `AfterEachTestSubscriber`;
+- first-party optional framework packages may remain in grouped optional methods at the bottom of the subscriber;
+- third-party packages and app/private package repos should use `extra.hypervel.test-state` and `TestState` registrars;
+- do not add `AfterEachTestCleanup` itself to the subscriber's flush list.
+
+This prevents future contributors from hardcoding private/third-party cleanup into the framework subscriber.
+
+## Implementation Steps
+
+1. Read current `AfterEachTestExtension`, `AfterEachTestSubscriber`, `PackageManifest`, app skeleton `phpunit.xml`, app skeleton `composer.json`, `testing.md`, and `packages.md` before editing.
+2. Add `src/testing/src/PHPUnit/AfterEachTestCleanup.php`.
+3. Add tests for `AfterEachTestCleanup` under `tests/Testing/PHPUnit/AfterEachTestCleanupTest.php`.
+4. Refactor `AfterEachTestSubscriber`:
+   - `notify()` delegates to `flushStateAfterTest()`;
+   - `flushStateAfterTest()` runs custom callbacks before framework cleanup;
+   - existing framework cleanup body moves to `flushFrameworkState()`;
+   - optional package methods stay grouped at the bottom.
+5. Add tests for subscriber callback ordering and failure behavior under `tests/Testing/PHPUnit/AfterEachTestSubscriberTest.php`.
+6. Add `hypervel/filesystem` as a direct dependency in `src/testing/composer.json`.
+7. Extract `PackageManifest::discoverInstalledPackages()`.
+8. Update `PackageManifest::build()` to call the helper through `$this->packagesToIgnore()` and keep cached output identical.
+9. Add/adjust Foundation and Testbench package manifest tests for the pure helper, byte-identical build output, and preserved testbench ignore behavior.
+10. Add `src/testing/src/PHPUnit/TestStateRegistrars.php` or equivalent discoverer.
+11. Update `AfterEachTestExtension` to run registrar discovery before registering the subscriber.
+12. Add tests for registrar discovery:
+    - package registrars from `extra.hypervel.test-state`;
+    - root registrars from root `composer.json`;
+    - package registrars run before root registrars;
+    - missing `composer.json` and missing `installed.json` degrade cleanly;
+    - declared missing registrar class throws a clear exception;
+    - declared registrar without `register()` throws a clear exception;
+    - duplicate callback names are idempotent and last-wins.
+13. Update app skeleton:
+    - add `AfterEachTestExtension` to `phpunit.xml`;
+    - add root `extra.hypervel.test-state`;
+    - add `tests/Support/TestState.php`.
+14. Surface the `SlowTestExtension` skeleton decision to the owner before making any slow-test skeleton change.
+15. Update `src/boost/docs/testing.md`.
+16. Update `src/boost/docs/packages.md`.
+17. Update `AGENTS.md` cleanup guidance and correct the stale `tests/AfterEachTestSubscriber.php` path to `src/testing/src/PHPUnit/AfterEachTestSubscriber.php`.
+18. Run focused tests after each changed test file.
+19. Run the app skeleton test command from `contrib/hypervel/hypervel` after changing the skeleton.
+20. Run `composer fix` from `contrib/hypervel/components`.
+21. Do a full self-review of all changes, tracing discovery, registration, callback execution, manifest scanning, skeleton config, and docs.
+22. Request code review from Claude and loop until signoff.
+
+## Testing Plan
+
+### AfterEachTestCleanup
+
+Create `tests/Testing/PHPUnit/AfterEachTestCleanupTest.php`.
+
+The test class should call `AfterEachTestCleanup::forgetCallbacks()` in `tearDown()` because the registry intentionally persists for the PHPUnit worker lifetime.
+
+Assertions:
+
+- `flushUsing()` registers callbacks by name.
+- `runCallbacks()` executes callbacks in registration order.
+- callbacks persist across multiple `runCallbacks()` calls.
+- registering the same name replaces the callback.
+- unique root/app callback registered after package callback runs after package callback.
+- `forgetCallbacks()` clears all callbacks.
+- if one callback throws, later callbacks still run and the first exception is rethrown.
+
+Run immediately after creating the file:
+
+```shell
+cd contrib/hypervel/components
+./vendor/bin/phpunit --no-progress tests/Testing/PHPUnit/AfterEachTestCleanupTest.php
+```
+
+### AfterEachTestSubscriber
+
+Create `tests/Testing/PHPUnit/AfterEachTestSubscriberTest.php`.
+
+The test class should call `AfterEachTestCleanup::forgetCallbacks()` in `tearDown()` and reset any framework state it mutates if the assertion fails before the subscriber cleanup runs.
+
+Assertions:
+
+- `flushStateAfterTest()` runs custom callbacks before framework cleanup.
+- framework cleanup still runs when a custom callback throws.
+- the thrown callback exception still surfaces after cleanup.
+
+Do not call the real `flushFrameworkState()` from this test. It clears the container instance, coroutine context, facade resolved instances, and other state that the test process itself is using. Instead, test ordering and `finally` behavior with an anonymous subclass:
+
+```php
+$subscriber = new class extends AfterEachTestSubscriber {
+    /**
+     * The observed cleanup order.
+     *
+     * @var array<int, string>
+     */
+    public array $order = [];
+
+    /**
+     * Flush framework-owned static state.
+     */
+    protected function flushFrameworkState(): void
+    {
+        $this->order[] = 'framework';
+    }
+};
+
+AfterEachTestCleanup::flushUsing('probe', function () use ($subscriber): void {
+    $subscriber->order[] = 'custom';
+});
+
+$subscriber->flushStateAfterTest();
+
+$this->assertSame(['custom', 'framework'], $subscriber->order);
+```
+
+Do not construct PHPUnit's `Finished` event; test the direct method. The real `flushFrameworkState()` body is exercised by the global subscriber during the suite.
+
+Run immediately:
+
+```shell
+cd contrib/hypervel/components
+./vendor/bin/phpunit --no-progress tests/Testing/PHPUnit/AfterEachTestSubscriberTest.php
+```
+
+### PackageManifest
+
+Extend `tests/Foundation/FoundationPackageManifestTest.php`.
+
+Assertions:
+
+- `PackageManifest::discoverInstalledPackages(new Filesystem, $vendorPath, $baseIgnore)` returns the same manifest array that `build()` writes for the existing fixture when `$baseIgnore` comes from root composer metadata.
+- the helper handles Composer 2 object format using the current fixture.
+- add a small bare-array `installed.json` fixture or temporary file if no existing test covers legacy bare-array format.
+- root `dont-discover` and package `dont-discover` still filter the same packages.
+- version keys remain present.
+- version-only packages remain present unless filtered, matching current behavior.
+- missing `installed.json` returns `[]` and does not write.
+- malformed `installed.json` returns `[]` without PHP warnings.
+- malformed root `composer.json` yields an empty base ignore list without PHP warnings.
+- `Hypervel\Testbench\Foundation\PackageManifest` still bypasses root `dont-discover` during build through its `packagesToIgnore()` override.
+- `Hypervel\Testbench\Foundation\PackageManifest::providersFromRoot()` still works because `format()` remains available.
+
+Run immediately:
+
+```shell
+cd contrib/hypervel/components
+./vendor/bin/phpunit --no-progress tests/Foundation/FoundationPackageManifestTest.php
+```
+
+### TestStateRegistrars
+
+Create `tests/Testing/PHPUnit/TestStateRegistrarsTest.php`.
+
+The test class should call `AfterEachTestCleanup::forgetCallbacks()` in `tearDown()` because registrar tests intentionally mutate the cleanup registry.
+
+Use temporary Composer roots under `ParallelTesting::tempDir()` rather than writing to committed fixtures, unless a small static fixture is clearer and read-only. Construct `TestStateRegistrars` directly with the temp root and temp vendor path; do not rely on `InstalledVersions::getRootPackage()` in unit tests.
+
+The test root should contain:
+
+- root `composer.json`;
+- `vendor/composer/installed.json`;
+- fixture registrar classes autoloadable from the test suite.
+
+Assertions:
+
+- package registrar classes listed in package `extra.hypervel.test-state` have `register()` called.
+- root `extra.hypervel.test-state` registrar is called after package registrars.
+- package `dont-discover` suppresses package test-state discovery consistently with provider discovery.
+- root `dont-discover` suppresses package test-state discovery but not root test-state.
+- missing `composer.json` does not throw.
+- missing `vendor/composer/installed.json` does not throw.
+- malformed root `composer.json` and malformed `vendor/composer/installed.json` do not emit PHP warnings.
+- missing declared registrar class throws a `RuntimeException` naming the class and source package.
+- declared registrar class without `register()` throws a `RuntimeException` naming the class and source package.
+- `forRootInstall()` honors `COMPOSER_VENDOR_DIR`.
+
+Run immediately:
+
+```shell
+cd contrib/hypervel/components
+./vendor/bin/phpunit --no-progress tests/Testing/PHPUnit/TestStateRegistrarsTest.php
+```
+
+### Application Skeleton
+
+The app skeleton is a sibling repository at `contrib/hypervel/hypervel`, not the committed testbench skeleton under `src/testbench/hypervel`. Do not add a components test that depends on a sibling checkout being present in upstream CI.
+
+Verify the skeleton directly after updating it:
+
+```shell
+cd contrib/hypervel/hypervel
+composer test
+```
+
+Also inspect these files during self-review:
+
+- `phpunit.xml` contains `Hypervel\Testing\PHPUnit\AfterEachTestExtension`;
+- root `composer.json` lists `Tests\\Support\\TestState` under `extra.hypervel.test-state`;
+- `tests/Support/TestState.php` exists and registers the `app` callback.
+
+### Documentation And Static Analysis
+
+After code and docs are updated:
+
+```shell
+cd contrib/hypervel/components
+composer fix
+```
+
+`composer fix` runs php-cs-fixer, phpstan, and the parallel test suite in the configured order.
+
+## Self-Review Checklist
+
+Before requesting code review:
+
+- Re-read `AfterEachTestCleanup` and confirm it does not have `flushState()` and is not called by the subscriber's framework cleanup list.
+- Trace `AfterEachTestExtension::bootstrap()` and confirm registrar discovery happens before the subscriber is registered.
+- Trace `TestStateRegistrars` with:
+  - normal app root;
+  - package repo root;
+  - missing root `composer.json`;
+  - missing `vendor/composer/installed.json`;
+  - bad declared registrar class;
+  - class with missing `register()`;
+  - duplicate callback names.
+- Trace `PackageManifest::build()` and verify the cache array is unchanged for existing fixtures.
+- Confirm package discovery and provider/alias discovery still use one owner for installed package scan semantics.
+- Confirm root `test-state` is read separately from installed package metadata.
+- Confirm `dont-discover` affects package registrars consistently with providers and aliases.
+- Confirm root `test-state` still registers even when root `dont-discover` disables all package discovery.
+- Confirm custom callbacks run before framework cleanup and framework cleanup still runs when a custom callback throws.
+- Confirm docs do not tell users to manually flush framework macro state in `tearDown()`.
+- Confirm app skeleton tests use the generated `Tests\Support\TestState` class and no custom `tests/bootstrap.php`.
+- Confirm no stale comments, workaround language, old API names such as `test-cleanup`, or dead helpers remain.

--- a/src/boost/docs/packages.md
+++ b/src/boost/docs/packages.md
@@ -3,6 +3,7 @@
 - [Introduction](#introduction)
     - [A Note on Facades](#a-note-on-facades)
 - [Package Discovery](#package-discovery)
+    - [Test State Cleanup](#test-state-cleanup)
 - [Inspecting Installed Packages](#inspecting-installed-packages)
 - [Service Providers](#service-providers)
     - [Provider Priority](#provider-priority)
@@ -85,6 +86,48 @@ You may disable package discovery for all packages using the `*` character insid
     }
 },
 ```
+
+<a name="test-state-cleanup"></a>
+### Test State Cleanup
+
+Packages that keep worker-lifetime state for tests may declare a test-state registrar:
+
+```json
+"extra": {
+    "hypervel": {
+        "test-state": [
+            "Vendor\\Package\\Testing\\TestState"
+        ]
+    }
+}
+```
+
+The registrar must be autoloadable from the package's normal `autoload` section and must define `register()`. Use the registrar as one package-level entry point that aggregates the cleanup for any stateful classes your package owns:
+
+```php
+<?php
+
+namespace Vendor\Package\Testing;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+
+class TestState
+{
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('vendor/package', fn () => static::flushState());
+    }
+
+    public static function flushState(): void
+    {
+        InvoiceNumbers::flushState();
+        TaxRates::flushState();
+        ReceiptMacros::flushState();
+    }
+}
+```
+
+Use your Composer package name as the callback name. Registrar classes are discovered during PHPUnit extension bootstrap, so package cleanup runs even in workers that only execute unit tests and never boot a Hypervel application.
 
 <a name="inspecting-installed-packages"></a>
 ## Inspecting Installed Packages

--- a/src/boost/docs/testing.md
+++ b/src/boost/docs/testing.md
@@ -4,6 +4,7 @@
 - [Environment](#environment)
 - [Creating Tests](#creating-tests)
     - [Running Tests in Coroutines](#running-tests-in-coroutines)
+    - [Test State Cleanup](#test-state-cleanup)
     - [Macro State](#macro-state)
     - [Using Pest](#using-pest)
 - [Running Tests](#running-tests)
@@ -167,40 +168,48 @@ By default, Hypervel copies coroutine context values prepared outside the test m
 protected bool $copyNonCoroutineContext = false;
 ```
 
+<a name="test-state-cleanup"></a>
+### Test State Cleanup
+
+Hypervel applications keep framework objects, static caches, macros, and manager state in memory for the life of the PHP process. During tests, Hypervel's PHPUnit extension flushes framework-owned state after every test method.
+
+If your application has its own worker-lifetime state, add its cleanup to `tests/Support/TestState.php`. Use this class as one application-level entry point that aggregates the cleanup for any stateful classes your app owns:
+
+```php
+<?php
+
+namespace Tests\Support;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+
+class TestState
+{
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('app', fn () => static::flushState());
+    }
+
+    public static function flushState(): void
+    {
+        InvoiceNumbers::flushState();
+        TaxRates::flushState();
+        ReceiptMacros::flushState();
+    }
+}
+```
+
+Callbacks registered by your application run after package cleanup callbacks and before Hypervel flushes framework state. This means framework services are still available while your callback runs, then Hypervel tears them down immediately after.
+
+Do not call `AfterEachTestCleanup::forgetCallbacks()` from ordinary application tests. That method clears all registered callbacks for the current PHPUnit worker, including callbacks discovered from application and package metadata.
+
 <a name="macro-state"></a>
 ### Macro State
 
 Macroable classes store registered macros in static state for the life of the PHP process. Typically, macros should be registered during application boot from a [service provider](/docs/{{version}}/providers).
 
-If you register a temporary macro from inside a test, flush that class's macro state before the test finishes so the macro does not affect later tests in the same process:
+Hypervel already flushes framework macroable classes such as `Collection`, `ResponseFactory`, `View\Factory`, and testing helpers after every test. Do not add teardown cleanup for framework classes already handled by Hypervel.
 
-```php
-<?php
-
-namespace Tests\Feature;
-
-use Hypervel\Support\Collection;
-use Tests\TestCase;
-
-class CollectionMacroTest extends TestCase
-{
-    protected function tearDown(): void
-    {
-        Collection::flushMacros();
-
-        parent::tearDown();
-    }
-
-    public function test_collection_macro(): void
-    {
-        Collection::macro('summary', function () {
-            return $this->implode(', ');
-        });
-
-        $this->assertSame('first, second', collect(['first', 'second'])->summary());
-    }
-}
-```
+If your application or package defines its own macroable class and registers temporary macros inside a test, add that class to your test-state cleanup.
 
 <a name="using-pest"></a>
 ### Using Pest

--- a/src/foundation/composer.json
+++ b/src/foundation/composer.json
@@ -24,6 +24,7 @@
     ],
     "require": {
         "php": "^8.4",
+        "composer-runtime-api": "^2.2",
         "laravel/serializable-closure": "^2.0.10",
         "nesbot/carbon": "^3.8.4",
         "psr/clock": "^1.0",

--- a/src/foundation/src/PackageManifest.php
+++ b/src/foundation/src/PackageManifest.php
@@ -195,15 +195,27 @@ class PackageManifest
             $installed = json_decode($files->get($path), true);
 
             if (is_array($installed)) {
-                $packages = $installed['packages'] ?? $installed;
+                $installedPackages = $installed['packages'] ?? $installed;
+
+                if (is_array($installedPackages)) {
+                    $packages = $installedPackages;
+                }
             }
         }
 
         $ignore = $baseIgnore;
 
-        return (new Collection($packages))->mapWithKeys(function (array $package) use ($vendorPath) {
+        return (new Collection($packages))->filter(function (mixed $package): bool {
+            return is_array($package) && is_string($package['name'] ?? null);
+        })->mapWithKeys(function (array $package) use ($vendorPath) {
+            $configuration = $package['extra']['hypervel'] ?? [];
+
+            if (! is_array($configuration)) {
+                $configuration = [];
+            }
+
             return [static::formatPackageName($package['name'], $vendorPath) => [
-                ...($package['extra']['hypervel'] ?? []),
+                ...$configuration,
                 'version' => $package['version'] ?? null,
             ]];
         })->each(function (array $configuration) use (&$ignore) {
@@ -253,8 +265,18 @@ class PackageManifest
      */
     public static function packagesToIgnoreFromComposer(Filesystem $files, string $basePath): array
     {
+        $ignore = static::rootHypervelExtra($files, $basePath, 'dont-discover');
+
+        return is_array($ignore) ? $ignore : [];
+    }
+
+    /**
+     * Get a root Composer extra.hypervel value.
+     */
+    public static function rootHypervelExtra(Filesystem $files, string $basePath, string $key): mixed
+    {
         if (! $files->isFile($basePath . '/composer.json')) {
-            return [];
+            return null;
         }
 
         $composer = json_decode($files->get(
@@ -262,12 +284,10 @@ class PackageManifest
         ), true);
 
         if (! is_array($composer)) {
-            return [];
+            return null;
         }
 
-        $ignore = $composer['extra']['hypervel']['dont-discover'] ?? [];
-
-        return is_array($ignore) ? $ignore : [];
+        return $composer['extra']['hypervel'][$key] ?? null;
     }
 
     /**

--- a/src/foundation/src/PackageManifest.php
+++ b/src/foundation/src/PackageManifest.php
@@ -287,7 +287,13 @@ class PackageManifest
             return null;
         }
 
-        return $composer['extra']['hypervel'][$key] ?? null;
+        $hypervel = $composer['extra']['hypervel'] ?? null;
+
+        if (! is_array($hypervel)) {
+            return null;
+        }
+
+        return $hypervel[$key] ?? null;
     }
 
     /**

--- a/src/foundation/src/PackageManifest.php
+++ b/src/foundation/src/PackageManifest.php
@@ -183,30 +183,46 @@ class PackageManifest
     }
 
     /**
-     * Build the manifest and write it to disk.
+     * Discover installed Hypervel package metadata.
+     *
+     * @param array<int, string> $baseIgnore
      */
-    public function build(): void
+    public static function discoverInstalledPackages(Filesystem $files, string $vendorPath, array $baseIgnore): array
     {
         $packages = [];
 
-        if ($this->files->exists($path = $this->vendorPath . '/composer/installed.json')) {
-            $installed = json_decode($this->files->get($path), true);
+        if ($files->exists($path = $vendorPath . '/composer/installed.json')) {
+            $installed = json_decode($files->get($path), true);
 
-            $packages = $installed['packages'] ?? $installed;
+            if (is_array($installed)) {
+                $packages = $installed['packages'] ?? $installed;
+            }
         }
 
-        $ignore = $this->packagesToIgnore();
+        $ignore = $baseIgnore;
 
-        $manifest = (new Collection($packages))->mapWithKeys(function (array $package) {
-            return [$this->format($package['name']) => [
+        return (new Collection($packages))->mapWithKeys(function (array $package) use ($vendorPath) {
+            return [static::formatPackageName($package['name'], $vendorPath) => [
                 ...($package['extra']['hypervel'] ?? []),
                 'version' => $package['version'] ?? null,
             ]];
         })->each(function (array $configuration) use (&$ignore) {
-            $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
+            $ignore = array_merge($ignore, (array) ($configuration['dont-discover'] ?? []));
         })->reject(function (array $configuration, string $package) use ($ignore) {
-            return in_array($package, $ignore, true);
+            return in_array('*', $ignore, true) || in_array($package, $ignore, true);
         })->filter()->all();
+    }
+
+    /**
+     * Build the manifest and write it to disk.
+     */
+    public function build(): void
+    {
+        $manifest = static::discoverInstalledPackages(
+            $this->files,
+            $this->vendorPath,
+            $this->packagesToIgnore()
+        );
 
         $this->write($manifest);
 
@@ -219,7 +235,39 @@ class PackageManifest
      */
     protected function format(string $package): string
     {
-        return str_replace($this->vendorPath . '/', '', $package);
+        return static::formatPackageName($package, $this->vendorPath);
+    }
+
+    /**
+     * Format the given package name with the given vendor path.
+     */
+    protected static function formatPackageName(string $package, string $vendorPath): string
+    {
+        return str_replace($vendorPath . '/', '', $package);
+    }
+
+    /**
+     * Get the package names ignored by root composer metadata.
+     *
+     * @return array<int, string>
+     */
+    public static function packagesToIgnoreFromComposer(Filesystem $files, string $basePath): array
+    {
+        if (! $files->isFile($basePath . '/composer.json')) {
+            return [];
+        }
+
+        $composer = json_decode($files->get(
+            $basePath . '/composer.json'
+        ), true);
+
+        if (! is_array($composer)) {
+            return [];
+        }
+
+        $ignore = $composer['extra']['hypervel']['dont-discover'] ?? [];
+
+        return is_array($ignore) ? $ignore : [];
     }
 
     /**
@@ -231,13 +279,7 @@ class PackageManifest
      */
     protected function packagesToIgnore(): array
     {
-        if (! is_file($this->basePath . '/composer.json')) {
-            return [];
-        }
-
-        return json_decode(file_get_contents(
-            $this->basePath . '/composer.json'
-        ), true)['extra']['hypervel']['dont-discover'] ?? [];
+        return static::packagesToIgnoreFromComposer($this->files, $this->basePath);
     }
 
     /**

--- a/src/testbench/composer.json
+++ b/src/testbench/composer.json
@@ -24,6 +24,7 @@
     ],
     "require": {
         "php": "^8.4",
+        "composer-runtime-api": "^2.2",
         "mockery/mockery": "1.6.x-dev",
         "phpunit/phpunit": "^13.0.3",
         "symfony/yaml": "^8.0.12",

--- a/src/testing/composer.json
+++ b/src/testing/composer.json
@@ -31,6 +31,7 @@
     "require": {
         "php": "^8.4",
         "ext-dom": "*",
+        "composer-runtime-api": "^2.2",
         "mockery/mockery": "1.6.x-dev",
         "symfony/console": "^8.0",
         "symfony/http-foundation": "^8.0",

--- a/src/testing/composer.json
+++ b/src/testing/composer.json
@@ -43,6 +43,7 @@
         "hypervel/contracts": "^0.4",
         "hypervel/cookie": "^0.4",
         "hypervel/database": "^0.4",
+        "hypervel/filesystem": "^0.4",
         "hypervel/foundation": "^0.4",
         "hypervel/http": "^0.4",
         "hypervel/macroable": "^0.4",

--- a/src/testing/src/PHPUnit/AfterEachTestCleanup.php
+++ b/src/testing/src/PHPUnit/AfterEachTestCleanup.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Testing\PHPUnit;
+
+use Closure;
+use Throwable;
+
+/**
+ * Process-local after-each cleanup callbacks for apps and packages.
+ *
+ * This class intentionally does not expose `flushState()` and should not be
+ * added to `AfterEachTestSubscriber`; callbacks are suite-level registrations
+ * that must persist for the PHPUnit worker lifetime.
+ */
+class AfterEachTestCleanup
+{
+    /**
+     * The registered after-each cleanup callbacks.
+     *
+     * @var array<string, Closure(): void>
+     */
+    protected static array $callbacks = [];
+
+    /**
+     * Register a callback to flush test state after every test.
+     *
+     * Boot or tests only. The callback persists in static state for the
+     * PHPUnit worker lifetime and runs after every subsequent test.
+     */
+    public static function flushUsing(string $name, callable $callback): void
+    {
+        static::$callbacks[$name] = Closure::fromCallable($callback);
+    }
+
+    /**
+     * Run registered callbacks.
+     *
+     * @throws Throwable
+     */
+    public static function runCallbacks(): void
+    {
+        /** @var null|Throwable $exception */
+        $exception = null;
+
+        foreach (static::$callbacks as $callback) {
+            try {
+                $callback();
+            } catch (Throwable $throwable) {
+                $exception ??= $throwable;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Forget all registered callbacks.
+     *
+     * Boot or tests only. This removes process-local cleanup registrations
+     * for the current PHPUnit worker, including callbacks discovered from
+     * app and package metadata.
+     */
+    public static function forgetCallbacks(): void
+    {
+        static::$callbacks = [];
+    }
+}

--- a/src/testing/src/PHPUnit/AfterEachTestCleanup.php
+++ b/src/testing/src/PHPUnit/AfterEachTestCleanup.php
@@ -48,6 +48,7 @@ class AfterEachTestCleanup
             try {
                 $callback();
             } catch (Throwable $throwable) {
+                // Keep running cleanup, then surface the first failure as the root cause.
                 $exception ??= $throwable;
             }
         }

--- a/src/testing/src/PHPUnit/AfterEachTestExtension.php
+++ b/src/testing/src/PHPUnit/AfterEachTestExtension.php
@@ -9,12 +9,6 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 
-/**
- * PHPUnit extension that registers the AfterEachTestSubscriber.
- *
- * This ensures Mockery cleanup runs after every test method, eliminating
- * the need for explicit m::close() calls in individual test tearDown methods.
- */
 class AfterEachTestExtension implements Extension
 {
     /**
@@ -22,6 +16,8 @@ class AfterEachTestExtension implements Extension
      */
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
+        TestStateRegistrars::forRootInstall()->register();
+
         $facade->registerSubscriber(new AfterEachTestSubscriber);
     }
 }

--- a/src/testing/src/PHPUnit/AfterEachTestSubscriber.php
+++ b/src/testing/src/PHPUnit/AfterEachTestSubscriber.php
@@ -22,6 +22,26 @@ class AfterEachTestSubscriber implements FinishedSubscriber
      */
     public function notify(Finished $event): void
     {
+        $this->flushStateAfterTest();
+    }
+
+    /**
+     * Flush all test state after a test finishes.
+     */
+    public function flushStateAfterTest(): void
+    {
+        try {
+            AfterEachTestCleanup::runCallbacks();
+        } finally {
+            $this->flushFrameworkState();
+        }
+    }
+
+    /**
+     * Flush framework-owned static state.
+     */
+    protected function flushFrameworkState(): void
+    {
         Mockery::close();
 
         \Carbon\Carbon::resetMacros();

--- a/src/testing/src/PHPUnit/TestStateRegistrars.php
+++ b/src/testing/src/PHPUnit/TestStateRegistrars.php
@@ -60,16 +60,22 @@ class TestStateRegistrars
     protected static function installedRootPath(): string
     {
         $rootPackage = InstalledVersions::getRootPackage();
-        $basePath = $rootPackage['install_path'] ?? getcwd();
 
-        if (! is_string($basePath) || $basePath === '') {
-            $currentPath = getcwd();
-            $basePath = $currentPath === false ? '.' : $currentPath;
+        return static::resolveInstalledRootPath($rootPackage['install_path'] ?? null);
+    }
+
+    /**
+     * Resolve and validate the Composer root install path.
+     */
+    protected static function resolveInstalledRootPath(mixed $installPath): string
+    {
+        if (! is_string($installPath) || $installPath === '') {
+            throw new RuntimeException('Composer runtime metadata is missing the root package install path.');
         }
 
-        $realPath = realpath($basePath);
+        $realPath = realpath($installPath);
 
-        return $realPath === false ? $basePath : $realPath;
+        return $realPath === false ? $installPath : $realPath;
     }
 
     /**
@@ -79,19 +85,7 @@ class TestStateRegistrars
      */
     protected function rootRegistrars(): array
     {
-        $path = $this->basePath . '/composer.json';
-
-        if (! $this->files->isFile($path)) {
-            return [];
-        }
-
-        $composer = json_decode($this->files->get($path), true);
-
-        if (! is_array($composer)) {
-            return [];
-        }
-
-        return (array) ($composer['extra']['hypervel']['test-state'] ?? []);
+        return (array) PackageManifest::rootHypervelExtra($this->files, $this->basePath, 'test-state');
     }
 
     /**

--- a/src/testing/src/PHPUnit/TestStateRegistrars.php
+++ b/src/testing/src/PHPUnit/TestStateRegistrars.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Testing\PHPUnit;
+
+use Composer\InstalledVersions;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Foundation\PackageManifest;
+use Hypervel\Support\Env;
+use RuntimeException;
+
+class TestStateRegistrars
+{
+    /**
+     * The filesystem instance.
+     */
+    protected Filesystem $files;
+
+    /**
+     * Create a test-state registrar discoverer.
+     */
+    public function __construct(
+        protected string $basePath,
+        protected string $vendorPath,
+        ?Filesystem $files = null
+    ) {
+        $this->files = $files ?? new Filesystem;
+    }
+
+    /**
+     * Create a discoverer for the current Composer root install.
+     */
+    public static function forRootInstall(): static
+    {
+        $basePath = static::installedRootPath();
+        $vendorPath = Env::get('COMPOSER_VENDOR_DIR');
+
+        return new static(
+            $basePath,
+            is_string($vendorPath) && $vendorPath !== '' ? $vendorPath : $basePath . '/vendor'
+        );
+    }
+
+    /**
+     * Register discovered test-state registrars.
+     */
+    public function register(): void
+    {
+        foreach ($this->registrars() as $source => $classes) {
+            foreach ($classes as $class) {
+                $this->registerClass($source, $class);
+            }
+        }
+    }
+
+    /**
+     * Get the Composer root package path.
+     */
+    protected static function installedRootPath(): string
+    {
+        $rootPackage = InstalledVersions::getRootPackage();
+        $basePath = $rootPackage['install_path'] ?? getcwd();
+
+        if (! is_string($basePath) || $basePath === '') {
+            $currentPath = getcwd();
+            $basePath = $currentPath === false ? '.' : $currentPath;
+        }
+
+        $realPath = realpath($basePath);
+
+        return $realPath === false ? $basePath : $realPath;
+    }
+
+    /**
+     * Get root test-state registrar classes.
+     *
+     * @return array<int|string, mixed>
+     */
+    protected function rootRegistrars(): array
+    {
+        $path = $this->basePath . '/composer.json';
+
+        if (! $this->files->isFile($path)) {
+            return [];
+        }
+
+        $composer = json_decode($this->files->get($path), true);
+
+        if (! is_array($composer)) {
+            return [];
+        }
+
+        return (array) ($composer['extra']['hypervel']['test-state'] ?? []);
+    }
+
+    /**
+     * Get registrar classes keyed by their source package.
+     *
+     * @return array<string, array<int|string, mixed>>
+     */
+    protected function registrars(): array
+    {
+        $registrars = [];
+        $baseIgnore = PackageManifest::packagesToIgnoreFromComposer($this->files, $this->basePath);
+
+        foreach (PackageManifest::discoverInstalledPackages($this->files, $this->vendorPath, $baseIgnore) as $package => $configuration) {
+            if (isset($configuration['test-state'])) {
+                $registrars[$package] = (array) $configuration['test-state'];
+            }
+        }
+
+        $rootRegistrars = $this->rootRegistrars();
+
+        if ($rootRegistrars !== []) {
+            $registrars['root'] = $rootRegistrars;
+        }
+
+        return $registrars;
+    }
+
+    /**
+     * Register one registrar class.
+     */
+    protected function registerClass(string $source, mixed $class): void
+    {
+        if (! is_string($class) || $class === '') {
+            throw new RuntimeException(
+                "Test-state registrar declared by [{$source}] must be a class name string."
+            );
+        }
+
+        if (! class_exists($class)) {
+            throw new RuntimeException(
+                "Test-state registrar [{$class}] declared by [{$source}] does not exist. Check that it is in normal autoload, not dependency autoload-dev."
+            );
+        }
+
+        if (! method_exists($class, 'register')) {
+            throw new RuntimeException(
+                "Test-state registrar [{$class}] declared by [{$source}] must define a register method."
+            );
+        }
+
+        $class::register();
+    }
+}

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -267,6 +267,20 @@ class FoundationPackageManifestTest extends TestCase
         );
     }
 
+    public function testRootHypervelExtraReturnsNullForMalformedHypervelMetadata(): void
+    {
+        $filesystem = new Filesystem;
+        $basePath = $this->makeTempComposerRoot('malformed-root-hypervel-metadata');
+        $filesystem->put($basePath . '/composer.json', json_encode([
+            'extra' => [
+                'hypervel' => 'invalid',
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertNull(PackageManifest::rootHypervelExtra($filesystem, $basePath, 'test-state'));
+        $this->assertSame([], PackageManifest::packagesToIgnoreFromComposer($filesystem, $basePath));
+    }
+
     public function testVersionReturnsPackageVersion()
     {
         $manifest = $this->makeManifest();

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -15,6 +15,13 @@ class FoundationPackageManifestTest extends TestCase
 
     private string $manifestPath;
 
+    /**
+     * Temporary directories created by this test.
+     *
+     * @var array<int, string>
+     */
+    private array $tempDirectories = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -29,6 +36,12 @@ class FoundationPackageManifestTest extends TestCase
     {
         @unlink($this->manifestPath);
 
+        $filesystem = new Filesystem;
+
+        foreach ($this->tempDirectories as $directory) {
+            $filesystem->deleteDirectory($directory);
+        }
+
         PackageManifest::flushState();
 
         parent::tearDown();
@@ -37,6 +50,19 @@ class FoundationPackageManifestTest extends TestCase
     private function makeManifest(): PackageManifest
     {
         return new PackageManifest(new Filesystem, $this->basePath, $this->manifestPath);
+    }
+
+    private function makeTempComposerRoot(string $name): string
+    {
+        $path = sys_get_temp_dir() . '/hypervel_package_manifest_' . getmypid() . '_' . $name;
+        $filesystem = new Filesystem;
+
+        $filesystem->deleteDirectory($path);
+        $filesystem->ensureDirectoryExists($path . '/vendor/composer');
+
+        $this->tempDirectories[] = $path;
+
+        return $path;
     }
 
     public function testProvidersReturnsDiscoveredProviders()
@@ -88,6 +114,106 @@ class FoundationPackageManifestTest extends TestCase
 
         $this->assertSame('v1.0.1', $cached['vendor-a/package-a']['version']);
         $this->assertSame('v2.3.0', $cached['vendor-a/package-b']['version']);
+    }
+
+    public function testDiscoverInstalledPackagesMatchesBuildCacheForFixtures(): void
+    {
+        $filesystem = new Filesystem;
+        $manifest = $this->makeManifest();
+
+        $manifest->build();
+
+        $this->assertSame(
+            require $this->manifestPath,
+            PackageManifest::discoverInstalledPackages(
+                $filesystem,
+                $this->basePath . '/vendor',
+                PackageManifest::packagesToIgnoreFromComposer($filesystem, $this->basePath)
+            )
+        );
+    }
+
+    public function testDiscoverInstalledPackagesHandlesLegacyBareInstalledJsonFormat(): void
+    {
+        $filesystem = new Filesystem;
+        $basePath = $this->makeTempComposerRoot('legacy');
+        $filesystem->put($basePath . '/composer.json', '{}');
+        $filesystem->put($basePath . '/vendor/composer/installed.json', json_encode([
+            [
+                'name' => 'vendor-a/package-a',
+                'version' => 'v1.0.0',
+                'extra' => [
+                    'hypervel' => [
+                        'providers' => ['Vendor\Package\Provider'],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertSame(
+            [
+                'vendor-a/package-a' => [
+                    'providers' => ['Vendor\Package\Provider'],
+                    'version' => 'v1.0.0',
+                ],
+            ],
+            PackageManifest::discoverInstalledPackages($filesystem, $basePath . '/vendor', [])
+        );
+    }
+
+    public function testDiscoverInstalledPackagesKeepsVersionOnlyPackagesUnlessIgnored(): void
+    {
+        $packages = PackageManifest::discoverInstalledPackages(
+            new Filesystem,
+            $this->basePath . '/vendor',
+            []
+        );
+
+        $this->assertSame(['version' => 'v3.1.4'], $packages['vendor-a/package-d']);
+    }
+
+    public function testDiscoverInstalledPackagesHonorsWildcardDontDiscover(): void
+    {
+        $this->assertSame(
+            [],
+            PackageManifest::discoverInstalledPackages(new Filesystem, $this->basePath . '/vendor', ['*'])
+        );
+    }
+
+    public function testDiscoverInstalledPackagesReturnsEmptyArrayForMissingInstalledJson(): void
+    {
+        $basePath = $this->makeTempComposerRoot('missing-installed-json');
+
+        (new Filesystem)->delete($basePath . '/vendor/composer/installed.json');
+
+        $this->assertSame(
+            [],
+            PackageManifest::discoverInstalledPackages(new Filesystem, $basePath . '/vendor', [])
+        );
+    }
+
+    public function testDiscoverInstalledPackagesReturnsEmptyArrayForMalformedInstalledJson(): void
+    {
+        $filesystem = new Filesystem;
+        $basePath = $this->makeTempComposerRoot('malformed-installed-json');
+        $filesystem->put($basePath . '/vendor/composer/installed.json', '{');
+
+        $this->assertSame(
+            [],
+            PackageManifest::discoverInstalledPackages($filesystem, $basePath . '/vendor', [])
+        );
+    }
+
+    public function testPackagesToIgnoreFromComposerReturnsEmptyArrayForMalformedComposerJson(): void
+    {
+        $filesystem = new Filesystem;
+        $basePath = $this->makeTempComposerRoot('malformed-composer-json');
+        $filesystem->put($basePath . '/composer.json', '{');
+
+        $this->assertSame(
+            [],
+            PackageManifest::packagesToIgnoreFromComposer($filesystem, $basePath)
+        );
     }
 
     public function testVersionReturnsPackageVersion()

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -204,6 +204,57 @@ class FoundationPackageManifestTest extends TestCase
         );
     }
 
+    public function testDiscoverInstalledPackagesReturnsEmptyArrayForMalformedPackagesShape(): void
+    {
+        $filesystem = new Filesystem;
+        $basePath = $this->makeTempComposerRoot('malformed-packages-shape');
+        $filesystem->put($basePath . '/vendor/composer/installed.json', json_encode([
+            'packages' => 'invalid',
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertSame(
+            [],
+            PackageManifest::discoverInstalledPackages($filesystem, $basePath . '/vendor', [])
+        );
+    }
+
+    public function testDiscoverInstalledPackagesSkipsMalformedPackageEntries(): void
+    {
+        $filesystem = new Filesystem;
+        $basePath = $this->makeTempComposerRoot('malformed-package-entries');
+        $filesystem->put($basePath . '/vendor/composer/installed.json', json_encode([
+            'packages' => [
+                'invalid',
+                [
+                    'version' => 'v1.0.0',
+                ],
+                [
+                    'name' => 'vendor-a/package-a',
+                    'version' => 'v1.0.0',
+                ],
+                [
+                    'name' => 'vendor-a/package-b',
+                    'version' => 'v2.0.0',
+                    'extra' => [
+                        'hypervel' => 'invalid',
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertSame(
+            [
+                'vendor-a/package-a' => [
+                    'version' => 'v1.0.0',
+                ],
+                'vendor-a/package-b' => [
+                    'version' => 'v2.0.0',
+                ],
+            ],
+            PackageManifest::discoverInstalledPackages($filesystem, $basePath . '/vendor', [])
+        );
+    }
+
     public function testPackagesToIgnoreFromComposerReturnsEmptyArrayForMalformedComposerJson(): void
     {
         $filesystem = new Filesystem;

--- a/tests/Testbench/Foundation/Fixtures/PackageManifest/composer.json
+++ b/tests/Testbench/Foundation/Fixtures/PackageManifest/composer.json
@@ -7,7 +7,10 @@
             ],
             "aliases": {
                 "RootAlias": "RootClass"
-            }
+            },
+            "dont-discover": [
+                "vendor-a/package-a"
+            ]
         }
     }
 }

--- a/tests/Testbench/Foundation/PackageManifestTest.php
+++ b/tests/Testbench/Foundation/PackageManifestTest.php
@@ -128,6 +128,21 @@ class PackageManifestTest extends TestCase
     }
 
     #[Test]
+    public function itDoesNotApplyRootComposerDontDiscoverDuringBuild(): void
+    {
+        $manifest = $this->makeManifest(
+            testbench: $this->makeTestbench([]),
+            rootPackage: $this->rootPackageFixture()
+        );
+
+        $manifest->build();
+
+        $cached = require $this->manifestPath;
+
+        $this->assertArrayHasKey('vendor-a/package-a', $cached);
+    }
+
+    #[Test]
     public function itCanBuildManifestWithoutRootComposerMetadata(): void
     {
         $manifest = $this->makeManifest(

--- a/tests/Testing/PHPUnit/AfterEachTestCleanupTest.php
+++ b/tests/Testing/PHPUnit/AfterEachTestCleanupTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testing\PHPUnit;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+use Hypervel\Tests\TestCase;
+use Override;
+use RuntimeException;
+
+class AfterEachTestCleanupTest extends TestCase
+{
+    #[Override]
+    protected function tearDown(): void
+    {
+        AfterEachTestCleanup::forgetCallbacks();
+
+        parent::tearDown();
+    }
+
+    public function testFlushUsingRegistersCallbacksByName(): void
+    {
+        $calls = [];
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use (&$calls): void {
+            $calls[] = 'package';
+        });
+
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['package'], $calls);
+    }
+
+    public function testCallbacksRunInRegistrationOrder(): void
+    {
+        $calls = [];
+
+        AfterEachTestCleanup::flushUsing('vendor/first', function () use (&$calls): void {
+            $calls[] = 'first';
+        });
+        AfterEachTestCleanup::flushUsing('vendor/second', function () use (&$calls): void {
+            $calls[] = 'second';
+        });
+
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['first', 'second'], $calls);
+    }
+
+    public function testCallbacksPersistAcrossRuns(): void
+    {
+        $calls = [];
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use (&$calls): void {
+            $calls[] = 'package';
+        });
+
+        AfterEachTestCleanup::runCallbacks();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['package', 'package'], $calls);
+    }
+
+    public function testRegisteringTheSameNameReplacesTheCallback(): void
+    {
+        $calls = [];
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use (&$calls): void {
+            $calls[] = 'first';
+        });
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use (&$calls): void {
+            $calls[] = 'second';
+        });
+
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['second'], $calls);
+    }
+
+    public function testRootCallbackRegisteredAfterPackageCallbackRunsAfterPackageCallback(): void
+    {
+        $calls = [];
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use (&$calls): void {
+            $calls[] = 'package';
+        });
+        AfterEachTestCleanup::flushUsing('app', function () use (&$calls): void {
+            $calls[] = 'app';
+        });
+
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['package', 'app'], $calls);
+    }
+
+    public function testForgetCallbacksClearsCallbacks(): void
+    {
+        $calls = [];
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use (&$calls): void {
+            $calls[] = 'package';
+        });
+
+        AfterEachTestCleanup::forgetCallbacks();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame([], $calls);
+    }
+
+    public function testRunCallbacksContinuesAfterExceptionAndRethrowsFirstException(): void
+    {
+        $calls = [];
+        $firstException = new RuntimeException('first');
+
+        AfterEachTestCleanup::flushUsing('vendor/first', function () use (&$calls, $firstException): void {
+            $calls[] = 'first';
+
+            throw $firstException;
+        });
+        AfterEachTestCleanup::flushUsing('vendor/second', function () use (&$calls): void {
+            $calls[] = 'second';
+        });
+
+        try {
+            AfterEachTestCleanup::runCallbacks();
+
+            $this->fail('Expected callback exception was not thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($firstException, $exception);
+        }
+
+        $this->assertSame(['first', 'second'], $calls);
+    }
+}

--- a/tests/Testing/PHPUnit/AfterEachTestSubscriberTest.php
+++ b/tests/Testing/PHPUnit/AfterEachTestSubscriberTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testing\PHPUnit;
+
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+use Hypervel\Testing\PHPUnit\AfterEachTestSubscriber;
+use Hypervel\Tests\TestCase;
+use Override;
+use RuntimeException;
+
+class AfterEachTestSubscriberTest extends TestCase
+{
+    #[Override]
+    protected function tearDown(): void
+    {
+        AfterEachTestCleanup::forgetCallbacks();
+
+        parent::tearDown();
+    }
+
+    public function testFlushStateAfterTestRunsCustomCallbacksBeforeFrameworkCleanup(): void
+    {
+        $subscriber = new class extends AfterEachTestSubscriber {
+            /**
+             * The observed cleanup order.
+             *
+             * @var array<int, string>
+             */
+            public array $order = [];
+
+            /**
+             * Flush framework-owned static state.
+             */
+            protected function flushFrameworkState(): void
+            {
+                $this->order[] = 'framework';
+            }
+        };
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use ($subscriber): void {
+            $subscriber->order[] = 'custom';
+        });
+
+        $subscriber->flushStateAfterTest();
+
+        $this->assertSame(['custom', 'framework'], $subscriber->order);
+    }
+
+    public function testFlushStateAfterTestRunsFrameworkCleanupWhenCustomCallbackThrows(): void
+    {
+        $subscriber = new class extends AfterEachTestSubscriber {
+            /**
+             * The observed cleanup order.
+             *
+             * @var array<int, string>
+             */
+            public array $order = [];
+
+            /**
+             * Flush framework-owned static state.
+             */
+            protected function flushFrameworkState(): void
+            {
+                $this->order[] = 'framework';
+            }
+        };
+        $expectedException = new RuntimeException('custom cleanup failed');
+
+        AfterEachTestCleanup::flushUsing('vendor/package', function () use ($subscriber, $expectedException): void {
+            $subscriber->order[] = 'custom';
+
+            throw $expectedException;
+        });
+
+        try {
+            $subscriber->flushStateAfterTest();
+
+            $this->fail('Expected cleanup exception was not thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($expectedException, $exception);
+        }
+
+        $this->assertSame(['custom', 'framework'], $subscriber->order);
+    }
+}

--- a/tests/Testing/PHPUnit/TestStateRegistrarsTest.php
+++ b/tests/Testing/PHPUnit/TestStateRegistrarsTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testing\PHPUnit;
+
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Support\Env;
+use Hypervel\Testing\ParallelTesting;
+use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
+use Hypervel\Testing\PHPUnit\TestStateRegistrars;
+use Hypervel\Tests\TestCase;
+use Override;
+use RuntimeException;
+
+class TestStateRegistrarsTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    private string $basePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+        $this->basePath = ParallelTesting::tempDir('TestStateRegistrarsTest');
+
+        $this->filesystem->deleteDirectory($this->basePath);
+        $this->filesystem->ensureDirectoryExists($this->basePath . '/vendor/composer');
+
+        TestStateRegistrarRecorder::$calls = [];
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        AfterEachTestCleanup::forgetCallbacks();
+        TestStateRegistrarRecorder::$calls = [];
+        $this->filesystem->deleteDirectory($this->basePath);
+
+        parent::tearDown();
+    }
+
+    public function testRegistersPackageRegistrarsFromInstalledPackages(): void
+    {
+        $this->writeRootComposer();
+        $this->writeInstalledPackages([
+            $this->package('vendor/package', [PackageTestStateRegistrar::class]),
+        ]);
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['package'], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testRegistersRootRegistrarsAfterPackageRegistrars(): void
+    {
+        $this->writeRootComposer([
+            'test-state' => [RootTestStateRegistrar::class],
+        ]);
+        $this->writeInstalledPackages([
+            $this->package('vendor/package', [PackageTestStateRegistrar::class]),
+        ]);
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['package', 'root'], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testPackageDontDiscoverSuppressesPackageTestStateDiscovery(): void
+    {
+        $this->writeRootComposer();
+        $this->writeInstalledPackages([
+            $this->package('vendor/first', [], ['vendor/second']),
+            $this->package('vendor/second', [PackageTestStateRegistrar::class]),
+        ]);
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame([], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testRootDontDiscoverSuppressesPackageRegistrarsButNotRootRegistrars(): void
+    {
+        $this->writeRootComposer([
+            'dont-discover' => ['*'],
+            'test-state' => [RootTestStateRegistrar::class],
+        ]);
+        $this->writeInstalledPackages([
+            $this->package('vendor/package', [PackageTestStateRegistrar::class]),
+        ]);
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['root'], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testMissingRootComposerJsonDoesNotThrow(): void
+    {
+        $this->writeInstalledPackages([]);
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame([], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testMissingInstalledJsonDoesNotThrow(): void
+    {
+        $this->writeRootComposer();
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame([], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testMalformedComposerAndInstalledJsonDoNotThrow(): void
+    {
+        $this->filesystem->put($this->basePath . '/composer.json', '{');
+        $this->filesystem->put($this->basePath . '/vendor/composer/installed.json', '{');
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame([], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testMissingDeclaredRegistrarThrows(): void
+    {
+        $this->writeRootComposer();
+        $this->writeInstalledPackages([
+            $this->package('vendor/package', ['Missing\TestStateRegistrar']),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Test-state registrar [Missing\TestStateRegistrar] declared by [vendor/package] does not exist.');
+
+        $this->makeRegistrars()->register();
+    }
+
+    public function testDeclaredRegistrarWithoutRegisterMethodThrows(): void
+    {
+        $this->writeRootComposer();
+        $this->writeInstalledPackages([
+            $this->package('vendor/package', [RegistrarWithoutRegisterMethod::class]),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Test-state registrar [' . RegistrarWithoutRegisterMethod::class . '] declared by [vendor/package] must define a register method.');
+
+        $this->makeRegistrars()->register();
+    }
+
+    public function testNonStringDeclaredRegistrarThrows(): void
+    {
+        $this->writeRootComposer();
+        $this->writeInstalledPackages([
+            $this->package('vendor/package', [123]),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Test-state registrar declared by [vendor/package] must be a class name string.');
+
+        $this->makeRegistrars()->register();
+    }
+
+    public function testDuplicateCallbackNamesAreLastWins(): void
+    {
+        $this->writeRootComposer();
+        $this->writeInstalledPackages([
+            $this->package('vendor/first', [PackageTestStateRegistrar::class]),
+            $this->package('vendor/second', [ReplacementPackageTestStateRegistrar::class]),
+        ]);
+
+        $this->makeRegistrars()->register();
+        AfterEachTestCleanup::runCallbacks();
+
+        $this->assertSame(['replacement'], TestStateRegistrarRecorder::$calls);
+    }
+
+    public function testForRootInstallUsesComposerVendorDirEnvironmentOverride(): void
+    {
+        $originalVendorPath = Env::get('COMPOSER_VENDOR_DIR');
+        $customVendorPath = $this->basePath . '/custom-vendor';
+
+        Env::deleteMany(['COMPOSER_VENDOR_DIR']);
+        Env::flushRepository();
+        Env::getRepository()->set('COMPOSER_VENDOR_DIR', $customVendorPath);
+
+        try {
+            $this->assertSame(
+                $customVendorPath,
+                TestStateRegistrarsProbe::forRootInstall()->vendorPath()
+            );
+        } finally {
+            Env::deleteMany(['COMPOSER_VENDOR_DIR']);
+            Env::flushRepository();
+
+            if (is_string($originalVendorPath)) {
+                Env::getRepository()->set('COMPOSER_VENDOR_DIR', $originalVendorPath);
+            }
+        }
+    }
+
+    private function makeRegistrars(): TestStateRegistrars
+    {
+        return new TestStateRegistrars(
+            $this->basePath,
+            $this->basePath . '/vendor',
+            $this->filesystem
+        );
+    }
+
+    /**
+     * Write the root composer.json file.
+     *
+     * @param array<string, mixed> $hypervel
+     */
+    private function writeRootComposer(array $hypervel = []): void
+    {
+        $this->filesystem->put($this->basePath . '/composer.json', json_encode([
+            'extra' => [
+                'hypervel' => $hypervel,
+            ],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Write Composer's installed package metadata.
+     *
+     * @param array<int, array<string, mixed>> $packages
+     */
+    private function writeInstalledPackages(array $packages): void
+    {
+        $this->filesystem->put($this->basePath . '/vendor/composer/installed.json', json_encode([
+            'packages' => $packages,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Build package metadata.
+     *
+     * @param array<int, class-string|int|string> $registrars
+     * @param array<int, string> $dontDiscover
+     *
+     * @return array<string, mixed>
+     */
+    private function package(string $name, array $registrars = [], array $dontDiscover = []): array
+    {
+        $hypervel = [];
+
+        if ($registrars !== []) {
+            $hypervel['test-state'] = $registrars;
+        }
+
+        if ($dontDiscover !== []) {
+            $hypervel['dont-discover'] = $dontDiscover;
+        }
+
+        return [
+            'name' => $name,
+            'version' => 'v1.0.0',
+            'extra' => [
+                'hypervel' => $hypervel,
+            ],
+        ];
+    }
+}
+
+class TestStateRegistrarRecorder
+{
+    /**
+     * The recorded cleanup calls.
+     *
+     * @var array<int, string>
+     */
+    public static array $calls = [];
+}
+
+class PackageTestStateRegistrar
+{
+    /**
+     * Register package test-state cleanup.
+     */
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('vendor/package', function (): void {
+            TestStateRegistrarRecorder::$calls[] = 'package';
+        });
+    }
+}
+
+class ReplacementPackageTestStateRegistrar
+{
+    /**
+     * Register replacement package test-state cleanup.
+     */
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('vendor/package', function (): void {
+            TestStateRegistrarRecorder::$calls[] = 'replacement';
+        });
+    }
+}
+
+class RootTestStateRegistrar
+{
+    /**
+     * Register root test-state cleanup.
+     */
+    public static function register(): void
+    {
+        AfterEachTestCleanup::flushUsing('app', function (): void {
+            TestStateRegistrarRecorder::$calls[] = 'root';
+        });
+    }
+}
+
+class RegistrarWithoutRegisterMethod
+{
+}
+
+class TestStateRegistrarsProbe extends TestStateRegistrars
+{
+    /**
+     * Get the configured vendor path.
+     */
+    public function vendorPath(): string
+    {
+        return $this->vendorPath;
+    }
+}

--- a/tests/Testing/PHPUnit/TestStateRegistrarsTest.php
+++ b/tests/Testing/PHPUnit/TestStateRegistrarsTest.php
@@ -208,6 +208,30 @@ class TestStateRegistrarsTest extends TestCase
         }
     }
 
+    public function testResolveInstalledRootPathThrowsForInvalidComposerRootInstallPath(): void
+    {
+        foreach ([null, '', 123] as $installPath) {
+            try {
+                TestStateRegistrarsProbe::resolveInstalledRootPath($installPath);
+
+                $this->fail('Expected a runtime exception for invalid Composer root install path.');
+            } catch (RuntimeException $exception) {
+                $this->assertSame(
+                    'Composer runtime metadata is missing the root package install path.',
+                    $exception->getMessage()
+                );
+            }
+        }
+    }
+
+    public function testResolveInstalledRootPathReturnsRealPathWhenAvailable(): void
+    {
+        $this->assertSame(
+            realpath($this->basePath),
+            TestStateRegistrarsProbe::resolveInstalledRootPath($this->basePath)
+        );
+    }
+
     private function makeRegistrars(): TestStateRegistrars
     {
         return new TestStateRegistrars(
@@ -328,6 +352,14 @@ class RegistrarWithoutRegisterMethod
 
 class TestStateRegistrarsProbe extends TestStateRegistrars
 {
+    /**
+     * Resolve and validate the Composer root install path.
+     */
+    public static function resolveInstalledRootPath(mixed $installPath): string
+    {
+        return parent::resolveInstalledRootPath($installPath);
+    }
+
     /**
      * Get the configured vendor path.
      */

--- a/tests/Testing/PHPUnit/TestStateRegistrarsTest.php
+++ b/tests/Testing/PHPUnit/TestStateRegistrarsTest.php
@@ -11,6 +11,7 @@ use Hypervel\Testing\PHPUnit\AfterEachTestCleanup;
 use Hypervel\Testing\PHPUnit\TestStateRegistrars;
 use Hypervel\Tests\TestCase;
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
 class TestStateRegistrarsTest extends TestCase
@@ -208,20 +209,22 @@ class TestStateRegistrarsTest extends TestCase
         }
     }
 
-    public function testResolveInstalledRootPathThrowsForInvalidComposerRootInstallPath(): void
+    #[DataProvider('invalidComposerRootInstallPaths')]
+    public function testResolveInstalledRootPathThrowsForInvalidComposerRootInstallPath(mixed $installPath): void
     {
-        foreach ([null, '', 123] as $installPath) {
-            try {
-                TestStateRegistrarsProbe::resolveInstalledRootPath($installPath);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Composer runtime metadata is missing the root package install path.');
 
-                $this->fail('Expected a runtime exception for invalid Composer root install path.');
-            } catch (RuntimeException $exception) {
-                $this->assertSame(
-                    'Composer runtime metadata is missing the root package install path.',
-                    $exception->getMessage()
-                );
-            }
-        }
+        TestStateRegistrarsProbe::resolveInstalledRootPath($installPath);
+    }
+
+    public static function invalidComposerRootInstallPaths(): array
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'non-string' => [123],
+        ];
     }
 
     public function testResolveInstalledRootPathReturnsRealPathWhenAvailable(): void


### PR DESCRIPTION
This adds a first-class after-each test cleanup registration path for Hypervel apps and packages.

The testing package already owns framework-level static cleanup through its PHPUnit extension. This change keeps that centralized, but adds a small app/package layer on top so userland packages can clean worker-lifetime state without requiring every consuming app to know about their internals.

What changed:

- Add `AfterEachTestCleanup`, a named callback registry for after-each cleanup.
- Add `TestStateRegistrars`, discovered during PHPUnit extension bootstrap from `extra.hypervel.test-state`.
- Run app/package callbacks before framework cleanup, while still flushing framework state in a `finally`.
- Extract no-write package metadata discovery from `PackageManifest` so testing bootstrap can read Composer metadata without writing `bootstrap/cache`.
- Document the app/package API and update contributor cleanup guidance.

A package can now declare:

```json
"extra": {
    "hypervel": {
        "test-state": [
            "Vendor\\Package\\Testing\\TestState"
        ]
    }
}
```

and that registrar will be loaded before the first test in each PHPUnit/Paratest worker, even if that worker only runs unit tests that never boot an application.

A few details worth calling out:

- Root app registrars are appended after package registrars.
- `dont-discover` suppresses package test-state registrars consistently with provider discovery.
- Root `test-state` still runs when root `dont-discover` disables package discovery.
- Declared bad registrars fail fast with attributed errors. Missing or malformed Composer metadata degrades to framework cleanup only.
- `AfterEachTestCleanup::forgetCallbacks()` is intentionally documented as test-internal because it clears discovered app/package registrations for the whole worker.

The Hypervel app skeleton was updated separately on its own `0.4` branch to register the extension and provide an empty `Tests\Support\TestState` class by default.

Tests:

- `./vendor/bin/phpunit --no-progress tests/Testing/PHPUnit/TestStateRegistrarsTest.php`
- `composer fix`

Final `composer fix` result: php-cs-fixer clean, phpstan clean, Paratest passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extensible per-worker test-state cleanup hooks, letting apps and packages register named after-each cleanup callbacks.
  * Enabled automatic discovery of cleanup registrars from project composer metadata.
* **Bug Fixes**
  * Ensured app/package cleanup callbacks run before framework cleanup and that framework cleanup still happens even if a callback throws.
  * Improved robustness of package discovery when composer metadata is missing or malformed.
* **Documentation**
  * Updated testing and package development guides with “Test State Cleanup” instructions.
  * Clarified cleanup registration guidance in AGENTS documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->