### PR TITLE
Complete guard-driven auth siloing

### DIFF
--- a/docs/plans/2026-07-07-guard-siloing-completion.md
+++ b/docs/plans/2026-07-07-guard-siloing-completion.md
@@ -727,6 +727,16 @@ While verifying the bot-review findings against the upstream source (`examples/l
 
 **Docs.** One-line entries in the session and sanctum README `Differences From Laravel` sections: Laravel's raw-hash backward-compatibility fallback is intentionally omitted — Hypervel has no released legacy sessions; only the HMAC format is valid.
 
+## Addendum (2026-07-07, post-bot-review): input and remembered-session hardening
+
+The follow-up bot pass found three small hardening issues. Consensus (Claude/Codex, owner-directed): fix all three in this PR.
+
+**Fortify confirmed-password status input.** `ConfirmedPasswordStatusController` passed `$request->input('seconds')` directly into `PasswordConfirmation::timeout()`, whose override parameter is typed `string|int|null`. Request input is attacker-controlled and `mixed`; array input such as `?seconds[]=900` can throw before the helper runs. The controller now normalizes at the boundary with `$request->has('seconds') ? $request->integer('seconds') : null`, matching the previous cast-style behavior without widening the helper's contract.
+
+**Sanctum remembered-session validation.** Sanctum's session middleware uses `logoutCurrentDevice()`, matching core `auth.session` and upstream Sanctum. That is the right logout primitive, but core `auth.session` also validates the remember-cookie password-HMAC before accepting a remembered user. Sanctum now performs the same per-guard recaller validation for already-resolved `SessionGuard` instances where `viaRemember()` is true. Missing, malformed, or stale recaller hash segments flow through the same `$shouldLogout` path as stale `password_hash_{guard}` values, so the guard list, session flush, and `AuthenticationException` behavior stay identical. This intentionally exceeds upstream Sanctum, which currently lacks this validation.
+
+**Malformed stored hash values fail closed.** `password_hash_{guard}` is framework-owned and normally written only as a string by the session middlewares. A non-string value still must not wedge the user in a persistent 500 loop: the corrupt value lives in the session, and the code path that would clear it is the one that would otherwise throw a `TypeError`. Both core session and Sanctum validators now accept `mixed $storedValue`, return `false` unless it is a string, and then compare with `hash_equals()`. This is a narrow fail-closed auth-artifact check, not a precedent for broad defensive guards.
+
 ## Explicitly Unchanged
 
 - **`auth.verification.expire` stays global** — a signed-URL TTL with no cross-silo hazard; the URL is already signed per user.

--- a/docs/plans/2026-07-07-guard-siloing-completion.md
+++ b/docs/plans/2026-07-07-guard-siloing-completion.md
@@ -700,6 +700,33 @@ grep -rn "'auth\.password_timeout'" src/ | grep -v "PasswordConfirmation.php\|fo
 
 (The last grep's two exclusions are the only permitted occurrences: the config definition and the single reader, `PasswordConfirmation::timeout()`.)
 
+## Addendum (2026-07-07, post-bot-review): HMAC-only password-hash artifacts
+
+While verifying the bot-review findings against the upstream source (`examples/laravel/sanctum`), the owner surfaced a missed upstream hardening and a live interop bug in the sanctum port. Consensus (Claude/Codex, owner-directed): fix both in this PR.
+
+**Upstream chronology.** Laravel framework `b5f9532ce2` (PR #58107, shipped v12.45.0) changed remember-cookie/session password-hash artifacts from the raw password hash to an HMAC via `SessionGuard::hashPasswordForCookie()`. Laravel Sanctum `dadd227` (PR #582, v4.2.4) added the matching support to Sanctum's `AuthenticateSession`: store HMAC when the guard exposes the method, validate HMAC first, fall back to the raw hash for legacy sessions. Hypervel's `SessionGuard` (`hashPasswordForCookie()`, line 538) and core session `AuthenticateSession` already carry the HMAC format (with Laravel's raw fallback ported); the sanctum middleware port predates it and still stores/compares the raw hash.
+
+**The interop bug.** Both middlewares share the `password_hash_{guard}` session keys. Core `auth.session` writes the HMAC format; sanctum's middleware compared the same key against the raw `getAuthPassword()` with `!==`. In the standard SPA setup (web login via `auth.session`, stateful API via sanctum's middleware) the comparison always mismatches, falsely logging the user out on the first stateful API request — single guard, stock configuration. Not just parity hardening; a real defect on this branch's surface.
+
+**Greenfield decision (owner).** Hypervel 0.4 is unreleased: the HMAC format is the only valid password-hash artifact. Two distinct fallbacks are deleted, for different reasons:
+
+- The raw-*value* fallback (`|| hash_equals($passwordHash, $storedValue)` and Sanctum's equivalent) is legacy-runtime-artifact compatibility for sessions Hypervel never issued. Deleted.
+- The missing-*method* fallback (core middleware's `try/catch BadMethodCallException`) is API-surface tolerance. Deleted without replacement: a guard used with `auth.session` that cannot produce the artifact fails loudly with the natural `BadMethodCallException` (fail-fast rule). The import goes with it.
+
+**Implementation.**
+
+- Core `src/session/src/Middleware/AuthenticateSession.php`: `storePasswordHashInSession()` keeps HMAC storage; `validatePasswordHash()` becomes HMAC-only (`hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)`); both try/catches and the `BadMethodCallException` import deleted.
+- Sanctum `src/sanctum/src/Http/Middleware/AuthenticateSession.php`: per-guard validation and storage (from the bot-review follow-up) use the already-resolved concrete `SessionGuard` instances from the derived guard list — `hashPasswordForCookie()` is guaranteed by the `instanceof SessionGuard` filter, so no `method_exists`, no re-resolution through the auth manager, no raw fallback. Validation helper `validatePasswordHash(SessionGuard $guard, ?string $passwordHash, string $storedValue): bool` compares with `hash_equals()` (also replacing the pre-existing non-timing-safe `!==`). Nullable hashes remain supported (`hashPasswordForCookie(?string)`; passkey-only accounts).
+- Current upstream source is the porting reference; the commits above are chronology/rationale only.
+
+**Tests.**
+
+- Cross-middleware interop regression (the discovered bug): core `auth.session` stores the hash for a guard, sanctum's middleware validates the same session, no logout.
+- Sanctum: HMAC round-trip within the middleware; raw stored values are rejected (logout).
+- Core session middleware: `OldFormatCookie*` backward-compatibility tests removed with a concise `REMOVED:` comment at the site per AGENTS.md; an inverted test proves raw values are now invalid.
+
+**Docs.** One-line entries in the session and sanctum README `Differences From Laravel` sections: Laravel's raw-hash backward-compatibility fallback is intentionally omitted — Hypervel has no released legacy sessions; only the HMAC format is valid.
+
 ## Explicitly Unchanged
 
 - **`auth.verification.expire` stays global** — a signed-URL TTL with no cross-silo hazard; the URL is already signed per user.

--- a/docs/plans/2026-07-07-guard-siloing-completion.md
+++ b/docs/plans/2026-07-07-guard-siloing-completion.md
@@ -1,0 +1,712 @@
+# Guard Siloing Completion
+
+Complete the principle established by `2026-07-06-auth-guard-declared-password-brokers.md` (PR #420): the current auth guard is the single source of auth siloing truth. This plan closes the remaining places where an auth decision — password confirmation, guest-route guard selection, sanctum's stateful session acceptance, viaRequest provider resolution, permission's default guard, login throttling — reads a global root or ignores the current guard.
+
+## Background
+
+### The audit
+
+After PR #420 shipped, a full framework audit (Claude + Codex independently, cross-verified against source, owner arbitrating, 2026-07-07) looked for auth decisions that bypass the current guard. "Current guard" always means `AuthManager::getDefaultDriver()`: the coroutine-context override set by `shouldUse()` (via `auth:x`, `auth.guard:x`) falling back to `auth.defaults.guard`.
+
+The design principle, agreed by all parties:
+
+> For auth decisions that decide which actor silo may authenticate, reset passwords, confirm passwords, use sessions, accept tokens, or rate-limit login attempts, the guard is the local source of truth. Any other config key must be either route-selection only (like `fortify.guard`) or a general mechanic that does not choose an actor silo.
+
+Hypervel 0.4 is unreleased. Backward compatibility is not a goal; no fallbacks, shims, or dual roots survive. The final code reads as if designed this way from the start.
+
+### Confirmed holes (each verified against source)
+
+1. **Password confirmation is not guard-siloed.** The session stores one shared key `auth.password_confirmed_at` (`src/session/src/Store.php:705`, `src/fortify/src/Http/Controllers/ConfirmablePasswordController.php:50`) read by `RequirePassword` (`src/auth/src/Middleware/RequirePassword.php:65`) and `ConfirmedPasswordStatusController` (`src/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:28`). A user logged into two guards in one browser session confirms under one guard and satisfies `password.confirm` under the other. Every sibling session artifact is already guard-scoped (`login_{guard}_{hash}`, `password_hash_{guard}`, `remember_{guard}_*`); this key is the odd one out. The timeout is also global (`auth.password_timeout`) and baked into the `RequirePassword` singleton at construction (`src/auth/src/AuthServiceProvider.php:77`), so no per-guard timeout can work without moving the read to handle-time.
+2. **`guest:admin` names a guard but does not select it.** `RedirectIfAuthenticated::handle()` (`src/auth/src/Middleware/RedirectIfAuthenticated.php:33-44`) checks the named guards and passes through without `shouldUse()`. A login page behind `guest:admin` calling bare `Password::sendResetLink()` resolves the *default* guard's broker — the wrong-table bug class PR #420 eliminated. `auth:admin` selects the matched guard on success (`src/auth/src/Middleware/Authenticate.php:63-64`); `guest:admin` selecting on pass-through completes the rule: naming a guard on an auth middleware makes it current.
+3. **Sanctum's stateful accept-list is a process-global second root.** `SanctumGuard::user()` iterates `config('sanctum.guard', 'web')` (`src/sanctum/src/SanctumGuard.php:81`), so every sanctum guard trusts the same session guards; two sanctum guards with different providers cannot declare different trusted sessions. The default is fail-open: a *missing* key means `'web'` is trusted. The stateful path also skips the provider match that the bearer-token path performs (`hasValidProvider()`, `SanctumGuard.php:204`) — a session user from any listed guard is returned even when it does not belong to this guard's provider. Sanctum's `AuthenticateSession` middleware reads the same global (`src/sanctum/src/Http/Middleware/AuthenticateSession.php:38`).
+4. **`sanctum.stateful` is misnamed.** It holds *domains*, its env var is already `SANCTUM_STATEFUL_DOMAINS`, and the new per-guard session list needs the "stateful" vocabulary. The repo rule that env vars mirror config key paths makes `sanctum.stateful_domains` the correct name.
+5. **`auth.defaults.provider` is a second defaulting root, and viaRequest guards ignore their declared provider.** `CreatesUserProviders::getDefaultUserProvider()` (`src/auth/src/CreatesUserProviders.php:91-94`) reads a key the shipped config does not declare. Its only live consumer is `AuthManager::viaRequest()` (`AuthManager.php:202-207`), which builds its `RequestGuard` with a bare `createUserProvider()` even though the extend closure receives the guard's `$config` — the guard entry's `provider` key is silently ignored. Verified: every other `createUserProvider()` caller passes `$config['provider'] ?? null` (JWT `JWTServiceProvider.php:112`, Sanctum `SanctumServiceProvider.php:52`, broker manager `PasswordBrokerManager.php:65`, both AuthManager guard creators).
+6. **Permission has two notions of "default guard".** `Support\Config::defaultGuard()` (`src/permission/src/Support/Config.php:136-139`) reads `auth.defaults.guard` from config, bypassing the coroutine-context override, while `Guard::getDefaultName()` correctly uses the auth manager. `defaultGuard()` feeds the `users()` relations on `Role`/`Permission` and `HasAssignedModels`.
+7. **Fortify's login throttle key ignores the guard.** `LoginRateLimiter::throttleKey()` (`src/fortify/src/LoginRateLimiter.php:64-66`) is `username|ip`. One Fortify install serving multiple guard silos (the documented multi-guard pattern) shares lockout buckets across silos: a member lockout blocks admin login for the same email + IP.
+8. **Generators read `auth.defaults.guard` directly.** `PolicyMakeCommand.php:76` and `GeneratorCommand::userProviderModel()` (`src/console/src/GeneratorCommand.php:445-455`) read config instead of asking the auth manager. Console has no ambient override so behavior is identical today; this is a consistency alignment that completes the "one way to ask for the default guard" invariant.
+
+### Rejected alternatives
+
+- **Ambient-following sanctum accept-list ("null means current default guard").** Rejected: the set of sessions an API guard accepts would depend on whatever guard was ambient when `auth:sanctum` evaluates — middleware-order-sensitive, silent, and an API route accidentally nested in a member route group would accept member sessions on an admin API guard. Declarations, not context, decide acceptance.
+- **Keeping `sanctum.guard` as a global fallback behind the per-guard key.** Rejected by the owner: a second defaulting root for an auth silo decision, the exact disease `auth.defaults.passwords` had.
+- **Missing `session_guards` silently meaning tokens-only.** Rejected: unlike password brokers (where tolerated absence still throws at the moment of need), sanctum silence would stay silent forever — the classic "why doesn't my SPA authenticate" time-sink. Throw an instructive config error; `[]` is the explicit tokens-only declaration and doubles as documentation.
+- **Per-guard `stateful_domains`.** Rejected: the domains decision runs pre-auth in `EnsureFrontendRequestsAreStateful`, where no guard exists; deriving one would require route-middleware string inference. Cross-origin control is CORS's job; the `statefulDomains()` override hook covers dynamic cases. Stays app-level.
+- **Dot-nested confirmation session key (`auth.password_confirmed_at.{guard}`).** Rejected: session keys pass through `Arr::set()` dot segmentation, and the sibling artifacts (`password_hash_{guard}`) use the guard-suffix convention. Use `auth.password_confirmed_at_{guard}`.
+- **`guest` with multiple guards selecting nothing.** Rejected: two rules instead of one. `guest:a,b` selects the first listed — deterministic, matches `auth`'s try-in-order semantics where the first is primary. Bare `guest` selects nothing (there is no named guard to select).
+- **A new "resolve provider/model for guard" framework API.** Rejected: the guard entry plus `createUserProvider()` already is that API; no consumer exists for more surface.
+
+## Final Behavior
+
+- Confirming a password proves it for the current guard only. `password.confirm` under another guard in the same session prompts again. Guards may declare `password_timeout`; resolution is route parameter → `auth.guards.{guard}.password_timeout` → `auth.password_timeout` (default 10800).
+- `guest:admin` makes `admin` the current guard when the request passes through. `guest:a,b` selects `a`. Bare `guest` selects nothing.
+- Every sanctum-driver guard entry declares `session_guards`. `['web']` trusts web sessions, `[]` means bearer tokens only, a missing key throws naming the guard and both fixes. Listed guards must be stateful (`StatefulGuard`) or resolution throws. A trusted session user must match the sanctum guard's provider or it is skipped and the next listed guard (then the token path) is tried.
+- `sanctum.stateful_domains` is the domains list; `sanctum.guard` no longer exists.
+- A `viaRequest` guard uses the `provider` its guard entry declares. `auth.defaults.provider` no longer exists; `createUserProvider(null)` means "no provider". `getDefaultUserProvider()` survives, redefined as "the provider declared by the current default guard" — the same redefinition treatment `Password::getDefaultDriver()` received when `auth.defaults.passwords` was removed.
+- Permission's default guard is the auth manager's, context override included.
+- Fortify's login throttle key is `guard|username|ip`.
+- `make:policy` and generator model inference resolve the default guard through the auth manager.
+
+## Implementation
+
+All work happens in `contrib/hypervel/components`. Every file keeps `declare(strict_types=1);` and follows AGENTS.md (method docblocks, imports not FQCNs, `->make()` not array access, no defensive guards without a real reachable path).
+
+### 1. New: `src/auth/src/PasswordConfirmation.php`
+
+The single owner of confirmation key format and the full timeout resolution chain (explicit override → guard declaration → global fallback), consumed by the auth middleware, both Fortify controllers, and the session store. `final` because it is a fully static utility — subclassing is inert. The guard/global tiers branch on `has()` rather than nesting the global read as a default argument: PHP evaluates default arguments eagerly, so nesting would let a malformed global `auth.password_timeout` throw even when a valid per-guard declaration should win.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Auth;
+
+use Hypervel\Contracts\Config\Repository;
+
+final class PasswordConfirmation
+{
+    /**
+     * Get the session key holding the password confirmation timestamp for the guard.
+     */
+    public static function sessionKey(string $guard): string
+    {
+        return "auth.password_confirmed_at_{$guard}";
+    }
+
+    /**
+     * Get the password confirmation timeout in seconds for the guard.
+     *
+     * An explicit override (per-route middleware parameter or request input)
+     * wins, then the guard's own "password_timeout" declaration, then the
+     * application-wide auth.password_timeout value.
+     */
+    public static function timeout(Repository $config, string $guard, string|int|null $override = null): int
+    {
+        if ($override !== null) {
+            return (int) $override;
+        }
+
+        $key = "auth.guards.{$guard}.password_timeout";
+
+        if ($config->has($key)) {
+            return $config->integer($key);
+        }
+
+        return $config->integer('auth.password_timeout', 10800);
+    }
+}
+```
+
+### 2. `src/auth/src/Middleware/RequirePassword.php`
+
+Timeout and key resolution move to handle-time so the current guard and any per-guard timeout apply. Constructor becomes pure DI; the `$passwordTimeout` property and constructor parameter are deleted. `using()` and `handle()` signatures are unchanged (the per-route `$passwordTimeoutSeconds` override remains the first tier).
+
+```php
+use Closure;
+use Hypervel\Auth\PasswordConfirmation;
+use Hypervel\Contracts\Auth\Factory as AuthFactory;
+use Hypervel\Contracts\Config\Repository;
+use Hypervel\Contracts\Routing\ResponseFactory;
+use Hypervel\Contracts\Routing\UrlGenerator;
+use Hypervel\Http\Request;
+use Hypervel\Support\Facades\Date;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequirePassword
+{
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct(
+        protected ResponseFactory $responseFactory,
+        protected UrlGenerator $urlGenerator,
+        protected AuthFactory $auth,
+        protected Repository $config,
+    ) {
+    }
+
+    // using(): unchanged.
+    // handle(): unchanged.
+
+    /**
+     * Determine if the confirmation timeout has expired.
+     *
+     * The confirmation timestamp and timeout are scoped to the current
+     * guard, so confirming a password under one guard never satisfies
+     * password confirmation under another.
+     */
+    protected function shouldConfirmPassword(Request $request, string|int|null $passwordTimeoutSeconds = null): bool
+    {
+        $guard = $this->auth->getDefaultDriver();
+
+        $confirmedAt = Date::now()->unix() - $request->session()->get(PasswordConfirmation::sessionKey($guard), 0);
+
+        return $confirmedAt > PasswordConfirmation::timeout($this->config, $guard, $passwordTimeoutSeconds);
+    }
+}
+```
+
+### 3. `src/auth/src/AuthServiceProvider.php`
+
+Delete `registerRequirePassword()` and its call in `register()`. All four constructor dependencies are container-resolvable, so auto-singleton handles the middleware with no explicit binding: `ResponseFactory` contract is singleton-bound (`src/routing/src/RoutingServiceProvider.php:174`), `UrlGenerator` contract is core-aliased (`src/foundation/src/Application.php:1386`), `Factory` contract via the `auth` alias (`Application.php:1271`), config `Repository` contract via the `config` alias (`Application.php:1293`). Remove the now-unused imports: `RequirePassword`, `ResponseFactory`, `UrlGenerator` (verified: each is referenced only by the deleted method).
+
+### 4. `src/session/src/Store.php`
+
+`passwordConfirmed()` becomes the single confirmation writer, guard-scoped. Imports: add `Hypervel\Auth\PasswordConfirmation`, `Hypervel\Container\Container`, `Hypervel\Contracts\Auth\Factory as AuthFactory`. `Container::getInstance()` is the correct access here — the store is constructed by the session manager without container injection, and the guard must be resolved at call time, not construction time.
+
+```php
+    /**
+     * Specify that the user has confirmed their password.
+     *
+     * The confirmation is scoped to the given guard, or to the current
+     * default guard when none is given.
+     */
+    public function passwordConfirmed(?string $guard = null): void
+    {
+        $guard ??= Container::getInstance()->make(AuthFactory::class)->getDefaultDriver();
+
+        $this->put(PasswordConfirmation::sessionKey($guard), Date::now()->unix());
+    }
+```
+
+### 5. `src/session/composer.json`
+
+Add `"hypervel/auth": "^0.4"` to `require` (alphabetically first, before `hypervel/cache`). This also fixes a pre-existing packaging bug: `src/session/src/Middleware/AuthenticateSession.php:9` already imports the concrete `Hypervel\Auth\AuthenticationException` with no declared dependency, so a standalone subtree-split install of `hypervel/session` is broken today. No cycle: `src/auth/composer.json` only *suggests* `hypervel/session`. The root `composer.json` needs no change (monorepo `replace` covers all packages).
+
+### 6. `src/support/src/Facades/Session.php` and `src/contracts/src/Session/Session.php`
+
+Docblock line 70: `@method static void passwordConfirmed(string|null $guard = null)`. The `Session` contract also gains `passwordConfirmed(?string $guard = null): void` (implementation-round improvement over the original "no contract change" call): `Request::session()` is typed to the contract, Fortify's controller calls the method through it, and the contract already carries the sibling Store conveniences (`previousUrl()`, `setPreviousRoute()`) — password-confirmation stamping is framework behavior every conforming session implementation must provide now that `RequirePassword` reads the key convention.
+
+### 7. `src/fortify/src/Http/Controllers/ConfirmablePasswordController.php`
+
+Line 50 becomes the single-writer call; the direct `put()` and the now-unused `Hypervel\Support\Facades\Date` import are removed (verified: `Date` is used only on that line).
+
+```php
+        if ($confirmed) {
+            $request->session()->passwordConfirmed();
+        }
+```
+
+The confirmation was verified against `Fortify::guard()` — the current guard — and `passwordConfirmed()` now stamps that same guard's key.
+
+### 8. `src/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php`
+
+Read the current guard's key and timeout through the shared helper. Imports: add `Hypervel\Auth\PasswordConfirmation`, `Hypervel\Fortify\Fortify`.
+
+```php
+    /**
+     * Get the password confirmation status.
+     */
+    public function show(Request $request): JsonResponse
+    {
+        $guard = Fortify::guardName();
+
+        $lastConfirmation = (int) $request->session()->get(PasswordConfirmation::sessionKey($guard), 0);
+        $lastConfirmed = Date::now()->unix() - $lastConfirmation;
+        $confirmed = $lastConfirmed < PasswordConfirmation::timeout($this->config, $guard, $request->input('seconds'));
+        // ... response unchanged
+```
+
+Deliberate fix folded in: this controller's fallback default was `900` while the middleware's is `10800` — an upstream Laravel/Fortify inconsistency. Both now resolve through `PasswordConfirmation::timeout()` (default 10800). The shipped config always sets `auth.password_timeout`, so the default only matters for apps that delete the key; unifying it removes a trap.
+
+### 9. `src/auth/src/Middleware/RedirectIfAuthenticated.php`
+
+```php
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next, string ...$guards): Response
+    {
+        $checkGuards = $guards ?: [null];
+
+        foreach ($checkGuards as $guard) {
+            if (Auth::guard($guard)->check()) {
+                return redirect($this->redirectTo($request));
+            }
+        }
+
+        // Naming a guard on an auth middleware makes it current: auth:admin
+        // selects the matched guard on success, so guest:admin selects its
+        // guard on pass-through. The first listed guard is the primary.
+        if ($guards !== []) {
+            Auth::shouldUse($guards[0]);
+        }
+
+        return $next($request);
+    }
+```
+
+No selection on the redirect path (an authenticated user is leaving this route group) and none for bare `guest` (no named guard exists).
+
+### 10. `src/sanctum/config/sanctum.php`
+
+- Rename the `'stateful'` key to `'stateful_domains'` (same value expression, same comment block — the header already reads "Stateful Domains"). The env var `SANCTUM_STATEFUL_DOMAINS` now mirrors the key path exactly.
+- Delete the entire `'guard'` entry and its "Sanctum Guards" comment block. The replacement comment is unnecessary — the declaration now lives in `config/auth.php` where it is documented.
+
+### 11. `src/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php`
+
+Line 84: `return config('sanctum.stateful_domains', []);`. The overridable `statefulDomains()` hook is otherwise unchanged.
+
+### 12. `src/sanctum/src/SanctumServiceProvider.php`
+
+`registerSanctumGuard()` validates the declaration at guard resolution time and passes the list into the guard. Import `InvalidArgumentException`. While in the method, fix the container-access rule violations (`$app['events']`, `$app['config']` → `->make()`; `has()` → `bound()`, matching the framework's optional-events pattern).
+
+```php
+        $this->callAfterResolving(AuthManager::class, function (AuthManager $authManager) {
+            $authManager->extend('sanctum', function ($app, $name, $config) use ($authManager) {
+                $sessionGuards = $config['session_guards'] ?? null;
+                $isSessionGuardName = static fn (mixed $guard): bool => is_string($guard) && $guard !== '';
+
+                if (! is_array($sessionGuards) || array_filter($sessionGuards, $isSessionGuardName) !== $sessionGuards) {
+                    throw new InvalidArgumentException(
+                        "Auth guard [{$name}] uses the sanctum driver but does not declare a valid session guards list. "
+                        . "Set auth.guards.{$name}.session_guards to an array of session guard names, or [] to disable stateful session authentication."
+                    );
+                }
+
+                return new SanctumGuard(
+                    name: $name,
+                    provider: $authManager->createUserProvider($config['provider'] ?? null),
+                    app: $app,
+                    sessionGuards: $sessionGuards,
+                    events: $app->bound('events') ? $app->make('events') : null,
+                    expiration: $app->make('config')->get('sanctum.expiration'),
+                );
+            });
+        });
+```
+
+One validation covers all four config-shape errors — missing key, non-array value, non-string entries, empty-string entries — with the same instructive message. An empty string inside the list is malformed config (the explicit tokens-only mode is `[]`), and without this check it would surface later as a confusing `Auth guard [] is not defined.` A bare constructor `TypeError` or a downstream `AuthManager::guard()` type error would lose the config-key pointer this design promises; this is boundary validation of a declared config shape (the same philosophy as the typed config readers), not a defensive runtime guard.
+
+### 13. `src/sanctum/src/SanctumGuard.php`
+
+Constructor gains the declared list (after `$app`, before the optional parameters — a required identity collaborator):
+
+```php
+    public function __construct(
+        protected string $name,
+        UserProvider $provider,
+        protected Container $app,
+        protected array $sessionGuards,
+        protected ?Dispatcher $events = null,
+        protected ?int $expiration = null,
+    ) {
+        $this->provider = $provider;
+    }
+```
+
+The stateful section of `user()` (currently lines 79-93) is replaced. Imports: add `Hypervel\Contracts\Auth\StatefulGuard`, `InvalidArgumentException`; the `Hypervel\Support\Arr` import goes if no longer used elsewhere in the file (verified: `Arr` is used only in the deleted loop).
+
+```php
+        // Check the trusted stateful guards declared by this guard's config
+        $authFactory = $this->app->make('auth');
+
+        foreach ($this->sessionGuards as $sessionGuardName) {
+            $sessionGuard = $authFactory->guard($sessionGuardName);
+
+            if (! $sessionGuard instanceof StatefulGuard) {
+                throw new InvalidArgumentException(
+                    "Auth guard [{$this->name}] lists [{$sessionGuardName}] in session_guards, but that guard is not a stateful guard."
+                );
+            }
+
+            if (! $sessionGuard->check()) {
+                continue;
+            }
+
+            $user = $sessionGuard->user();
+
+            if (! $this->hasValidProvider($user)) {
+                continue;
+            }
+
+            if ($this->supportsTokens($user)) {
+                /** @var Authenticatable&\Hypervel\Sanctum\Contracts\HasApiTokens $tokenUser */
+                $tokenUser = $user;
+                $user = $tokenUser->withAccessToken(new TransientToken);
+            }
+
+            CoroutineContext::set($contextKey, $user);
+
+            return $user;
+        }
+```
+
+Behavior deltas, all intended:
+
+- **Provider match on the stateful path** mirrors the bearer-token path's `hasValidProvider()`. A session user outside this guard's provider is skipped; the loop continues to the next listed guard, then falls through to token auth. Skip-and-continue (not abort) because a shared-API guard listing `['member', 'admin']` needs later entries tried.
+- **The old `$guard !== $this->name` silent self-skip is deleted.** Listing a sanctum guard (self or another) now throws via the `StatefulGuard` check — `SanctumGuard` implements only the base `Guard` contract. This also closes a real hazard: two sanctum guards listing each other would re-enter `user()` before the coroutine-context cache is populated, recursing without bound.
+- The `StatefulGuard` contract check (not `driver === 'session'` config inspection) keeps custom stateful guards registered via `extend()` valid and avoids config-shape inference.
+
+No `getSessionGuards()` accessor: nothing consumes it (the middleware below derives its own list), and dead API surface is not added speculatively.
+
+### 14. `src/sanctum/src/Http/Middleware/AuthenticateSession.php`
+
+The middleware runs at group level, before route auth selects a guard, so it cannot ask "the current sanctum guard" for its list. It derives the union of every sanctum-driver guard's `session_guards` from config: password-hash invalidation correctly applies to any session guard that participates in stateful sanctum auth anywhere in the app (checking a guard the route doesn't use is harmless — it only logs out sessions whose password actually changed, which is correct behavior wherever it happens). Constructor gains the config repository; line 38's `Collection::make(Arr::wrap(config('sanctum.guard')))` becomes `Collection::make($this->sanctumSessionGuards())`. The `Arr` import goes if now unused (verified: `Arr::wrap` at line 38 is its only use); add `Hypervel\Contracts\Config\Repository`.
+
+```php
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct(
+        protected AuthFactory $auth,
+        protected Repository $config,
+    ) {
+    }
+
+    /**
+     * Get the session guards declared by the application's sanctum guards.
+     *
+     * The union across every sanctum-driver guard entry: password-hash
+     * invalidation applies to any session guard participating in stateful
+     * sanctum authentication anywhere in the application.
+     */
+    protected function sanctumSessionGuards(): array
+    {
+        $sessionGuards = [];
+
+        foreach ($this->config->array('auth.guards', []) as $guard) {
+            if (($guard['driver'] ?? null) !== 'sanctum') {
+                continue;
+            }
+
+            $declared = $guard['session_guards'] ?? null;
+
+            if (! is_array($declared)) {
+                continue;
+            }
+
+            $sessionGuards = [...$sessionGuards, ...array_filter($declared, static fn (mixed $guard): bool => is_string($guard) && $guard !== '')];
+        }
+
+        return array_values(array_unique($sessionGuards));
+    }
+```
+
+A sanctum entry with a missing or malformed `session_guards` declaration contributes nothing here — the loud instructive error belongs to the resolution of the guard that declares it (the service-provider validation above), and a group-level middleware must not turn one unrelated bad entry into a request-wide failure. Nothing is masked: using the bad guard still throws. The existing `instanceof SessionGuard` filter stays: the password-hash mechanism is genuinely session-specific, and non-`SessionGuard` stateful guards have no hash to validate.
+
+### 15. `src/foundation/config/auth.php`
+
+- The `sanctum` guard entry gains its declaration:
+
+```php
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => ['web'],
+        ],
+```
+
+- Guards section comment: after the existing `passwords` paragraph, add: "Sanctum guards declare the session guards they trust for first-party SPA requests with the `session_guards` key; set it to an empty array for bearer-token-only APIs. Guards may also override the password confirmation window with a `password_timeout` key."
+- `password_timeout` section comment (line ~161): append "Individual guards may override this with a `password_timeout` key in their guard configuration."
+
+The `jwt` guard entry is unchanged (not a sanctum driver). `src/testbench/hypervel/config/auth.php` needs no change — it overrides only `providers.users` and inherits `guards` from this base config.
+
+### 16. `src/auth/src/AuthManager.php` — viaRequest
+
+```php
+    /**
+     * Register a new callback based request guard.
+     */
+    public function viaRequest(string $driver, callable $callback): static
+    {
+        return $this->extend($driver, function ($app, $name, $config) use ($callback) {
+            return new RequestGuard($name, $callback, $app, $this->createUserProvider($config['provider'] ?? null));
+        });
+    }
+```
+
+`callCustomCreator()` already invokes creators with `($this->app, $name, $config)` (`AuthManager.php:100-103`), so the third parameter is available today and simply unused.
+
+### 17. `src/auth/src/CreatesUserProviders.php`
+
+`getDefaultUserProvider()` is kept but redefined: it no longer reads the removed `auth.defaults.provider` root — it derives from the current default guard, exactly as `PasswordBrokerManager::getDefaultDriver()` was redefined when `auth.defaults.passwords` was removed. Humans and LLMs reaching for the Laravel-shaped method get the guard-siloing-correct answer instead of a missing-method failure (owner decision, 2026-07-07):
+
+The trait is used by `AuthManager`, which itself provides `getDefaultDriver()`, so the body calls it directly:
+
+```php
+    /**
+     * Get the provider name declared by the current default guard.
+     */
+    public function getDefaultUserProvider(): ?string
+    {
+        return $this->app->make('config')->get('auth.guards.' . $this->getDefaultDriver() . '.provider');
+    }
+```
+
+The boundary that matters is unchanged: `createUserProvider()` does **not** call this method. `createUserProvider(null)` means "no provider" — during guard construction the ambient guard can be a different guard than the one being built, so an implicit ambient fallback there would be a wrong-provider hazard. The method is read-only introspection.
+
+`getProviderConfiguration()` becomes null-only (no falsey reinterpretation — consistent with the `??=` fixes in PR #420's follow-up):
+
+```php
+    /**
+     * Get the user provider configuration.
+     */
+    protected function getProviderConfiguration(?string $provider): ?array
+    {
+        if (is_null($provider)) {
+            return null;
+        }
+
+        return $this->app->make('config')->get('auth.providers.' . $provider);
+    }
+```
+
+### 18. `src/support/src/Facades/Auth.php`
+
+No change: docblock line 25 (`@method static ?string getDefaultUserProvider()`) stays — the redefined method keeps the same signature and nullable return. The `Hypervel\Contracts\Auth\Factory` contract never declared either method (verified), so no contract change.
+
+### 19. `src/permission/src/Support/Config.php`
+
+Import `Hypervel\Contracts\Auth\Factory as AuthFactory` (the class already imports `Container`):
+
+```php
+    /**
+     * Get the default auth guard name.
+     */
+    public static function defaultGuard(): string
+    {
+        return Container::getInstance()->make(AuthFactory::class)->getDefaultDriver();
+    }
+```
+
+The `Repository` import stays (used by `repository()` and other methods). This aligns `defaultGuard()` with `Guard::getDefaultName()` — one answer to "what is the default guard" package-wide, context override included.
+
+### 20. `src/fortify/src/LoginRateLimiter.php`
+
+```php
+    /**
+     * Get the throttle key for the given request.
+     *
+     * Scoped to the current guard so lockouts in one actor silo never
+     * block logins in another for the same username and IP.
+     */
+    private function throttleKey(Request $request): string
+    {
+        return Str::transliterate(Fortify::guardName() . '|' . Str::lower((string) $request->input(Fortify::username())) . '|' . $request->ip());
+    }
+```
+
+No import change (`Fortify` is the same namespace).
+
+### 21. `src/foundation/src/Console/PolicyMakeCommand.php`
+
+Line 74-76: fix the container-access violation while resolving the guard through the manager:
+
+```php
+        $config = $this->hypervel->make('config');
+
+        $guard = $this->option('guard') ?: $this->hypervel->make('auth')->getDefaultDriver();
+```
+
+Foundation apps always have auth registered and the base config always provides `auth.defaults.guard`, so no soft path is needed. The rest of the method (LogicException for undefined guards, provider/model lookups) is unchanged.
+
+### 22. `src/console/src/GeneratorCommand.php`
+
+`userProviderModel()` (lines 445-455): the console package does not require `hypervel/auth` (verified in `src/console/composer.json`), so the auth binding is genuinely optional here — the `bound()` check protects a real reachable path (standalone console usage), replacing the current silent null-guard concatenation:
+
+```php
+    /**
+     * Get the model for the default guard's user provider.
+     */
+    protected function userProviderModel(): ?string
+    {
+        // Best-effort guess: console may run without the auth package installed.
+        if (! $this->hypervel->bound('auth')) {
+            return null;
+        }
+
+        $config = $this->hypervel->make('config');
+
+        $provider = $config->get('auth.guards.' . $this->hypervel->make('auth')->getDefaultDriver() . '.provider');
+
+        return $config->get("auth.providers.{$provider}.model");
+    }
+```
+
+### 23. Documentation (`src/boost/docs/`) — Edit, never rewrite files
+
+**`authentication.md`**
+
+- Line 366 (guest middleware section): append a sentence — when the `guest` middleware names a guard and the request continues, that guard becomes the current default guard for the request; with multiple guards, the first listed is selected.
+- Line 391 (the multi-guard paragraph added by PR #420): rewrite. New wording: "Guards that send password reset links declare their password broker with the `passwords` key. Multi-guard applications should set this per guard. On guest routes such as login and password reset requests, naming the guard on the `guest` middleware selects it for the request — `guest:admin` makes `admin` the current guard, so authentication, policies, and password reset flows all follow the same user type. For guest routes that do not use the `guest` middleware, apply `auth.guard:admin` instead:" (the guards config code block that follows the paragraph is unchanged).
+- Password confirmation configuration (line ~711): append — confirmation is scoped to the current guard (confirming under one guard never satisfies `password.confirm` under another), and individual guards may override the window with a `password_timeout` key in their guard configuration.
+
+**`sanctum.md`**
+
+- "Setting Sanctum Guard" section (anchor at line 93): rewrite the section body to document `session_guards` on the guard entry: what it declares, the `['web']` default in a fresh app, `[]` as the explicit bearer-token-only mode, the config error when missing, the `StatefulGuard` requirement, and that a trusted session user must belong to the sanctum guard's provider. Retitle the section "Declaring Trusted Session Guards" and update the TOC entry at line 7.
+- Lines 417-421: `stateful` configuration option references become `stateful_domains`. The `statefulDomains()` override example (lines 430-438) is unchanged (method name is not renamed).
+
+**`fortify.md`**
+
+- Line 222: the sentence "Named middleware such as `auth:admin` or `guest:admin` checks that guard, but it does not set the default guard that controller code and other packages use." is factually wrong today for `auth:admin` (`Authenticate::authenticate()` calls `shouldUse()` on success) and becomes wrong for `guest:admin` with this plan. Replace with: "Named middleware select their guard as the request default: `auth:admin` selects `admin` when authentication succeeds, and `guest:admin` selects `admin` when the request passes the guest check. Use middleware like the example above when many routes should share one guard without naming it on each middleware."
+- Line 371 ("Password confirmation uses the current default guard.") stays — it is now true in the strong sense; append: "Confirmation is stored per guard, and lockout throttling for login attempts is also scoped per guard."
+
+### 24. Package README `Differences From Laravel` entries
+
+Per AGENTS.md, removed or diverged Laravel surfaces are recorded where future upstream merges will look. Owner-approved entries (added during the code-review round; wording may be tightened in place):
+
+**`src/sanctum/README.md`** (existing section, append):
+- The global `sanctum.guard` accept-list is removed. Each sanctum-driver guard declares its trusted session guards with `auth.guards.{guard}.session_guards` — `[]` means bearer tokens only, and a missing key is a config error. Stateful session users must also match the sanctum guard's provider; Laravel returns any listed guard's user unchecked.
+- `sanctum.stateful` is renamed `sanctum.stateful_domains`, matching the `SANCTUM_STATEFUL_DOMAINS` env var and the key's actual contents.
+
+**`src/fortify/README.md`** (existing section, append):
+- Login throttling is scoped per guard (`guard|username|ip`), so a lockout in one actor silo never blocks logins in another.
+- Password confirmation follows the current guard: guard-scoped session key, optional per-guard `password_timeout`, and the confirmed-password status endpoint uses the same resolution (also unifying Laravel's mismatched 900/10800 fallback defaults).
+
+**`src/auth/README.md`** (new `## Differences From Laravel` section — includes retroactive entries for PR #420, which never recorded its removals here):
+- Password brokers are guard-declared via `auth.guards.{guard}.passwords`; `auth.defaults.passwords` and `AUTH_PASSWORD_BROKER` do not exist, and bare `Password::` calls resolve through the current guard or throw.
+- `auth.defaults.provider` does not exist; `getDefaultUserProvider()` returns the provider declared by the current default guard, and `createUserProvider(null)` means no provider.
+- `guest:{guard}` selects the first named guard as the request's default guard on pass-through, mirroring how `auth:{guard}` selects on success.
+- Password confirmation is guard-scoped (`auth.password_confirmed_at_{guard}`) with an optional per-guard `password_timeout`; `RequirePassword` resolves guard and timeout at handle-time.
+
+**`src/session/README.md`** (new `## Differences From Laravel` section):
+- `Store::passwordConfirmed(?string $guard = null)` stamps a guard-scoped key (`auth.password_confirmed_at_{guard}`) instead of Laravel's single shared key, resolving the current guard when none is given.
+
+Passkeys and foundation need no entries: passkeys inherits the confirmation change through the session store with no API of its own changing, and foundation's config shape is documented in the config comments and boost docs.
+
+### 25. Verified inventory: nothing else reads the removed roots
+
+Repo-wide greps (source, non-test) match exactly the lines this plan changes:
+
+- `sanctum.guard`: `SanctumGuard.php:81`, `Http/Middleware/AuthenticateSession.php:38`, `config/sanctum.php:36`, plus `tests/Sanctum/GuardTest.php:53` and `tests/Sanctum/AuthenticateRequestsTest.php:54`.
+- `sanctum.stateful`: `config/sanctum.php:17`, `EnsureFrontendRequestsAreStateful.php:84`, `sanctum.md`.
+- `auth.defaults.provider`: `CreatesUserProviders.php:93` (read replaced by the guard-derived redefinition), `tests/Auth/AuthManagerTest.php:167,257` (tests rewritten). `getDefaultUserProvider` deliberately remains in `CreatesUserProviders.php` and `Facades/Auth.php:25` with new semantics.
+- `auth.password_confirmed_at` (unsuffixed): `Store.php:705`, `RequirePassword.php:65`, `ConfirmablePasswordController.php:50`, `ConfirmedPasswordStatusController.php:28`, `tests/Session/SessionStoreTest.php:484-486`, `tests/Auth/RequirePasswordMiddlewareTest.php` (5 sites), `tests/Fortify/ConfirmablePasswordControllerTest.php` (7 sites), `tests/Passkeys/Feature/Controllers/PasskeyConfirmationTest.php:126`, `tests/Passkeys/Feature/Controllers/PasskeyRegistrationTest.php` (8 sites: lines 27, 52, 70, 125, 148, 205, 229, 280).
+- `auth.password_timeout` reads outside config: `AuthServiceProvider.php:77`, `ConfirmedPasswordStatusController.php:32` — both replaced by `PasswordConfirmation::timeout()`.
+- `.env` / `.env.example`: no occurrences of `SANCTUM_STATEFUL_DOMAINS` or `AUTH_PASSWORD_TIMEOUT` (nothing to update).
+
+## Test Plan
+
+Run each file immediately after changing it (`./vendor/bin/phpunit --no-progress <file>`), then `composer test:parallel`, phpstan, cs-fixer at the end. All from the repo root.
+
+### `tests/Auth/PasswordConfirmationTest.php` (new)
+
+Unit tests on `Hypervel\Tests\TestCase` with a real `Hypervel\Config\Repository`:
+
+1. `testSessionKeyIsGuardSuffixed` — `sessionKey('admin') === 'auth.password_confirmed_at_admin'`.
+2. `testTimeoutUsesGuardDeclaration` — `auth.guards.admin.password_timeout = 900` → `timeout($config, 'admin') === 900`.
+3. `testTimeoutFallsBackToGlobal` — no guard key, `auth.password_timeout = 3600` → `3600`.
+4. `testTimeoutDefaultsWhenUnconfigured` — empty config → `10800`.
+5. `testTimeoutFailsFastOnMalformedGuardValue` — guard key set to `'abc'` → the config repository's typed-read `InvalidArgumentException`.
+6. `testGuardDeclarationWinsWhenGlobalIsMalformed` — guard key `900`, global set to `'abc'` → `900` with no exception (pins the `has()` branch: the global tier is never read when the guard declares).
+7. `testExplicitOverrideWinsOverAllTiers` — guard and global both set, `timeout($config, 'admin', '300') === 300` (also pins the string-to-int cast of route parameters).
+
+### `tests/Auth/RequirePasswordMiddlewareTest.php` (update + extend)
+
+Existing tests construct the middleware directly and mock the session with the old key — five construction sites (`new RequirePassword($responseFactory, $urlGenerator)` at lines 49, 81, 114, 147, 174), each updated to the new four-argument constructor (add `m::mock(AuthFactory::class)` returning a guard name from `getDefaultDriver()` and a real config `Repository`), and every session expectation updated to `auth.password_confirmed_at_{guard}`. No other code constructs the middleware directly (verified: the only `new RequirePassword` outside this file is the provider binding being deleted). New tests:
+
+8. `testConfirmationIsScopedToCurrentGuard` — auth factory returns `admin`; session holds a fresh `..._web` timestamp but no `..._admin`; middleware redirects (cross-guard confirmation does not satisfy).
+9. `testPerGuardTimeoutIsHonored` — guard `admin` declares `password_timeout = 10`; confirmation 11 seconds old → redirect; 9 seconds old → pass.
+10. `testRouteParameterOverridesPerGuardTimeout` — route param 5 beats guard declaration 10.
+
+### `tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php` (extend)
+
+Testbench-based; asserts via `Auth::getDefaultDriver()` / `CoroutineContext::has(AuthManager::DEFAULT_GUARD_CONTEXT_KEY)`:
+
+11. `testNamedGuardIsSelectedOnPassThrough` — `handle($request, $next, 'admin')` with no authenticated user → next called and default driver is `admin`.
+12. `testFirstListedGuardIsSelectedForMultipleGuards` — `handle(..., 'admin', 'web')` → `admin`.
+13. `testBareGuestSelectsNothing` — `handle($request, $next)` → context key absent.
+14. `testNoSelectionOnRedirect` — authenticated user → redirect returned and context key absent.
+
+### `tests/Auth/AuthManagerTest.php` (rewrite three tests)
+
+- `testGetDefaultUserProvider` (line ~162): rewrite for the redefined semantics — `auth.defaults.guard = 'web'`, `auth.guards.web.provider = 'users'` → `'users'`; add a context case (`shouldUse('admin')` with `auth.guards.admin.provider = 'admins'` → `'admins'`); add a missing-provider case (current guard entry without a `provider` key → null).
+- `testCreateUserProviderReturnsNullWhenNoProviderIsConfigured` (line ~171): drop the `getDefaultUserProvider()` assertion (its null-return path is now covered by the missing-provider case above); keep `assertNull($manager->createUserProvider())` pinning that the bare call never consults the redefined method.
+- The viaRequest test at line ~245: replace `auth.defaults.provider = 'foo'` with `'auth.guards.foo' => ['driver' => 'custom', 'provider' => 'foo']`; add an assertion that the resolved `RequestGuard`'s provider is the registered `foo` provider instance (via `getProvider()`).
+- New: `testViaRequestGuardWithoutProviderKeyGetsNullProvider` — guard entry without `provider` → `getProvider()` returns null.
+
+### `tests/Session/SessionStoreTest.php` (update + extend)
+
+- Line 484-486: update to the explicit-guard form — `$session->passwordConfirmed('web')` sets `auth.password_confirmed_at_web`.
+- New: `testPasswordConfirmedResolvesCurrentGuardWhenNoneGiven` — bind a mock `AuthFactory` (`getDefaultDriver()` → `'admin'`) on `Container::getInstance()`, call `passwordConfirmed()`, assert the `_admin` key. Follow the file's existing container-interaction style.
+
+### `tests/Fortify/ConfirmablePasswordControllerTest.php` (update + extend)
+
+Update existing assertions from the shared key to `auth.password_confirmed_at_{guard}` for the test's guard. New:
+
+15. `testConfirmationStampsCurrentGuardKey` — confirm under the `admin` guard (the Fortify TestCase already configures `web` + `admin`); assert the `_admin` key is set and `_web` is not.
+16. Status endpoint: `testStatusReadsCurrentGuardConfirmation` — stamp `_admin`, query the status route under `admin` → confirmed true; under `web` → confirmed false.
+17. `testStatusUsesPerGuardTimeout` — `auth.guards.web.password_timeout = 10`, stamp 11 seconds ago → confirmed false.
+
+### `tests/Passkeys/Feature/Controllers/PasskeyConfirmationTest.php` and `PasskeyRegistrationTest.php` (update)
+
+- `PasskeyConfirmationTest.php:126` — update the `session('auth.password_confirmed_at')` assertion to the guard-scoped key (the controller path flows through `Store::passwordConfirmed()` and becomes guard-scoped automatically).
+- `PasskeyRegistrationTest.php` — eight `withSession(['auth.password_confirmed_at' => time()])` seeds (lines 27, 52, 70, 125, 148, 205, 229, 280) satisfy the `password.confirm` middleware on the management routes; each becomes the guard-suffixed key for the route's guard.
+
+### `tests/Fortify/AuthenticatedSessionControllerTest.php` (extend)
+
+18. `testLockoutIsScopedToGuard` — drive the `web` login into lockout (five failed attempts for one email + IP), then with the current guard `admin` assert `LoginRateLimiter::tooManyAttempts()` is false for the same request shape (or via a second login route under the admin guard, following the file's existing throttle-test style).
+
+### `tests/Sanctum/GuardTest.php` (config migration + matrix)
+
+Replace `'sanctum.guard' => ['web']` (line 53) with `'session_guards' => ['web']` inside the `auth.guards.sanctum` entry. New tests:
+
+19. `testEmptySessionGuardsIsTokenOnly` — `session_guards => []`, active web session → guard returns null without a token, returns the token user with one.
+20. `testMissingSessionGuardsThrowsInstructiveError` — guard entry without the key → `InvalidArgumentException` with the exact message on first resolution.
+21. `testNonArraySessionGuardsThrowsInstructiveError` — `session_guards => 'web'` → the same instructive `InvalidArgumentException` (not a `TypeError`).
+22. `testInvalidSessionGuardEntriesThrowInstructiveError` — `session_guards => [123]` and `session_guards => ['']` each → the same instructive `InvalidArgumentException` (an empty-string entry is malformed config; the explicit tokens-only mode is `[]`).
+23. `testNonStatefulSessionGuardThrows` — `session_guards => ['other-sanctum']` where `other-sanctum` is a sanctum guard → `InvalidArgumentException` naming both guards (also pins the recursion-hazard fix).
+24. `testStatefulUserMustMatchProvider` — two providers/models; web session holds a user from the *other* provider → stateful path skips it and token auth still works (mirror of the existing token-path provider test).
+25. `testSecondListedSessionGuardIsTried` — `session_guards => ['admin', 'web']`, only `web` session authenticated with a matching-provider user → user returned.
+
+### `tests/Sanctum/AuthenticateRequestsTest.php`, `tests/Sanctum/ActingAsTest.php`, `tests/Sanctum/SimpleGuardTest.php` (config migration)
+
+Move `sanctum.guard` config (AuthenticateRequestsTest line 54) into the guard entries. Every `driver => 'sanctum'` test guard entry gets `'session_guards' => ['web']` — including ActingAsTest's `sanctum` and `api` entries and SimpleGuardTest's `sanctum` entry, which today set no `sanctum.guard` and therefore ran under the old fail-open default of `['web']`; declaring `['web']` preserves their current behavior exactly (the `[]` mode is exercised by the new matrix test, not by retrofitting existing tests). Grep to catch them all: `grep -rn "'driver' => 'sanctum'" tests/`.
+
+### `tests/Sanctum/AuthenticateSessionTest.php` (new)
+
+Tests for the middleware's config-derived union (Testbench base, mirroring `tests/Session/Middleware/AuthenticateSessionTest.php` style):
+
+26. `testUnionOfSanctumGuardsSessionGuardsIsChecked` — two sanctum guard entries declaring `['web']` and `['admin']`; a password change under `admin` logs that session guard out through the middleware.
+27. `testSanctumEntryWithoutSessionGuardsContributesNothing` — a sanctum entry missing the key does not break the middleware (no exception from the union derivation; the loud error stays at guard resolution).
+28. `testMalformedSessionGuardsEntriesAreSkippedByUnion` — one unused sanctum entry with `session_guards => 'web'` (string) and another with `[123, '', 'admin']`; the middleware still functions and only checks `admin` (the loud error for the malformed entries stays at their guard resolution).
+
+### `tests/Permission/Support/ConfigTest.php` (new)
+
+29. `testDefaultGuardFallsBackToConfig` — no context override → `auth.defaults.guard` value.
+30. `testDefaultGuardFollowsCurrentGuard` — `Auth::shouldUse('admin')` → `Config::defaultGuard() === 'admin'` (each test runs in its own coroutine; context cleanup is automatic).
+
+### Existing suites as regression gates
+
+- `tests/Integration/Generators/PolicyMakeCommandTest.php` — behavior is equivalent (console has no context override); the existing suite passing is the coverage. The `GeneratorCommand` unbound-auth branch is not testable in this suite (auth is always bound under testbench) and is deliberately left to the existing best-effort contract; no artificial container surgery to fake a missing package.
+- `tests/Fortify/`, `tests/Passkeys/`, `tests/Session/`, `tests/Sanctum/`, `tests/Auth/`, `tests/Permission/` full runs after their respective steps.
+
+No new coroutine-isolation test files: the only context-backed state these changes touch is `DEFAULT_GUARD_CONTEXT_KEY`, whose isolation is already pinned by `tests/Auth/UseGuardMiddlewareTest.php` and the broker manager tests; the new confirmation state is session-stored (per session by nature, not per coroutine).
+
+## Execution Order
+
+1. `PasswordConfirmation` class + `RequirePassword` + `AuthServiceProvider` + `foundation/config/auth.php` comments/`password_timeout` doc text; run `tests/Auth/PasswordConfirmationTest.php`, `tests/Auth/RequirePasswordMiddlewareTest.php`.
+2. `Store::passwordConfirmed()` + session composer.json + `Session` facade docblock; run `tests/Session/SessionStoreTest.php`.
+3. Fortify confirmation controllers; run `tests/Fortify/ConfirmablePasswordControllerTest.php`, then `tests/Passkeys/Feature/Controllers/PasskeyConfirmationTest.php` and `tests/Passkeys/Feature/Controllers/PasskeyRegistrationTest.php`.
+4. `RedirectIfAuthenticated`; run its test file.
+5. viaRequest + `CreatesUserProviders` + `Auth` facade docblock; run `tests/Auth/AuthManagerTest.php`.
+6. Sanctum: config rename/deletion, `EnsureFrontendRequestsAreStateful`, service provider, `SanctumGuard`, `AuthenticateSession`, foundation `auth.php` sanctum entry; run `tests/Sanctum/` in full.
+7. Permission `Config::defaultGuard()`; run `tests/Permission/Support/ConfigTest.php` + `tests/Permission/GuardTest.php`.
+8. `LoginRateLimiter`; run `tests/Fortify/AuthenticatedSessionControllerTest.php`.
+9. Generators; run `tests/Integration/Generators/PolicyMakeCommandTest.php`.
+10. Docs (`authentication.md`, `sanctum.md`, `fortify.md`) and the package README `Differences From Laravel` entries (§24).
+11. Final greps (below), then `composer test:parallel`, `./vendor/bin/phpstan`, `./vendor/bin/php-cs-fixer fix` (no flags).
+
+Final verification greps (clear the phpstan cache first: `rm -rf .cache/phpstan`), each expected to return nothing:
+
+```bash
+grep -rn "auth\.defaults\.provider" src/ tests/
+grep -rn "sanctum\.guard" src/ tests/
+grep -rn "sanctum\.stateful[^_]" src/ tests/
+grep -REn "auth\.password_confirmed_at([^_A-Za-z0-9]|$)" src/ tests/
+grep -rn "'auth\.password_timeout'" src/ | grep -v "PasswordConfirmation.php\|foundation/config/auth.php"
+```
+
+(The last grep's two exclusions are the only permitted occurrences: the config definition and the single reader, `PasswordConfirmation::timeout()`.)
+
+## Explicitly Unchanged
+
+- **`auth.verification.expire` stays global** — a signed-URL TTL with no cross-silo hazard; the URL is already signed per user.
+- **Permission's model-to-guard inference (`Guard::getConfigAuthGuards()`) stays** — Spatie's architecture, used only when a model declares no `guard_name`, and `getDefaultName()` already prefers the current guard when it is a candidate.
+- **JWT settings stay** — the JWT guard already owns its provider and supports per-guard TTL; signing defaults are not actor-silo decisions.
+- **`EnsureFrontendRequestsAreStateful` stays app-level** — pre-auth infrastructure; per-guard domains were considered and rejected (see Rejected Alternatives). The `statefulDomains()` override hook is the extension point.
+- **Sanctum's bearer-token path** — `hasValidProvider()` was already correct; the stateful path now matches it.
+- **Core session `AuthenticateSession`** — already guard-scoped via `password_hash_{guard}`.
+- **`Sanctum::actingAs()` `'sanctum'` default** — an explicit test helper, Laravel parity, callers pass a guard when they mean another.
+- **`UseGuard` / `auth.guard` middleware** — unchanged and still the right tool for selecting a guard on route groups that use neither `auth` nor `guest`.

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -5,6 +5,13 @@ Auth for Hypervel
 
 <!-- @TODO: Move to 0.4 documentation -->
 
+## Differences From Laravel
+
+- Password brokers are guard-declared via `auth.guards.{guard}.passwords`; `auth.defaults.passwords` and `AUTH_PASSWORD_BROKER` do not exist, and bare `Password::` calls resolve through the current guard or throw.
+- `auth.defaults.provider` does not exist; `getDefaultUserProvider()` returns the provider declared by the current default guard, and `createUserProvider(null)` means no provider.
+- `guest:{guard}` selects the first named guard as the request's default guard on pass-through, mirroring how `auth:{guard}` selects on success.
+- Password confirmation is guard-scoped (`auth.password_confirmed_at_{guard}`) with an optional per-guard `password_timeout`; `RequirePassword` resolves the guard and timeout at handle time.
+
 ## User Lookup Cache
 
 Optional cross-request cache for `EloquentUserProvider::retrieveById()`. Disabled by default. When enabled, each authenticated request can hit the cache instead of re-querying the database for the current user — a large win under Swoole where workers are long-lived and request volume is high.

--- a/src/auth/src/AuthManager.php
+++ b/src/auth/src/AuthManager.php
@@ -201,8 +201,8 @@ class AuthManager implements FactoryContract
      */
     public function viaRequest(string $driver, callable $callback): static
     {
-        return $this->extend($driver, function ($app, $name) use ($callback) {
-            return new RequestGuard($name, $callback, $app, $this->createUserProvider());
+        return $this->extend($driver, function ($app, $name, $config) use ($callback) {
+            return new RequestGuard($name, $callback, $app, $this->createUserProvider($config['provider'] ?? null));
         });
     }
 

--- a/src/auth/src/AuthServiceProvider.php
+++ b/src/auth/src/AuthServiceProvider.php
@@ -6,11 +6,8 @@ namespace Hypervel\Auth;
 
 use Hypervel\Auth\Access\Gate;
 use Hypervel\Auth\Console\ClearResetsCommand;
-use Hypervel\Auth\Middleware\RequirePassword;
 use Hypervel\Contracts\Auth\Access\Gate as GateContract;
 use Hypervel\Contracts\Auth\Authenticatable as AuthenticatableContract;
-use Hypervel\Contracts\Routing\ResponseFactory;
-use Hypervel\Contracts\Routing\UrlGenerator;
 use Hypervel\Http\Request;
 use Hypervel\Support\ServiceProvider;
 
@@ -24,7 +21,6 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerAuthenticator();
         $this->registerUserResolver();
         $this->registerAccessGate();
-        $this->registerRequirePassword();
         $this->registerRequestUserResolver();
         $this->registerEventRebindHandler();
         $this->commands([ClearResetsCommand::class]);
@@ -41,7 +37,7 @@ class AuthServiceProvider extends ServiceProvider
         // current default guard per-coroutine via Context. The actual guard
         // instances are still cached by AuthManager; this binding just needs
         // to resolve which cached guard is current at call time.
-        $this->app->bind('auth.driver', fn ($app) => $app['auth']->guard());
+        $this->app->bind('auth.driver', fn ($app) => $app->make('auth')->guard());
     }
 
     /**
@@ -52,7 +48,7 @@ class AuthServiceProvider extends ServiceProvider
         // bind() is required here — each resolution must call the user resolver
         // fresh to get the current coroutine's authenticated user from Context.
         // A singleton would cache the first user and leak it across requests.
-        $this->app->bind(AuthenticatableContract::class, fn ($app) => call_user_func($app['auth']->userResolver()));
+        $this->app->bind(AuthenticatableContract::class, fn ($app) => call_user_func($app->make('auth')->userResolver()));
     }
 
     /**
@@ -61,21 +57,7 @@ class AuthServiceProvider extends ServiceProvider
     protected function registerAccessGate(): void
     {
         $this->app->singleton(GateContract::class, function ($app) {
-            return new Gate($app, fn () => call_user_func($app['auth']->userResolver()));
-        });
-    }
-
-    /**
-     * Register the require password middleware.
-     */
-    protected function registerRequirePassword(): void
-    {
-        $this->app->singleton(RequirePassword::class, function ($app) {
-            return new RequirePassword(
-                $app[ResponseFactory::class],
-                $app[UrlGenerator::class],
-                $app->make('config')->integer('auth.password_timeout', 10800),
-            );
+            return new Gate($app, fn () => call_user_func($app->make('auth')->userResolver()));
         });
     }
 
@@ -91,7 +73,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->callAfterResolving(Request::class, function (Request $request) {
             $request->setUserResolver(function (?string $guard = null) {
-                return call_user_func($this->app['auth']->userResolver(), $guard);
+                return call_user_func($this->app->make('auth')->userResolver(), $guard);
             });
         });
     }

--- a/src/auth/src/CreatesUserProviders.php
+++ b/src/auth/src/CreatesUserProviders.php
@@ -43,15 +43,23 @@ trait CreatesUserProviders
     }
 
     /**
+     * Get the provider name declared by the current default guard.
+     */
+    public function getDefaultUserProvider(): ?string
+    {
+        return $this->app->make('config')->get('auth.guards.' . $this->getDefaultDriver() . '.provider');
+    }
+
+    /**
      * Get the user provider configuration.
      */
     protected function getProviderConfiguration(?string $provider): ?array
     {
-        if ($provider = $provider ?: $this->getDefaultUserProvider()) {
-            return $this->app->make('config')->get('auth.providers.' . $provider);
+        if (is_null($provider)) {
+            return null;
         }
 
-        return null;
+        return $this->app->make('config')->get('auth.providers.' . $provider);
     }
 
     /**
@@ -60,8 +68,8 @@ trait CreatesUserProviders
     protected function createDatabaseProvider(array $config): DatabaseUserProvider
     {
         return new DatabaseUserProvider(
-            $this->app['db']->connection($config['connection'] ?? null),
-            $this->app['hash'],
+            $this->app->make('db')->connection($config['connection'] ?? null),
+            $this->app->make('hash'),
             $config['table'],
         );
     }
@@ -71,7 +79,7 @@ trait CreatesUserProviders
      */
     protected function createEloquentProvider(array $config): EloquentUserProvider
     {
-        $provider = new EloquentUserProvider($this->app['hash'], $config['model']);
+        $provider = new EloquentUserProvider($this->app->make('hash'), $config['model']);
 
         if (! empty($config['cache']['enabled'])) {
             $provider->enableCache(
@@ -83,13 +91,5 @@ trait CreatesUserProviders
         }
 
         return $provider;
-    }
-
-    /**
-     * Get the default user provider name.
-     */
-    public function getDefaultUserProvider(): ?string
-    {
-        return $this->app->make('config')->get('auth.defaults.provider');
     }
 }

--- a/src/auth/src/Middleware/RedirectIfAuthenticated.php
+++ b/src/auth/src/Middleware/RedirectIfAuthenticated.php
@@ -32,12 +32,18 @@ class RedirectIfAuthenticated
      */
     public function handle(Request $request, Closure $next, string ...$guards): Response
     {
-        $guards = empty($guards) ? [null] : $guards;
+        $checkGuards = $guards ?: [null];
 
-        foreach ($guards as $guard) {
+        foreach ($checkGuards as $guard) {
             if (Auth::guard($guard)->check()) {
                 return redirect($this->redirectTo($request));
             }
+        }
+
+        // Naming a guard on an auth middleware makes it current. The first
+        // listed guard is the primary guard for guest pass-through.
+        if ($guards !== []) {
+            Auth::shouldUse($guards[0]);
         }
 
         return $next($request);

--- a/src/auth/src/Middleware/RequirePassword.php
+++ b/src/auth/src/Middleware/RequirePassword.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Hypervel\Auth\Middleware;
 
 use Closure;
+use Hypervel\Auth\PasswordConfirmation;
+use Hypervel\Contracts\Auth\Factory as AuthFactory;
+use Hypervel\Contracts\Config\Repository;
 use Hypervel\Contracts\Routing\ResponseFactory;
 use Hypervel\Contracts\Routing\UrlGenerator;
 use Hypervel\Http\Request;
@@ -14,19 +17,14 @@ use Symfony\Component\HttpFoundation\Response;
 class RequirePassword
 {
     /**
-     * The password timeout in seconds.
-     */
-    protected int $passwordTimeout;
-
-    /**
      * Create a new middleware instance.
      */
     public function __construct(
         protected ResponseFactory $responseFactory,
         protected UrlGenerator $urlGenerator,
-        ?int $passwordTimeout = null,
+        protected AuthFactory $auth,
+        protected Repository $config,
     ) {
-        $this->passwordTimeout = $passwordTimeout ?: 10800;
     }
 
     /**
@@ -59,11 +57,16 @@ class RequirePassword
 
     /**
      * Determine if the confirmation timeout has expired.
+     *
+     * The confirmation timestamp and timeout are scoped to the current
+     * guard, so confirming a password under one guard never satisfies
+     * password confirmation under another.
      */
     protected function shouldConfirmPassword(Request $request, string|int|null $passwordTimeoutSeconds = null): bool
     {
-        $confirmedAt = Date::now()->unix() - $request->session()->get('auth.password_confirmed_at', 0);
+        $guard = $this->auth->getDefaultDriver();
+        $confirmedAt = Date::now()->unix() - $request->session()->get(PasswordConfirmation::sessionKey($guard), 0);
 
-        return $confirmedAt > ($passwordTimeoutSeconds ?? $this->passwordTimeout);
+        return $confirmedAt > PasswordConfirmation::timeout($this->config, $guard, $passwordTimeoutSeconds);
     }
 }

--- a/src/auth/src/PasswordConfirmation.php
+++ b/src/auth/src/PasswordConfirmation.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Auth;
+
+use Hypervel\Contracts\Config\Repository;
+
+final class PasswordConfirmation
+{
+    /**
+     * Get the session key holding the password confirmation timestamp for the guard.
+     */
+    public static function sessionKey(string $guard): string
+    {
+        return "auth.password_confirmed_at_{$guard}";
+    }
+
+    /**
+     * Get the password confirmation timeout in seconds for the guard.
+     *
+     * An explicit override wins, followed by the guard declaration, then
+     * the application-wide timeout.
+     */
+    public static function timeout(Repository $config, string $guard, string|int|null $override = null): int
+    {
+        if ($override !== null) {
+            return (int) $override;
+        }
+
+        $key = "auth.guards.{$guard}.password_timeout";
+
+        if ($config->has($key)) {
+            return $config->integer($key);
+        }
+
+        return $config->integer('auth.password_timeout', 10800);
+    }
+}

--- a/src/boost/docs/authentication.md
+++ b/src/boost/docs/authentication.md
@@ -377,6 +377,8 @@ use Hypervel\Http\Request;
 })
 ```
 
+When the `guest` middleware names a guard and the request continues, that guard becomes the current default guard for the request. If multiple guards are listed, the first guard is selected.
+
 <a name="specifying-a-guard"></a>
 #### Specifying a Guard
 
@@ -388,7 +390,7 @@ Route::get('/flights', function () {
 })->middleware('auth:admin');
 ```
 
-Guards that send password reset links declare their password broker with the `passwords` key. Multi-guard applications should set this per guard. On guest routes such as login and password reset requests, no `auth` middleware runs to select a guard, so apply the `auth.guard:admin` middleware to the route group — authentication, policies, and password reset flows then all follow the same user type:
+Guards that send password reset links declare their password broker with the `passwords` key. Multi-guard applications should set this per guard. On guest routes such as login and password reset requests, naming the guard on the `guest` middleware selects it for the request — `guest:admin` makes `admin` the current guard, so authentication, policies, and password reset flows all follow the same user type. For guest routes that do not use the `guest` middleware, apply `auth.guard:admin` instead:
 
 ```php
 'guards' => [
@@ -409,7 +411,7 @@ Guards that send password reset links declare their password broker with the `pa
 <a name="login-throttling"></a>
 ### Login Throttling
 
-If you are using one of our [application starter kits](/docs/{{version}}/starter-kits), rate limiting will automatically be applied to login attempts. By default, the user will not be able to login for one minute if they fail to provide the correct credentials after several attempts. The throttling is unique to the user's username / email address and their IP address.
+If you are using one of our [application starter kits](/docs/{{version}}/starter-kits), rate limiting will automatically be applied to login attempts. By default, the user will not be able to login for one minute if they fail to provide the correct credentials after several attempts. The throttling is unique to the current guard, the user's username / email address, and their IP address.
 
 > [!NOTE]
 > If you would like to rate limit other routes in your application, check out the [rate limiting documentation](/docs/{{version}}/routing#rate-limiting).
@@ -708,7 +710,7 @@ While building your application, you may occasionally have actions that should r
 <a name="password-confirmation-configuration"></a>
 ### Configuration
 
-After confirming their password, a user will not be asked to confirm their password again for three hours. However, you may configure the length of time before the user is re-prompted for their password by changing the value of the `password_timeout` configuration value within your application's `config/auth.php` configuration file.
+After confirming their password, a user will not be asked to confirm their password again for three hours. However, you may configure the length of time before the user is re-prompted for their password by changing the value of the `password_timeout` configuration value within your application's `config/auth.php` configuration file. Password confirmation is scoped to the current guard, so confirming under one guard never satisfies the `password.confirm` middleware under another guard. Individual guards may override the timeout with a `password_timeout` key in their guard configuration.
 
 <a name="password-confirmation-routing"></a>
 ### Routing

--- a/src/boost/docs/fortify.md
+++ b/src/boost/docs/fortify.md
@@ -219,7 +219,7 @@ final class SelectAuthenticationGuard
 }
 ```
 
-Run this middleware before `guest`, `auth`, `password.confirm`, Fortify controllers, and Passkeys controllers. Named middleware such as `auth:admin` or `guest:admin` checks that guard, but it does not set the default guard that controller code and other packages use.
+Run this middleware before `guest`, `auth`, `password.confirm`, Fortify controllers, and Passkeys controllers. Named middleware select their guard as the request default: `auth:admin` selects `admin` when authentication succeeds, and `guest:admin` selects `admin` when the request passes the guest check. Use middleware like the example above when many routes should share one guard without naming it on each middleware.
 
 If every built-in Fortify route should use the same guard, set `fortify.guard` instead of writing custom middleware. Fortify will apply that guard to its own routes and to integrated passkey routes. When using `hypervel/passkeys` without Fortify, use the standalone `passkeys.guard` setting the same way.
 
@@ -368,7 +368,7 @@ Hypervel Fortify uses Hypervel's framework password rule directly. Laravel Forti
 <a name="password-confirmation"></a>
 ## Password Confirmation
 
-Fortify supports password confirmation through the `password.confirm` middleware and built-in confirmation routes. Password confirmation uses the current default guard.
+Fortify supports password confirmation through the `password.confirm` middleware and built-in confirmation routes. Password confirmation uses the current default guard. Confirmation is stored per guard, and lockout throttling for login attempts is also scoped per guard.
 
 You may customize password confirmation:
 

--- a/src/boost/docs/sanctum.md
+++ b/src/boost/docs/sanctum.md
@@ -4,7 +4,7 @@
     - [How it Works](#how-it-works)
 - [Installation](#installation)
 - [Configuration](#configuration)
-    - [Setting Sanctum Guard](#setting-sanctum-guard)
+    - [Declaring Trusted Session Guards](#declaring-trusted-session-guards)
     - [Overriding Default Models](#overriding-default-models)
     - [Token Caching](#token-caching)
     - [Token Prefix](#token-prefix)
@@ -90,8 +90,8 @@ Next, if you plan to utilize Sanctum to authenticate an SPA, please refer to the
 <a name="configuration"></a>
 ## Configuration
 
-<a name="setting-sanctum-guard"></a>
-### Setting Sanctum Guard
+<a name="declaring-trusted-session-guards"></a>
+### Declaring Trusted Session Guards
 
 Hypervel's default authentication configuration includes a `sanctum` guard. If your application does not already define this guard, add it to your application's `config/auth.php` file:
 
@@ -100,9 +100,26 @@ Hypervel's default authentication configuration includes a `sanctum` guard. If y
     'sanctum' => [
         'driver' => 'sanctum',
         'provider' => 'users',
+        'session_guards' => ['web'],
     ],
 ],
 ```
+
+The `session_guards` key declares which stateful session guards this Sanctum guard trusts for first-party SPA requests before falling back to bearer-token authentication. A fresh Hypervel application uses `['web']`, meaning the `sanctum` guard accepts a logged-in `web` session or a valid bearer token for the configured provider.
+
+Set `session_guards` to an empty array when a Sanctum guard should accept bearer tokens only:
+
+```php
+'guards' => [
+    'api' => [
+        'driver' => 'sanctum',
+        'provider' => 'users',
+        'session_guards' => [],
+    ],
+],
+```
+
+Every Sanctum guard must declare `session_guards`; omitting the key will throw a configuration exception that names the guard and the setting to add. Each listed guard must implement Hypervel's `StatefulGuard` contract, such as the built-in `session` driver. If a listed session guard returns a user that does not match the Sanctum guard's provider, Sanctum skips that session guard and continues to the next listed guard, then to bearer-token authentication.
 
 <a name="overriding-default-models"></a>
 ### Overriding Default Models
@@ -414,7 +431,7 @@ For this feature, Sanctum does not use tokens of any kind. Instead, Sanctum uses
 <a name="configuring-your-first-party-domains"></a>
 #### Configuring Your First-Party Domains
 
-First, you should configure which domains your SPA will be making requests from. You may configure these domains using the `stateful` configuration option in your `sanctum` configuration file. This configuration setting determines which domains will maintain "stateful" authentication using Hypervel session cookies when making requests to your API.
+First, you should configure which domains your SPA will be making requests from. You may configure these domains using the `stateful_domains` configuration option in your `sanctum` configuration file. This configuration setting determines which domains will maintain "stateful" authentication using Hypervel session cookies when making requests to your API.
 
 To assist you in setting up your first-party stateful domains, Sanctum provides two helper methods that you can include in the configuration. First, `Sanctum::currentApplicationUrlWithPort()` will return the current application URL from the `APP_URL` environment variable, and `Sanctum::currentRequestHost()` will inject a placeholder into the stateful domain list which, at runtime, will be replaced by the host from the current request so that all requests with the same domain are considered stateful.
 

--- a/src/console/src/GeneratorCommand.php
+++ b/src/console/src/GeneratorCommand.php
@@ -445,10 +445,18 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function userProviderModel(): ?string
     {
+        // Best-effort guess: console may run without the auth package installed.
+        if (! $this->hypervel->bound('auth')) {
+            return null;
+        }
+
         $config = $this->hypervel->make('config');
 
-        // This best-effort guess returns null when auth config is absent.
-        $provider = $config->get('auth.guards.' . $config->get('auth.defaults.guard') . '.provider');
+        if (! $config->has('auth.defaults.guard')) {
+            return null;
+        }
+
+        $provider = $config->get('auth.guards.' . $this->hypervel->make('auth')->getDefaultDriver() . '.provider');
 
         return $config->get("auth.providers.{$provider}.model");
     }

--- a/src/contracts/src/Session/Session.php
+++ b/src/contracts/src/Session/Session.php
@@ -160,6 +160,11 @@ interface Session
     public function setPreviousUrl(string $url): void;
 
     /**
+     * Specify that the user has confirmed their password.
+     */
+    public function passwordConfirmed(?string $guard = null): void;
+
+    /**
      * Get the session handler instance.
      */
     public function getHandler(): SessionHandlerInterface;

--- a/src/fortify/README.md
+++ b/src/fortify/README.md
@@ -14,6 +14,8 @@ See `src/boost/docs/fortify.md` for the canonical Fortify and Passkeys documenta
 - Fortify integrates with the standalone `hypervel/passkeys` package and keeps passkeys polymorphic across authenticatable model classes.
 - Fortify supports boot-time request-aware redirect callbacks for dynamic post-login destinations, such as for custom domains, multi-guard apps, or multi-tenant apps.
 - Fortify throttles two-factor challenge submissions by default.
+- Fortify scopes login throttling per guard (`guard|username|ip`), so a lockout in one actor silo never blocks logins in another.
+- Fortify password confirmation follows the current guard: guard-scoped session key, optional per-guard `password_timeout`, and the confirmed-password status endpoint uses the same resolution. This also unifies Laravel's mismatched 900/10800 fallback defaults.
 - Fortify fixes Laravel's two-factor response contract mismatch.
 - Fortify's two-factor provider uses OTPHP with mandatory PSR clock injection, fresh per-secret TOTP objects, and a default secret length of `32` characters.
 - Fortify renders two-factor QR SVGs through a concrete internal chillerlan renderer.

--- a/src/fortify/src/Http/Controllers/ConfirmablePasswordController.php
+++ b/src/fortify/src/Http/Controllers/ConfirmablePasswordController.php
@@ -36,6 +36,8 @@ class ConfirmablePasswordController extends Controller
      */
     public function store(Request $request): Responsable
     {
+        $guardName = Fortify::guardName();
+
         /** @var Authenticatable&Model $user */
         $user = $request->user();
 
@@ -46,7 +48,7 @@ class ConfirmablePasswordController extends Controller
         );
 
         if ($confirmed) {
-            $request->session()->passwordConfirmed();
+            $request->session()->passwordConfirmed($guardName);
         }
 
         return $confirmed

--- a/src/fortify/src/Http/Controllers/ConfirmablePasswordController.php
+++ b/src/fortify/src/Http/Controllers/ConfirmablePasswordController.php
@@ -15,7 +15,6 @@ use Hypervel\Fortify\Contracts\PasswordConfirmedResponse;
 use Hypervel\Fortify\Fortify;
 use Hypervel\Http\Request;
 use Hypervel\Routing\Controller;
-use Hypervel\Support\Facades\Date;
 
 class ConfirmablePasswordController extends Controller
 {
@@ -47,7 +46,7 @@ class ConfirmablePasswordController extends Controller
         );
 
         if ($confirmed) {
-            $request->session()->put('auth.password_confirmed_at', Date::now()->unix());
+            $request->session()->passwordConfirmed();
         }
 
         return $confirmed

--- a/src/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php
+++ b/src/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php
@@ -30,7 +30,8 @@ class ConfirmedPasswordStatusController extends Controller
         $guard = Fortify::guardName();
         $lastConfirmation = (int) $request->session()->get(PasswordConfirmation::sessionKey($guard), 0);
         $lastConfirmed = Date::now()->unix() - $lastConfirmation;
-        $confirmed = $lastConfirmed < PasswordConfirmation::timeout($this->config, $guard, $request->input('seconds'));
+        $seconds = $request->has('seconds') ? $request->integer('seconds') : null;
+        $confirmed = $lastConfirmed < PasswordConfirmation::timeout($this->config, $guard, $seconds);
 
         return response()->json([
             'confirmed' => $confirmed,

--- a/src/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php
+++ b/src/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Hypervel\Fortify\Http\Controllers;
 
+use Hypervel\Auth\PasswordConfirmation;
 use Hypervel\Contracts\Config\Repository as Config;
+use Hypervel\Fortify\Fortify;
 use Hypervel\Http\JsonResponse;
 use Hypervel\Http\Request;
 use Hypervel\Routing\Controller;
@@ -25,12 +27,10 @@ class ConfirmedPasswordStatusController extends Controller
      */
     public function show(Request $request): JsonResponse
     {
-        $lastConfirmation = (int) $request->session()->get('auth.password_confirmed_at', 0);
+        $guard = Fortify::guardName();
+        $lastConfirmation = (int) $request->session()->get(PasswordConfirmation::sessionKey($guard), 0);
         $lastConfirmed = Date::now()->unix() - $lastConfirmation;
-        $confirmed = $lastConfirmed < (int) $request->input(
-            'seconds',
-            $this->config->integer('auth.password_timeout', 900),
-        );
+        $confirmed = $lastConfirmed < PasswordConfirmation::timeout($this->config, $guard, $request->input('seconds'));
 
         return response()->json([
             'confirmed' => $confirmed,

--- a/src/fortify/src/LoginRateLimiter.php
+++ b/src/fortify/src/LoginRateLimiter.php
@@ -60,9 +60,12 @@ class LoginRateLimiter
 
     /**
      * Get the throttle key for the given request.
+     *
+     * Scoped to the current guard so lockouts in one actor silo never
+     * block logins in another for the same username and IP.
      */
     private function throttleKey(Request $request): string
     {
-        return Str::transliterate(Str::lower((string) $request->input(Fortify::username())) . '|' . $request->ip());
+        return Str::transliterate(Fortify::guardName() . '|' . Str::lower((string) $request->input(Fortify::username())) . '|' . $request->ip());
     }
 }

--- a/src/foundation/config/auth.php
+++ b/src/foundation/config/auth.php
@@ -33,6 +33,10 @@ return [
     |
     | Guards that send password reset links declare their broker with
     | the "passwords" key, referencing an entry in the passwords array.
+    | Sanctum guards declare the session guards they trust for first-party
+    | SPA requests with the "session_guards" key; set it to an empty array
+    | for bearer-token-only APIs. Guards may also override the password
+    | confirmation window with a "password_timeout" key.
     |
     | Supported by default: "session". Install hypervel/sanctum to use
     | the "sanctum" guard, and hypervel/jwt to use the "jwt" guard
@@ -48,6 +52,7 @@ return [
         'sanctum' => [
             'driver' => 'sanctum',
             'provider' => 'users',
+            'session_guards' => ['web'],
         ],
         'jwt' => [
             'driver' => 'jwt',
@@ -165,6 +170,8 @@ return [
     | Here you may define the number of seconds before a password confirmation
     | window expires and users are asked to re-enter their password via the
     | confirmation screen. By default, the timeout lasts for three hours.
+    | Individual guards may override this with a "password_timeout" key in
+    | their guard configuration.
     |
     */
 

--- a/src/foundation/src/Console/PolicyMakeCommand.php
+++ b/src/foundation/src/Console/PolicyMakeCommand.php
@@ -71,9 +71,9 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function userProviderModel(): ?string
     {
-        $config = $this->hypervel['config'];
+        $config = $this->hypervel->make('config');
 
-        $guard = $this->option('guard') ?: $config->string('auth.defaults.guard');
+        $guard = $this->option('guard') ?: $this->hypervel->make('auth')->getDefaultDriver();
 
         if (is_null($guardProvider = $config->get('auth.guards.' . $guard . '.provider'))) {
             throw new LogicException('The [' . $guard . '] guard is not defined in your "auth" configuration file.');

--- a/src/passkeys/src/Http/Controllers/PasskeyConfirmationController.php
+++ b/src/passkeys/src/Http/Controllers/PasskeyConfirmationController.php
@@ -56,6 +56,8 @@ class PasskeyConfirmationController extends Controller
         PasskeyVerificationRequest $request,
         VerifyPasskey $verify,
     ): PasskeyConfirmationResponse {
+        $guardName = Passkeys::guardName();
+
         $user = Passkeys::guard()->user()
             ?? throw new AuthenticationException;
 
@@ -72,7 +74,7 @@ class PasskeyConfirmationController extends Controller
         /** @var SessionStore $session */
         $session = $request->session();
 
-        $session->passwordConfirmed();
+        $session->passwordConfirmed($guardName);
 
         return $this->container->make(PasskeyConfirmationResponse::class);
     }

--- a/src/permission/src/Support/Config.php
+++ b/src/permission/src/Support/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Permission\Support;
 
 use Hypervel\Container\Container;
+use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Contracts\Config\Repository;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Permission\Contracts\Wildcard;
@@ -135,7 +136,7 @@ class Config
      */
     public static function defaultGuard(): string
     {
-        return self::repository()->string('auth.defaults.guard');
+        return Container::getInstance()->make(AuthFactory::class)->getDefaultDriver();
     }
 
     /**

--- a/src/sanctum/README.md
+++ b/src/sanctum/README.md
@@ -9,3 +9,5 @@ Ported from: https://github.com/laravel/sanctum
 
 - Hypervel only supports the `id|token` format returned by `createToken()`. Laravel's legacy plain-token lookup is omitted because Hypervel's token cache and invalidation paths are keyed by token ID.
 - Hypervel includes optional token and tokenable lookup caching for Swoole workers. Missing token IDs and missing tokenable models are cached as `null` for the configured TTL to avoid repeated database reads.
+- The global `sanctum.guard` accept-list is removed. Each sanctum-driver guard declares its trusted session guards with `auth.guards.{guard}.session_guards`; `[]` means bearer tokens only, and a missing key is a config error. Stateful session users must also match the sanctum guard's provider; Laravel returns any listed guard's user unchecked.
+- `sanctum.stateful` is renamed `sanctum.stateful_domains`, matching the `SANCTUM_STATEFUL_DOMAINS` environment variable and the key's actual contents.

--- a/src/sanctum/README.md
+++ b/src/sanctum/README.md
@@ -11,3 +11,4 @@ Ported from: https://github.com/laravel/sanctum
 - Hypervel includes optional token and tokenable lookup caching for Swoole workers. Missing token IDs and missing tokenable models are cached as `null` for the configured TTL to avoid repeated database reads.
 - The global `sanctum.guard` accept-list is removed. Each sanctum-driver guard declares its trusted session guards with `auth.guards.{guard}.session_guards`; `[]` means bearer tokens only, and a missing key is a config error. Stateful session users must also match the sanctum guard's provider; Laravel returns any listed guard's user unchecked.
 - `sanctum.stateful` is renamed `sanctum.stateful_domains`, matching the `SANCTUM_STATEFUL_DOMAINS` environment variable and the key's actual contents.
+- Sanctum's session password-hash artifacts are HMAC-only. Laravel's raw-hash fallback for legacy sessions is intentionally omitted because Hypervel 0.4 has no released legacy sessions.

--- a/src/sanctum/config/sanctum.php
+++ b/src/sanctum/config/sanctum.php
@@ -14,25 +14,11 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+    'stateful_domains' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         env('APP_URL') ? ',' . parse_url(env('APP_URL'), PHP_URL_HOST) : ''
     ))),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Sanctum Guards
-    |--------------------------------------------------------------------------
-    |
-    | This array contains the authentication guards that will be checked when
-    | Sanctum is trying to authenticate a request. If none of these guards
-    | are able to authenticate the request, Sanctum will use the bearer
-    | token that's present on an incoming request for authentication.
-    |
-    */
-
-    'guard' => ['web'],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/sanctum/src/Http/Middleware/AuthenticateSession.php
+++ b/src/sanctum/src/Http/Middleware/AuthenticateSession.php
@@ -11,7 +11,6 @@ use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Contracts\Config\Repository;
 use Hypervel\Contracts\Session\Middleware\AuthenticatesSessions;
 use Hypervel\Http\Request;
-use Hypervel\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuthenticateSession implements AuthenticatesSessions
@@ -36,59 +35,54 @@ class AuthenticateSession implements AuthenticatesSessions
             return $next($request);
         }
 
-        $guards = Collection::make($this->sanctumSessionGuards())
-            ->mapWithKeys(fn ($guard) => [$guard => $this->auth->guard($guard)])
-            ->filter(fn ($guard) => $guard instanceof SessionGuard);
+        $guards = [];
 
-        // Get the authenticated user from the guards
-        $user = null;
-        foreach ($guards as $guard) {
-            if ($guard->check()) {
-                $user = $guard->user();
-                break;
+        foreach ($this->sanctumSessionGuards() as $name) {
+            $guard = $this->auth->guard($name);
+
+            if ($guard instanceof SessionGuard) {
+                $guards[$name] = $guard;
             }
         }
 
-        if (! $user) {
+        $authenticatedGuards = array_filter($guards, fn (SessionGuard $guard): bool => $guard->check());
+
+        if ($authenticatedGuards === []) {
             return $next($request);
         }
 
-        $shouldLogout = $guards->filter(
-            fn (mixed $guard, string $driver) => $request->session()->has('password_hash_' . $driver)
-        )->filter(
-            fn (mixed $guard, string $driver) => $request->session()->get('password_hash_' . $driver)
-                                    !== $user->getAuthPassword()
-        );
+        $shouldLogout = [];
 
-        if ($shouldLogout->isNotEmpty()) {
-            $shouldLogout->each(function ($guard) {
-                /** @var SessionGuard $guard */
-                $guard->logout();
-            });
+        foreach ($authenticatedGuards as $driver => $guard) {
+            if ($request->session()->has('password_hash_' . $driver)
+                && ! $this->validatePasswordHash(
+                    $guard,
+                    $guard->user()->getAuthPassword(),
+                    $request->session()->get('password_hash_' . $driver)
+                )) {
+                $shouldLogout[$driver] = $guard;
+            }
+        }
+
+        if ($shouldLogout !== []) {
+            foreach ($shouldLogout as $guard) {
+                $guard->logoutCurrentDevice();
+            }
 
             $request->session()->flush();
 
-            throw new AuthenticationException('Unauthenticated.', [...$shouldLogout->keys()->all(), 'sanctum']);
+            throw new AuthenticationException('Unauthenticated.', [...array_keys($shouldLogout), 'sanctum']);
         }
 
-        // Store password hash after successful request
         $response = $next($request);
 
-        if (! is_null($guard = $this->getFirstGuardWithUser($guards->keys()))) {
-            $this->storePasswordHashInSession($request, $guard);
+        foreach ($guards as $name => $guard) {
+            if ($guard->hasUser()) {
+                $this->storePasswordHashInSession($request, $name, $guard);
+            }
         }
 
         return $response;
-    }
-
-    /**
-     * Get the first authentication guard that has a user.
-     */
-    protected function getFirstGuardWithUser(Collection $guards): ?string
-    {
-        return $guards->first(function (string $guard) {
-            return $this->auth->guard($guard)->hasUser();
-        });
     }
 
     /**
@@ -125,10 +119,21 @@ class AuthenticateSession implements AuthenticatesSessions
     /**
      * Store the user's current password hash in the session.
      */
-    protected function storePasswordHashInSession(Request $request, string $guard): void
+    protected function storePasswordHashInSession(Request $request, string $guard, SessionGuard $guardInstance): void
     {
         $request->session()->put([
-            "password_hash_{$guard}" => $this->auth->guard($guard)->user()->getAuthPassword(),
+            "password_hash_{$guard}" => $guardInstance->hashPasswordForCookie($guardInstance->user()->getAuthPassword()),
         ]);
+    }
+
+    /**
+     * Validate the password hash against the stored value.
+     *
+     * Only HMAC artifacts are valid; Hypervel has no released raw-hash
+     * session artifacts to accept.
+     */
+    protected function validatePasswordHash(SessionGuard $guard, ?string $passwordHash, string $storedValue): bool
+    {
+        return hash_equals($guard->hashPasswordForCookie($passwordHash), $storedValue);
     }
 }

--- a/src/sanctum/src/Http/Middleware/AuthenticateSession.php
+++ b/src/sanctum/src/Http/Middleware/AuthenticateSession.php
@@ -8,9 +8,9 @@ use Closure;
 use Hypervel\Auth\AuthenticationException;
 use Hypervel\Auth\SessionGuard;
 use Hypervel\Contracts\Auth\Factory as AuthFactory;
+use Hypervel\Contracts\Config\Repository;
 use Hypervel\Contracts\Session\Middleware\AuthenticatesSessions;
 use Hypervel\Http\Request;
-use Hypervel\Support\Arr;
 use Hypervel\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,6 +21,7 @@ class AuthenticateSession implements AuthenticatesSessions
      */
     public function __construct(
         protected AuthFactory $auth,
+        protected Repository $config,
     ) {
     }
 
@@ -35,7 +36,7 @@ class AuthenticateSession implements AuthenticatesSessions
             return $next($request);
         }
 
-        $guards = Collection::make(Arr::wrap(config('sanctum.guard')))
+        $guards = Collection::make($this->sanctumSessionGuards())
             ->mapWithKeys(fn ($guard) => [$guard => $this->auth->guard($guard)])
             ->filter(fn ($guard) => $guard instanceof SessionGuard);
 
@@ -88,6 +89,37 @@ class AuthenticateSession implements AuthenticatesSessions
         return $guards->first(function (string $guard) {
             return $this->auth->guard($guard)->hasUser();
         });
+    }
+
+    /**
+     * Get the session guards declared by the application's sanctum guards.
+     *
+     * The union across every sanctum-driver guard entry: password-hash
+     * invalidation applies to any session guard participating in stateful
+     * sanctum authentication anywhere in the application.
+     */
+    protected function sanctumSessionGuards(): array
+    {
+        $sessionGuards = [];
+
+        foreach ($this->config->array('auth.guards', []) as $guard) {
+            if (! is_array($guard) || ($guard['driver'] ?? null) !== 'sanctum') {
+                continue;
+            }
+
+            $declared = $guard['session_guards'] ?? null;
+
+            if (! is_array($declared)) {
+                continue;
+            }
+
+            $sessionGuards = [
+                ...$sessionGuards,
+                ...array_filter($declared, static fn (mixed $guard): bool => is_string($guard) && $guard !== ''),
+            ];
+        }
+
+        return array_values(array_unique($sessionGuards));
     }
 
     /**

--- a/src/sanctum/src/Http/Middleware/AuthenticateSession.php
+++ b/src/sanctum/src/Http/Middleware/AuthenticateSession.php
@@ -54,12 +54,16 @@ class AuthenticateSession implements AuthenticatesSessions
         $shouldLogout = [];
 
         foreach ($authenticatedGuards as $driver => $guard) {
-            if ($request->session()->has('password_hash_' . $driver)
+            $hasStaleRecallerHash = $guard->viaRemember()
+                && ! $this->validateRecallerPasswordHash($request, $guard);
+            $hasStaleSessionHash = $request->session()->has('password_hash_' . $driver)
                 && ! $this->validatePasswordHash(
                     $guard,
                     $guard->user()->getAuthPassword(),
                     $request->session()->get('password_hash_' . $driver)
-                )) {
+                );
+
+            if ($hasStaleRecallerHash || $hasStaleSessionHash) {
                 $shouldLogout[$driver] = $guard;
             }
         }
@@ -132,8 +136,27 @@ class AuthenticateSession implements AuthenticatesSessions
      * Only HMAC artifacts are valid; Hypervel has no released raw-hash
      * session artifacts to accept.
      */
-    protected function validatePasswordHash(SessionGuard $guard, ?string $passwordHash, string $storedValue): bool
+    protected function validatePasswordHash(SessionGuard $guard, ?string $passwordHash, mixed $storedValue): bool
     {
-        return hash_equals($guard->hashPasswordForCookie($passwordHash), $storedValue);
+        return is_string($storedValue)
+            && hash_equals($guard->hashPasswordForCookie($passwordHash), $storedValue);
+    }
+
+    /**
+     * Validate the remembered-login password hash against the guard's current user.
+     */
+    protected function validateRecallerPasswordHash(Request $request, SessionGuard $guard): bool
+    {
+        $recaller = $request->cookies->get($guard->getRecallerName());
+
+        if (! is_string($recaller)) {
+            return false;
+        }
+
+        return $this->validatePasswordHash(
+            $guard,
+            $guard->user()->getAuthPassword(),
+            explode('|', $recaller)[2] ?? null
+        );
     }
 }

--- a/src/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -81,6 +81,6 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function statefulDomains(): array
     {
-        return config('sanctum.stateful', []);
+        return config('sanctum.stateful_domains', []);
     }
 }

--- a/src/sanctum/src/SanctumGuard.php
+++ b/src/sanctum/src/SanctumGuard.php
@@ -9,12 +9,13 @@ use Hypervel\Context\CoroutineContext;
 use Hypervel\Context\RequestContext;
 use Hypervel\Contracts\Auth\Authenticatable;
 use Hypervel\Contracts\Auth\Guard as GuardContract;
+use Hypervel\Contracts\Auth\StatefulGuard;
 use Hypervel\Contracts\Auth\UserProvider;
 use Hypervel\Contracts\Container\Container;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Sanctum\Events\TokenAuthenticated;
-use Hypervel\Support\Arr;
 use Hypervel\Support\Traits\Macroable;
+use InvalidArgumentException;
 use stdClass;
 
 /**
@@ -47,6 +48,7 @@ class SanctumGuard implements GuardContract
         protected string $name,
         UserProvider $provider,
         protected Container $app,
+        protected array $sessionGuards,
         protected ?Dispatcher $events = null,
         protected ?int $expiration = null,
     ) {
@@ -76,20 +78,36 @@ class SanctumGuard implements GuardContract
             return $cached;
         }
 
-        // Check stateful guards first (like 'web')
         $authFactory = $this->app->make('auth');
-        foreach (Arr::wrap(config('sanctum.guard', 'web')) as $guard) {
-            if ($guard !== $this->name && $authFactory->guard($guard)->check()) {
-                $user = $authFactory->guard($guard)->user();
-                if ($this->supportsTokens($user)) {
-                    /** @var Authenticatable&\Hypervel\Sanctum\Contracts\HasApiTokens $tokenUser */
-                    $tokenUser = $user;
-                    $user = $tokenUser->withAccessToken(new TransientToken);
-                }
-                CoroutineContext::set($contextKey, $user ?? self::$nullUserSentinel);
 
-                return $user;
+        foreach ($this->sessionGuards as $sessionGuardName) {
+            $sessionGuard = $authFactory->guard($sessionGuardName);
+
+            if (! $sessionGuard instanceof StatefulGuard) {
+                throw new InvalidArgumentException(
+                    "Auth guard [{$this->name}] lists [{$sessionGuardName}] in session_guards, but that guard is not a stateful guard."
+                );
             }
+
+            if (! $sessionGuard->check()) {
+                continue;
+            }
+
+            $user = $sessionGuard->user();
+
+            if (! $this->hasValidProvider($user)) {
+                continue;
+            }
+
+            if ($this->supportsTokens($user)) {
+                /** @var Authenticatable&\Hypervel\Sanctum\Contracts\HasApiTokens $tokenUser */
+                $tokenUser = $user;
+                $user = $tokenUser->withAccessToken(new TransientToken);
+            }
+
+            CoroutineContext::set($contextKey, $user);
+
+            return $user;
         }
 
         // Check for token authentication

--- a/src/sanctum/src/SanctumGuard.php
+++ b/src/sanctum/src/SanctumGuard.php
@@ -95,7 +95,7 @@ class SanctumGuard implements GuardContract
 
             $user = $sessionGuard->user();
 
-            if (! $this->hasValidProvider($user)) {
+            if (! $user || ! $this->hasValidProvider($user)) {
                 continue;
             }
 

--- a/src/sanctum/src/SanctumServiceProvider.php
+++ b/src/sanctum/src/SanctumServiceProvider.php
@@ -10,6 +10,7 @@ use Hypervel\Sanctum\Console\Commands\PruneExpired;
 use Hypervel\Session\Middleware\StartSession;
 use Hypervel\Support\Facades\Route;
 use Hypervel\Support\ServiceProvider;
+use InvalidArgumentException;
 
 class SanctumServiceProvider extends ServiceProvider
 {
@@ -47,12 +48,23 @@ class SanctumServiceProvider extends ServiceProvider
     {
         $this->callAfterResolving(AuthManager::class, function (AuthManager $authManager) {
             $authManager->extend('sanctum', function ($app, $name, $config) use ($authManager) {
+                $sessionGuards = $config['session_guards'] ?? null;
+                $isSessionGuardName = static fn (mixed $guard): bool => is_string($guard) && $guard !== '';
+
+                if (! is_array($sessionGuards) || array_filter($sessionGuards, $isSessionGuardName) !== $sessionGuards) {
+                    throw new InvalidArgumentException(
+                        "Auth guard [{$name}] uses the sanctum driver but does not declare a valid session guards list. "
+                        . "Set auth.guards.{$name}.session_guards to an array of session guard names, or [] to disable stateful session authentication."
+                    );
+                }
+
                 return new SanctumGuard(
                     name: $name,
                     provider: $authManager->createUserProvider($config['provider'] ?? null),
                     app: $app,
-                    events: $app->has('events') ? $app['events'] : null,
-                    expiration: $app['config']->get('sanctum.expiration'),
+                    sessionGuards: $sessionGuards,
+                    events: $app->bound('events') ? $app->make('events') : null,
+                    expiration: $app->make('config')->get('sanctum.expiration'),
                 );
             });
         });

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -2,3 +2,7 @@ Session for Hypervel
 ===
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hypervel/session)
+
+## Differences From Laravel
+
+- `Store::passwordConfirmed(?string $guard = null)` stamps a guard-scoped key (`auth.password_confirmed_at_{guard}`) instead of Laravel's single shared key, resolving the current guard when none is given.

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -6,3 +6,4 @@ Session for Hypervel
 ## Differences From Laravel
 
 - `Store::passwordConfirmed(?string $guard = null)` stamps a guard-scoped key (`auth.password_confirmed_at_{guard}`) instead of Laravel's single shared key, resolving the current guard when none is given.
+- Password-hash session artifacts are HMAC-only. Laravel's raw-hash fallback for legacy sessions is intentionally omitted because Hypervel 0.4 has no released legacy sessions.

--- a/src/session/composer.json
+++ b/src/session/composer.json
@@ -31,6 +31,7 @@
     "require": {
         "php": "^8.4",
         "ext-session": "*",
+        "hypervel/auth": "^0.4",
         "hypervel/cache": "^0.4",
         "hypervel/collections": "^0.4",
         "hypervel/console": "^0.4",

--- a/src/session/src/Middleware/AuthenticateSession.php
+++ b/src/session/src/Middleware/AuthenticateSession.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Session\Middleware;
 
-use BadMethodCallException;
 use Closure;
 use Hypervel\Auth\AuthenticationException;
 use Hypervel\Contracts\Auth\Factory as AuthFactory;
@@ -74,10 +73,7 @@ class AuthenticateSession implements AuthenticatesSessions
 
         $passwordHash = $request->user()->getAuthPassword();
 
-        try {
-            $passwordHash = $this->guard()->hashPasswordForCookie($passwordHash); // @phpstan-ignore method.notFound
-        } catch (BadMethodCallException) {
-        }
+        $passwordHash = $this->guard()->hashPasswordForCookie($passwordHash); // @phpstan-ignore method.notFound
 
         $request->session()->put([
             'password_hash_' . $this->auth->getDefaultDriver() => $passwordHash, // @phpstan-ignore method.notFound
@@ -86,16 +82,13 @@ class AuthenticateSession implements AuthenticatesSessions
 
     /**
      * Validate the password hash against the stored value.
+     *
+     * Only HMAC artifacts are valid; Hypervel has no released raw-hash
+     * session artifacts to accept.
      */
     protected function validatePasswordHash(string $passwordHash, string $storedValue): bool
     {
-        try {
-            // Try new HMAC format first, then fall back to raw password hash format for backward compatibility
-            return hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue) // @phpstan-ignore method.notFound
-                || hash_equals($passwordHash, $storedValue);
-        } catch (BadMethodCallException) {
-            return hash_equals($passwordHash, $storedValue);
-        }
+        return hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue); // @phpstan-ignore method.notFound
     }
 
     /**

--- a/src/session/src/Middleware/AuthenticateSession.php
+++ b/src/session/src/Middleware/AuthenticateSession.php
@@ -86,9 +86,10 @@ class AuthenticateSession implements AuthenticatesSessions
      * Only HMAC artifacts are valid; Hypervel has no released raw-hash
      * session artifacts to accept.
      */
-    protected function validatePasswordHash(string $passwordHash, string $storedValue): bool
+    protected function validatePasswordHash(string $passwordHash, mixed $storedValue): bool
     {
-        return hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue); // @phpstan-ignore method.notFound
+        return is_string($storedValue)
+            && hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue); // @phpstan-ignore method.notFound
     }
 
     /**

--- a/src/session/src/Store.php
+++ b/src/session/src/Store.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Hypervel\Session;
 
 use Closure;
+use Hypervel\Auth\PasswordConfirmation;
+use Hypervel\Container\Container;
 use Hypervel\Context\CoroutineContext;
+use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Contracts\Cache\Repository as CacheRepository;
 use Hypervel\Contracts\Session\Session;
 use Hypervel\Http\Request;
@@ -699,10 +702,15 @@ class Store implements Session
 
     /**
      * Specify that the user has confirmed their password.
+     *
+     * The confirmation is scoped to the given guard, or to the current
+     * default guard when none is given.
      */
-    public function passwordConfirmed(): void
+    public function passwordConfirmed(?string $guard = null): void
     {
-        $this->put('auth.password_confirmed_at', Date::now()->unix());
+        $guard ??= Container::getInstance()->make(AuthFactory::class)->getDefaultDriver();
+
+        $this->put(PasswordConfirmation::sessionKey($guard), Date::now()->unix());
     }
 
     /**

--- a/src/support/src/Facades/Session.php
+++ b/src/support/src/Facades/Session.php
@@ -67,7 +67,7 @@ namespace Hypervel\Support\Facades;
  * @method static void setPreviousUrl(string $url)
  * @method static string|null previousRoute()
  * @method static void setPreviousRoute(string|null $route)
- * @method static void passwordConfirmed()
+ * @method static void passwordConfirmed(string|null $guard = null)
  * @method static \SessionHandlerInterface getHandler()
  * @method static \SessionHandlerInterface setHandler(\SessionHandlerInterface $handler)
  * @method static bool handlerNeedsRequest()

--- a/tests/Auth/AuthManagerTest.php
+++ b/tests/Auth/AuthManagerTest.php
@@ -160,21 +160,35 @@ class AuthManagerTest extends TestCase
         $this->assertSame($manager, $boundTo);
     }
 
-    public function testGetDefaultUserProvider()
-    {
-        $manager = new AuthManager($container = $this->getContainer());
-        $container->make('config')
-            ->set('auth.defaults.provider', 'foo');
-
-        $this->assertSame('foo', $manager->getDefaultUserProvider());
-    }
-
     public function testCreateUserProviderReturnsNullWhenNoProviderIsConfigured(): void
     {
         $manager = new AuthManager($this->getContainer());
 
-        $this->assertNull($manager->getDefaultUserProvider());
         $this->assertNull($manager->createUserProvider());
+    }
+
+    public function testGetDefaultUserProviderUsesCurrentDefaultGuard(): void
+    {
+        $manager = new AuthManager($container = $this->getContainer());
+        $config = $container->make('config');
+        $config->set('auth.defaults.guard', 'web');
+        $config->set('auth.guards.web.provider', 'users');
+        $config->set('auth.guards.admin.provider', 'admins');
+
+        $this->assertSame('users', $manager->getDefaultUserProvider());
+
+        $manager->shouldUse('admin');
+
+        $this->assertSame('admins', $manager->getDefaultUserProvider());
+    }
+
+    public function testGetDefaultUserProviderReturnsNullWhenCurrentGuardHasNoProvider(): void
+    {
+        $manager = new AuthManager($container = $this->getContainer());
+        $container->make('config')->set('auth.defaults.guard', 'api');
+        $container->make('config')->set('auth.guards.api', ['driver' => 'token']);
+
+        $this->assertNull($manager->getDefaultUserProvider());
     }
 
     public function testCreateNullUserProvider()
@@ -252,17 +266,43 @@ class AuthManagerTest extends TestCase
         $this->app->make('config')
             ->set('auth.guards.foo', [
                 'driver' => 'custom',
+                'provider' => 'foo',
             ]);
-        $this->app->make('config')
-            ->set('auth.defaults.provider', 'foo');
 
         $provider = m::mock(UserProvider::class);
         $manager->provider('foo', fn () => $provider);
 
         $user = m::mock(Authenticatable::class);
-        $manager->viaRequest('custom', fn () => $user);
+        $manager->viaRequest('custom', function (Request $request, ?UserProvider $requestProvider) use ($provider, $user) {
+            $this->assertSame($provider, $requestProvider);
+
+            return $user;
+        });
 
         $this->assertInstanceOf(RequestGuard::class, $guard = $manager->guard('foo'));
+        $this->assertSame($provider, $guard->getProvider());
+        $this->assertSame($user, $guard->user());
+    }
+
+    public function testViaRequestGuardWithoutProviderKeyGetsNullProvider(): void
+    {
+        $manager = new AuthManager($this->app);
+        RequestContext::set(Request::create('/'));
+
+        $this->app->make('config')
+            ->set('auth.guards.foo', [
+                'driver' => 'custom',
+            ]);
+
+        $user = m::mock(Authenticatable::class);
+        $manager->viaRequest('custom', function (Request $request, ?UserProvider $requestProvider) use ($user) {
+            $this->assertNull($requestProvider);
+
+            return $user;
+        });
+
+        $this->assertInstanceOf(RequestGuard::class, $guard = $manager->guard('foo'));
+        $this->assertNull($guard->getProvider());
         $this->assertSame($user, $guard->user());
     }
 

--- a/tests/Auth/AuthManagerTest.php
+++ b/tests/Auth/AuthManagerTest.php
@@ -254,7 +254,7 @@ class AuthManagerTest extends TestCase
         $this->assertSame('foo', $manager->userResolver()());
     }
 
-    public function testViaRequest()
+    public function testViaRequest(): void
     {
         $manager = new AuthManager($this->app);
         RequestContext::set(Request::create('/'));

--- a/tests/Auth/PasswordConfirmationTest.php
+++ b/tests/Auth/PasswordConfirmationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Auth;
+
+use Hypervel\Auth\PasswordConfirmation;
+use Hypervel\Config\Repository;
+use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
+
+class PasswordConfirmationTest extends TestCase
+{
+    public function testSessionKeyIsGuardSuffixed(): void
+    {
+        $this->assertSame('auth.password_confirmed_at_admin', PasswordConfirmation::sessionKey('admin'));
+    }
+
+    public function testTimeoutUsesGuardDeclaration(): void
+    {
+        $config = new Repository([
+            'auth' => [
+                'guards' => [
+                    'admin' => [
+                        'password_timeout' => 900,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(900, PasswordConfirmation::timeout($config, 'admin'));
+    }
+
+    public function testTimeoutFallsBackToGlobal(): void
+    {
+        $config = new Repository([
+            'auth' => [
+                'password_timeout' => 3600,
+            ],
+        ]);
+
+        $this->assertSame(3600, PasswordConfirmation::timeout($config, 'admin'));
+    }
+
+    public function testTimeoutDefaultsWhenUnconfigured(): void
+    {
+        $this->assertSame(10800, PasswordConfirmation::timeout(new Repository, 'admin'));
+    }
+
+    public function testTimeoutFailsFastOnMalformedGuardValue(): void
+    {
+        $config = new Repository([
+            'auth' => [
+                'guards' => [
+                    'admin' => [
+                        'password_timeout' => 'abc',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Configuration value for key [auth.guards.admin.password_timeout] must be an integer, string given.');
+
+        PasswordConfirmation::timeout($config, 'admin');
+    }
+
+    public function testGuardDeclarationWinsWhenGlobalIsMalformed(): void
+    {
+        $config = new Repository([
+            'auth' => [
+                'password_timeout' => 'abc',
+                'guards' => [
+                    'admin' => [
+                        'password_timeout' => 900,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(900, PasswordConfirmation::timeout($config, 'admin'));
+    }
+
+    public function testExplicitOverrideWinsOverAllTiers(): void
+    {
+        $config = new Repository([
+            'auth' => [
+                'password_timeout' => 3600,
+                'guards' => [
+                    'admin' => [
+                        'password_timeout' => 900,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(300, PasswordConfirmation::timeout($config, 'admin', '300'));
+    }
+}

--- a/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
+++ b/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
@@ -10,6 +10,7 @@ use Hypervel\Auth\Middleware\RedirectIfAuthenticated;
 use Hypervel\Auth\RequestGuard;
 use Hypervel\Config\Repository;
 use Hypervel\Container\Container;
+use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Auth\Authenticatable;
 use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Contracts\Auth\Guard;
@@ -125,6 +126,7 @@ class RedirectIfAuthenticatedMiddlewareTest extends TestCase
         $factory = m::mock(AuthFactory::class);
         $factory->shouldReceive('guard')->with('web')->andReturn($guard1);
         $factory->shouldReceive('guard')->with('api')->andReturn($guard2);
+        $factory->shouldReceive('shouldUse')->once()->with('web');
         Auth::swap($factory);
 
         $request = Request::create('/login', 'GET');
@@ -134,6 +136,65 @@ class RedirectIfAuthenticatedMiddlewareTest extends TestCase
         $result = $middleware->handle($request, fn () => $response, 'web', 'api');
 
         $this->assertSame($response, $result);
+    }
+
+    public function testNamedGuardIsSelectedOnPassThrough(): void
+    {
+        $auth = $this->makeAuthManager(webAuthenticated: false, secondaryAuthenticated: false);
+        Auth::swap($auth);
+
+        $request = Request::create('/login', 'GET');
+        $response = new Response('ok');
+
+        $middleware = new RedirectIfAuthenticated;
+        $result = $middleware->handle($request, fn () => $response, 'secondary');
+
+        $this->assertSame($response, $result);
+        $this->assertSame('secondary', $auth->getDefaultDriver());
+    }
+
+    public function testFirstListedGuardIsSelectedForMultipleGuards(): void
+    {
+        $auth = $this->makeAuthManager(webAuthenticated: false, secondaryAuthenticated: false);
+        Auth::swap($auth);
+
+        $request = Request::create('/login', 'GET');
+        $response = new Response('ok');
+
+        $middleware = new RedirectIfAuthenticated;
+        $result = $middleware->handle($request, fn () => $response, 'secondary', 'web');
+
+        $this->assertSame($response, $result);
+        $this->assertSame('secondary', $auth->getDefaultDriver());
+    }
+
+    public function testBareGuestSelectsNothing(): void
+    {
+        $auth = $this->makeAuthManager(webAuthenticated: false, secondaryAuthenticated: false);
+        Auth::swap($auth);
+
+        $request = Request::create('/login', 'GET');
+        $response = new Response('ok');
+
+        $middleware = new RedirectIfAuthenticated;
+        $result = $middleware->handle($request, fn () => $response);
+
+        $this->assertSame($response, $result);
+        $this->assertFalse(CoroutineContext::has(AuthManager::DEFAULT_GUARD_CONTEXT_KEY));
+    }
+
+    public function testNoSelectionOnRedirect(): void
+    {
+        $auth = $this->makeAuthManager(webAuthenticated: false, secondaryAuthenticated: true);
+        Auth::swap($auth);
+
+        $request = Request::create('/login', 'GET');
+
+        $middleware = new RedirectIfAuthenticated;
+        $result = $middleware->handle($request, fn () => new Response('should not reach'), 'secondary');
+
+        $this->assertSame(302, $result->getStatusCode());
+        $this->assertFalse(CoroutineContext::has(AuthManager::DEFAULT_GUARD_CONTEXT_KEY));
     }
 
     public function testBareGuestMiddlewareUsesCurrentDefaultGuardSelectedByShouldUse()

--- a/tests/Auth/RequirePasswordMiddlewareTest.php
+++ b/tests/Auth/RequirePasswordMiddlewareTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Auth;
 
 use Hypervel\Auth\Middleware\RequirePassword;
+use Hypervel\Config\Repository;
+use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Contracts\Routing\ResponseFactory;
 use Hypervel\Contracts\Routing\UrlGenerator;
 use Hypervel\Contracts\Session\Session;
@@ -18,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RequirePasswordMiddlewareTest extends TestCase
 {
-    public function testUsingGeneratesCorrectMiddlewareString()
+    public function testUsingGeneratesCorrectMiddlewareString(): void
     {
         $this->assertSame(
             RequirePassword::class . ':,',
@@ -31,22 +33,19 @@ class RequirePasswordMiddlewareTest extends TestCase
         );
     }
 
-    public function testPassesThroughWhenPasswordConfirmationIsFresh()
+    public function testPassesThroughWhenPasswordConfirmationIsFresh(): void
     {
         Carbon::setTestNow(Carbon::createFromTimestamp(1000));
 
         $session = m::mock(Session::class);
         $session->shouldReceive('get')
-            ->with('auth.password_confirmed_at', 0)
+            ->with('auth.password_confirmed_at_web', 0)
             ->andReturn(999); // Confirmed 1 second ago
 
         $request = m::mock(Request::class);
         $request->shouldReceive('session')->andReturn($session);
 
-        $responseFactory = m::mock(ResponseFactory::class);
-        $urlGenerator = m::mock(UrlGenerator::class);
-
-        $middleware = new RequirePassword($responseFactory, $urlGenerator);
+        $middleware = $this->middleware();
 
         $expectedResponse = new Response('ok');
         $result = $middleware->handle($request, fn () => $expectedResponse);
@@ -56,13 +55,13 @@ class RequirePasswordMiddlewareTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function testReturnsJson423WhenStaleAndRequestExpectsJson()
+    public function testReturnsJson423WhenStaleAndRequestExpectsJson(): void
     {
         Carbon::setTestNow(Carbon::createFromTimestamp(20000));
 
         $session = m::mock(Session::class);
         $session->shouldReceive('get')
-            ->with('auth.password_confirmed_at', 0)
+            ->with('auth.password_confirmed_at_web', 0)
             ->andReturn(0); // Never confirmed
 
         $request = m::mock(Request::class);
@@ -78,7 +77,7 @@ class RequirePasswordMiddlewareTest extends TestCase
 
         $urlGenerator = m::mock(UrlGenerator::class);
 
-        $middleware = new RequirePassword($responseFactory, $urlGenerator);
+        $middleware = $this->middleware(responseFactory: $responseFactory, urlGenerator: $urlGenerator);
         $result = $middleware->handle($request, fn () => new Response('should not reach'));
 
         $this->assertSame($jsonResponse, $result);
@@ -86,13 +85,13 @@ class RequirePasswordMiddlewareTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function testRedirectsWhenStaleAndRequestDoesNotExpectJson()
+    public function testRedirectsWhenStaleAndRequestDoesNotExpectJson(): void
     {
         Carbon::setTestNow(Carbon::createFromTimestamp(20000));
 
         $session = m::mock(Session::class);
         $session->shouldReceive('get')
-            ->with('auth.password_confirmed_at', 0)
+            ->with('auth.password_confirmed_at_web', 0)
             ->andReturn(0);
 
         $request = m::mock(Request::class);
@@ -111,7 +110,7 @@ class RequirePasswordMiddlewareTest extends TestCase
             ->with('password.confirm')
             ->andReturn('/password/confirm');
 
-        $middleware = new RequirePassword($responseFactory, $urlGenerator);
+        $middleware = $this->middleware(responseFactory: $responseFactory, urlGenerator: $urlGenerator);
         $result = $middleware->handle($request, fn () => new Response('should not reach'));
 
         $this->assertSame($redirectResponse, $result);
@@ -119,13 +118,13 @@ class RequirePasswordMiddlewareTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function testCustomRouteIsUsed()
+    public function testCustomRouteIsUsed(): void
     {
         Carbon::setTestNow(Carbon::createFromTimestamp(20000));
 
         $session = m::mock(Session::class);
         $session->shouldReceive('get')
-            ->with('auth.password_confirmed_at', 0)
+            ->with('auth.password_confirmed_at_web', 0)
             ->andReturn(0);
 
         $request = m::mock(Request::class);
@@ -144,7 +143,7 @@ class RequirePasswordMiddlewareTest extends TestCase
             ->with('custom.confirm')
             ->andReturn('/custom-confirm');
 
-        $middleware = new RequirePassword($responseFactory, $urlGenerator);
+        $middleware = $this->middleware(responseFactory: $responseFactory, urlGenerator: $urlGenerator);
         $result = $middleware->handle(
             $request,
             fn () => new Response('should not reach'),
@@ -156,13 +155,13 @@ class RequirePasswordMiddlewareTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function testCustomTimeoutIsHonored()
+    public function testCustomTimeoutIsHonored(): void
     {
         Carbon::setTestNow(Carbon::createFromTimestamp(1000));
 
         $session = m::mock(Session::class);
         $session->shouldReceive('get')
-            ->with('auth.password_confirmed_at', 0)
+            ->with('auth.password_confirmed_at_web', 0)
             ->andReturn(990); // Confirmed 10 seconds ago
 
         $request = m::mock(Request::class);
@@ -171,7 +170,7 @@ class RequirePasswordMiddlewareTest extends TestCase
         $responseFactory = m::mock(ResponseFactory::class);
         $urlGenerator = m::mock(UrlGenerator::class);
 
-        $middleware = new RequirePassword($responseFactory, $urlGenerator);
+        $middleware = $this->middleware(responseFactory: $responseFactory, urlGenerator: $urlGenerator);
 
         // With default timeout (10800), 10 seconds would pass through
         $expectedResponse = new Response('ok');
@@ -195,5 +194,128 @@ class RequirePasswordMiddlewareTest extends TestCase
         $this->assertSame($jsonResponse, $result);
 
         Carbon::setTestNow();
+    }
+
+    public function testConfirmationIsScopedToCurrentGuard(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(20000));
+
+        $session = m::mock(Session::class);
+        $session->shouldReceive('get')
+            ->with('auth.password_confirmed_at_admin', 0)
+            ->andReturn(0);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('session')->andReturn($session);
+        $request->shouldReceive('expectsJson')->andReturnTrue();
+
+        $responseFactory = m::mock(ResponseFactory::class);
+        $responseFactory->shouldReceive('json')
+            ->with(['message' => 'Password confirmation required.'], 423)
+            ->once()
+            ->andReturn($jsonResponse = new JsonResponse(['message' => 'Password confirmation required.'], 423));
+
+        $result = $this->middleware(responseFactory: $responseFactory, guard: 'admin')
+            ->handle($request, fn () => new Response('should not reach'));
+
+        $this->assertSame($jsonResponse, $result);
+
+        Carbon::setTestNow();
+    }
+
+    public function testPerGuardTimeoutIsHonored(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+
+        $session = m::mock(Session::class);
+        $session->shouldReceive('get')
+            ->with('auth.password_confirmed_at_admin', 0)
+            ->twice()
+            ->andReturn(989, 991);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('session')->andReturn($session);
+
+        $responseFactory = m::mock(ResponseFactory::class);
+        $responseFactory->shouldReceive('json')
+            ->with(['message' => 'Password confirmation required.'], 423)
+            ->once()
+            ->andReturn($jsonResponse = new JsonResponse(['message' => 'Password confirmation required.'], 423));
+
+        $config = new Repository([
+            'auth' => [
+                'guards' => [
+                    'admin' => [
+                        'password_timeout' => 10,
+                    ],
+                ],
+            ],
+        ]);
+
+        $middleware = $this->middleware(responseFactory: $responseFactory, config: $config, guard: 'admin');
+
+        $request->shouldReceive('expectsJson')->andReturnTrue();
+        $result = $middleware->handle($request, fn () => new Response('should not reach'));
+        $this->assertSame($jsonResponse, $result);
+
+        $expectedResponse = new Response('ok');
+        $result = $middleware->handle($request, fn () => $expectedResponse);
+        $this->assertSame($expectedResponse, $result);
+
+        Carbon::setTestNow();
+    }
+
+    public function testRouteParameterOverridesPerGuardTimeout(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+
+        $session = m::mock(Session::class);
+        $session->shouldReceive('get')
+            ->with('auth.password_confirmed_at_admin', 0)
+            ->andReturn(994);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('session')->andReturn($session);
+        $request->shouldReceive('expectsJson')->andReturnTrue();
+
+        $responseFactory = m::mock(ResponseFactory::class);
+        $responseFactory->shouldReceive('json')
+            ->with(['message' => 'Password confirmation required.'], 423)
+            ->once()
+            ->andReturn($jsonResponse = new JsonResponse(['message' => 'Password confirmation required.'], 423));
+
+        $config = new Repository([
+            'auth' => [
+                'guards' => [
+                    'admin' => [
+                        'password_timeout' => 10,
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $this->middleware(responseFactory: $responseFactory, config: $config, guard: 'admin')
+            ->handle($request, fn () => new Response('should not reach'), null, 5);
+
+        $this->assertSame($jsonResponse, $result);
+
+        Carbon::setTestNow();
+    }
+
+    private function middleware(
+        ?ResponseFactory $responseFactory = null,
+        ?UrlGenerator $urlGenerator = null,
+        ?Repository $config = null,
+        string $guard = 'web'
+    ): RequirePassword {
+        $auth = m::mock(AuthFactory::class);
+        $auth->shouldReceive('getDefaultDriver')->andReturn($guard);
+
+        return new RequirePassword(
+            $responseFactory ?? m::mock(ResponseFactory::class),
+            $urlGenerator ?? m::mock(UrlGenerator::class),
+            $auth,
+            $config ?? new Repository,
+        );
     }
 }

--- a/tests/Fortify/AuthenticatedSessionControllerTest.php
+++ b/tests/Fortify/AuthenticatedSessionControllerTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Fortify;
 
 use Hypervel\Auth\Events\Logout;
+use Hypervel\Cache\ArrayStore;
 use Hypervel\Cache\RateLimiter;
+use Hypervel\Cache\Repository;
 use Hypervel\Contracts\Auth\Authenticatable;
 use Hypervel\Fortify\Contracts\LoginViewResponse;
 use Hypervel\Fortify\LoginRateLimiter;
@@ -125,7 +127,7 @@ class AuthenticatedSessionControllerTest extends TestCase
             }
         );
 
-        self::assertSame($expectedResult . '|192.168.0.1', $method->invoke($loginRateLimiter, $request));
+        self::assertSame('web|' . $expectedResult . '|192.168.0.1', $method->invoke($loginRateLimiter, $request));
     }
 
     public static function usernameProvider(): array
@@ -136,6 +138,30 @@ class AuthenticatedSessionControllerTest extends TestCase
             'special character numbers' => ['test⑩⓸③@laravel.com', 'test1043@laravel.com'],
             'default email' => ['test@laravel.com', 'test@laravel.com'],
         ];
+    }
+
+    public function testLockoutIsScopedToGuard(): void
+    {
+        $loginRateLimiter = new LoginRateLimiter(
+            new RateLimiter(new Repository(new ArrayStore))
+        );
+
+        $request = Request::create('/login', 'POST', [
+            'email' => 'taylor@laravel.com',
+        ]);
+        $request->server->set('REMOTE_ADDR', '192.168.0.1');
+
+        Auth::shouldUse('web');
+
+        for ($attempt = 0; $attempt < 5; ++$attempt) {
+            $loginRateLimiter->increment($request);
+        }
+
+        $this->assertTrue($loginRateLimiter->tooManyAttempts($request));
+
+        Auth::shouldUse('admin');
+
+        $this->assertFalse($loginRateLimiter->tooManyAttempts($request));
     }
 
     public function testTheUserCanLogoutOfTheApplication(): void

--- a/tests/Fortify/ConfirmablePasswordControllerTest.php
+++ b/tests/Fortify/ConfirmablePasswordControllerTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Fortify;
 
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Database\Schema\Blueprint;
 use Hypervel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Hypervel\Fortify\Fortify;
 use Hypervel\Foundation\Auth\User;
 use Hypervel\Foundation\Testing\RefreshDatabase;
+use Hypervel\Support\Facades\Auth;
 use Hypervel\Support\Facades\Date;
+use Hypervel\Support\Facades\Schema;
 use Hypervel\Testbench\Attributes\WithConfig;
 use Hypervel\Testbench\Attributes\WithMigration;
+use Hypervel\Tests\Fortify\Fixtures\Admin;
 
 #[WithMigration]
 class ConfirmablePasswordControllerTest extends TestCase
@@ -27,6 +31,19 @@ class ConfirmablePasswordControllerTest extends TestCase
             'email' => 'taylor@laravel.com',
             'password' => bcrypt('secret'),
         ]);
+
+        Schema::create('admins', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password')->nullable();
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+            $table->rememberToken();
+            $table->timestamps();
+        });
     }
 
     public function testTheConfirmPasswordViewIsReturned(): void
@@ -55,7 +72,7 @@ class ConfirmablePasswordControllerTest extends TestCase
                 ['password' => 'secret']
             );
 
-        $response->assertSessionHas('auth.password_confirmed_at', Date::now()->unix());
+        $response->assertSessionHas('auth.password_confirmed_at_web', Date::now()->unix());
         $response->assertRedirect('http://foo.com/bar');
     }
 
@@ -70,7 +87,7 @@ class ConfirmablePasswordControllerTest extends TestCase
             );
 
         $response->assertSessionHasErrors(['password']);
-        $response->assertSessionMissing('auth.password_confirmed_at');
+        $response->assertSessionMissing('auth.password_confirmed_at_web');
         $response->assertRedirect();
         $this->assertNotEquals($response->getTargetUrl(), 'http://foo.com/bar');
     }
@@ -86,7 +103,7 @@ class ConfirmablePasswordControllerTest extends TestCase
             );
 
         $response->assertSessionHasErrors(['password']);
-        $response->assertSessionMissing('auth.password_confirmed_at');
+        $response->assertSessionMissing('auth.password_confirmed_at_web');
         $response->assertRedirect();
         $this->assertNotEquals($response->getTargetUrl(), 'http://foo.com/bar');
     }
@@ -107,7 +124,7 @@ class ConfirmablePasswordControllerTest extends TestCase
                 ['password' => 'invalid']
             );
 
-        $response->assertSessionHas('auth.password_confirmed_at', Date::now()->unix());
+        $response->assertSessionHas('auth.password_confirmed_at_web', Date::now()->unix());
         $response->assertRedirect('http://foo.com/bar');
 
         Fortify::flushState();
@@ -129,7 +146,7 @@ class ConfirmablePasswordControllerTest extends TestCase
                 ['password' => null]
             );
 
-        $response->assertSessionHas('auth.password_confirmed_at', Date::now()->unix());
+        $response->assertSessionHas('auth.password_confirmed_at_web', Date::now()->unix());
         $response->assertRedirect('http://foo.com/bar');
 
         Fortify::flushState();
@@ -164,7 +181,7 @@ class ConfirmablePasswordControllerTest extends TestCase
 
         $response = $this->withoutExceptionHandling()
             ->actingAs($this->user)
-            ->withSession(['auth.password_confirmed_at' => now()->subMinute(1)->unix()])
+            ->withSession(['auth.password_confirmed_at_web' => now()->subMinute(1)->unix()])
             ->get(
                 '/user/confirmed-password-status',
             );
@@ -181,7 +198,7 @@ class ConfirmablePasswordControllerTest extends TestCase
 
         $response = $this->withoutExceptionHandling()
             ->actingAs($this->user)
-            ->withSession(['auth.password_confirmed_at' => now()->subMinutes(10)->unix()])
+            ->withSession(['auth.password_confirmed_at_web' => now()->subMinutes(10)->unix()])
             ->get(
                 '/user/confirmed-password-status',
             );
@@ -205,6 +222,87 @@ class ConfirmablePasswordControllerTest extends TestCase
         $response->assertOk()
             ->assertJson(['confirmed' => false])
             ->assertHeaderMissing('X-Retry-After');
+    }
+
+    #[WithConfig('fortify.guard', 'admin')]
+    public function testConfirmationStampsCurrentGuardKey(): void
+    {
+        $this->freezeSecond();
+
+        $admin = $this->createAdmin();
+        Auth::guard('admin')->setUser($admin);
+
+        $response = $this->withoutExceptionHandling()
+            ->withSession(['url.intended' => 'http://foo.com/admin'])
+            ->post(
+                '/user/confirm-password',
+                ['password' => 'secret']
+            );
+
+        $response->assertSessionHas('auth.password_confirmed_at_admin', Date::now()->unix());
+        $response->assertSessionMissing('auth.password_confirmed_at_web');
+        $response->assertRedirect('http://foo.com/admin');
+    }
+
+    #[WithConfig('fortify.guard', 'admin')]
+    public function testStatusReadsCurrentGuardConfirmation(): void
+    {
+        $this->freezeSecond();
+
+        $admin = $this->createAdmin();
+        Auth::guard('admin')->setUser($admin);
+
+        $response = $this->withoutExceptionHandling()
+            ->withSession(['auth.password_confirmed_at_admin' => now()->subMinute(1)->unix()])
+            ->get(
+                '/user/confirmed-password-status',
+            );
+
+        $response->assertOk()
+            ->assertJson(['confirmed' => true])
+            ->assertHeader('X-Retry-After', 60);
+    }
+
+    public function testStatusDoesNotReadAnotherGuardConfirmation(): void
+    {
+        $this->freezeSecond();
+
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['auth.password_confirmed_at_admin' => now()->subMinute(1)->unix()])
+            ->get(
+                '/user/confirmed-password-status',
+            );
+
+        $response->assertOk()
+            ->assertJson(['confirmed' => false])
+            ->assertHeaderMissing('X-Retry-After');
+    }
+
+    public function testStatusUsesPerGuardTimeout(): void
+    {
+        $this->freezeSecond();
+        $this->app->make('config')->set('auth.guards.web.password_timeout', 10);
+
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['auth.password_confirmed_at_web' => now()->subSeconds(11)->unix()])
+            ->get(
+                '/user/confirmed-password-status',
+            );
+
+        $response->assertOk()
+            ->assertJson(['confirmed' => false])
+            ->assertHeaderMissing('X-Retry-After');
+    }
+
+    private function createAdmin(): Admin
+    {
+        return Admin::forceCreate([
+            'name' => 'Admin User',
+            'email' => 'admin@example.test',
+            'password' => bcrypt('secret'),
+        ]);
     }
 
     protected function defineEnvironment(ApplicationContract $app): void

--- a/tests/Fortify/ConfirmablePasswordControllerTest.php
+++ b/tests/Fortify/ConfirmablePasswordControllerTest.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Fortify;
 
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
-use Hypervel\Database\Schema\Blueprint;
 use Hypervel\Fortify\Contracts\ConfirmPasswordViewResponse;
 use Hypervel\Fortify\Fortify;
 use Hypervel\Foundation\Auth\User;
 use Hypervel\Foundation\Testing\RefreshDatabase;
 use Hypervel\Support\Facades\Auth;
 use Hypervel\Support\Facades\Date;
-use Hypervel\Support\Facades\Schema;
 use Hypervel\Testbench\Attributes\WithConfig;
 use Hypervel\Testbench\Attributes\WithMigration;
 use Hypervel\Tests\Fortify\Fixtures\Admin;
@@ -32,18 +30,7 @@ class ConfirmablePasswordControllerTest extends TestCase
             'password' => bcrypt('secret'),
         ]);
 
-        Schema::create('admins', function (Blueprint $table): void {
-            $table->id();
-            $table->string('name')->nullable();
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password')->nullable();
-            $table->text('two_factor_secret')->nullable();
-            $table->text('two_factor_recovery_codes')->nullable();
-            $table->timestamp('two_factor_confirmed_at')->nullable();
-            $table->rememberToken();
-            $table->timestamps();
-        });
+        $this->createAdminsTable();
     }
 
     public function testTheConfirmPasswordViewIsReturned(): void

--- a/tests/Fortify/ConfirmablePasswordControllerTest.php
+++ b/tests/Fortify/ConfirmablePasswordControllerTest.php
@@ -283,6 +283,22 @@ class ConfirmablePasswordControllerTest extends TestCase
             ->assertHeaderMissing('X-Retry-After');
     }
 
+    public function testStatusNormalizesMalformedSecondsInput(): void
+    {
+        $this->freezeSecond();
+
+        $response = $this->withoutExceptionHandling()
+            ->actingAs($this->user)
+            ->withSession(['auth.password_confirmed_at_web' => now()->subSeconds(2)->unix()])
+            ->get(
+                '/user/confirmed-password-status?seconds[]=900',
+            );
+
+        $response->assertOk()
+            ->assertJson(['confirmed' => false])
+            ->assertHeaderMissing('X-Retry-After');
+    }
+
     private function createAdmin(): Admin
     {
         return Admin::forceCreate([

--- a/tests/Fortify/TestCase.php
+++ b/tests/Fortify/TestCase.php
@@ -70,6 +70,17 @@ abstract class TestCase extends TestbenchTestCase
             $table->timestamps();
         });
 
+        $this->createAdminsTable();
+
+        Schema::create('password_reset_tokens', function (Blueprint $table): void {
+            $table->string('email')->primary();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    protected function createAdminsTable(): void
+    {
         Schema::create('admins', function (Blueprint $table): void {
             $table->id();
             $table->string('name')->nullable();
@@ -81,12 +92,6 @@ abstract class TestCase extends TestbenchTestCase
             $table->timestamp('two_factor_confirmed_at')->nullable();
             $table->rememberToken();
             $table->timestamps();
-        });
-
-        Schema::create('password_reset_tokens', function (Blueprint $table): void {
-            $table->string('email')->primary();
-            $table->string('token');
-            $table->timestamp('created_at')->nullable();
         });
     }
 

--- a/tests/Fortify/TestCase.php
+++ b/tests/Fortify/TestCase.php
@@ -70,6 +70,19 @@ abstract class TestCase extends TestbenchTestCase
             $table->timestamps();
         });
 
+        Schema::create('admins', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password')->nullable();
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
         Schema::create('password_reset_tokens', function (Blueprint $table): void {
             $table->string('email')->primary();
             $table->string('token');

--- a/tests/Passkeys/Feature/Controllers/PasskeyConfirmationTest.php
+++ b/tests/Passkeys/Feature/Controllers/PasskeyConfirmationTest.php
@@ -123,6 +123,6 @@ class PasskeyConfirmationTest extends TestCase
             ->assertJsonStructure(['redirect'])
             ->assertJsonMissing(['confirmed']);
 
-        $this->assertNotNull(session('auth.password_confirmed_at'));
+        $this->assertNotNull(session('auth.password_confirmed_at_web'));
     }
 }

--- a/tests/Passkeys/Feature/Controllers/PasskeyRegistrationTest.php
+++ b/tests/Passkeys/Feature/Controllers/PasskeyRegistrationTest.php
@@ -24,7 +24,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->getJson('/user/passkeys/options')
             ->assertOk()
             ->assertJsonStructure([
@@ -49,7 +49,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->getJson('/user/passkeys/options')
             ->assertOk();
 
@@ -67,7 +67,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->getJson('/user/passkeys/options')
             ->assertOk();
 
@@ -122,7 +122,7 @@ class PasskeyRegistrationTest extends TestCase
             ->getMock());
 
         $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->withSession(['passkey.registration_options' => 'serialized-options'])
             ->postJson('/user/passkeys', [
                 'name' => 'My Passkey',
@@ -145,7 +145,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->postJson('/user/passkeys', [
                 'name' => 'My Passkey',
                 'credential' => [
@@ -202,7 +202,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->deleteJson("/user/passkeys/{$passkey->id}")
             ->assertOk()
             ->assertJson(['status' => 'passkey-deleted']);
@@ -226,7 +226,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->deleteJson("/user/passkeys/{$passkey->credential_id}")
             ->assertOk()
             ->assertJson(['status' => 'passkey-deleted']);
@@ -277,7 +277,7 @@ class PasskeyRegistrationTest extends TestCase
         ]);
 
         $this->actingAs($otherUser)
-            ->withSession(['auth.password_confirmed_at' => time()])
+            ->withSession(['auth.password_confirmed_at_web' => time()])
             ->deleteJson("/user/passkeys/{$passkey->id}")
             ->assertForbidden();
 

--- a/tests/Permission/Support/ConfigTest.php
+++ b/tests/Permission/Support/ConfigTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Permission\Support;
+
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Permission\Support\Config;
+use Hypervel\Support\Facades\Auth;
+use Hypervel\Testbench\TestCase;
+
+class ConfigTest extends TestCase
+{
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app->make('config')->set([
+            'auth.defaults.guard' => 'web',
+            'auth.guards.web' => ['driver' => 'session', 'provider' => 'users'],
+            'auth.guards.admin' => ['driver' => 'session', 'provider' => 'admins'],
+        ]);
+    }
+
+    public function testDefaultGuardFallsBackToConfig(): void
+    {
+        $this->assertSame('web', Config::defaultGuard());
+    }
+
+    public function testDefaultGuardFollowsCurrentGuard(): void
+    {
+        Auth::shouldUse('admin');
+
+        $this->assertSame('admin', Config::defaultGuard());
+    }
+}

--- a/tests/Sanctum/ActingAsTest.php
+++ b/tests/Sanctum/ActingAsTest.php
@@ -25,10 +25,12 @@ class ActingAsTest extends TestCase
             'auth.guards.sanctum' => [
                 'driver' => 'sanctum',
                 'provider' => 'users',
+                'session_guards' => ['web'],
             ],
             'auth.guards.api' => [
                 'driver' => 'sanctum',
                 'provider' => 'users',
+                'session_guards' => ['web'],
             ],
             'auth.providers.users' => [
                 'driver' => 'eloquent',

--- a/tests/Sanctum/AuthenticateRequestsTest.php
+++ b/tests/Sanctum/AuthenticateRequestsTest.php
@@ -43,6 +43,7 @@ class AuthenticateRequestsTest extends TestCase
             'auth.guards.sanctum' => [
                 'driver' => 'sanctum',
                 'provider' => 'users',
+                'session_guards' => ['web'],
             ],
             'auth.guards.web' => [
                 'driver' => 'session',
@@ -50,8 +51,7 @@ class AuthenticateRequestsTest extends TestCase
             ],
             'auth.providers.users.model' => TestUser::class,
             'auth.providers.users.driver' => 'eloquent',
-            'sanctum.stateful' => ['localhost', '127.0.0.1'],
-            'sanctum.guard' => ['web'],
+            'sanctum.stateful_domains' => ['localhost', '127.0.0.1'],
         ]);
     }
 

--- a/tests/Sanctum/AuthenticateSessionTest.php
+++ b/tests/Sanctum/AuthenticateSessionTest.php
@@ -10,6 +10,7 @@ use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Http\Request;
 use Hypervel\Sanctum\Http\Middleware\AuthenticateSession;
 use Hypervel\Session\ArraySessionHandler;
+use Hypervel\Session\Middleware\AuthenticateSession as SessionAuthenticateSession;
 use Hypervel\Session\Store;
 use Hypervel\Testbench\TestCase;
 use Hypervel\Tests\Sanctum\Fixtures\TestUser;
@@ -55,7 +56,7 @@ class AuthenticateSessionTest extends TestCase
         $this->app->make('auth')->guard('admin')->setUser($this->user('new-password'));
 
         $request = $this->requestWithSession();
-        $request->session()->put('password_hash_admin', 'old-password');
+        $request->session()->put('password_hash_admin', $this->passwordHash('admin', 'old-password'));
 
         try {
             $this->middleware()->handle($request, fn () => new Response('next'));
@@ -65,6 +66,111 @@ class AuthenticateSessionTest extends TestCase
             $this->assertSame(['admin', 'sanctum'], $exception->guards());
             $this->assertFalse($request->session()->has('password_hash_admin'));
         }
+    }
+
+    public function testPasswordHashesAreComparedAgainstEachGuardsOwnUser(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($this->user('web-password'));
+        $auth->guard('admin')->setUser($this->user('admin-password'));
+
+        $request = $this->requestWithSession();
+        $request->session()->put('password_hash_web', $this->passwordHash('web', 'web-password'));
+        $request->session()->put('password_hash_admin', $this->passwordHash('admin', 'admin-password'));
+
+        $response = $this->middleware()->handle($request, fn () => new Response('next'));
+
+        $this->assertSame('next', $response->getContent());
+        $this->assertSame($this->passwordHash('web', 'web-password'), $request->session()->get('password_hash_web'));
+        $this->assertSame($this->passwordHash('admin', 'admin-password'), $request->session()->get('password_hash_admin'));
+    }
+
+    public function testOnlyGuardWithStalePasswordHashIsReportedBeforeSessionFlush(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($this->user('web-password'));
+        $auth->guard('admin')->setUser($this->user('new-admin-password'));
+
+        $request = $this->requestWithSession();
+        $request->session()->put('password_hash_web', $this->passwordHash('web', 'web-password'));
+        $request->session()->put('password_hash_admin', $this->passwordHash('admin', 'old-admin-password'));
+
+        try {
+            $this->middleware()->handle($request, fn () => new Response('next'));
+            $this->fail('Expected authentication exception was not thrown.');
+        } catch (AuthenticationException $exception) {
+            $this->assertSame('Unauthenticated.', $exception->getMessage());
+            $this->assertSame(['admin', 'sanctum'], $exception->guards());
+            $this->assertFalse($request->session()->has('password_hash_web'));
+            $this->assertFalse($request->session()->has('password_hash_admin'));
+        }
+    }
+
+    public function testAuthenticatedSessionGuardsStorePasswordHashesAfterRequest(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($this->user('web-password'));
+        $auth->guard('admin')->setUser($this->user('admin-password'));
+
+        $request = $this->requestWithSession();
+
+        $response = $this->middleware()->handle($request, fn () => new Response('next'));
+
+        $this->assertSame('next', $response->getContent());
+        $this->assertSame($this->passwordHash('web', 'web-password'), $request->session()->get('password_hash_web'));
+        $this->assertSame($this->passwordHash('admin', 'admin-password'), $request->session()->get('password_hash_admin'));
+    }
+
+    public function testRawPasswordHashIsRejected(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($this->user('web-password'));
+
+        $request = $this->requestWithSession();
+        $request->session()->put('password_hash_web', 'web-password');
+
+        try {
+            $this->middleware()->handle($request, fn () => new Response('next'));
+            $this->fail('Expected authentication exception was not thrown.');
+        } catch (AuthenticationException $exception) {
+            $this->assertSame('Unauthenticated.', $exception->getMessage());
+            $this->assertSame(['web', 'sanctum'], $exception->guards());
+            $this->assertFalse($request->session()->has('password_hash_web'));
+        }
+    }
+
+    public function testSessionAuthenticateSessionHashIsAcceptedBySanctum(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($user = $this->user('web-password'));
+
+        $request = $this->requestWithSession();
+        $request->setUserResolver(fn () => $user);
+
+        $sessionMiddleware = new SessionAuthenticateSession($auth);
+        $sessionMiddleware->handle($request, fn () => new Response('session'));
+
+        $this->assertSame($this->passwordHash('web', 'web-password'), $request->session()->get('password_hash_web'));
+
+        $response = $this->middleware()->handle($request, fn () => new Response('sanctum'));
+
+        $this->assertSame('sanctum', $response->getContent());
+        $this->assertSame($this->passwordHash('web', 'web-password'), $request->session()->get('password_hash_web'));
     }
 
     public function testSanctumEntryWithoutSessionGuardsContributesNothing(): void
@@ -103,18 +209,33 @@ class AuthenticateSessionTest extends TestCase
 
         $request = $this->requestWithSession();
         $request->session()->put('password_hash_web', 'stale-web-password');
-        $request->session()->put('password_hash_admin', 'admin-password');
+        $request->session()->put('password_hash_admin', $this->passwordHash('admin', 'admin-password'));
 
         $response = $this->middleware()->handle($request, fn () => new Response('next'));
 
         $this->assertSame('next', $response->getContent());
         $this->assertSame('stale-web-password', $request->session()->get('password_hash_web'));
-        $this->assertSame('admin-password', $request->session()->get('password_hash_admin'));
+        $this->assertSame($this->passwordHash('admin', 'admin-password'), $request->session()->get('password_hash_admin'));
     }
 
     private function middleware(): AuthenticateSession
     {
         return $this->app->make(AuthenticateSession::class);
+    }
+
+    private function configureWebAndAdminSanctumGuards(): void
+    {
+        $config = $this->app->make('config');
+        $config->set('auth.guards.sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => ['web'],
+        ]);
+        $config->set('auth.guards.admin-api', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => ['admin'],
+        ]);
     }
 
     private function requestWithSession(): Request
@@ -123,6 +244,11 @@ class AuthenticateSessionTest extends TestCase
         $request->setHypervelSession(new Store('name', new ArraySessionHandler(1)));
 
         return $request;
+    }
+
+    private function passwordHash(string $guard, ?string $password): string
+    {
+        return $this->app->make('auth')->guard($guard)->hashPasswordForCookie($password);
     }
 
     private function user(string $password): AuthenticatableContract

--- a/tests/Sanctum/AuthenticateSessionTest.php
+++ b/tests/Sanctum/AuthenticateSessionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Sanctum;
 
 use Hypervel\Auth\AuthenticationException;
+use Hypervel\Auth\SessionGuard;
 use Hypervel\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Http\Request;
@@ -151,6 +152,83 @@ class AuthenticateSessionTest extends TestCase
         }
     }
 
+    public function testMalformedPasswordHashIsRejected(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($this->user('web-password'));
+
+        $request = $this->requestWithSession();
+        $request->session()->put('password_hash_web', ['not-a-password-hash']);
+
+        try {
+            $this->middleware()->handle($request, fn () => new Response('next'));
+            $this->fail('Expected authentication exception was not thrown.');
+        } catch (AuthenticationException $exception) {
+            $this->assertSame('Unauthenticated.', $exception->getMessage());
+            $this->assertSame(['web', 'sanctum'], $exception->guards());
+            $this->assertFalse($request->session()->has('password_hash_web'));
+        }
+    }
+
+    public function testValidRememberCookieHashIsAccepted(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $guard = $this->rememberedGuard('web', 'web-password');
+
+        $request = $this->requestWithSession([
+            $guard->getRecallerName() => '1|token|' . $this->passwordHash('web', 'web-password'),
+        ]);
+
+        $response = $this->middleware()->handle($request, fn () => new Response('next'));
+
+        $this->assertSame('next', $response->getContent());
+        $this->assertSame($this->passwordHash('web', 'web-password'), $request->session()->get('password_hash_web'));
+    }
+
+    public function testStaleRememberCookieHashIsRejected(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $guard = $this->rememberedGuard('web', 'new-web-password');
+
+        $request = $this->requestWithSession([
+            $guard->getRecallerName() => '1|token|' . $this->passwordHash('web', 'old-web-password'),
+        ]);
+
+        try {
+            $this->middleware()->handle($request, fn () => new Response('next'));
+            $this->fail('Expected authentication exception was not thrown.');
+        } catch (AuthenticationException $exception) {
+            $this->assertSame('Unauthenticated.', $exception->getMessage());
+            $this->assertSame(['web', 'sanctum'], $exception->guards());
+            $this->assertFalse($request->session()->has('password_hash_web'));
+        }
+    }
+
+    public function testMissingRememberCookieHashIsRejected(): void
+    {
+        $this->configureWebAndAdminSanctumGuards();
+
+        $guard = $this->rememberedGuard('web', 'web-password');
+
+        $request = $this->requestWithSession([
+            $guard->getRecallerName() => '1|token',
+        ]);
+
+        try {
+            $this->middleware()->handle($request, fn () => new Response('next'));
+            $this->fail('Expected authentication exception was not thrown.');
+        } catch (AuthenticationException $exception) {
+            $this->assertSame('Unauthenticated.', $exception->getMessage());
+            $this->assertSame(['web', 'sanctum'], $exception->guards());
+            $this->assertFalse($request->session()->has('password_hash_web'));
+        }
+    }
+
     public function testSessionAuthenticateSessionHashIsAcceptedBySanctum(): void
     {
         $this->configureWebAndAdminSanctumGuards();
@@ -238,12 +316,28 @@ class AuthenticateSessionTest extends TestCase
         ]);
     }
 
-    private function requestWithSession(): Request
+    private function requestWithSession(array $cookies = []): Request
     {
-        $request = new Request;
+        $request = new Request(cookies: $cookies);
         $request->setHypervelSession(new Store('name', new ArraySessionHandler(1)));
 
         return $request;
+    }
+
+    private function rememberedGuard(string $guard, string $password): SessionGuard
+    {
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+
+        /** @var SessionGuard $guardInstance */
+        $guardInstance = $auth->guard($guard);
+        $guardInstance->setUser($this->user($password));
+
+        (function (): void {
+            $this->setContextState('viaRemember', true);
+        })->call($guardInstance);
+
+        return $guardInstance;
     }
 
     private function passwordHash(string $guard, ?string $password): string

--- a/tests/Sanctum/AuthenticateSessionTest.php
+++ b/tests/Sanctum/AuthenticateSessionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Sanctum;
+
+use Hypervel\Auth\AuthenticationException;
+use Hypervel\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Http\Request;
+use Hypervel\Sanctum\Http\Middleware\AuthenticateSession;
+use Hypervel\Session\ArraySessionHandler;
+use Hypervel\Session\Store;
+use Hypervel\Testbench\TestCase;
+use Hypervel\Tests\Sanctum\Fixtures\TestUser;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateSessionTest extends TestCase
+{
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app->make('config')->set([
+            'auth.guards.web' => [
+                'driver' => 'session',
+                'provider' => 'users',
+            ],
+            'auth.guards.admin' => [
+                'driver' => 'session',
+                'provider' => 'users',
+            ],
+            'auth.providers.users' => [
+                'driver' => 'eloquent',
+                'model' => TestUser::class,
+            ],
+        ]);
+    }
+
+    public function testUnionOfSanctumGuardsSessionGuardsIsChecked(): void
+    {
+        $config = $this->app->make('config');
+        $config->set('auth.guards.sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => ['web'],
+        ]);
+        $config->set('auth.guards.admin-api', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => ['admin'],
+        ]);
+
+        $this->app->make('auth')->forgetGuards();
+        $this->app->make('auth')->guard('admin')->setUser($this->user('new-password'));
+
+        $request = $this->requestWithSession();
+        $request->session()->put('password_hash_admin', 'old-password');
+
+        try {
+            $this->middleware()->handle($request, fn () => new Response('next'));
+            $this->fail('Expected authentication exception was not thrown.');
+        } catch (AuthenticationException $exception) {
+            $this->assertSame('Unauthenticated.', $exception->getMessage());
+            $this->assertSame(['admin', 'sanctum'], $exception->guards());
+            $this->assertFalse($request->session()->has('password_hash_admin'));
+        }
+    }
+
+    public function testSanctumEntryWithoutSessionGuardsContributesNothing(): void
+    {
+        $this->app->make('config')->set('auth.guards.sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ]);
+        $this->app->make('auth')->forgetGuards();
+
+        $request = $this->requestWithSession();
+
+        $response = $this->middleware()->handle($request, fn () => new Response('next'));
+
+        $this->assertSame('next', $response->getContent());
+    }
+
+    public function testMalformedSessionGuardsEntriesAreSkippedByUnion(): void
+    {
+        $config = $this->app->make('config');
+        $config->set('auth.guards.bad-api', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => 'web',
+        ]);
+        $config->set('auth.guards.sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => [123, '', 'admin'],
+        ]);
+
+        $auth = $this->app->make('auth');
+        $auth->forgetGuards();
+        $auth->guard('web')->setUser($this->user('web-password'));
+        $auth->guard('admin')->setUser($this->user('admin-password'));
+
+        $request = $this->requestWithSession();
+        $request->session()->put('password_hash_web', 'stale-web-password');
+        $request->session()->put('password_hash_admin', 'admin-password');
+
+        $response = $this->middleware()->handle($request, fn () => new Response('next'));
+
+        $this->assertSame('next', $response->getContent());
+        $this->assertSame('stale-web-password', $request->session()->get('password_hash_web'));
+        $this->assertSame('admin-password', $request->session()->get('password_hash_admin'));
+    }
+
+    private function middleware(): AuthenticateSession
+    {
+        return $this->app->make(AuthenticateSession::class);
+    }
+
+    private function requestWithSession(): Request
+    {
+        $request = new Request;
+        $request->setHypervelSession(new Store('name', new ArraySessionHandler(1)));
+
+        return $request;
+    }
+
+    private function user(string $password): AuthenticatableContract
+    {
+        return new class($password) implements AuthenticatableContract {
+            public function __construct(
+                private readonly string $password,
+            ) {
+            }
+
+            public function getAuthIdentifierName(): string
+            {
+                return 'id';
+            }
+
+            public function getAuthIdentifier(): int
+            {
+                return 1;
+            }
+
+            public function getAuthPasswordName(): string
+            {
+                return 'password';
+            }
+
+            public function getAuthPassword(): string
+            {
+                return $this->password;
+            }
+
+            public function getRememberToken(): ?string
+            {
+                return null;
+            }
+
+            public function setRememberToken(string $value): void
+            {
+            }
+
+            public function getRememberTokenName(): string
+            {
+                return 'remember_token';
+            }
+        };
+    }
+}

--- a/tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Sanctum/EnsureFrontendRequestsAreStatefulTest.php
@@ -15,7 +15,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->make('config')->set('sanctum.stateful', ['test.com', '*.test.com']);
+        $this->app->make('config')->set('sanctum.stateful_domains', ['test.com', '*.test.com']);
     }
 
     public function testRequestFromFrontendIsIdentified(): void

--- a/tests/Sanctum/FrontendCookieHardeningTest.php
+++ b/tests/Sanctum/FrontendCookieHardeningTest.php
@@ -28,7 +28,7 @@ class FrontendCookieHardeningTest extends TestCase
             'session.driver' => 'array',
             'session.http_only' => false,
             'session.same_site' => 'strict',
-            'sanctum.stateful' => ['test.com'],
+            'sanctum.stateful_domains' => ['test.com'],
         ]);
     }
 

--- a/tests/Sanctum/GuardTest.php
+++ b/tests/Sanctum/GuardTest.php
@@ -14,6 +14,8 @@ use Hypervel\Sanctum\TransientToken;
 use Hypervel\Support\Facades\Route;
 use Hypervel\Testbench\TestCase;
 use Hypervel\Tests\Sanctum\Fixtures\TestUser;
+use Hypervel\Tests\Sanctum\Fixtures\User as SanctumTestUser;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class GuardTest extends TestCase
@@ -43,6 +45,7 @@ class GuardTest extends TestCase
             'auth.guards.sanctum' => [
                 'driver' => 'sanctum',
                 'provider' => 'users',
+                'session_guards' => ['web'],
             ],
             'auth.guards.web' => [
                 'driver' => 'session',
@@ -50,7 +53,6 @@ class GuardTest extends TestCase
             ],
             'auth.providers.users.model' => TestUser::class,
             'auth.providers.users.driver' => 'eloquent',
-            'sanctum.guard' => ['web'],
         ]);
     }
 
@@ -73,6 +75,20 @@ class GuardTest extends TestCase
     protected function createUsersTable(): void
     {
         $this->app->make('db')->connection()->getSchemaBuilder()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Create the alternate users table for provider matching tests.
+     */
+    protected function createSanctumTestUsersTable(): void
+    {
+        $this->app->make('db')->connection()->getSchemaBuilder()->create('sanctum_test_users', function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();
@@ -136,6 +152,18 @@ class GuardTest extends TestCase
         return [$user, $token, $token->id . '|' . $plainTextToken];
     }
 
+    /**
+     * Expect the invalid session guards configuration exception.
+     */
+    protected function expectInvalidSessionGuardsConfiguration(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Auth guard [sanctum] uses the sanctum driver but does not declare a valid session guards list. '
+            . 'Set auth.guards.sanctum.session_guards to an array of session guard names, or [] to disable stateful session authentication.'
+        );
+    }
+
     public function testAuthenticationIsAttemptedWithWebMiddleware(): void
     {
         // Create a user in the database
@@ -176,6 +204,156 @@ class GuardTest extends TestCase
                 'user_id' => $user->id,
                 'user_email' => $user->email,
                 'token_id' => $token->id,
+            ]);
+    }
+
+    public function testEmptySessionGuardsIsTokenOnly(): void
+    {
+        $this->app->make('config')->set('auth.guards.sanctum.session_guards', []);
+
+        $sessionUser = TestUser::create([
+            'name' => 'Session User',
+            'email' => 'session@example.com',
+            'password' => password_hash('password', PASSWORD_DEFAULT),
+        ]);
+
+        $this->app->make('auth')->guard('web')->setUser($sessionUser);
+
+        $this->getJson('/test/user')
+            ->assertOk()
+            ->assertJson([
+                'authenticated' => false,
+                'user_id' => null,
+            ]);
+
+        [$tokenUser, $token, $plainToken] = $this->createUserWithToken(plainTextToken: 'token-only');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer ' . $plainToken,
+        ])->getJson('/test/user')
+            ->assertOk()
+            ->assertJson([
+                'authenticated' => true,
+                'user_id' => $tokenUser->id,
+                'token_id' => $token->id,
+            ]);
+    }
+
+    public function testMissingSessionGuardsThrowsInstructiveError(): void
+    {
+        $this->app->make('config')->set('auth.guards.sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ]);
+        $this->app->make('auth')->forgetGuards();
+
+        $this->expectInvalidSessionGuardsConfiguration();
+
+        $this->app->make('auth')->guard('sanctum');
+    }
+
+    public function testNonArraySessionGuardsThrowsInstructiveError(): void
+    {
+        $this->app->make('config')->set('auth.guards.sanctum.session_guards', 'web');
+        $this->app->make('auth')->forgetGuards();
+
+        $this->expectInvalidSessionGuardsConfiguration();
+
+        $this->app->make('auth')->guard('sanctum');
+    }
+
+    #[DataProvider('invalidSessionGuardsDataProvider')]
+    public function testInvalidSessionGuardEntriesThrowInstructiveError(array $sessionGuards): void
+    {
+        $this->app->make('config')->set('auth.guards.sanctum.session_guards', $sessionGuards);
+        $this->app->make('auth')->forgetGuards();
+
+        $this->expectInvalidSessionGuardsConfiguration();
+
+        $this->app->make('auth')->guard('sanctum');
+    }
+
+    public static function invalidSessionGuardsDataProvider(): array
+    {
+        return [
+            [[123]],
+            [['']],
+        ];
+    }
+
+    public function testNonStatefulSessionGuardThrows(): void
+    {
+        $config = $this->app->make('config');
+        $config->set('auth.guards.sanctum.session_guards', ['other-sanctum']);
+        $config->set('auth.guards.other-sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+            'session_guards' => [],
+        ]);
+        $this->app->make('auth')->forgetGuards();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Auth guard [sanctum] lists [other-sanctum] in session_guards, but that guard is not a stateful guard.');
+
+        $this->withoutExceptionHandling()->getJson('/test/user');
+    }
+
+    public function testStatefulUserMustMatchProvider(): void
+    {
+        $this->createSanctumTestUsersTable();
+
+        $config = $this->app->make('config');
+        $config->set('auth.providers.admins', [
+            'driver' => 'eloquent',
+            'model' => SanctumTestUser::class,
+        ]);
+        $config->set('auth.guards.web.provider', 'admins');
+        $this->app->make('auth')->forgetGuards();
+
+        $sessionUser = SanctumTestUser::create([
+            'name' => 'Session User',
+            'email' => 'session@example.com',
+            'password' => password_hash('password', PASSWORD_DEFAULT),
+        ]);
+        $this->app->make('auth')->guard('web')->setUser($sessionUser);
+
+        [$tokenUser, $token, $plainToken] = $this->createUserWithToken(plainTextToken: 'provider-match');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer ' . $plainToken,
+        ])->getJson('/test/user')
+            ->assertOk()
+            ->assertJson([
+                'authenticated' => true,
+                'user_id' => $tokenUser->id,
+                'token_id' => $token->id,
+            ]);
+    }
+
+    public function testSecondListedSessionGuardIsTried(): void
+    {
+        $config = $this->app->make('config');
+        $config->set('auth.guards.admin', [
+            'driver' => 'session',
+            'provider' => 'users',
+        ]);
+        $config->set('auth.guards.sanctum.session_guards', ['admin', 'web']);
+        $this->app->make('auth')->forgetGuards();
+
+        $user = TestUser::create([
+            'name' => 'Test User',
+            'email' => 'test-second@example.com',
+            'password' => password_hash('password', PASSWORD_DEFAULT),
+        ]);
+
+        $this->app->make('auth')->guard('web')->setUser($user);
+
+        $this->getJson('/test/user')
+            ->assertOk()
+            ->assertJson([
+                'authenticated' => true,
+                'user_id' => $user->id,
+                'token_class' => TransientToken::class,
             ]);
     }
 

