### PR TITLE
Add hypervel/json-schema to the replace list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -237,6 +237,7 @@
         "hypervel/horizon": "self.version",
         "hypervel/http": "self.version",
         "hypervel/inertia": "self.version",
+        "hypervel/json-schema": "self.version",
         "hypervel/jwt": "self.version",
         "hypervel/log": "self.version",
         "hypervel/macroable": "self.version",


### PR DESCRIPTION
The `json-schema` split package exists (`src/json-schema`, named `hypervel/json-schema`) and is mapped in the root PSR-4 autoload, but is missing from the `replace` list — every other split package is there. Requiring `hypervel/json-schema` alongside `hypervel/components` installs the split package a second time and duplicates its classes.