### PR TITLE
Add development process orchestration

### DIFF
--- a/docs/plans/2026-07-14-development-command-orchestration.md
+++ b/docs/plans/2026-07-14-development-command-orchestration.md
@@ -131,7 +131,7 @@ Add the Node package-manager contract, manager, and Bun/npm/pnpm/Yarn implementa
 
 Add:
 
-- `DevCommand`, the immutable command definition and fluent color API.
+- `DevCommand`, the typed command definition and fluent color API.
 - `DevCommandColor`, the backed color enum.
 - `DevCommands`, the worker-lifetime process registry.
 - `Foundation\Console\DevCommand`, the process orchestrator.

--- a/docs/plans/2026-07-14-development-command-orchestration.md
+++ b/docs/plans/2026-07-14-development-command-orchestration.md
@@ -1,0 +1,171 @@
+# Development Command Orchestration
+
+Add Laravel-shaped `dev` and `dev:list` commands to Hypervel while adapting process ownership, package-manager detection, and shutdown behavior for a long-running Swoole development environment.
+
+The public API stays aligned with Laravel. Hypervel-specific behavior is limited to places where the runtime or package layout requires it: Watcher owns the development server, Composer path repositories must be classified correctly, package-manager lockfiles may live above the application directory, and child processes must be stopped when Watcher receives a termination signal.
+
+## Background
+
+Laravel provides a registry of development processes and two console commands:
+
+- `dev` renders the effective process list and launches it through `concurrently`.
+- `dev:list` shows registered processes, their source, and their registration priority.
+
+The registry allows framework defaults, package registrations, and application registrations to share process names. Higher-priority registrations replace lower-priority registrations, while `only()` and `except()` filters select the effective process list.
+
+Hypervel needs the same application-facing API, but the default server process cannot use Laravel's request-per-process `serve` assumptions. Hypervel Watcher owns the Swoole server process and restarts it when source files change. The supported default process chain is therefore:
+
+```text
+php artisan dev
+  -> php artisan watch
+    -> php artisan serve
+```
+
+Hypervel also has no Pail-equivalent command, so the default process list contains the server, queue listener, and frontend development server without a log-tail process.
+
+## Design
+
+### Development process registry
+
+`Hypervel\Foundation\DevCommands` is the process-wide registry. It stores command definitions, filters, color assignment state, and the lazily detected Node package manager.
+
+The framework registers these defaults during console boot:
+
+```text
+server  php artisan watch
+queue   php artisan queue:listen --tries=1 --timeout=0
+vite    <package-manager> run dev
+```
+
+Applications and packages can register processes through the Laravel-compatible methods:
+
+- `DevCommands::register()` for arbitrary shell commands.
+- `DevCommands::artisan()` for Artisan commands.
+- `DevCommands::node()` for package scripts.
+- `DevCommands::nodeExec()` for installed Node binaries.
+- `DevCommands::only()` and `DevCommands::except()` for boot-time filtering.
+
+The registry is static boot-time state. Its public mutators document that registrations and filters persist for the worker lifetime. `flushState()` resets every static field, and the PHPUnit after-each subscriber invokes it between tests.
+
+### Registration priority
+
+Development process names may be registered by framework defaults, Composer dependencies, or the application. Registration priority is:
+
+```text
+application > dependency > framework default
+```
+
+Priority is determined from the full registration backtrace. Dependency frames continue scanning because an application may call through a package helper; any later application frame makes the registration application-owned.
+
+Composer path repositories require extra care. Composer exposes their real install directories rather than paths below `base_path('vendor')`. Priority detection therefore:
+
+1. Resolves source paths with `realpath()` when possible.
+2. Reads the Composer root package name.
+3. Checks real install paths for every non-root installed package.
+4. Uses directory-boundary-safe comparisons for both installed packages and the normal vendor directory.
+5. Treats unknown non-vendor frames as application code.
+
+This preserves Laravel's normal behavior while correctly handling framework and package development through Composer path repositories.
+
+### Node package-manager detection
+
+Laravel checks lockfiles only in the current directory. That selects npm incorrectly when an application is nested in a pnpm, Yarn, or Bun workspace and does not have its own lockfile.
+
+Hypervel walks from `getcwd()` to the filesystem root. At each directory it checks lockfiles in this order:
+
+1. Bun: `bun.lock`, then `bun.lockb`.
+2. pnpm: `pnpm-lock.yaml`.
+3. Yarn: `yarn.lock`.
+4. npm: `package-lock.json`.
+
+The nearest directory with a recognized lockfile wins. npm remains the fallback when no lockfile exists.
+
+The concrete package-manager classes keep Laravel's no-argument `matches(): bool` API. The ancestor traversal stays private to the manager and does not change public method signatures or process-global working directories.
+
+Installed binary execution uses each package manager's project-local command:
+
+- Bun: `bunx`
+- pnpm: `pnpm exec`
+- Yarn: `yarn run`
+- npm: `npx`
+
+### The `dev` command
+
+The command resolves the effective registry once and reuses that snapshot for validation, display, and process construction.
+
+It fails before process construction when no commands remain after filtering. This avoids calling `max()` on an empty name list and gives the developer a clear console error.
+
+When the effective `server` process is still the framework default, the command verifies that `watch` is registered with the console application. A missing Watcher package returns a failure with the installation command:
+
+```text
+composer require --dev hypervel/watcher
+```
+
+Filtering out the default server or replacing it with a higher-priority registration bypasses this check because the developer then owns the server process.
+
+The command runs outside Hypervel's normal console coroutine. It launches long-running subprocesses and hands the native console process to `pcntl_exec` when available. Running natively ensures the process receiving terminal signals is the process that owns the `concurrently` process tree.
+
+The final command preserves Laravel's names, colors, `--kill-others-on-fail`, `pcntl_exec`, `passthru`, and terminal-column restoration behavior.
+
+### The `dev:list` command
+
+The list command preserves Laravel's filtering, vendor-only view, JSON output, source formatting, and interactive table behavior.
+
+Source truncation handles terminals too narrow to display a source column. When no source width remains, the source is omitted rather than passing a negative width to string truncation. The command text remains visible even at a one-column terminal width.
+
+### Watcher shutdown ownership
+
+Targeted termination of the Watcher command can bypass cleanup that normally occurs after `Watcher::run()` returns. The command therefore traps `SIGINT`, `SIGTERM`, and `SIGQUIT` before entering the watcher loop.
+
+The signal callback stops the driver first, then guarantees restart-strategy cleanup with `finally`. This order stops the file-watching process before the strategy-owned server process and still cleans up the server if driver shutdown throws.
+
+`WatchCommand` retains its public `Hypervel\Contracts\Container\Container` constructor dependency. It resolves the Foundation application contract internally when checking console mode, avoiding a dependency on the concrete Foundation application.
+
+## Implementation
+
+### Support package
+
+Add the Node package-manager contract, manager, and Bun/npm/pnpm/Yarn implementations. Cover direct command generation, public `matches()` behavior, nearest ancestor detection, lockfile priority, and npm fallback.
+
+### Foundation package
+
+Add:
+
+- `DevCommand`, the immutable command definition and fluent color API.
+- `DevCommandColor`, the backed color enum.
+- `DevCommands`, the worker-lifetime process registry.
+- `Foundation\Console\DevCommand`, the process orchestrator.
+- `Foundation\Console\DevListCommand`, the registry inspector.
+
+Register both console commands and framework defaults from `FoundationServiceProvider`. Add `hypervel/prompts` as a direct Foundation dependency because both commands use the terminal API.
+
+### Testing package
+
+Reset registry state and the `dev` command's prohibition flag from `AfterEachTestSubscriber`. This prevents static boot-time configuration from crossing test boundaries in a PHPUnit worker.
+
+### Watcher package
+
+Resolve the Foundation application through its contract and register termination cleanup before `Watcher::run()`. Test normal signal cleanup and guaranteed restart-strategy cleanup when driver shutdown throws.
+
+### Documentation
+
+Document the intentional Laravel differences in the Foundation, Support, and Watcher package READMEs:
+
+- Watcher replaces the default `serve` process and Hypervel omits Pail.
+- Lockfile detection walks ancestor directories and pnpm/Yarn use project-local execution.
+- Watcher owns and stops its driver and server children on termination.
+
+## Verification
+
+The implementation is verified at three levels:
+
+1. Focused tests cover every new value object, package manager, registry path, console command, provider registration, and Watcher cleanup branch.
+2. Static analysis runs against both repository PHPStan configurations.
+3. `composer fix` runs CS Fixer, the complete framework suite, Testbench's package-mode suite, and the dogfood package suite.
+
+The final verification completed with:
+
+- 22,638 framework tests and 64,321 assertions.
+- 327 Testbench tests and 955 assertions.
+- 4 dogfood tests and 7 assertions.
+- No CS Fixer or PHPStan failures.

--- a/docs/plans/2026-07-14-development-command-orchestration.md
+++ b/docs/plans/2026-07-14-development-command-orchestration.md
@@ -165,7 +165,7 @@ The implementation is verified at three levels:
 
 The final verification completed with:
 
-- 22,638 framework tests and 64,321 assertions.
+- 22,640 framework tests and 64,325 assertions.
 - 327 Testbench tests and 955 assertions.
 - 4 dogfood tests and 7 assertions.
 - No CS Fixer or PHPStan failures.

--- a/src/foundation/README.md
+++ b/src/foundation/README.md
@@ -6,3 +6,7 @@ Foundation for Hypervel
 ## Differences From Laravel
 
 Laravel's deprecated `Middleware::validateCsrfTokens()` alias is intentionally not ported. Configure request-forgery protection with `preventRequestForgery()`.
+
+The default `dev` server process runs `php artisan watch` so the Watcher package can own and restart the long-running Swoole server. Official Hypervel skeletons and starter kits include `hypervel/watcher` as a development dependency.
+
+Laravel's default Pail process is omitted because Hypervel has no Pail-equivalent command. Application logging remains controlled by the application's logging configuration.

--- a/src/foundation/composer.json
+++ b/src/foundation/composer.json
@@ -55,6 +55,7 @@
         "hypervel/http": "^0.4",
         "hypervel/http-server": "^0.4",
         "hypervel/macroable": "^0.4",
+        "hypervel/prompts": "^0.4",
         "hypervel/queue": "^0.4",
         "hypervel/reflection": "^0.4",
         "hypervel/routing": "^0.4",

--- a/src/foundation/src/Console/DevCommand.php
+++ b/src/foundation/src/Console/DevCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation\Console;
+
+use Hypervel\Console\Command;
+use Hypervel\Console\Prohibitable;
+use Hypervel\Foundation\DevCommand as RegisteredDevCommand;
+use Hypervel\Foundation\DevCommands;
+use Hypervel\Prompts\Prompt;
+use Hypervel\Support\NodePackageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'dev')]
+class DevCommand extends Command
+{
+    use Prohibitable;
+
+    /**
+     * The console command name.
+     */
+    protected ?string $name = 'dev';
+
+    /**
+     * The console command description.
+     */
+    protected string $description = 'Run the dev processes';
+
+    /**
+     * Whether to execute in a coroutine environment.
+     *
+     * Native execution lets pcntl_exec replace the console process that owns
+     * the long-running development subprocesses.
+     */
+    protected bool $coroutine = false;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(NodePackageManager $packageManager): int
+    {
+        if ($this->isProhibited()) {
+            return self::FAILURE;
+        }
+
+        $devCommands = DevCommands::commands();
+
+        if ($devCommands === []) {
+            $this->components->error('No development commands are configured to run.');
+
+            return self::FAILURE;
+        }
+
+        if (array_any(
+            $devCommands,
+            fn (array $command): bool => $command['name'] === 'server'
+                && $command['priority'] === RegisteredDevCommand::PRIORITY_DEFAULT,
+        ) && ! $this->getApplication()->has('watch')) {
+            $this->components->error(
+                'The default [server] process requires Hypervel Watcher. Install it with [composer require --dev hypervel/watcher].'
+            );
+
+            return self::FAILURE;
+        }
+
+        $commands = array_column($devCommands, 'command');
+        $colors = array_column($devCommands, 'color');
+        $names = array_column($devCommands, 'name');
+
+        $longestName = max(array_map(strlen(...), $names));
+
+        $columns = getenv('COLUMNS');
+
+        putenv('COLUMNS=' . max(Prompt::terminal()->cols() - $longestName - 4, 1));
+
+        $this->line('');
+
+        foreach ($devCommands as $devCommand) {
+            $this->line(
+                sprintf(
+                    '<fg=%s>[%s]</>%s%s',
+                    $devCommand['color'],
+                    $devCommand['name'],
+                    str_repeat(' ', ($longestName - strlen($devCommand['name'])) + 1),
+                    $devCommand['command'],
+                ),
+            );
+        }
+
+        $this->line('');
+
+        $command = $packageManager->getExecCommand(sprintf(
+            'concurrently -c "%s" "%s" --names=%s --kill-others-on-fail',
+            implode(',', $colors),
+            implode('" "', $commands),
+            implode(',', $names)
+        ));
+
+        if (extension_loaded('pcntl')) {
+            pcntl_exec('/usr/bin/env', ['sh', '-c', $command]);
+        }
+
+        passthru($command, $exitCode);
+
+        $columns === false ? putenv('COLUMNS') : putenv("COLUMNS={$columns}");
+
+        return $exitCode;
+    }
+}