--- a/tests/Sanctum/GuardTest.php
+++ b/tests/Sanctum/GuardTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Sanctum;
 
+use Hypervel\Contracts\Auth\Authenticatable;
+use Hypervel\Contracts\Auth\StatefulGuard;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Foundation\Testing\RefreshDatabase;
@@ -357,6 +359,62 @@ class GuardTest extends TestCase
             ]);
     }
 
+    public function testNullUserFromStatefulGuardFallsThroughToLaterSessionGuard(): void
+    {
+        $auth = $this->app->make('auth');
+        $auth->extend('null-stateful', fn () => new NullUserStatefulGuard);
+
+        $config = $this->app->make('config');
+        $config->set('auth.guards.null-stateful', [
+            'driver' => 'null-stateful',
+            'provider' => 'users',
+        ]);
+        $config->set('auth.guards.sanctum.session_guards', ['null-stateful', 'web']);
+        $auth->forgetGuards();
+
+        $user = TestUser::create([
+            'name' => 'Test User',
+            'email' => 'test-null-stateful@example.com',
+            'password' => password_hash('password', PASSWORD_DEFAULT),
+        ]);
+
+        $auth->guard('web')->setUser($user);
+
+        $this->getJson('/test/user')
+            ->assertOk()
+            ->assertJson([
+                'authenticated' => true,
+                'user_id' => $user->id,
+                'token_class' => TransientToken::class,
+            ]);
+    }
+
+    public function testNullUserFromStatefulGuardFallsThroughToBearerToken(): void
+    {
+        $auth = $this->app->make('auth');
+        $auth->extend('null-stateful', fn () => new NullUserStatefulGuard);
+
+        $config = $this->app->make('config');
+        $config->set('auth.guards.null-stateful', [
+            'driver' => 'null-stateful',
+            'provider' => 'users',
+        ]);
+        $config->set('auth.guards.sanctum.session_guards', ['null-stateful']);
+        $auth->forgetGuards();
+
+        [$user, $token, $plainToken] = $this->createUserWithToken(plainTextToken: 'null-stateful-token');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer ' . $plainToken,
+        ])->getJson('/test/user')
+            ->assertOk()
+            ->assertJson([
+                'authenticated' => true,
+                'user_id' => $user->id,
+                'token_id' => $token->id,
+            ]);
+    }
+
     public function testAuthenticationWithTokenFailsIfExpired(): void
     {
         $user = TestUser::create([
@@ -589,5 +647,76 @@ class GuardTest extends TestCase
                 'can_write' => true,
                 'can_delete' => false,
             ]);
+    }
+}
+
+class NullUserStatefulGuard implements StatefulGuard
+{
+    public function attempt(array $credentials = [], bool $remember = false): bool
+    {
+        return false;
+    }
+
+    public function once(array $credentials = []): bool
+    {
+        return false;
+    }
+
+    public function login(Authenticatable $user, bool $remember = false): void
+    {
+    }
+
+    public function loginUsingId(mixed $id, bool $remember = false): Authenticatable|false
+    {
+        return false;
+    }
+
+    public function onceUsingId(mixed $id): Authenticatable|false
+    {
+        return false;
+    }
+
+    public function viaRemember(): bool
+    {
+        return false;
+    }
+
+    public function logout(): void
+    {
+    }
+
+    public function check(): bool
+    {
+        return true;
+    }
+
+    public function guest(): bool
+    {
+        return false;
+    }
+
+    public function user(): ?Authenticatable
+    {
+        return null;
+    }
+
+    public function id(): int|string|null
+    {
+        return null;
+    }
+
+    public function validate(array $credentials = []): bool
+    {
+        return false;
+    }
+
+    public function hasUser(): bool
+    {
+        return false;
+    }
+
+    public function setUser(Authenticatable $user): static
+    {
+        return $this;
     }
 }

