### PR TITLE
Bootstrap the application when tests refresh it

### DIFF
--- a/src/foundation/src/Application.php
+++ b/src/foundation/src/Application.php
@@ -46,6 +46,24 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public const VERSION = '0.4';
 
     /**
+     * The default bootstrap sequence for the application.
+     *
+     * Shared by the HTTP and console kernels and by the testing
+     * infrastructure so the boot paths cannot drift apart.
+     *
+     * @var array<int, class-string>
+     */
+    public const DEFAULT_BOOTSTRAPPERS = [
+        \Hypervel\Foundation\Bootstrap\LoadEnvironmentVariables::class,
+        \Hypervel\Foundation\Bootstrap\LoadConfiguration::class,
+        \Hypervel\Foundation\Bootstrap\HandleExceptions::class,
+        \Hypervel\Foundation\Bootstrap\RegisterFacades::class,
+        \Hypervel\Foundation\Bootstrap\RegisterProviders::class,
+        \Hypervel\Di\Bootstrap\GenerateProxies::class,
+        \Hypervel\Foundation\Bootstrap\BootProviders::class,
+    ];
+
+    /**
      * The base path for the Hypervel installation.
      */
     protected ?string $basePath = null;

--- a/src/foundation/src/Console/Kernel.php
+++ b/src/foundation/src/Console/Kernel.php
@@ -88,15 +88,7 @@ class Kernel implements KernelContract
     /**
      * The console application bootstrappers.
      */
-    protected array $bootstrappers = [
-        \Hypervel\Foundation\Bootstrap\LoadEnvironmentVariables::class,
-        \Hypervel\Foundation\Bootstrap\LoadConfiguration::class,
-        \Hypervel\Foundation\Bootstrap\HandleExceptions::class,
-        \Hypervel\Foundation\Bootstrap\RegisterFacades::class,
-        \Hypervel\Foundation\Bootstrap\RegisterProviders::class,
-        \Hypervel\Di\Bootstrap\GenerateProxies::class,
-        \Hypervel\Foundation\Bootstrap\BootProviders::class,
-    ];
+    protected array $bootstrappers = \Hypervel\Foundation\Application::DEFAULT_BOOTSTRAPPERS;
 
     public function __construct(
         protected ContainerContract $app,

--- a/src/foundation/src/Http/Kernel.php
+++ b/src/foundation/src/Http/Kernel.php
@@ -42,15 +42,7 @@ class Kernel implements KernelContract
      *
      * @var string[]
      */
-    protected array $bootstrappers = [
-        \Hypervel\Foundation\Bootstrap\LoadEnvironmentVariables::class,
-        \Hypervel\Foundation\Bootstrap\LoadConfiguration::class,
-        \Hypervel\Foundation\Bootstrap\HandleExceptions::class,
-        \Hypervel\Foundation\Bootstrap\RegisterFacades::class,
-        \Hypervel\Foundation\Bootstrap\RegisterProviders::class,
-        \Hypervel\Di\Bootstrap\GenerateProxies::class,
-        \Hypervel\Foundation\Bootstrap\BootProviders::class,
-    ];
+    protected array $bootstrappers = \Hypervel\Foundation\Application::DEFAULT_BOOTSTRAPPERS;
 
     /**
      * The application's middleware stack.

--- a/src/foundation/src/Testing/TestCase.php
+++ b/src/foundation/src/Testing/TestCase.php
@@ -67,6 +67,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected function refreshApplication(): void
     {
         $this->app = $this->createApplication();
+
+        // Bootstrap the freshly-created app for the test context. Without this the
+        // bootstrappers (RegisterFacades, RegisterProviders, BootProviders, …) never
+        // run in tests — only on the HTTP/console boot path — so the facade root is
+        // never bound and the very next facade call in setUp fails. HandleExceptions is
+        // deliberately omitted so PHPUnit (not the app's Swoole error handler) reports failures.
+        if (! $this->app->hasBeenBootstrapped()) {
+            $this->app->bootstrapWith([
+                \Hypervel\Foundation\Bootstrap\LoadEnvironmentVariables::class,
+                \Hypervel\Foundation\Bootstrap\LoadConfiguration::class,
+                \Hypervel\Foundation\Bootstrap\RegisterFacades::class,
+                \Hypervel\Foundation\Bootstrap\RegisterProviders::class,
+                \Hypervel\Di\Bootstrap\GenerateProxies::class,
+                \Hypervel\Foundation\Bootstrap\BootProviders::class,
+            ]);
+        }
     }
 
     /**

--- a/src/foundation/src/Testing/TestCase.php
+++ b/src/foundation/src/Testing/TestCase.php
@@ -74,14 +74,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         // never bound and the very next facade call in setUp fails. HandleExceptions is
         // deliberately omitted so PHPUnit (not the app's Swoole error handler) reports failures.
         if (! $this->app->hasBeenBootstrapped()) {
-            $this->app->bootstrapWith([
-                \Hypervel\Foundation\Bootstrap\LoadEnvironmentVariables::class,
-                \Hypervel\Foundation\Bootstrap\LoadConfiguration::class,
-                \Hypervel\Foundation\Bootstrap\RegisterFacades::class,
-                \Hypervel\Foundation\Bootstrap\RegisterProviders::class,
-                \Hypervel\Di\Bootstrap\GenerateProxies::class,
-                \Hypervel\Foundation\Bootstrap\BootProviders::class,
-            ]);
+            $this->app->bootstrapWith(array_values(array_diff(
+                Application::DEFAULT_BOOTSTRAPPERS,
+                [\Hypervel\Foundation\Bootstrap\HandleExceptions::class],
+            )));
         }
     }
 


### PR DESCRIPTION
The default `ExampleTest` of a freshly scaffolded 0.4 application fails out of the box:

```
RuntimeException: A facade root has not been set.
  src/support/src/Facades/Facade.php:349
  src/foundation/src/Testing/Concerns/InteractsWithTestCaseLifecycle.php:71
  src/foundation/src/Testing/TestCase.php:61
```

`refreshApplication()` only creates the application — the bootstrappers (`LoadConfiguration`, `RegisterFacades`, `RegisterProviders`, `BootProviders`, …) run on the HTTP and console boot paths but never on the test path, so the facade root is never bound and the first facade call in `setUp()` throws. The components suite doesn't catch this because unit tests don't boot a container and Testbench has its own bootstrap path; only real applications extend `Foundation\Testing\TestCase` directly.

This bootstraps the freshly-created application in `refreshApplication()`. `HandleExceptions` is deliberately omitted so PHPUnit reports failures instead of the app's Swoole error handler.

Verified on a fresh skeleton app:
```
vendor/bin/phpunit tests/Feature/
OK (2 tests, 3 assertions)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test startup reliability by ensuring the application is properly bootstrapped before tests run.
  * Test runs now surface failures more directly when the app isn’t fully initialized, reducing flaky “incomplete setup” failures.

* **Improvements**
  * Centralized the default application bootstrap sequence and applied it consistently to both HTTP and console kernels for more predictable startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->