--- a/src/foundation/src/Console/DevCommand.php
+++ b/src/foundation/src/Console/DevCommand.php
@@ -91,10 +91,10 @@ class DevCommand extends Command
         $this->line('');
 
         $command = $packageManager->getExecCommand(sprintf(
-            'concurrently -c "%s" "%s" --names=%s --kill-others-on-fail',
-            implode(',', $colors),
-            implode('" "', $commands),
-            implode(',', $names)
+            'concurrently -c %s %s --names=%s --kill-others-on-fail',
+            escapeshellarg(implode(',', $colors)),
+            implode(' ', array_map(escapeshellarg(...), $commands)),
+            escapeshellarg(implode(',', $names)),
         ));
 
         if (extension_loaded('pcntl')) {

--- a/src/foundation/src/Console/DevListCommand.php
+++ b/src/foundation/src/Console/DevListCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation\Console;
+
+use Hypervel\Console\Command;
+use Hypervel\Foundation\DevCommand;
+use Hypervel\Foundation\DevCommands;
+use Hypervel\Prompts\Prompt;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'dev:list')]
+class DevListCommand extends Command
+{
+    /**
+     * The console command name.
+     */
+    protected ?string $name = 'dev:list';
+
+    /**
+     * The console command description.
+     */
+    protected string $description = 'List the registered dev processes';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $devCommands = array_map(fn (array $command): array => array_merge($command, [
+            'source' => $this->formatSource($command['source']),
+        ]), $this->filterCommands(DevCommands::commands()));
+
+        if ($this->option('json') || ! $this->input->isInteractive()) {
+            $this->output->writeln(json_encode($devCommands, JSON_THROW_ON_ERROR));
+
+            return empty($devCommands) && $this->isFiltering() ? self::FAILURE : self::SUCCESS;
+        }
+
+        $this->newLine();
+
+        if (empty($devCommands)) {
+            if ($this->isFiltering()) {
+                $this->components->error("Your application doesn't have any dev processes matching the given criteria.");
+
+                return self::FAILURE;
+            }
+
+            $this->components->warn("Your application doesn't have any dev processes.");
+
+            return self::SUCCESS;
+        }
+
+        $names = array_column($devCommands, 'name');
+        $longestName = max(array_map(strlen(...), $names));
+
+        $columns = Prompt::terminal()->cols();
+
+        foreach ($devCommands as $devCommand) {
+            $label = str_pad($devCommand['name'], $longestName);
+            $command = $devCommand['command'];
+            $source = ' ' . $devCommand['source'];
+            $textWidth = mb_strwidth($label) + mb_strwidth($command) + mb_strwidth($source);
+            $spaceBuffer = 6;
+
+            $dots = str_repeat('.', max(0, $columns - $textWidth - $spaceBuffer));
+
+            // Truncate source if it doesn't fit, but ensure command is always fully visible.
+            if ($textWidth + $spaceBuffer > $columns) {
+                $availableSourceWidth = max(
+                    0,
+                    $columns - mb_strwidth($label) - mb_strwidth($command) - mb_strwidth($dots) - $spaceBuffer
+                );
+
+                $source = $availableSourceWidth >= 2
+                    ? str($source)->limit($availableSourceWidth - 1, '…')->toString()
+                    : '';
+            }
+
+            $this->line(
+                sprintf(
+                    '  <fg=%s>%s</> %s <fg=#6C7280>%s%s</>',
+                    $devCommand['color'],
+                    $label,
+                    $command,
+                    $dots,
+                    $source,
+                ),
+            );
+        }
+
+        $countText = 'Showing [' . count($devCommands) . '] dev ' . (count($devCommands) === 1 ? 'command' : 'commands') . ' ';
+
+        $countSpaces = max(0, $columns - mb_strwidth($countText) - 1);
+        $spaces = str_repeat(' ', $countSpaces);
+
+        $this->newLine();
+        $this->line($spaces . '<fg=blue;options=bold>' . $countText . '</>');
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Determine if the given command is registered by a vendor package.
+     *
+     * @param array{command: string, name: string, color: string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int} $command
+     */
+    protected function isVendorCommand(array $command): bool
+    {
+        return $command['priority'] === DevCommand::PRIORITY_VENDOR;
+    }
+
+    /**
+     * Determine if any filtering options are active.
+     */
+    protected function isFiltering(): bool
+    {
+        return $this->option('filter') || $this->option('except-vendor') || $this->option('only-vendor');
+    }
+
+    /**
+     * Filter the given commands based on the provided options.
+     *
+     * @param list<array{command: string, name: string, color: string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}> $commands
+     * @return list<array{command: string, name: string, color: string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}>
+     */
+    protected function filterCommands(array $commands): array
+    {
+        $filter = $this->option('filter');
+
+        if (is_string($filter) && $filter !== '') {
+            $commands = array_filter(
+                $commands,
+                fn (array $command): bool => str_contains($command['name'], $filter) || str_contains($command['command'], $filter),
+            );
+        }
+
+        if ($this->option('except-vendor')) {
+            $commands = array_filter(
+                $commands,
+                fn (array $command): bool => ! $this->isVendorCommand($command),
+            );
+        }
+
+        if ($this->option('only-vendor')) {
+            $commands = array_filter(
+                $commands,
+                $this->isVendorCommand(...),
+            );
+        }
+
+        return array_values($commands);
+    }
+
+    /**
+     * Format the source information for display.
+     *
+     * @param array{file?: string, line?: int, class?: string, function?: string} $source
+     */
+    protected function formatSource(array $source): string
+    {
+        $file = $source['file'] ?? null;
+        $line = $source['line'] ?? null;
+        $class = $source['class'] ?? null;
+        $function = $source['function'] ?? null;
+
+        if ($class) {
+            return "{$class}@{$function}";
+        }
+
+        return implode(':', array_filter([$file, $line]));
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array<int, array{string, null, int, string}>
+     */
+    protected function getOptions(): array
+    {
+        return [
+            ['json', null, InputOption::VALUE_NONE, 'Output the dev process list as JSON'],
+            ['filter', null, InputOption::VALUE_REQUIRED, 'Filter the dev processes by name or command'],
+            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display dev processes registered by vendor packages'],
+            ['only-vendor', null, InputOption::VALUE_NONE, 'Only display dev processes registered by vendor packages'],
+        ];
+    }
+}

--- a/src/foundation/src/Console/DevListCommand.php
+++ b/src/foundation/src/Console/DevListCommand.php
@@ -118,7 +118,11 @@ class DevListCommand extends Command
      */
     protected function isFiltering(): bool
     {
-        return $this->option('filter') || $this->option('except-vendor') || $this->option('only-vendor');
+        $filter = $this->option('filter');
+
+        return (is_string($filter) && $filter !== '')
+            || $this->option('except-vendor')
+            || $this->option('only-vendor');
     }
 
     /**

--- a/src/foundation/src/DevCommand.php
+++ b/src/foundation/src/DevCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation;
+
+class DevCommand
+{
+    /**
+     * The priority level for default commands that are registered by the framework.
+     */
+    public const int PRIORITY_DEFAULT = 0;
+
+    /**
+     * The priority level for commands that are registered by packages in the vendor directory.
+     */
+    public const int PRIORITY_VENDOR = 1;
+
+    /**
+     * The priority level for commands that are registered by the user in their application.
+     */
+    public const int PRIORITY_USERLAND = 2;
+
+    /**
+     * Color of the command when output to the console.
+     */
+    protected ?string $color = null;
+
+    /**
+     * Create a new DevCommand instance.
+     *
+     * @param array{file?: string, line?: int, class?: string, function?: string} $source
+     * @param self::PRIORITY_DEFAULT|self::PRIORITY_USERLAND|self::PRIORITY_VENDOR $priority
+     */
+    public function __construct(
+        protected string $command,
+        protected array $source,
+        protected ?string $name = null,
+        protected int $priority = self::PRIORITY_USERLAND,
+    ) {
+        $this->name ??= self::nameFromCommand($command);
+    }
+
+    /**
+     * Derive the name from a command string.
+     */
+    public static function nameFromCommand(string $command): string
+    {
+        return strstr($command, ' ', true) ?: $command;
+    }
+
+    /**
+     * Get the command name.
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the command priority.
+     */
+    public function priority(): int
+    {
+        return $this->priority;
+    }
+
+    /**
+     * Set the command color.
+     */
+    public function color(string $color): self
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * Set the command color to blue.
+     */
+    public function blue(): self
+    {
+        return $this->color(DevCommandColor::Blue->value);
+    }
+
+    /**
+     * Set the command color to purple.
+     */
+    public function purple(): self
+    {
+        return $this->color(DevCommandColor::Purple->value);
+    }
+
+    /**
+     * Set the command color to pink.
+     */
+    public function pink(): self
+    {
+        return $this->color(DevCommandColor::Pink->value);
+    }
+
+    /**
+     * Set the command color to orange.
+     */
+    public function orange(): self
+    {
+        return $this->color(DevCommandColor::Orange->value);
+    }
+
+    /**
+     * Set the command color to green.
+     */
+    public function green(): self
+    {
+        return $this->color(DevCommandColor::Green->value);
+    }
+
+    /**
+     * Set the command color to yellow.
+     */
+    public function yellow(): self
+    {
+        return $this->color(DevCommandColor::Yellow->value);
+    }
+
+    /**
+     * Get the command as an array.
+     *
+     * @return array{command: string, name: string, color: null|string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'command' => $this->command,
+            'name' => $this->name,
+            'color' => $this->color,
+            'source' => $this->source,
+            'priority' => $this->priority,
+        ];
+    }
+}

--- a/src/foundation/src/DevCommandColor.php
+++ b/src/foundation/src/DevCommandColor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation;
+
+enum DevCommandColor: string
+{
+    case Blue = '#93c5fd';
+    case Purple = '#c4b5fd';
+    case Pink = '#fb7185';
+    case Orange = '#fdba74';
+    case Green = '#86efac';
+    case Yellow = '#fcd34d';
+}

--- a/src/foundation/src/DevCommands.php
+++ b/src/foundation/src/DevCommands.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation;
+
+use Composer\InstalledVersions;
+use Hypervel\Support\NodePackageManager;
+use ReflectionClass;
+
+class DevCommands
+{
+    /**
+     * The resolved NodePackageManager instance.
+     */
+    protected static ?NodePackageManager $packageManager = null;
+
+    /**
+     * Counter to keep track of how many colors have been assigned.
+     *
+     * Used to ensure colors are reused only after all have been used at least once.
+     */
+    protected static int $colorCount = 0;
+
+    /**
+     * The registered development commands.
+     *
+     * @var array<string, DevCommand>
+     */
+    protected static array $commands = [];
+
+    /**
+     * The names of commands that should be included when running the "dev" command.
+     *
+     * @var list<string>
+     */
+    protected static array $only = [];
+
+    /**
+     * The names of commands that should be excluded when running the "dev" command.
+     *
+     * @var list<string>
+     */
+    protected static array $except = [];
+
+    /**
+     * Register the default development commands.
+     *
+     * Boot-only. The commands persist in static properties for the worker lifetime
+     * and affect every subsequent development command invocation.
+     */
+    public static function registerDefaults(): void
+    {
+        if (! app()->runningInConsole()) {
+            return;
+        }
+
+        // Watcher owns the Swoole server process and restarts it after file changes.
+        self::artisan('watch', 'server');
+        self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
+        // REMOVED: Hypervel has no Pail-equivalent command for the default logs process.
+        self::node('dev', 'vite');
+    }
+
+    /**
+     * Register a development command.
+     *
+     * Boot-only. The command persists in a static property for the worker lifetime
+     * and affects every subsequent development command invocation.
+     */
+    public static function register(string $command, ?string $name = null): DevCommand
+    {
+        if (! app()->runningInConsole()) {
+            return new DevCommand('', [], '');
+        }
+
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $source = self::resolveSource($trace);
+        $priority = self::resolvePriority($trace);
+
+        $devCommand = new DevCommand($command, $source, $name, $priority);
+
+        $existing = self::$commands[$devCommand->name()] ?? null;
+
+        if (! $existing || $devCommand->priority() >= $existing->priority()) {
+            self::$commands[$devCommand->name()] = $devCommand;
+        }
+
+        return $devCommand;
+    }
+
+    /**
+     * Register an Artisan command, automatically prefixing it with "php artisan".
+     *
+     * Boot-only. The command persists in a static property for the worker lifetime
+     * and affects every subsequent development command invocation.
+     */
+    public static function artisan(string $command, ?string $name = null): DevCommand
+    {
+        return self::register("php artisan {$command}", $name ?? DevCommand::nameFromCommand($command));
+    }
+
+    /**
+     * Register a Node command, automatically prefixing it with the detected package manager's run command.
+     *
+     * Boot-only. The command persists in a static property for the worker lifetime
+     * and affects every subsequent development command invocation.
+     */
+    public static function node(string $command, ?string $name = null): DevCommand
+    {
+        return self::register(self::getPackageManager()->getRunCommand($command), $name ?? DevCommand::nameFromCommand($command));
+    }
+
+    /**
+     * Register a Node command, automatically prefixing it with the detected package manager's exec command.
+     *
+     * Boot-only. The command persists in a static property for the worker lifetime
+     * and affects every subsequent development command invocation.
+     */
+    public static function nodeExec(string $command, ?string $name = null): DevCommand
+    {
+        return self::register(self::getPackageManager()->getExecCommand($command), $name ?? DevCommand::nameFromCommand($command));
+    }
+
+    /**
+     * Get the registered development commands.
+     *
+     * @return list<array{command: string, name: string, color: string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}>
+     */
+    public static function commands(): array
+    {
+        $commands = [];
+
+        foreach (self::$commands as $command) {
+            $cmd = $command->toArray();
+
+            if ((! empty(self::$only) && ! in_array($cmd['name'], self::$only, true)) || in_array($cmd['name'], self::$except, true)) {
+                continue;
+            }
+
+            $commands[] = $cmd;
+        }
+
+        return self::fillInEmptyColors($commands);
+    }
+
+    /**
+     * Fill in any empty colors in the given commands array, ensuring each command has a color assigned.
+     *
+     * @param list<array{command: string, name: string, color: null|string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}> $commands
+     * @return list<array{command: string, name: string, color: string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}>
+     */
+    protected static function fillInEmptyColors(array $commands): array
+    {
+        foreach ($commands as &$command) {
+            if (empty($command['color'])) {
+                $command['color'] = self::getColor($commands);
+            }
+        }
+
+        return $commands;
+    }
+
+    /**
+     * Get a color for a command, ensuring that colors are reused only after all available colors have been used at least once.
+     *
+     * @param list<array{command: string, name: string, color: null|string, source: array{file?: string, line?: int, class?: string, function?: string}, priority: int}> $commands
+     */
+    protected static function getColor(array $commands): string
+    {
+        $available = array_values(array_diff(
+            $colors = array_map(fn (DevCommandColor $color): string => $color->value, DevCommandColor::cases()),
+            $existing = array_values(array_filter(array_column($commands, 'color')))
+        ));
+
+        return $available[0] ?? $colors[self::$colorCount++ % count($colors)];
+    }
+
+    /**
+     * Resolve the first external caller frame from a debug backtrace.
+     *
+     * @param array<int, array{file?: string, line?: int, class?: string, function?: string}> $trace
+     * @return array{file?: string, line?: int, class?: string, function?: string}
+     */
+    protected static function resolveSource(array $trace): array
+    {
+        foreach ($trace as $frame) {
+            if (($frame['file'] ?? null) === __FILE__) {
+                continue;
+            }
+
+            if (($frame['class'] ?? null) === self::class) {
+                continue;
+            }
+
+            return $frame;
+        }
+
+        return [];
+    }
+
+    /**
+     * Determine the registration priority from a debug backtrace.
+     *
+     * @param array<int, array{file?: string, line?: int, class?: string, function?: string}> $trace
+     * @return DevCommand::PRIORITY_DEFAULT|DevCommand::PRIORITY_USERLAND|DevCommand::PRIORITY_VENDOR
+     */
+    protected static function resolvePriority(array $trace): int
+    {
+        $vendorPath = realpath(base_path('vendor')) ?: base_path('vendor');
+
+        foreach ($trace as $frame) {
+            $file = $frame['file'] ?? null;
+            $class = $frame['class'] ?? null;
+
+            if ($file === __FILE__) {
+                continue;
+            }
+
+            if ($class === self::class && ($frame['function'] ?? null) === 'registerDefaults') {
+                return DevCommand::PRIORITY_DEFAULT;
+            }
+
+            if (! $file && $class) {
+                $file = (new ReflectionClass($class))->getFileName();
+            }
+
+            if (! $file || $file === base_path('artisan')) {
+                continue;
+            }
+
+            $file = realpath($file) ?: $file;
+
+            if (self::isDependencyFile($file)) {
+                continue;
+            }
+
+            if (! self::isWithinPath($file, $vendorPath)) {
+                return DevCommand::PRIORITY_USERLAND;
+            }
+        }
+
+        return DevCommand::PRIORITY_VENDOR;
+    }
+
+    /**
+     * Determine whether a file belongs to an installed Composer dependency.
+     */
+    protected static function isDependencyFile(string $file): bool
+    {
+        $rootPackage = InstalledVersions::getRootPackage()['name'];
+
+        foreach (InstalledVersions::getInstalledPackages() as $package) {
+            if ($package === $rootPackage) {
+                continue;
+            }
+
+            $installPath = InstalledVersions::getInstallPath($package);
+
+            if ($installPath === null || ($installPath = realpath($installPath)) === false) {
+                continue;
+            }
+
+            if (self::isWithinPath($file, $installPath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether a path is the given directory or one of its descendants.
+     */
+    protected static function isWithinPath(string $path, string $directory): bool
+    {
+        return $path === $directory || str_starts_with($path, $directory . DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Set the commands that should be included when running the "dev" command.
+     *
+     * Boot-only. The filter persists in a static property for the worker lifetime
+     * and affects every subsequent development command invocation.
+     */
+    public static function only(string ...$names): void
+    {
+        self::$only = $names;
+    }
+
+    /**
+     * Set the commands that should be excluded when running the "dev" command.
+     *
+     * Boot-only. The filter persists in a static property for the worker lifetime
+     * and affects every subsequent development command invocation.
+     */
+    public static function except(string ...$names): void
+    {
+        self::$except = $names;
+    }
+
+    /**
+     * Resolve and return the NodePackageManager instance.
+     */
+    protected static function getPackageManager(): NodePackageManager
+    {
+        return self::$packageManager ??= new NodePackageManager;
+    }
+
+    /**
+     * Flush all static state.
+     */
+    public static function flushState(): void
+    {
+        self::$packageManager = null;
+        self::$colorCount = 0;
+        self::$commands = [];
+        self::$only = [];
+        self::$except = [];
+    }
+}

--- a/src/foundation/src/Providers/FoundationServiceProvider.php
+++ b/src/foundation/src/Providers/FoundationServiceProvider.php
@@ -34,6 +34,8 @@ use Hypervel\Foundation\Console\ConfigMakeCommand;
 use Hypervel\Foundation\Console\ConfigPublishCommand;
 use Hypervel\Foundation\Console\ConfigShowCommand;
 use Hypervel\Foundation\Console\ConsoleMakeCommand;
+use Hypervel\Foundation\Console\DevCommand;
+use Hypervel\Foundation\Console\DevListCommand;
 use Hypervel\Foundation\Console\DownCommand;
 use Hypervel\Foundation\Console\EnumMakeCommand;
 use Hypervel\Foundation\Console\EnvironmentCommand;
@@ -78,6 +80,7 @@ use Hypervel\Foundation\Console\VendorPublishCommand;
 use Hypervel\Foundation\Console\ViewCacheCommand;
 use Hypervel\Foundation\Console\ViewClearCommand;
 use Hypervel\Foundation\Console\ViewMakeCommand;
+use Hypervel\Foundation\DevCommands;
 use Hypervel\Foundation\Exceptions\Renderer\Listener;
 use Hypervel\Foundation\Exceptions\Renderer\Mappers\BladeMapper;
 use Hypervel\Foundation\Exceptions\Renderer\Renderer;
@@ -114,6 +117,7 @@ class FoundationServiceProvider extends ServiceProvider
     {
         $this->setDefaultTimezone();
         $this->setInternalEncoding();
+        DevCommands::registerDefaults();
 
         $events = $this->app->make('events');
 
@@ -172,6 +176,8 @@ class FoundationServiceProvider extends ServiceProvider
             ConfigPublishCommand::class,
             ConfigShowCommand::class,
             ConsoleMakeCommand::class,
+            DevCommand::class,
+            DevListCommand::class,
             DownCommand::class,
             EnvironmentCommand::class,
             EnvironmentDecryptCommand::class,

--- a/src/support/README.md
+++ b/src/support/README.md
@@ -2,3 +2,9 @@ Support for Hypervel
 ===
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hypervel/support)
+
+## Differences From Laravel
+
+Node package-manager detection walks from the current directory to the filesystem root, so applications inside a workspace use the nearest ancestor lockfile. Within each directory, detection prefers Bun, pnpm, Yarn, then npm.
+
+pnpm and Yarn execute installed package binaries with `pnpm exec` and `yarn run`, keeping development tools tied to the project's installed versions.

--- a/src/support/src/Contracts/NodePackageManager.php
+++ b/src/support/src/Contracts/NodePackageManager.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Support\Contracts;
+
+interface NodePackageManager
+{
+    /**
+     * Determine if the package manager is in use.
+     */
+    public static function matches(): bool;
+
+    /**
+     * Get the command to run a script using the package manager.
+     */
+    public function getRunCommand(string $command): string;
+
+    /**
+     * Get the command to execute a package using the package manager.
+     */
+    public function getExecCommand(string $command): string;
+}

--- a/src/support/src/NodePackageManager.php
+++ b/src/support/src/NodePackageManager.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Support;
+
+use Hypervel\Support\Contracts\NodePackageManager as NodePackageManagerContract;
+
+class NodePackageManager
+{
+    /**
+     * Create a new NodePackageManager manager instance.
+     */
+    public function __construct(protected ?NodePackageManagerContract $packageManager = null)
+    {
+    }
+
+    /**
+     * Get the command to execute a package using the detected package manager.
+     */
+    public function getExecCommand(string $command): string
+    {
+        return $this->packageManager()->getExecCommand($command);
+    }
+
+    /**
+     * Get the command to run a script using the detected package manager.
+     */
+    public function getRunCommand(string $command): string
+    {
+        return $this->packageManager()->getRunCommand($command);
+    }
+
+    /**
+     * Get the Node package manager in use.
+     */
+    public function packageManager(): NodePackageManagerContract
+    {
+        return $this->packageManager ??= $this->detect();
+    }
+
+    /**
+     * Detect the current package manager.
+     */
+    protected function detect(): NodePackageManagerContract
+    {
+        $directory = getcwd();
+        /** @var array<class-string<NodePackageManagerContract>, list<string>> $packageManagers */
+        $packageManagers = [
+            NodePackageManagers\Bun::class => ['bun.lock', 'bun.lockb'],
+            NodePackageManagers\Pnpm::class => ['pnpm-lock.yaml'],
+            NodePackageManagers\Yarn::class => ['yarn.lock'],
+            NodePackageManagers\Npm::class => ['package-lock.json'],
+        ];
+
+        while ($directory !== false) {
+            foreach ($packageManagers as $packageManager => $lockFiles) {
+                if (array_any($lockFiles, fn (string $lockFile): bool => file_exists($directory . '/' . $lockFile))) {
+                    return new $packageManager;
+                }
+            }
+
+            $parentDirectory = dirname($directory);
+
+            if ($parentDirectory === $directory) {
+                break;
+            }
+
+            $directory = $parentDirectory;
+        }
+
+        return new NodePackageManagers\Npm;
+    }
+}

--- a/src/support/src/NodePackageManagers/Bun.php
+++ b/src/support/src/NodePackageManagers/Bun.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Support\NodePackageManagers;
+
+use Hypervel\Support\Contracts\NodePackageManager;
+
+class Bun implements NodePackageManager
+{
+    /**
+     * Determine if the Bun package manager is in use.
+     */
+    public static function matches(): bool
+    {
+        return array_any(['bun.lock', 'bun.lockb'], fn (string $lockFile): bool => file_exists(getcwd() . '/' . $lockFile));
+    }
+
+    /**
+     * Get the command to run a script using Bun.
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "bun run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using Bun.
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "bunx {$command}";
+    }
+}

--- a/src/support/src/NodePackageManagers/Npm.php
+++ b/src/support/src/NodePackageManagers/Npm.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Support\NodePackageManagers;
+
+use Hypervel\Support\Contracts\NodePackageManager;
+
+class Npm implements NodePackageManager
+{
+    /**
+     * Determine if the npm package manager is in use.
+     */
+    public static function matches(): bool
+    {
+        return file_exists(getcwd() . '/package-lock.json');
+    }
+
+    /**
+     * Get the command to run a script using npm.
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "npm run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using npm.
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "npx {$command}";
+    }
+}

--- a/src/support/src/NodePackageManagers/Pnpm.php
+++ b/src/support/src/NodePackageManagers/Pnpm.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Support\NodePackageManagers;
+
+use Hypervel\Support\Contracts\NodePackageManager;
+
+class Pnpm implements NodePackageManager
+{
+    /**
+     * Determine if the pnpm package manager is in use.
+     */
+    public static function matches(): bool
+    {
+        return file_exists(getcwd() . '/pnpm-lock.yaml');
+    }
+
+    /**
+     * Get the command to run a script using pnpm.
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "pnpm run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using pnpm.
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "pnpm exec {$command}";
+    }
+}

--- a/src/support/src/NodePackageManagers/Yarn.php
+++ b/src/support/src/NodePackageManagers/Yarn.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Support\NodePackageManagers;
+
+use Hypervel\Support\Contracts\NodePackageManager;
+
+class Yarn implements NodePackageManager
+{
+    /**
+     * Determine if the Yarn package manager is in use.
+     */
+    public static function matches(): bool
+    {
+        return file_exists(getcwd() . '/yarn.lock');
+    }
+
+    /**
+     * Get the command to run a script using Yarn.
+     */
+    public function getRunCommand(string $command): string
+    {
+        return "yarn run {$command}";
+    }
+
+    /**
+     * Get the command to execute a package using Yarn.
+     */
+    public function getExecCommand(string $command): string
+    {
+        return "yarn run {$command}";
+    }
+}

--- a/src/testing/src/PHPUnit/AfterEachTestSubscriber.php
+++ b/src/testing/src/PHPUnit/AfterEachTestSubscriber.php
@@ -183,9 +183,11 @@ class AfterEachTestSubscriber implements FinishedSubscriber
         \Hypervel\Foundation\Console\AboutCommand::flushState();
         \Hypervel\Foundation\Console\ChannelListCommand::flushState();
         \Hypervel\Foundation\Console\CliDumper::flushState();
+        \Hypervel\Foundation\Console\DevCommand::flushState();
         \Hypervel\Foundation\Console\EventListCommand::flushState();
         \Hypervel\Foundation\Console\RouteListCommand::flushState();
         \Hypervel\Foundation\Console\VendorPublishCommand::flushState();
+        \Hypervel\Foundation\DevCommands::flushState();
         \Hypervel\Foundation\Events\DiscoverEvents::flushState();
         \Hypervel\Foundation\Exceptions\Renderer\Frame::flushState();
         \Hypervel\Foundation\Http\FormRequest::flushState();

--- a/src/watcher/README.md
+++ b/src/watcher/README.md
@@ -58,6 +58,8 @@ php artisan watch --path=routes --path=database/**/*.php
 php artisan watch --no-restart
 ```
 
+When the watch command receives `SIGINT`, `SIGTERM`, or `SIGQUIT`, it stops the active driver and managed server before allowing the signal to terminate the command.
+
 ## Architecture
 
 The watcher separates three concerns:

--- a/src/watcher/src/Console/WatchCommand.php
+++ b/src/watcher/src/Console/WatchCommand.php
@@ -7,7 +7,7 @@ namespace Hypervel\Watcher\Console;
 use Hypervel\Console\Command;
 use Hypervel\Console\Concerns\NullDisableEventDispatcher;
 use Hypervel\Contracts\Container\Container;
-use Hypervel\Foundation\Application;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Watcher\Option;
 use Hypervel\Watcher\ServerRestartStrategy;
 use Hypervel\Watcher\Watcher;
@@ -33,7 +33,7 @@ class WatchCommand extends Command
      */
     public function handle(): void
     {
-        if (Application::getInstance()->runningInConsole()) {
+        if ($this->container->make(ApplicationContract::class)->runningInConsole()) {
             throw new RuntimeException(
                 'Error: APP_RUNNING_IN_CONSOLE is true. Your artisan binary may be outdated. Please update it so the serve and watch commands set APP_RUNNING_IN_CONSOLE=false before the server starts.'
             );
@@ -61,6 +61,14 @@ class WatchCommand extends Command
             'output' => $this->output,
             'strategy' => $strategy,
         ]);
+
+        $this->trap([SIGINT, SIGTERM, SIGQUIT], function () use ($driver, $strategy): void {
+            try {
+                $driver->stop();
+            } finally {
+                $strategy?->stop();
+            }
+        });
 
         $watcher->run();
     }

--- a/tests/Foundation/Console/DevCommandTest.php
+++ b/tests/Foundation/Console/DevCommandTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation\Console;
+
+use Hypervel\Foundation\Console\DevCommand;
+use Hypervel\Foundation\DevCommands;
+use Hypervel\Support\NodePackageManager;
+use Hypervel\Testbench\TestCase;
+use ReflectionClass;
+use RuntimeException;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DevCommandTest extends TestCase
+{
+    protected string|false $previousColumns = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DevCommands::flushState();
+        $this->app->setRunningInConsole(true);
+        $this->previousColumns = getenv('COLUMNS');
+        putenv('COLUMNS=120');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->previousColumns === false
+            ? putenv('COLUMNS')
+            : putenv("COLUMNS={$this->previousColumns}");
+
+        parent::tearDown();
+    }
+
+    public function testEmptyEffectiveCommandListFailsCleanly(): void
+    {
+        DevCommands::registerDefaults();
+        DevCommands::only('missing');
+
+        $tester = $this->commandTester(new Application);
+
+        $this->assertSame(SymfonyCommand::FAILURE, $tester->execute([]));
+        $this->assertStringContainsString('No development commands are configured to run.', $tester->getDisplay());
+    }
+
+    public function testMissingWatcherFailsWithActionableError(): void
+    {
+        DevCommands::registerDefaults();
+
+        $tester = $this->commandTester(new Application);
+
+        $this->assertSame(SymfonyCommand::FAILURE, $tester->execute([]));
+        $this->assertStringContainsString('composer require --dev hypervel/watcher', $tester->getDisplay());
+    }
+
+    public function testFilteringOutDefaultServerBypassesWatcherValidation(): void
+    {
+        DevCommands::registerDefaults();
+        DevCommands::except('server');
+
+        $packageManager = $this->captureProcessCommand();
+
+        $this->executeUntilProcessCommand(new Application);
+
+        $this->assertNotNull($packageManager->command);
+        $this->assertStringNotContainsString('php artisan watch', $packageManager->command);
+    }
+
+    public function testReplacingDefaultServerBypassesWatcherValidation(): void
+    {
+        DevCommands::registerDefaults();
+        DevCommands::register('custom-server', 'server');
+
+        $packageManager = $this->captureProcessCommand();
+
+        $this->executeUntilProcessCommand(new Application);
+
+        $this->assertNotNull($packageManager->command);
+        $this->assertStringContainsString('custom-server', $packageManager->command);
+    }
+
+    public function testWatcherPresentProceedsToProcessCommandConstruction(): void
+    {
+        DevCommands::registerDefaults();
+
+        $application = new Application;
+        $application->addCommand(new SymfonyCommand('watch'));
+        $packageManager = $this->captureProcessCommand();
+
+        $this->executeUntilProcessCommand($application);
+
+        $this->assertNotNull($packageManager->command);
+        $this->assertStringContainsString('concurrently', $packageManager->command);
+        $this->assertStringContainsString('php artisan watch', $packageManager->command);
+    }
+
+    public function testCommandsAreConsumedOnce(): void
+    {
+        DevCommands::registerDefaults();
+
+        for ($index = 1; $index <= 5; ++$index) {
+            DevCommands::register("command-{$index}", "command-{$index}");
+        }
+
+        $application = new Application;
+        $application->addCommand(new SymfonyCommand('watch'));
+        $this->captureProcessCommand();
+
+        $this->executeUntilProcessCommand($application);
+
+        $colorCount = (new ReflectionClass(DevCommands::class))->getProperty('colorCount')->getValue();
+
+        $this->assertSame(2, $colorCount);
+    }
+
+    public function testCommandDoesNotRunInACoroutine(): void
+    {
+        $defaults = (new ReflectionClass(DevCommand::class))->getDefaultProperties();
+
+        $this->assertFalse($defaults['coroutine']);
+    }
+
+    /**
+     * Bind a package manager that captures the orchestrator command.
+     */
+    protected function captureProcessCommand(): CapturingNodePackageManager
+    {
+        $packageManager = new CapturingNodePackageManager;
+        $this->app->instance(NodePackageManager::class, $packageManager);
+
+        return $packageManager;
+    }
+
+    /**
+     * Execute the command until process orchestration would begin.
+     */
+    protected function executeUntilProcessCommand(Application $application): void
+    {
+        try {
+            $this->commandTester($application)->execute([]);
+            $this->fail('Expected process command construction to stop the test.');
+        } catch (ProcessCommandConstructed) {
+        }
+    }
+
+    /**
+     * Create a tester for the development command.
+     */
+    protected function commandTester(Application $application): CommandTester
+    {
+        $command = new DevCommand;
+        $command->setHypervel($this->app);
+        $application->addCommand($command);
+
+        return new CommandTester($command);
+    }
+}
+
+class CapturingNodePackageManager extends NodePackageManager
+{
+    public ?string $command = null;
+
+    public function getExecCommand(string $command): string
+    {
+        $this->command = $command;
+
+        throw new ProcessCommandConstructed;
+    }
+}
+
+class ProcessCommandConstructed extends RuntimeException
+{
+}

--- a/tests/Foundation/Console/DevCommandTest.php
+++ b/tests/Foundation/Console/DevCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Foundation\Console;
 
 use Hypervel\Foundation\Console\DevCommand;
+use Hypervel\Foundation\DevCommandColor;
 use Hypervel\Foundation\DevCommands;
 use Hypervel\Support\NodePackageManager;
 use Hypervel\Testbench\TestCase;
@@ -97,6 +98,25 @@ class DevCommandTest extends TestCase
         $this->assertNotNull($packageManager->command);
         $this->assertStringContainsString('concurrently', $packageManager->command);
         $this->assertStringContainsString('php artisan watch', $packageManager->command);
+    }
+
+    public function testProcessCommandArgumentsAreShellEscaped(): void
+    {
+        $command = 'printf "%s\n" "$HOME" && php -r \'echo "quoted value";\'';
+        $name = 'quoted process';
+
+        DevCommands::register($command, $name)->blue();
+
+        $packageManager = $this->captureProcessCommand();
+
+        $this->executeUntilProcessCommand(new Application);
+
+        $this->assertSame(sprintf(
+            'concurrently -c %s %s --names=%s --kill-others-on-fail',
+            escapeshellarg(DevCommandColor::Blue->value),
+            escapeshellarg($command),
+            escapeshellarg($name),
+        ), $packageManager->command);
     }
 
     public function testCommandsAreConsumedOnce(): void

--- a/tests/Foundation/FoundationDevCommandTest.php
+++ b/tests/Foundation/FoundationDevCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation;
+
+use Hypervel\Foundation\DevCommand;
+use Hypervel\Foundation\DevCommandColor;
+use Hypervel\Tests\TestCase;
+
+class FoundationDevCommandTest extends TestCase
+{
+    public function testNameDefaultsToFirstWordOfCommand(): void
+    {
+        $command = new DevCommand('php artisan serve', []);
+
+        $this->assertSame('php', $command->name());
+    }
+
+    public function testNameCanBeExplicitlySet(): void
+    {
+        $command = new DevCommand('php artisan serve', [], 'server');
+
+        $this->assertSame('server', $command->name());
+    }
+
+    public function testToArrayReturnsCommandDetails(): void
+    {
+        $command = new DevCommand('php artisan serve', [], 'server');
+
+        $this->assertSame([
+            'command' => 'php artisan serve',
+            'name' => 'server',
+            'color' => null,
+            'source' => [],
+            'priority' => DevCommand::PRIORITY_USERLAND,
+        ], $command->toArray());
+    }
+
+    public function testColorCanBeSet(): void
+    {
+        $command = new DevCommand('php artisan serve', [], 'server');
+        $result = $command->color('#ff0000');
+
+        $this->assertSame($command, $result);
+        $this->assertSame('#ff0000', $command->toArray()['color']);
+    }
+
+    public function testBlueColor(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+        $result = $command->blue();
+
+        $this->assertSame($command, $result);
+        $this->assertSame(DevCommandColor::Blue->value, $command->toArray()['color']);
+    }
+
+    public function testPurpleColor(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+        $command->purple();
+
+        $this->assertSame(DevCommandColor::Purple->value, $command->toArray()['color']);
+    }
+
+    public function testPinkColor(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+        $command->pink();
+
+        $this->assertSame(DevCommandColor::Pink->value, $command->toArray()['color']);
+    }
+
+    public function testOrangeColor(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+        $command->orange();
+
+        $this->assertSame(DevCommandColor::Orange->value, $command->toArray()['color']);
+    }
+
+    public function testGreenColor(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+        $command->green();
+
+        $this->assertSame(DevCommandColor::Green->value, $command->toArray()['color']);
+    }
+
+    public function testYellowColor(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+        $command->yellow();
+
+        $this->assertSame(DevCommandColor::Yellow->value, $command->toArray()['color']);
+    }
+
+    public function testColorMethodsAreFluent(): void
+    {
+        $command = new DevCommand('cmd', [], 'test');
+
+        $this->assertSame($command, $command->blue());
+        $this->assertSame($command, $command->purple());
+        $this->assertSame($command, $command->pink());
+        $this->assertSame($command, $command->orange());
+        $this->assertSame($command, $command->green());
+        $this->assertSame($command, $command->yellow());
+    }
+}

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -1,0 +1,408 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation;
+
+use Composer\InstalledVersions;
+use Hypervel\Foundation\Application;
+use Hypervel\Foundation\DevCommand;
+use Hypervel\Foundation\DevCommandColor;
+use Hypervel\Foundation\DevCommands;
+use Hypervel\Tests\TestCase;
+use ReflectionClass;
+
+class FoundationDevCommandsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DevCommands::flushState();
+
+        $app = new Application(__DIR__);
+        $app['env'] = 'testing';
+        $app->setRunningInConsole(true);
+    }
+
+    public function testRegisterAddsCommand(): void
+    {
+        $devCommand = DevCommands::register('echo hello', 'greeter');
+
+        $this->assertInstanceOf(DevCommand::class, $devCommand);
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(1, $commands);
+        $this->assertSame('echo hello', $commands[0]['command']);
+        $this->assertSame('greeter', $commands[0]['name']);
+    }
+
+    public function testRegisterDerivesNameFromCommand(): void
+    {
+        DevCommands::register('echo hello world');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame('echo', $commands[0]['name']);
+    }
+
+    public function testArtisanPrefixesCommand(): void
+    {
+        DevCommands::artisan('serve --host=localhost', 'server');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame('php artisan serve --host=localhost', $commands[0]['command']);
+        $this->assertSame('server', $commands[0]['name']);
+    }
+
+    public function testArtisanDerivesNameFromCommand(): void
+    {
+        DevCommands::artisan('queue:listen --tries=1');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame('queue:listen', $commands[0]['name']);
+    }
+
+    public function testNodePrefixesCommandWithDetectedPackageManager(): void
+    {
+        DevCommands::node('dev', 'vite');
+
+        $this->assertSame('pnpm run dev', DevCommands::commands()[0]['command']);
+    }
+
+    public function testNodeExecPrefixesCommandWithDetectedPackageManager(): void
+    {
+        DevCommands::nodeExec('concurrently', 'processes');
+
+        $this->assertSame('pnpm exec concurrently', DevCommands::commands()[0]['command']);
+    }
+
+    public function testExceptExcludesCommands(): void
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+        DevCommands::register('echo three', 'three');
+
+        DevCommands::except('two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(2, $commands);
+        $this->assertSame('one', $commands[0]['name']);
+        $this->assertSame('three', $commands[1]['name']);
+    }
+
+    public function testOnlyIncludesOnlySpecifiedCommands(): void
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+        DevCommands::register('echo three', 'three');
+
+        DevCommands::only('one', 'three');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(2, $commands);
+        $this->assertSame('one', $commands[0]['name']);
+        $this->assertSame('three', $commands[1]['name']);
+    }
+
+    public function testOnlyTakesPrecedenceOverExcept(): void
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+        DevCommands::register('echo three', 'three');
+
+        DevCommands::only('one', 'two');
+        DevCommands::except('two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(1, $commands);
+        $this->assertSame('one', $commands[0]['name']);
+    }
+
+    public function testCommandsGetAutoAssignedColors(): void
+    {
+        DevCommands::register('echo one', 'one');
+        DevCommands::register('echo two', 'two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertNotNull($commands[0]['color']);
+        $this->assertNotNull($commands[1]['color']);
+        $this->assertNotSame($commands[0]['color'], $commands[1]['color']);
+    }
+
+    public function testExplicitColorIsPreserved(): void
+    {
+        DevCommands::register('echo one', 'one')->pink();
+        DevCommands::register('echo two', 'two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame(DevCommandColor::Pink->value, $commands[0]['color']);
+        $this->assertNotSame(DevCommandColor::Pink->value, $commands[1]['color']);
+    }
+
+    public function testAutoColorSkipsExplicitlyUsedColors(): void
+    {
+        DevCommands::register('echo one', 'one')->blue();
+        DevCommands::register('echo two', 'two');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame(DevCommandColor::Blue->value, $commands[0]['color']);
+        $this->assertNotSame(DevCommandColor::Blue->value, $commands[1]['color']);
+    }
+
+    public function testColorsRecycleWhenAllUsed(): void
+    {
+        DevCommands::register('cmd1', 'c1');
+        DevCommands::register('cmd2', 'c2');
+        DevCommands::register('cmd3', 'c3');
+        DevCommands::register('cmd4', 'c4');
+        DevCommands::register('cmd5', 'c5');
+        DevCommands::register('cmd6', 'c6');
+        DevCommands::register('cmd7', 'c7');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(7, $commands);
+
+        foreach ($commands as $command) {
+            $this->assertNotNull($command['color']);
+        }
+    }
+
+    public function testRegisteringCommandWithSameNameAndSamePriorityOverwritesPrevious(): void
+    {
+        DevCommands::register('echo old', 'myname');
+        DevCommands::register('echo new', 'myname');
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(1, $commands);
+        $this->assertSame('echo new', $commands[0]['command']);
+    }
+
+    public function testUserlandOverwritesVendorPriority(): void
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'myname' => new DevCommand('echo vendor', [], 'myname', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        // register() resolves as userland from test code — should overwrite vendor
+        DevCommands::register('echo userland', 'myname');
+
+        $result = DevCommands::commands();
+        $this->assertSame('echo userland', collect($result)->firstWhere('name', 'myname')['command']);
+    }
+
+    public function testUserlandOverwritesDefaultPriority(): void
+    {
+        // registerDefaults() gets DEFAULT priority, then register() gets USERLAND
+        DevCommands::registerDefaults();
+        DevCommands::register('custom-server', 'server');
+
+        $result = DevCommands::commands();
+        $server = collect($result)->firstWhere('name', 'server');
+        $this->assertSame('custom-server', $server['command']);
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $server['priority']);
+    }
+
+    public function testDefaultDoesNotOverwriteUserlandPriority(): void
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('userland-server', [], 'server', DevCommand::PRIORITY_USERLAND),
+        ]);
+
+        // registerDefaults() gets DEFAULT priority — should NOT overwrite userland
+        DevCommands::registerDefaults();
+
+        $result = DevCommands::commands();
+        $this->assertSame('userland-server', collect($result)->firstWhere('name', 'server')['command']);
+    }
+
+    public function testDefaultDoesNotOverwriteVendorPriority(): void
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $ref->getProperty('commands')->setValue(null, [
+            'server' => new DevCommand('vendor-server', [], 'server', DevCommand::PRIORITY_VENDOR),
+        ]);
+
+        // registerDefaults() gets DEFAULT priority — should NOT overwrite vendor
+        DevCommands::registerDefaults();
+
+        $result = DevCommands::commands();
+        $this->assertSame('vendor-server', collect($result)->firstWhere('name', 'server')['command']);
+    }
+
+    public function testDefaultPriorityIsLowest(): void
+    {
+        DevCommands::registerDefaults();
+
+        $commands = DevCommands::commands();
+        $serverCommand = collect($commands)->firstWhere('name', 'server');
+
+        $this->assertSame(DevCommand::PRIORITY_DEFAULT, $serverCommand['priority']);
+    }
+
+    public function testUserlandRegistrationGetsUserlandPriority(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $commands = DevCommands::commands();
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $commands[0]['priority']);
+    }
+
+    public function testResolvePriorityDetectsUserlandThroughDevCommandsFrame(): void
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $method = $ref->getMethod('resolvePriority');
+
+        $trace = [
+            ['file' => $ref->getFileName(), 'line' => 99, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('app/Providers/AppServiceProvider.php'), 'line' => 19, 'function' => 'artisan', 'class' => DevCommands::class],
+            ['file' => base_path('vendor/hypervel/framework/src/Hypervel/Foundation/Application.php'), 'line' => 896, 'function' => 'register', 'class' => 'App\Providers\AppServiceProvider'],
+        ];
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, $trace));
+    }
+
+    public function testResolvePriorityDetectsVendor(): void
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $method = $ref->getMethod('resolvePriority');
+
+        $trace = [
+            ['file' => $ref->getFileName(), 'line' => 99, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('vendor/some-package/src/ServiceProvider.php'), 'line' => 10, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('vendor/hypervel/framework/src/Hypervel/Foundation/Application.php'), 'line' => 896, 'function' => 'register', 'class' => 'Some\Package\ServiceProvider'],
+        ];
+
+        $this->assertSame(DevCommand::PRIORITY_VENDOR, $method->invoke(null, $trace));
+    }
+
+    public function testResolvePriorityDoesNotTreatVendorPrefixedSiblingAsVendor(): void
+    {
+        $method = (new ReflectionClass(DevCommands::class))->getMethod('resolvePriority');
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, [[
+            'file' => base_path('vendor-tools/ServiceProvider.php'),
+            'line' => 10,
+        ]]));
+    }
+
+    public function testResolvePriorityDetectsUserlandCallingVendorHelper(): void
+    {
+        $ref = new ReflectionClass(DevCommands::class);
+        $method = $ref->getMethod('resolvePriority');
+
+        $trace = [
+            ['file' => base_path('vendor/some-package/src/Helper.php'), 'line' => 10, 'function' => 'register', 'class' => DevCommands::class],
+            ['file' => base_path('app/Providers/AppServiceProvider.php'), 'line' => 25, 'function' => 'setupDev', 'class' => 'Some\Package\Helper'],
+            ['file' => base_path('vendor/hypervel/framework/src/Hypervel/Foundation/Application.php'), 'line' => 896, 'function' => 'register', 'class' => 'App\Providers\AppServiceProvider'],
+        ];
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, $trace));
+    }
+
+    public function testResolvePriorityTreatsComposerPathPackageAsVendor(): void
+    {
+        $installed = require dirname(__DIR__, 2) . '/vendor/composer/installed.php';
+        $pathPackageData = $installed;
+        $pathPackageData['versions']['example/path-package'] = [
+            'pretty_version' => 'dev-main',
+            'version' => 'dev-main',
+            'type' => 'library',
+            'install_path' => dirname(__DIR__, 2) . '/src/watcher',
+            'dev_requirement' => true,
+        ];
+
+        InstalledVersions::reload($pathPackageData);
+
+        try {
+            $method = (new ReflectionClass(DevCommands::class))->getMethod('resolvePriority');
+
+            $this->assertSame(DevCommand::PRIORITY_VENDOR, $method->invoke(null, [[
+                'file' => dirname(__DIR__, 2) . '/src/watcher/src/WatcherServiceProvider.php',
+                'line' => 1,
+            ]]));
+            $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, [[
+                'file' => dirname(__DIR__, 2) . '/src/watcher-adjacent/ServiceProvider.php',
+                'line' => 1,
+            ]]));
+        } finally {
+            InstalledVersions::reload($installed);
+        }
+    }
+
+    public function testRootPackageFilesRemainUserland(): void
+    {
+        $method = (new ReflectionClass(DevCommands::class))->getMethod('resolvePriority');
+
+        $this->assertSame(DevCommand::PRIORITY_USERLAND, $method->invoke(null, [[
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]]));
+    }
+
+    public function testRegisterDefaultsRegistersExpectedCommands(): void
+    {
+        DevCommands::registerDefaults();
+
+        $commands = DevCommands::commands();
+
+        $this->assertCount(3, $commands);
+
+        $names = array_column($commands, 'name');
+        $this->assertContains('server', $names);
+        $this->assertContains('queue', $names);
+        // REMOVED: Hypervel has no Pail-equivalent command for the default logs process.
+        $this->assertContains('vite', $names);
+
+        $this->assertSame('php artisan watch', collect($commands)->firstWhere('name', 'server')['command']);
+        $this->assertSame('php artisan queue:listen --tries=1 --timeout=0', collect($commands)->firstWhere('name', 'queue')['command']);
+        $this->assertSame('pnpm run dev', collect($commands)->firstWhere('name', 'vite')['command']);
+    }
+
+    public function testRegisteredCommandIncludesSource(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $commands = DevCommands::commands();
+
+        $this->assertArrayHasKey('source', $commands[0]);
+        $this->assertIsArray($commands[0]['source']);
+        $this->assertSame(__CLASS__, $commands[0]['source']['class']);
+    }
+
+    public function testFlushStateResetsAllRegistryState(): void
+    {
+        for ($index = 1; $index <= 7; ++$index) {
+            DevCommands::register("command-{$index}", "command-{$index}");
+        }
+
+        DevCommands::nodeExec('concurrently', 'processes');
+        DevCommands::commands();
+        DevCommands::only('processes');
+        DevCommands::except('server');
+
+        DevCommands::flushState();
+
+        $reflection = new ReflectionClass(DevCommands::class);
+
+        $this->assertNull($reflection->getProperty('packageManager')->getValue());
+        $this->assertSame(0, $reflection->getProperty('colorCount')->getValue());
+        $this->assertSame([], $reflection->getProperty('commands')->getValue());
+        $this->assertSame([], $reflection->getProperty('only')->getValue());
+        $this->assertSame([], $reflection->getProperty('except')->getValue());
+    }
+}

--- a/tests/Foundation/FoundationDevListCommandTest.php
+++ b/tests/Foundation/FoundationDevListCommandTest.php
@@ -100,6 +100,14 @@ class FoundationDevListCommandTest extends TestCase
             ->assertFailed();
     }
 
+    public function testFilterValueZeroReturnsFailureWhenNoMatch(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $this->artisan('dev:list', ['--filter' => '0', '--json' => true])
+            ->assertFailed();
+    }
+
     public function testEmptyStateWithNoCommands(): void
     {
         $this->artisan('dev:list')

--- a/tests/Foundation/FoundationDevListCommandTest.php
+++ b/tests/Foundation/FoundationDevListCommandTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation;
+
+use Hypervel\Contracts\Console\Kernel;
+use Hypervel\Foundation\Console\DevListCommand;
+use Hypervel\Foundation\DevCommand;
+use Hypervel\Foundation\DevCommands;
+use Hypervel\Support\Facades\Artisan;
+use Hypervel\Testbench\TestCase;
+use ReflectionClass;
+
+class FoundationDevListCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DevCommands::flushState();
+        $this->app->make(Kernel::class)->getArtisan()->resolve(DevListCommand::class);
+    }
+
+    public function testListsRegisteredCommands(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+        DevCommands::register('php artisan serve', 'server');
+
+        $this->artisan('dev:list')
+            ->expectsOutputToContain('greeter')
+            ->expectsOutputToContain('server')
+            ->expectsOutputToContain('Showing [2] dev commands')
+            ->assertSuccessful();
+    }
+
+    public function testShowsSingularCommandLabel(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $this->artisan('dev:list')
+            ->expectsOutputToContain('Showing [1] dev command ')
+            ->assertSuccessful();
+    }
+
+    public function testOmitsSourceWhenTerminalHasNoRoomWithoutTruncatingCommand(): void
+    {
+        $columns = getenv('COLUMNS');
+        putenv('COLUMNS=1');
+
+        try {
+            DevCommands::register('php artisan queue:listen --tries=1', 'queue');
+
+            $this->artisan('dev:list')
+                ->expectsOutputToContain('php artisan queue:listen --tries=1')
+                ->doesntExpectOutputToContain(__CLASS__)
+                ->assertSuccessful();
+        } finally {
+            $columns === false ? putenv('COLUMNS') : putenv("COLUMNS={$columns}");
+        }
+    }
+
+    public function testJsonOutputContainsAllFields(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $this->artisan('dev:list', ['--json' => true])
+            ->assertSuccessful();
+
+        $this->artisan('dev:list', ['--json' => true])
+            ->expectsOutput(json_encode(array_map(fn (array $command): array => array_merge($command, [
+                'source' => $this->formatSource($command['source']),
+            ]), DevCommands::commands()), JSON_THROW_ON_ERROR))
+            ->assertSuccessful();
+    }
+
+    public function testFilterByName(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+        DevCommands::register('php artisan serve', 'server');
+
+        $this->artisan('dev:list', ['--filter' => 'server', '--json' => true])
+            ->assertSuccessful();
+    }
+
+    public function testFilterByCommand(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+        DevCommands::register('php artisan serve', 'server');
+
+        $this->artisan('dev:list', ['--filter' => 'artisan', '--json' => true])
+            ->assertSuccessful();
+    }
+
+    public function testFilterReturnsFailureWhenNoMatch(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $this->artisan('dev:list', ['--filter' => 'nonexistent', '--json' => true])
+            ->assertFailed();
+    }
+
+    public function testEmptyStateWithNoCommands(): void
+    {
+        $this->artisan('dev:list')
+            ->expectsOutputToContain("doesn't have any dev processes")
+            ->assertSuccessful();
+    }
+
+    public function testEmptyStateWithFilterReturnsFailure(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $this->artisan('dev:list', ['--filter' => 'nonexistent'])
+            ->expectsOutputToContain("doesn't have any dev processes matching the given criteria")
+            ->assertFailed();
+    }
+
+    public function testExceptVendorExcludesVendorCommands(): void
+    {
+        DevCommands::register('echo hello', 'app-cmd');
+        $this->registerVendorCommand('echo vendor', 'vendor-cmd');
+
+        $output = $this->getJsonOutput(['--except-vendor' => true]);
+
+        $this->assertCount(1, $output);
+        $this->assertSame('app-cmd', $output[0]['name']);
+    }
+
+    public function testOnlyVendorWithNoVendorCommandsReturnsEmpty(): void
+    {
+        DevCommands::register('echo hello', 'app-cmd');
+
+        $this->artisan('dev:list', ['--only-vendor' => true, '--json' => true])
+            ->assertFailed();
+    }
+
+    public function testOnlyVendorIncludesVendorCommands(): void
+    {
+        DevCommands::register('echo hello', 'app-cmd');
+        $this->registerVendorCommand('echo vendor', 'vendor-cmd');
+
+        $output = $this->getJsonOutput(['--only-vendor' => true]);
+
+        $this->assertCount(1, $output);
+        $this->assertSame('vendor-cmd', $output[0]['name']);
+    }
+
+    public function testJsonOutputWithFilterContainsOnlyMatchingCommands(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+        DevCommands::register('php artisan serve', 'server');
+        DevCommands::register('php artisan queue:listen', 'queue');
+
+        $output = $this->getJsonOutput(['--filter' => 'artisan']);
+
+        $this->assertCount(2, $output);
+        $this->assertSame('server', $output[0]['name']);
+        $this->assertSame('queue', $output[1]['name']);
+    }
+
+    public function testJsonOutputIncludesSource(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+
+        $output = $this->getJsonOutput();
+
+        $this->assertArrayHasKey('source', $output[0]);
+        $this->assertStringContainsString(__CLASS__, $output[0]['source']);
+    }
+
+    public function testFormatSourceWithClassAndFunction(): void
+    {
+        $command = new DevListCommand;
+
+        $ref = new ReflectionClass($command);
+        $method = $ref->getMethod('formatSource');
+
+        $result = $method->invoke($command, [
+            'file' => '/some/path.php',
+            'line' => 42,
+            'class' => 'App\Providers\AppServiceProvider',
+            'function' => 'boot',
+        ]);
+
+        $this->assertSame('App\Providers\AppServiceProvider@boot', $result);
+    }
+
+    public function testFormatSourceWithFileAndLine(): void
+    {
+        $command = new DevListCommand;
+
+        $ref = new ReflectionClass($command);
+        $method = $ref->getMethod('formatSource');
+
+        $result = $method->invoke($command, [
+            'file' => '/app/routes/console.php',
+            'line' => 15,
+        ]);
+
+        $this->assertSame('/app/routes/console.php:15', $result);
+    }
+
+    public function testFormatSourceWithEmptyArray(): void
+    {
+        $command = new DevListCommand;
+
+        $ref = new ReflectionClass($command);
+        $method = $ref->getMethod('formatSource');
+
+        $result = $method->invoke($command, []);
+
+        $this->assertSame('', $result);
+    }
+
+    public function testCombinedFilterAndVendorOptions(): void
+    {
+        DevCommands::register('echo hello', 'greeter');
+        DevCommands::register('php artisan serve', 'server');
+
+        $output = $this->getJsonOutput(['--filter' => 'server', '--except-vendor' => true]);
+
+        $this->assertCount(1, $output);
+        $this->assertSame('server', $output[0]['name']);
+    }
+
+    protected function getJsonOutput(array $options = []): array
+    {
+        $options['--json'] = true;
+
+        Artisan::call('dev:list', $options);
+
+        return json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    protected function formatSource(array $source): string
+    {
+        $class = $source['class'] ?? null;
+        $function = $source['function'] ?? null;
+
+        if ($class) {
+            return "{$class}@{$function}";
+        }
+
+        return implode(':', array_filter([$source['file'] ?? null, $source['line'] ?? null]));
+    }
+
+    /**
+     * Register a command with vendor priority.
+     */
+    protected function registerVendorCommand(string $command, string $name): void
+    {
+        $property = (new ReflectionClass(DevCommands::class))->getProperty('commands');
+        $commands = $property->getValue();
+        $commands[$name] = new DevCommand($command, [], $name, DevCommand::PRIORITY_VENDOR);
+        $property->setValue(null, $commands);
+    }
+}

--- a/tests/Foundation/Providers/FoundationServiceProviderTest.php
+++ b/tests/Foundation/Providers/FoundationServiceProviderTest.php
@@ -6,7 +6,9 @@ namespace Hypervel\Tests\Foundation\Providers;
 
 use Carbon\CarbonImmutable;
 use Hypervel\Console\Scheduling\Schedule;
+use Hypervel\Contracts\Console\Kernel;
 use Hypervel\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
+use Hypervel\Foundation\DevCommands;
 use Hypervel\Foundation\WorkerCachedMaintenanceMode;
 use Hypervel\Http\Request;
 use Hypervel\Support\Carbon;
@@ -53,6 +55,19 @@ class FoundationServiceProviderTest extends TestCase
 
         $this->assertInstanceOf(Schedule::class, $schedule);
         $this->assertSame($schedule, $this->app->make(Schedule::class));
+    }
+
+    public function testDevelopmentCommandsAreRegistered(): void
+    {
+        $artisan = $this->app->make(Kernel::class)->getArtisan();
+
+        $this->assertTrue($artisan->has('dev'));
+        $this->assertTrue($artisan->has('dev:list'));
+    }
+
+    public function testDefaultDevelopmentProcessesAreRegistered(): void
+    {
+        $this->assertSame(['server', 'queue', 'vite'], array_column(DevCommands::commands(), 'name'));
     }
 
     public function testClockSingletonIsRegistered(): void

--- a/tests/Queue/QueueBackgroundQueueTest.php
+++ b/tests/Queue/QueueBackgroundQueueTest.php
@@ -161,6 +161,8 @@ class QueueBackgroundQueueTest extends TestCase
 
     public function testLaterWithDateInterval()
     {
+        Carbon::setTestNow('2024-01-01 12:00:00');
+
         $timer = m::mock(Timer::class);
         $timer->shouldReceive('after')
             ->once()
@@ -180,6 +182,8 @@ class QueueBackgroundQueueTest extends TestCase
 
         $this->assertInstanceOf(SyncJob::class, $_SERVER['__background.later.test'][0]);
         $this->assertEquals(['baz' => 'qux'], $_SERVER['__background.later.test'][1]);
+
+        Carbon::setTestNow();
     }
 
     public function testLaterWithDateTime()

--- a/tests/Queue/QueueDeferredQueueTest.php
+++ b/tests/Queue/QueueDeferredQueueTest.php
@@ -161,6 +161,8 @@ class QueueDeferredQueueTest extends TestCase
 
     public function testLaterWithDateInterval()
     {
+        Carbon::setTestNow('2024-01-01 12:00:00');
+
         $timer = m::mock(Timer::class);
         $timer->shouldReceive('after')
             ->once()
@@ -180,6 +182,8 @@ class QueueDeferredQueueTest extends TestCase
 
         $this->assertInstanceOf(SyncJob::class, $_SERVER['__deferred.later.test'][0]);
         $this->assertEquals(['baz' => 'qux'], $_SERVER['__deferred.later.test'][1]);
+
+        Carbon::setTestNow();
     }
 
     public function testLaterWithDateTime()

--- a/tests/Support/SupportNodePackageManagerTest.php
+++ b/tests/Support/SupportNodePackageManagerTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Support;
+
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Support\Contracts\NodePackageManager as NodePackageManagerContract;
+use Hypervel\Support\NodePackageManager;
+use Hypervel\Support\NodePackageManagers\Bun;
+use Hypervel\Support\NodePackageManagers\Npm;
+use Hypervel\Support\NodePackageManagers\Pnpm;
+use Hypervel\Support\NodePackageManagers\Yarn;
+use Hypervel\Testing\ParallelTesting;
+use Hypervel\Tests\TestCase;
+
+class SupportNodePackageManagerTest extends TestCase
+{
+    protected string $tempDirectory;
+
+    protected Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+        $this->tempDirectory = ParallelTesting::tempDir('SupportNodePackageManagerTest');
+        mkdir($this->tempDirectory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->deleteDirectory($this->tempDirectory);
+
+        parent::tearDown();
+    }
+
+    public function testNpmRunCommand(): void
+    {
+        $npm = new Npm;
+
+        $this->assertSame('npm run dev', $npm->getRunCommand('dev'));
+    }
+
+    public function testNpmExecCommand(): void
+    {
+        $npm = new Npm;
+
+        $this->assertSame('npx concurrently', $npm->getExecCommand('concurrently'));
+    }
+
+    public function testNpmMatches(): void
+    {
+        $directory = $this->makeDirectory('npm-matches');
+        touch($directory . '/package-lock.json');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertTrue(Npm::matches());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testNpmDoesNotMatchWithoutLockFile(): void
+    {
+        $directory = $this->makeDirectory('npm-no-match');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertFalse(Npm::matches());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testYarnRunCommand(): void
+    {
+        $yarn = new Yarn;
+
+        $this->assertSame('yarn run dev', $yarn->getRunCommand('dev'));
+    }
+
+    public function testYarnExecCommand(): void
+    {
+        $yarn = new Yarn;
+
+        $this->assertSame('yarn run concurrently', $yarn->getExecCommand('concurrently'));
+    }
+
+    public function testYarnMatches(): void
+    {
+        $directory = $this->makeDirectory('yarn-matches');
+        touch($directory . '/yarn.lock');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertTrue(Yarn::matches());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testPnpmRunCommand(): void
+    {
+        $pnpm = new Pnpm;
+
+        $this->assertSame('pnpm run dev', $pnpm->getRunCommand('dev'));
+    }
+
+    public function testPnpmExecCommand(): void
+    {
+        $pnpm = new Pnpm;
+
+        $this->assertSame('pnpm exec concurrently', $pnpm->getExecCommand('concurrently'));
+    }
+
+    public function testPnpmMatches(): void
+    {
+        $directory = $this->makeDirectory('pnpm-matches');
+        touch($directory . '/pnpm-lock.yaml');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertTrue(Pnpm::matches());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testBunRunCommand(): void
+    {
+        $bun = new Bun;
+
+        $this->assertSame('bun run dev', $bun->getRunCommand('dev'));
+    }
+
+    public function testBunExecCommand(): void
+    {
+        $bun = new Bun;
+
+        $this->assertSame('bunx concurrently', $bun->getExecCommand('concurrently'));
+    }
+
+    public function testBunMatchesWithBunLock(): void
+    {
+        $directory = $this->makeDirectory('bun-lock-matches');
+        touch($directory . '/bun.lock');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertTrue(Bun::matches());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testBunMatchesWithBunLockb(): void
+    {
+        $directory = $this->makeDirectory('bun-lockb-matches');
+        touch($directory . '/bun.lockb');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertTrue(Bun::matches());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testManagerDelegatesToInjectedPackageManager(): void
+    {
+        $mock = new class implements NodePackageManagerContract {
+            public static function matches(): bool
+            {
+                return true;
+            }
+
+            public function getRunCommand(string $command): string
+            {
+                return "custom run {$command}";
+            }
+
+            public function getExecCommand(string $command): string
+            {
+                return "custom exec {$command}";
+            }
+        };
+
+        $manager = new NodePackageManager($mock);
+
+        $this->assertSame('custom run dev', $manager->getRunCommand('dev'));
+        $this->assertSame('custom exec vite', $manager->getExecCommand('vite'));
+    }
+
+    public function testManagerDetectsPackageManagerWhenNoneInjected(): void
+    {
+        $directory = $this->makeDirectory('detect-npm');
+        touch($directory . '/package-lock.json');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertSame('npm run dev', $manager->getRunCommand('dev'));
+            $this->assertSame('npx vite', $manager->getExecCommand('vite'));
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testDetectionPriorityBunOverNpm(): void
+    {
+        $directory = $this->makeDirectory('priority-bun');
+        touch($directory . '/bun.lock');
+        touch($directory . '/package-lock.json');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertSame('bun run dev', $manager->getRunCommand('dev'));
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testDetectionUsesPackageManagerPriorityWithinTheNearestDirectory(): void
+    {
+        $directory = $this->makeDirectory('priority-order');
+        touch($directory . '/package-lock.json');
+        touch($directory . '/yarn.lock');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $this->assertInstanceOf(Yarn::class, (new NodePackageManager)->packageManager());
+
+            touch($directory . '/pnpm-lock.yaml');
+
+            $this->assertInstanceOf(Pnpm::class, (new NodePackageManager)->packageManager());
+
+            touch($directory . '/bun.lock');
+
+            $this->assertInstanceOf(Bun::class, (new NodePackageManager)->packageManager());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testDetectionWalksAncestorDirectories(): void
+    {
+        $directory = $this->makeDirectory('ancestor-lock');
+        $nestedDirectory = $directory . '/apps/starter';
+        mkdir($nestedDirectory, 0777, true);
+        touch($directory . '/pnpm-lock.yaml');
+
+        $original = getcwd();
+        chdir($nestedDirectory);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertInstanceOf(Pnpm::class, $manager->packageManager());
+            $this->assertSame('pnpm run dev', $manager->getRunCommand('dev'));
+            $this->assertSame('pnpm exec concurrently', $manager->getExecCommand('concurrently'));
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testDetectionUsesTheNearestLockFileBeforeAncestorPriority(): void
+    {
+        $directory = $this->makeDirectory('nearest-lock');
+        $nestedDirectory = $directory . '/app';
+        mkdir($nestedDirectory);
+        touch($directory . '/bun.lock');
+        touch($nestedDirectory . '/package-lock.json');
+
+        $original = getcwd();
+        chdir($nestedDirectory);
+
+        try {
+            $this->assertInstanceOf(Npm::class, (new NodePackageManager)->packageManager());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testDetectionFallsBackToNpm(): void
+    {
+        $directory = $this->makeDirectory('fallback-npm');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertSame('npm run dev', $manager->getRunCommand('dev'));
+        } finally {
+            chdir($original);
+        }
+    }
+
+    public function testPackageManagerMethodReturnsDetectedManager(): void
+    {
+        $directory = $this->makeDirectory('package-manager-method');
+        touch($directory . '/yarn.lock');
+
+        $original = getcwd();
+        chdir($directory);
+
+        try {
+            $manager = new NodePackageManager;
+
+            $this->assertInstanceOf(Yarn::class, $manager->packageManager());
+        } finally {
+            chdir($original);
+        }
+    }
+
+    /**
+     * Create a temporary test directory.
+     */
+    protected function makeDirectory(string $name): string
+    {
+        $directory = $this->tempDirectory . '/' . $name;
+        mkdir($directory);
+
+        return $directory;
+    }
+}

--- a/tests/Watcher/WatchCommandTest.php
+++ b/tests/Watcher/WatchCommandTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Watcher;
 
+use Closure;
 use Hypervel\Config\Repository;
-use Hypervel\Foundation\Application;
+use Hypervel\Contracts\Container\Container;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Testbench\TestCase;
 use Hypervel\Watcher\Console\WatchCommand;
 use Hypervel\Watcher\Driver\DriverInterface;
@@ -13,6 +15,7 @@ use Hypervel\Watcher\Driver\ScanFileDriver;
 use Hypervel\Watcher\Option;
 use Hypervel\Watcher\ServerRestartStrategy;
 use Hypervel\Watcher\Watcher;
+use Hypervel\Watcher\WatchPath;
 use Mockery as m;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -27,12 +30,15 @@ class WatchCommandTest extends TestCase
         parent::tearDown();
     }
 
-    public function testWatchCommandFailsFastWhenRunningInConsoleIsTrue()
+    public function testWatchCommandFailsFastWhenRunningInConsoleIsTrue(): void
     {
-        $command = new WatchCommand($this->app);
-        $command->setHypervel($this->app);
+        $container = m::mock(Container::class);
+        $application = m::mock(ApplicationContract::class);
+        $container->shouldReceive('make')->with(ApplicationContract::class)->once()->andReturn($application);
+        $application->shouldReceive('runningInConsole')->once()->andReturnTrue();
 
-        Application::getInstance()->setRunningInConsole(true);
+        $command = new WatchCommand($container);
+        $command->setHypervel($this->app);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error: APP_RUNNING_IN_CONSOLE is true. Your artisan binary may be outdated. Please update it so the serve and watch commands set APP_RUNNING_IN_CONSOLE=false before the server starts.');
@@ -40,7 +46,7 @@ class WatchCommandTest extends TestCase
         $command->run(new ArrayInput([]), new NullOutput);
     }
 
-    public function testWatchCommandRunsWatcherWhenRunningInConsoleIsFalse()
+    public function testWatchCommandRunsWatcherWhenRunningInConsoleIsFalse(): void
     {
         $this->app->instance('config', new Repository([
             'watcher' => [
@@ -72,14 +78,14 @@ class WatchCommandTest extends TestCase
         $command = new WatchCommand($this->app);
         $command->setHypervel($this->app);
 
-        Application::getInstance()->setRunningInConsole(false);
+        $this->app->setRunningInConsole(false);
 
         $result = $command->run(new ArrayInput([]), new NullOutput);
 
         $this->assertSame(0, $result);
     }
 
-    public function testWatchCommandWithNoRestartPassesNullStrategy()
+    public function testWatchCommandWithNoRestartPassesNullStrategy(): void
     {
         $this->app->instance('config', new Repository([
             'watcher' => [
@@ -104,14 +110,46 @@ class WatchCommandTest extends TestCase
         $command = new WatchCommand($this->app);
         $command->setHypervel($this->app);
 
-        Application::getInstance()->setRunningInConsole(false);
+        $this->app->setRunningInConsole(false);
 
         $result = $command->run(new ArrayInput(['--no-restart' => true]), new NullOutput);
 
         $this->assertSame(0, $result);
     }
 
-    public function testWatchCommandWithExtraPaths()
+    public function testTerminationSignalStopsDriverBeforeRestartStrategy(): void
+    {
+        $driver = m::mock(DriverInterface::class);
+        $strategy = m::mock(ServerRestartStrategy::class);
+        $driver->shouldReceive('stop')->once()->ordered();
+        $strategy->shouldReceive('stop')->once()->ordered();
+
+        $command = $this->runSignalCapturingCommand($driver, $strategy);
+
+        $this->assertSame([SIGINT, SIGTERM, SIGQUIT], $command->signals);
+
+        $command->invokeSignalHandler(SIGTERM);
+    }
+
+    public function testTerminationSignalStopsRestartStrategyWhenDriverCleanupFails(): void
+    {
+        $failure = new RuntimeException('driver cleanup failed');
+        $driver = m::mock(DriverInterface::class);
+        $strategy = m::mock(ServerRestartStrategy::class);
+        $driver->shouldReceive('stop')->once()->andThrow($failure);
+        $strategy->shouldReceive('stop')->once();
+
+        $command = $this->runSignalCapturingCommand($driver, $strategy);
+
+        try {
+            $command->invokeSignalHandler(SIGTERM);
+            $this->fail('Expected driver cleanup to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($failure, $exception);
+        }
+    }
+
+    public function testWatchCommandWithExtraPaths(): void
     {
         $this->app->instance('config', new Repository([
             'watcher' => [
@@ -140,7 +178,7 @@ class WatchCommandTest extends TestCase
         $command = new WatchCommand($this->app);
         $command->setHypervel($this->app);
 
-        Application::getInstance()->setRunningInConsole(false);
+        $this->app->setRunningInConsole(false);
 
         $result = $command->run(
             new ArrayInput(['--path' => ['.env', 'composer.json']]),
@@ -151,14 +189,64 @@ class WatchCommandTest extends TestCase
         $this->assertInstanceOf(Option::class, $capturedOption);
 
         $paths = $capturedOption->getWatchPaths();
-        $pathStrings = array_map(fn ($p) => $p->path, $paths);
+        $pathStrings = array_map(fn (WatchPath $path): string => $path->path, $paths);
         $this->assertContains('.env', $pathStrings);
         $this->assertContains('composer.json', $pathStrings);
 
         // .env and composer.json should be File type (they're not directories)
         $filePaths = $capturedOption->getFilePaths();
-        $filePathStrings = array_map(fn ($p) => $p->path, $filePaths);
+        $filePathStrings = array_map(fn (WatchPath $path): string => $path->path, $filePaths);
         $this->assertContains('.env', $filePathStrings);
         $this->assertContains('composer.json', $filePathStrings);
+    }
+
+    /**
+     * Run a watch command that captures its termination signal handler.
+     */
+    protected function runSignalCapturingCommand(
+        DriverInterface $driver,
+        ServerRestartStrategy $strategy,
+    ): SignalCapturingWatchCommand {
+        $this->app->instance('config', new Repository([
+            'watcher' => [
+                'driver' => ScanFileDriver::class,
+                'scan_interval' => 1000,
+                'watch' => ['app/**/*.php'],
+            ],
+        ]));
+
+        $watcher = m::mock(Watcher::class);
+        $watcher->shouldReceive('run')->once();
+
+        $this->app->bind(ScanFileDriver::class, fn () => $driver);
+        $this->app->bind(ServerRestartStrategy::class, fn () => $strategy);
+        $this->app->bind(Watcher::class, fn () => $watcher);
+
+        $command = new SignalCapturingWatchCommand($this->app);
+        $command->setHypervel($this->app);
+        $this->app->setRunningInConsole(false);
+
+        $this->assertSame(0, $command->run(new ArrayInput([]), new NullOutput));
+
+        return $command;
+    }
+}
+
+class SignalCapturingWatchCommand extends WatchCommand
+{
+    /** @var int[] */
+    public array $signals = [];
+
+    public Closure $signalHandler;
+
+    public function trap(array|int $signo, callable $callback): void
+    {
+        $this->signals = (array) $signo;
+        $this->signalHandler = Closure::fromCallable($callback);
+    }
+
+    public function invokeSignalHandler(int $signal): void
+    {
+        ($this->signalHandler)($signal);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds Laravel-shaped development process orchestration to Hypervel:

- A worker-lifetime `DevCommands` registry with framework, dependency, and application priorities.
- `dev` and `dev:list` console commands with filtering, source inspection, JSON output, colors, and process orchestration through `concurrently`.
- Bun, npm, pnpm, and Yarn adapters with workspace-aware lockfile detection.
- Watcher-owned server startup and signal-safe child process cleanup.
- Static state cleanup, package documentation, and focused regression coverage.

The default process set is `php artisan watch`, `php artisan queue:listen --tries=1 --timeout=0`, and the detected package manager's `dev` script. Hypervel does not add a Pail-equivalent process or change application logging.

For more detailes, see: docs/plans/2026-07-14-development-command-orchestration.md

## Motivation

Laravel now has a useful registry and command surface for running an application's development processes from one entry point. The public API maps well to Hypervel, but the implementation cannot be copied without accounting for Swoole process ownership and this repository's Composer and JavaScript workspace layouts.

Hypervel's development server is already owned by Watcher. Starting `serve` directly from `dev` would bypass file-change restarts and split process ownership between two commands. The default server process is therefore `php artisan watch`, which continues to own and restart `php artisan serve`.

The other important difference is package discovery. Composer path repositories resolve to their real source directories, and nested applications may inherit a package manager from a workspace lockfile above their own directory. Treating every non-`vendor` source as application code or checking lockfiles only in `getcwd()` produces incorrect results in both cases.

## Design

### Registration and priority

`DevCommands` stores named process definitions and assigns one of three priorities:

1. Framework defaults.
2. Composer dependencies.
3. Application registrations.

A higher-priority registration replaces a lower-priority process with the same name. The full registration backtrace is inspected rather than only the immediate caller, so application code calling through a package helper remains application-owned.

Dependency classification first checks Composer's real install paths for every non-root package. This handles path repositories without treating the root package as a dependency. Both installed package paths and the conventional vendor directory use boundary-safe comparisons, so a sibling such as `vendor-tools` remains application code. Source paths and the vendor directory are resolved through `realpath()` when available, which also keeps classification correct for symlinked base paths.

The registry exposes the Laravel-compatible `register`, `artisan`, `node`, `nodeExec`, `only`, and `except` methods. Its public mutators are documented as boot-only because the state persists for the worker lifetime. The PHPUnit after-each subscriber clears the complete registry and the `dev` prohibition flag between tests.

### Process orchestration

`dev` reads the effective process list once and uses that snapshot for validation, display, and command construction. An empty list returns a clear failure before attempting width or name calculations.

The command checks for Watcher only when the effective `server` entry is still the framework default. If Watcher is missing, it fails with:

```text
composer require --dev hypervel/watcher
```

Filtering out `server` or replacing it with a higher-priority registration bypasses that check because the developer then owns the server process.

Hypervel console commands normally execute inside a coroutine. `dev` explicitly runs in the native console process because it launches long-running subprocesses and hands the process to `pcntl_exec`. This ensures the terminal-facing process is also the process that owns the `concurrently` tree. The fallback path retains `passthru` behavior and restores the original `COLUMNS` environment variable.

### Package-manager detection

The package-manager API keeps Laravel's public signatures, including no-argument `matches(): bool` methods on each concrete adapter.

The manager privately walks from `getcwd()` to the filesystem root. At each directory it checks Bun, pnpm, Yarn, then npm lockfiles. The nearest recognized lockfile wins, and npm remains the fallback when no lockfile exists.

Execution uses project-local tools:

- `bunx` for Bun.
- `pnpm exec` for pnpm.
- `yarn run` for Yarn.
- `npx` for npm.

This lets an application nested in a workspace use the package manager and installed binaries selected by that workspace without changing the process-global working directory.

### Listing and terminal behavior

`dev:list` supports interactive output, JSON output, name filtering, dependency-only filtering, source paths, and registration priorities. It uses Hypervel Prompts for terminal width.

When a terminal is too narrow to display a source column, the source is omitted instead of passing a negative width to string truncation. The command remains visible even with `COLUMNS=1`.

### Watcher lifecycle

Targeted termination of the Watcher command can interrupt `Watcher::run()` before its normal cleanup path completes. `WatchCommand` now traps `SIGINT`, `SIGTERM`, and `SIGQUIT` before entering the watcher loop.

The trap stops the file-watching driver first and guarantees restart-strategy cleanup with `finally`. This prevents the Swoole server child from surviving command termination even when driver shutdown throws.

The command keeps its public container constructor and resolves `Hypervel\Contracts\Foundation\Application` internally. This removes the concrete Foundation application dependency without changing the constructor surface.

## Laravel compatibility

The public development command, registry, value object, color, and package-manager APIs remain aligned with Laravel. Hypervel-specific behavior is limited to runtime and repository-layout requirements:

- Watcher replaces Laravel's default direct server process.
- Hypervel omits the Pail process because no equivalent command exists.
- Lockfile detection searches ancestor directories.
- Composer path repositories are recognized as dependencies through installed package metadata.
- pnpm and Yarn execute project-local binaries.
- Watcher explicitly owns termination cleanup for its driver and server child.

Literal `php artisan` command strings are retained for parity and readable `dev:list` output.

## Verification

`composer fix` passes in full:

- CS Fixer: no remaining changes.
- Both PHPStan configurations: no errors.
- Framework suite: 22,640 tests, 64,325 assertions, 1,585 skipped.
- Testbench suite: 327 tests, 955 assertions, 3 skipped.
- Dogfood package suite: 4 tests, 7 assertions.

Focused coverage includes registry priority traversal, Composer path packages, vendor path boundaries, ancestor lockfile selection, command filtering and replacement, missing Watcher failures, single-snapshot consumption, coroutine opt-out, one-column terminal rendering, provider registration, state cleanup, signal trapping, and guaranteed Watcher child cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dev` to run server, queue, and frontend development processes together (with watcher integration).
  * Added `dev:list` to view, filter, and export configured dev processes as JSON or an interactive list.
  * Automatically detects Bun, pnpm, Yarn, or npm from nearest lockfiles and uses the right run/exec commands.
  * Added command coloring and priority-based process registration.

* **Bug Fixes**
  * Improved signal handling and shutdown ordering for the watcher to stop managed processes cleanly.

* **Documentation**
  * Documented `dev`/`dev:list` behavior, package-manager detection, and Hypervel-specific defaults and differences from Laravel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->