--- a/tests/Sanctum/SimpleGuardTest.php
+++ b/tests/Sanctum/SimpleGuardTest.php
@@ -55,6 +55,7 @@ class SimpleGuardTest extends TestCase
             'auth.guards.sanctum' => [
                 'driver' => 'sanctum',
                 'provider' => 'users',
+                'session_guards' => ['web'],
             ],
             'auth.providers.users.model' => TestUser::class,
             'auth.providers.users.driver' => 'eloquent',

--- a/tests/Session/Middleware/AuthenticateSessionTest.php
+++ b/tests/Session/Middleware/AuthenticateSessionTest.php
@@ -354,4 +354,45 @@ class AuthenticateSessionTest extends TestCase
         $this->assertNull($session->get('a'));
         $this->assertNull($session->get('b'));
     }
+
+    public function testHandleWithMalformedSessionPasswordHashLogsOut(): void
+    {
+        $user = new class {
+            public function getAuthPassword()
+            {
+                return 'my-pass-(*&^%$#!@';
+            }
+        };
+
+        $request = new Request;
+        $request->setUserResolver(fn () => $user);
+
+        $session = new Store('name', new ArraySessionHandler(1));
+        $session->put('a', '1');
+        $session->put('b', '2');
+        $session->put('password_hash_web', ['not-a-password-hash']);
+        $request->setHypervelSession($session);
+
+        $authFactory = m::mock(AuthFactory::class);
+        $authFactory->shouldReceive('viaRemember')->andReturn(false);
+        $authFactory->shouldReceive('getRecallerName')->never();
+        $authFactory->shouldReceive('logoutCurrentDevice')->once()->andReturn(null);
+        $authFactory->shouldReceive('getDefaultDriver')->andReturn('web');
+        $authFactory->shouldReceive('user')->andReturn(null);
+        $authFactory->shouldReceive('hashPasswordForCookie')->never();
+
+        $middleware = new AuthenticateSession($authFactory);
+
+        $message = '';
+        try {
+            $middleware->handle($request, fn () => 'next-10');
+        } catch (AuthenticationException $e) {
+            $message = $e->getMessage();
+        }
+
+        $this->assertEquals('Unauthenticated.', $message);
+        $this->assertNull($session->get('password_hash_web'));
+        $this->assertNull($session->get('a'));
+        $this->assertNull($session->get('b'));
+    }
 }

--- a/tests/Session/Middleware/AuthenticateSessionTest.php
+++ b/tests/Session/Middleware/AuthenticateSessionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Session\Middleware;
 
-use BadMethodCallException;
 use Hypervel\Auth\AuthenticationException;
 use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Http\Request;
@@ -274,7 +273,9 @@ class AuthenticateSessionTest extends TestCase
         $this->assertEquals('2', $session->get('b'));
     }
 
-    public function testHandleWithOldFormatCookieForBackwardCompatibility()
+    // REMOVED: Laravel's OldFormatCookie* backward-compatibility tests;
+    // Hypervel 0.4 is greenfield and only accepts HMAC artifacts.
+    public function testHandleWithRawRememberCookiePasswordHashLogsOut(): void
     {
         $user = new class {
             public function getAuthPassword()
@@ -283,37 +284,37 @@ class AuthenticateSessionTest extends TestCase
             }
         };
 
-        // Cookie contains OLD format (raw password hash, not HMAC)
         $request = new Request(cookies: ['recaller-name' => 'a|b|my-pass-(*&^%$#!@']);
         $request->setUserResolver(fn () => $user);
 
         $session = new Store('name', new ArraySessionHandler(1));
         $session->put('a', '1');
         $session->put('b', '2');
-        // Session also contains old format for this test
-        $session->put('password_hash_web', 'my-pass-(*&^%$#!@');
         $request->setHypervelSession($session);
 
         $authFactory = m::mock(AuthFactory::class);
         $authFactory->shouldReceive('viaRemember')->andReturn(true);
         $authFactory->shouldReceive('getRecallerName')->once()->andReturn('recaller-name');
+        $authFactory->shouldReceive('logoutCurrentDevice')->once()->andReturn(null);
         $authFactory->shouldReceive('getDefaultDriver')->andReturn('web');
-        $authFactory->shouldReceive('user')->andReturn($user);
-        // The HMAC won't match the old format, but fallback to raw hash should work
+        $authFactory->shouldReceive('user')->andReturn(null);
         $authFactory->shouldReceive('hashPasswordForCookie')->with('my-pass-(*&^%$#!@')->andReturn('mac:my-pass-(*&^%$#!@');
 
         $middleware = new AuthenticateSession($authFactory);
-        $response = $middleware->handle($request, fn () => 'next-9');
 
-        // Should succeed because of backward compatibility fallback
-        $this->assertEquals('next-9', $response);
-        // Session should be updated to new format (HMAC)
-        $this->assertEquals('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
-        $this->assertEquals('1', $session->get('a'));
-        $this->assertEquals('2', $session->get('b'));
+        $message = '';
+        try {
+            $middleware->handle($request, fn () => 'next-9');
+        } catch (AuthenticationException $e) {
+            $message = $e->getMessage();
+        }
+
+        $this->assertEquals('Unauthenticated.', $message);
+        $this->assertNull($session->get('a'));
+        $this->assertNull($session->get('b'));
     }
 
-    public function testHandleWithOldFormatCookieAndLegacyGuard()
+    public function testHandleWithRawSessionPasswordHashLogsOut(): void
     {
         $user = new class {
             public function getAuthPassword()
@@ -322,33 +323,35 @@ class AuthenticateSessionTest extends TestCase
             }
         };
 
-        // Cookie contains OLD format (raw password hash, not HMAC)
-        $request = new Request(cookies: ['recaller-name' => 'a|b|my-pass-(*&^%$#!@']);
+        $request = new Request;
         $request->setUserResolver(fn () => $user);
 
         $session = new Store('name', new ArraySessionHandler(1));
         $session->put('a', '1');
         $session->put('b', '2');
-        // Session also contains old format for this test
         $session->put('password_hash_web', 'my-pass-(*&^%$#!@');
         $request->setHypervelSession($session);
 
         $authFactory = m::mock(AuthFactory::class);
-        $authFactory->shouldReceive('viaRemember')->andReturn(true);
-        $authFactory->shouldReceive('getRecallerName')->once()->andReturn('recaller-name');
+        $authFactory->shouldReceive('viaRemember')->andReturn(false);
+        $authFactory->shouldReceive('getRecallerName')->never();
+        $authFactory->shouldReceive('logoutCurrentDevice')->once()->andReturn(null);
         $authFactory->shouldReceive('getDefaultDriver')->andReturn('web');
-        $authFactory->shouldReceive('user')->andReturn($user);
-        // For legacy guards without hashPasswordForCookie method, we use fallback to raw hash
-        $authFactory->shouldReceive('hashPasswordForCookie')->andThrowExceptions([new BadMethodCallException]);
+        $authFactory->shouldReceive('user')->andReturn(null);
+        $authFactory->shouldReceive('hashPasswordForCookie')->with('my-pass-(*&^%$#!@')->andReturn('mac:my-pass-(*&^%$#!@');
 
         $middleware = new AuthenticateSession($authFactory);
-        $response = $middleware->handle($request, fn () => 'next-9');
 
-        // Should succeed because of backward compatibility fallback
-        $this->assertEquals('next-9', $response);
-        // Session should stay intact
-        $this->assertEquals('my-pass-(*&^%$#!@', $session->get('password_hash_web'));
-        $this->assertEquals('1', $session->get('a'));
-        $this->assertEquals('2', $session->get('b'));
+        $message = '';
+        try {
+            $middleware->handle($request, fn () => 'next-9');
+        } catch (AuthenticationException $e) {
+            $message = $e->getMessage();
+        }
+
+        $this->assertEquals('Unauthenticated.', $message);
+        $this->assertNull($session->get('password_hash_web'));
+        $this->assertNull($session->get('a'));
+        $this->assertNull($session->get('b'));
     }
 }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Session;
 
+use Hypervel\Container\Container;
+use Hypervel\Contracts\Auth\Factory as AuthFactory;
 use Hypervel\Http\Request;
 use Hypervel\Session\CookieSessionHandler;
 use Hypervel\Session\Store;
@@ -481,9 +483,28 @@ class SessionStoreTest extends TestCase
     public function testPasswordConfirmed()
     {
         $session = $this->getSession();
-        $this->assertFalse($session->has('auth.password_confirmed_at'));
-        $session->passwordConfirmed();
-        $this->assertTrue($session->has('auth.password_confirmed_at'));
+        $this->assertFalse($session->has('auth.password_confirmed_at_web'));
+        $session->passwordConfirmed('web');
+        $this->assertTrue($session->has('auth.password_confirmed_at_web'));
+    }
+
+    public function testPasswordConfirmedResolvesCurrentGuardWhenNoneGiven()
+    {
+        $previousContainer = Container::getInstance();
+        $container = Container::setInstance(new Container);
+
+        try {
+            $auth = m::mock(AuthFactory::class);
+            $auth->shouldReceive('getDefaultDriver')->once()->andReturn('admin');
+            $container->instance(AuthFactory::class, $auth);
+
+            $session = $this->getSession();
+            $session->passwordConfirmed();
+
+            $this->assertTrue($session->has('auth.password_confirmed_at_admin'));
+        } finally {
+            Container::setInstance($previousContainer);
+        }
     }
 
     public function testKeyPush()

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -480,7 +480,7 @@ class SessionStoreTest extends TestCase
         $this->assertSame('https://example.com/foo/bar', $url);
     }
 
-    public function testPasswordConfirmed()
+    public function testPasswordConfirmed(): void
     {
         $session = $this->getSession();
         $this->assertFalse($session->has('auth.password_confirmed_at_web'));
@@ -488,7 +488,7 @@ class SessionStoreTest extends TestCase
         $this->assertTrue($session->has('auth.password_confirmed_at_web'));
     }
 
-    public function testPasswordConfirmedResolvesCurrentGuardWhenNoneGiven()
+    public function testPasswordConfirmedResolvesCurrentGuardWhenNoneGiven(): void
     {
         $previousContainer = Container::getInstance();
         $container = Container::setInstance(new Container);


### PR DESCRIPTION
## Summary

This completes the guard-driven auth siloing model across the remaining framework surfaces that were still reading global roots or ignoring the current guard.

For more detail, see: docs/plans/2026-07-07-guard-siloing-completion.md

After the password broker work, the intended rule was clear: when a request selects a guard, auth-adjacent decisions should follow that guard unless the setting is purely mechanical. This PR applies that rule to password confirmation, guest middleware, callback request guards, Sanctum stateful auth, Permission's default guard, Fortify login throttling, and a couple of generator paths.

The result is that `Auth::shouldUse()` / `auth:{guard}` / `guest:{guard}` become the local source of truth for actor siloing. Bare framework calls then do the expected thing for the selected guard instead of quietly falling back to package-level or root-level defaults.

## What changed

Password confirmation is now guard-scoped.

- Added `Hypervel\Auth\PasswordConfirmation` as the shared owner of confirmation keys and timeout resolution.
- `RequirePassword` resolves the guard and timeout at handle time.
- `Store::passwordConfirmed(?string $guard = null)` writes `auth.password_confirmed_at_{guard}`.
- Fortify confirmation controllers read and write through the same guard-scoped behavior.
- Guards may declare `password_timeout`; route overrides still win, then the guard value, then the app default.
- Passkeys tests were updated because they consume the same password confirmation session artifact.

Named guest middleware now selects its guard when the request continues.

- `guest:admin` makes `admin` the current guard on pass-through.
- `guest:a,b` selects `a`.
- Bare `guest` still selects nothing.
- Redirect paths do not select a guard because the request is leaving the guest route.

Callback request guards now use their own provider.

- `viaRequest()` passes the guard entry's `provider` into `RequestGuard`.
- `auth.defaults.provider` is gone.
- `getDefaultUserProvider()` remains as a Laravel-shaped helper, but now returns the provider declared by the current default guard.
- `createUserProvider(null)` still means no provider. It does not implicitly borrow the current guard.

Sanctum stateful auth is declared per Sanctum guard.

- Removed the global `sanctum.guard` accept-list.
- Sanctum guards now declare `session_guards` on their `auth.guards.{guard}` entry.
- `session_guards: []` is the explicit bearer-token-only mode.
- Missing or malformed `session_guards` throws an instructive config error.
- Listed session guards must implement `StatefulGuard`.
- Stateful session users must match the Sanctum guard provider, matching the bearer-token path's provider check.
- `AuthenticateSession` derives the union of session guards declared by all Sanctum guards so password-hash invalidation still works at middleware-group level.
- `sanctum.stateful` was renamed to `sanctum.stateful_domains` to match what the key actually contains and the existing env var name.

Other guard alignment work:

- Permission's `Config::defaultGuard()` now asks the auth manager, so coroutine `shouldUse()` overrides are honored.
- Fortify login throttling now keys by `guard|username|ip`, so one actor silo cannot lock out another with the same username and IP.
- Policy/generator default guard lookups now go through the auth manager when auth is available.
- Package READMEs now record the intentional Laravel differences for future upstream merges.

## Notes

This intentionally removes a few Laravel-compatible config roots rather than keeping them as fallbacks. Hypervel 0.4 has no backwards compatibility burden here, and keeping a second root for an auth silo decision would preserve the exact ambiguity this work is removing.

The public shape is still Laravel-familiar where it helps. For example, `getDefaultUserProvider()` stays, but its meaning is now guard-derived. That gives humans and LLMs a familiar method name without reintroducing `auth.defaults.provider` as another source of truth.

## Verification

Final `composer fix` was green after review fixes:

- php-cs-fixer: fixed 0 files
- phpstan: no errors
- full parallel suite: 21,420 tests, 60,676 assertions, 643 skipped
- package-mode testbench: 4 tests, 7 assertions

Claude also reviewed the final tree and signed off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password confirmation and related session state are now guard-scoped with guard-specific (and overrideable) timeouts.
  * Sanctum supports declaring trusted stateful session guards per auth guard.
  * Login throttling is scoped to the active guard.

* **Bug Fixes / Security**
  * Guest/auth guard selection is kept consistent across flows.
  * Default provider resolution now follows the current guard more reliably.
  * Session and Sanctum password-hash artifacts are now HMAC-only (legacy raw-hash fallback removed).

* **Documentation**
  * Updated auth, Fortify, Sanctum, and session docs for the new guard-scoped behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->