### PR TITLE
fix: fix redis auto-transform connection-state leak

### DIFF
--- a/src/redis/src/Redis.php
+++ b/src/redis/src/Redis.php
@@ -39,6 +39,8 @@ class Redis
         } catch (Throwable $e) {
             $exception = $e;
         } finally {
+            $connection->shouldTransform(false);
+
             $time = round((microtime(true) - $start) * 1000, 2);
             $connection->getEventDispatcher()?->dispatch(
                 new CommandExecuted(
@@ -60,9 +62,11 @@ class Redis
                     $connection->setDatabase((int) $db);
                 }
                 Context::set($this->getContextKey(), $connection);
-                defer(function () {
-                    $this->releaseContextConnection();
-                });
+                if (! $this->isInEagerReleaseMode()) {
+                    defer(function () {
+                        $this->releaseContextConnection();
+                    });
+                }
             } else {
                 // Release the connection
                 $connection->release();
@@ -77,6 +81,54 @@ class Redis
     }
 
     /**
+     * Execute commands in a pipeline.
+     */
+    public function pipeline(?callable $callback = null): mixed
+    {
+        return $this->executeMultiExec('pipeline', $callback);
+    }
+
+    /**
+     * Execute commands in a transaction.
+     */
+    public function transaction(?callable $callback = null): mixed
+    {
+        return $this->executeMultiExec('multi', $callback);
+    }
+
+    /**
+     * Execute multi-exec commands with an optional callback.
+     */
+    private function executeMultiExec(string $command, ?callable $callback = null): mixed
+    {
+        if ($callback === null) {
+            return $this->__call($command, []);
+        }
+
+        $hasExistingConnection = Context::has($this->getContextKey());
+
+        if (! $hasExistingConnection) {
+            $this->enterEagerReleaseMode();
+        }
+
+        try {
+            $instance = $this->__call($command, []);
+
+            $callback($instance);
+
+            return $instance->exec();
+        } finally {
+            if (! $hasExistingConnection) {
+                try {
+                    $this->releaseContextConnection();
+                } finally {
+                    $this->exitEagerReleaseMode();
+                }
+            }
+        }
+    }
+
+    /**
      * Release the connection stored in coroutine context.
      */
     protected function releaseContextConnection(): void
@@ -85,7 +137,7 @@ class Redis
         $connection = Context::get($contextKey);
 
         if ($connection) {
-            Context::set($contextKey, null);
+            Context::destroy($contextKey);
             $connection->release();
         }
     }
@@ -128,6 +180,38 @@ class Redis
     protected function getContextKey(): string
     {
         return sprintf('redis.connection.%s', $this->poolName);
+    }
+
+    /**
+     * Determine whether the current callback operation should release eagerly.
+     */
+    private function isInEagerReleaseMode(): bool
+    {
+        return (bool) Context::get($this->getEagerReleaseContextKey());
+    }
+
+    /**
+     * Mark the current callback operation for eager release.
+     */
+    private function enterEagerReleaseMode(): void
+    {
+        Context::set($this->getEagerReleaseContextKey(), true);
+    }
+
+    /**
+     * Clear the eager-release marker.
+     */
+    private function exitEagerReleaseMode(): void
+    {
+        Context::destroy($this->getEagerReleaseContextKey());
+    }
+
+    /**
+     * Get the context key used to mark eager-release operations.
+     */
+    private function getEagerReleaseContextKey(): string
+    {
+        return sprintf('redis.connection.%s.eager_release', $this->poolName);
     }
 
     /**

--- a/src/redis/src/Redis.php
+++ b/src/redis/src/Redis.php
@@ -9,6 +9,7 @@ use Hyperf\Redis\Exception\InvalidRedisConnectionException;
 use Hyperf\Redis\Pool\PoolFactory;
 use Hypervel\Context\ApplicationContext;
 use Hypervel\Context\Context;
+use RedisCluster;
 use Throwable;
 
 /**
@@ -112,9 +113,16 @@ class Redis
         }
 
         try {
+            /** @var \Redis|RedisCluster $instance */
             $instance = $this->__call($command, []);
 
-            $callback($instance);
+            try {
+                $callback($instance);
+            } catch (Throwable $callbackException) {
+                $this->abortMultiExec($instance);
+
+                throw $callbackException;
+            }
 
             return $instance->exec();
         } finally {
@@ -125,6 +133,40 @@ class Redis
                     $this->exitEagerReleaseMode();
                 }
             }
+        }
+    }
+
+    /**
+     * Abort an open pipeline or transaction without masking the callback error.
+     */
+    private function abortMultiExec(\Redis|RedisCluster $instance): void
+    {
+        try {
+            if ($instance->discard() !== false) {
+                return;
+            }
+        } catch (Throwable) {
+            // Reconnect the wrapper below when native cleanup fails.
+        }
+
+        $connection = Context::get($this->getContextKey());
+
+        if (! $connection instanceof RedisConnection) {
+            return;
+        }
+
+        try {
+            if ($connection->reconnect()) {
+                return;
+            }
+        } catch (Throwable) {
+            // Closing still prevents a dirty native connection from being reused.
+        }
+
+        try {
+            $connection->close();
+        } catch (Throwable) {
+            // Preserve the original callback exception.
         }
     }
 

--- a/tests/Redis/RedisTest.php
+++ b/tests/Redis/RedisTest.php
@@ -254,11 +254,23 @@ class RedisTest extends TestCase
 
     public function testCallbackPipelineExceptionCleansUpContextAndReleasesConnection(): void
     {
+        $discarded = false;
         $pipeline = Mockery::mock(PhpRedis::class);
         $pipeline->shouldNotReceive('exec');
+        $pipeline->shouldReceive('discard')
+            ->once()
+            ->andReturnUsing(function () use (&$discarded) {
+                $discarded = true;
+
+                return true;
+            });
 
         $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
-        $mockRedisConnection->shouldReceive('release')->once();
+        $mockRedisConnection->shouldReceive('release')
+            ->once()
+            ->andReturnUsing(function () use (&$discarded) {
+                $this->assertTrue($discarded);
+            });
 
         $redis = $this->createRedis($mockRedisConnection);
 
@@ -269,6 +281,93 @@ class RedisTest extends TestCase
             $this->fail('Expected exception was not thrown');
         } catch (RuntimeException $exception) {
             $this->assertSame('Callback failed', $exception->getMessage());
+        }
+
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackTransactionExceptionDiscardsBeforeReleasingConnection(): void
+    {
+        $discarded = false;
+        $transaction = Mockery::mock(PhpRedis::class);
+        $transaction->shouldNotReceive('exec');
+        $transaction->shouldReceive('discard')
+            ->once()
+            ->andReturnUsing(function () use (&$discarded) {
+                $discarded = true;
+
+                return true;
+            });
+
+        $mockRedisConnection = $this->createMockRedisConnection('multi', $transaction);
+        $mockRedisConnection->shouldReceive('release')
+            ->once()
+            ->andReturnUsing(function () use (&$discarded) {
+                $this->assertTrue($discarded);
+            });
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->transaction(function () {
+                throw new RuntimeException('Transaction callback failed');
+            });
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Transaction callback failed', $exception->getMessage());
+        }
+
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackExceptionReconnectsBeforeReleaseWhenDiscardFails(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldNotReceive('exec');
+        $pipeline->shouldReceive('discard')->once()->andThrow(new RuntimeException('Discard failed'));
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('reconnect')->once()->andReturnTrue();
+        $mockRedisConnection->shouldReceive('close')->never();
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->pipeline(function () {
+                throw new RuntimeException('Original callback failure');
+            });
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Original callback failure', $exception->getMessage());
+        }
+
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackExceptionClosesConnectionWhenDiscardAndReconnectFail(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldNotReceive('exec');
+        $pipeline->shouldReceive('discard')->once()->andReturnFalse();
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('reconnect')->once()->andThrow(new RuntimeException('Reconnect failed'));
+        $mockRedisConnection->shouldReceive('close')->once()->andReturnTrue();
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->pipeline(function () {
+                throw new RuntimeException('Original callback failure');
+            });
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Original callback failure', $exception->getMessage());
         }
 
         $this->assertFalse(Context::has('redis.connection.default'));
@@ -312,6 +411,32 @@ class RedisTest extends TestCase
         });
 
         $this->assertSame([], $result);
+        $this->assertSame($mockRedisConnection, Context::get('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackExceptionDiscardsAndPreservesExistingContextConnection(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldNotReceive('exec');
+        $pipeline->shouldReceive('discard')->once()->andReturnTrue();
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('release')->never();
+        $mockRedisConnection->shouldReceive('reconnect')->never();
+        Context::set('redis.connection.default', $mockRedisConnection);
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->pipeline(function () {
+                throw new RuntimeException('Existing callback failed');
+            });
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Existing callback failed', $exception->getMessage());
+        }
+
         $this->assertSame($mockRedisConnection, Context::get('redis.connection.default'));
         $this->assertFalse(Context::has('redis.connection.default.eager_release'));
     }

--- a/tests/Redis/RedisTest.php
+++ b/tests/Redis/RedisTest.php
@@ -5,18 +5,24 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Redis;
 
 use Exception;
+use Hyperf\Di\Container;
+use Hyperf\Di\Definition\DefinitionSource;
 use Hyperf\Pool\PoolOption;
 use Hyperf\Redis\Event\CommandExecuted;
 use Hyperf\Redis\Pool\PoolFactory;
 use Hyperf\Redis\Pool\RedisPool;
+use Hyperf\Redis\Redis as HyperfRedis;
 use Hypervel\Context\Context;
 use Hypervel\Foundation\Testing\Concerns\RunTestsInCoroutine;
 use Hypervel\Redis\Redis;
 use Hypervel\Redis\RedisConnection;
+use Hypervel\Tests\Redis\Stubs\NativeRedisStub;
+use Hypervel\Tests\Redis\Stubs\RedisClientConnectionStub;
 use Hypervel\Tests\TestCase;
 use Mockery;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Redis as PhpRedis;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -31,6 +37,7 @@ class RedisTest extends TestCase
     {
         parent::tearDown();
         Context::destroy('redis.connection.default');
+        Context::destroy('redis.connection.default.eager_release');
     }
 
     public function testSuccessfulCommandReleasesConnection(): void
@@ -203,6 +210,281 @@ class RedisTest extends TestCase
 
         $this->assertTrue($result);
         $this->assertSame($mockRedisConnection, Context::get('redis.connection.default'));
+    }
+
+    public function testCallbackPipelineExecutesAndReleasesConnectionImmediately(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldReceive('set')->with('pipeline-key', 'value')->once()->andReturnSelf();
+        $pipeline->shouldReceive('exec')->once()->andReturn(['QUEUED']);
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        $result = $redis->pipeline(function (PhpRedis $pipe) {
+            $pipe->set('pipeline-key', 'value');
+        });
+
+        $this->assertSame(['QUEUED'], $result);
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackTransactionExecutesAndReleasesConnectionImmediately(): void
+    {
+        $transaction = Mockery::mock(PhpRedis::class);
+        $transaction->shouldReceive('set')->with('transaction-key', 'value')->once()->andReturnSelf();
+        $transaction->shouldReceive('exec')->once()->andReturn([true]);
+
+        $mockRedisConnection = $this->createMockRedisConnection('multi', $transaction);
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        $result = $redis->transaction(function (PhpRedis $pipe) {
+            $pipe->set('transaction-key', 'value');
+        });
+
+        $this->assertSame([true], $result);
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackPipelineExceptionCleansUpContextAndReleasesConnection(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldNotReceive('exec');
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->pipeline(function () {
+                throw new RuntimeException('Callback failed');
+            });
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Callback failed', $exception->getMessage());
+        }
+
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackPipelineExecExceptionCleansUpContextAndReleasesConnection(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldReceive('exec')->once()->andThrow(new RuntimeException('Exec failed'));
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->pipeline(static function () {
+            });
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Exec failed', $exception->getMessage());
+        }
+
+        $this->assertFalse(Context::has('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testCallbackPipelinePreservesExistingContextConnection(): void
+    {
+        $pipeline = Mockery::mock(PhpRedis::class);
+        $pipeline->shouldReceive('exec')->once()->andReturn([]);
+
+        $mockRedisConnection = $this->createMockRedisConnection('pipeline', $pipeline);
+        $mockRedisConnection->shouldReceive('release')->never();
+        Context::set('redis.connection.default', $mockRedisConnection);
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        $result = $redis->pipeline(static function () {
+        });
+
+        $this->assertSame([], $result);
+        $this->assertSame($mockRedisConnection, Context::get('redis.connection.default'));
+        $this->assertFalse(Context::has('redis.connection.default.eager_release'));
+    }
+
+    public function testTransformationIsDisabledBetweenManualTransactionCalls(): void
+    {
+        $transformEnabled = false;
+        $mockRedisConnection = Mockery::mock(RedisConnection::class);
+        $mockRedisConnection->shouldReceive('shouldTransform')
+            ->andReturnUsing(function (bool $enabled = true) use (&$transformEnabled, $mockRedisConnection) {
+                $transformEnabled = $enabled;
+
+                return $mockRedisConnection;
+            });
+        $mockRedisConnection->shouldReceive('getConnection')->times(3)->andReturnSelf();
+        $mockRedisConnection->shouldReceive('getEventDispatcher')->times(3)->andReturnNull();
+        $mockRedisConnection->shouldReceive('multi')->once()->andReturnTrue();
+        $mockRedisConnection->shouldReceive('set')->with('key', 'value', 'EX', 10)->once()->andReturnTrue();
+        $mockRedisConnection->shouldReceive('exec')->once()->andReturn([true]);
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        $redis->multi();
+        $this->assertFalse($transformEnabled);
+
+        $redis->set('key', 'value', 'EX', 10);
+        $this->assertFalse($transformEnabled);
+
+        $this->assertSame([true], $redis->exec());
+        $this->assertFalse($transformEnabled);
+        $this->assertSame($mockRedisConnection, Context::get('redis.connection.default'));
+    }
+
+    public function testTransformationIsDisabledBeforeCommandEventDispatch(): void
+    {
+        $transformEnabled = false;
+        $mockEventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $mockEventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(function (CommandExecuted $event) use (&$transformEnabled) {
+                return $event->command === 'get' && $transformEnabled === false;
+            }));
+
+        $mockRedisConnection = Mockery::mock(RedisConnection::class);
+        $mockRedisConnection->shouldReceive('shouldTransform')
+            ->andReturnUsing(function (bool $enabled = true) use (&$transformEnabled, $mockRedisConnection) {
+                $transformEnabled = $enabled;
+
+                return $mockRedisConnection;
+            });
+        $mockRedisConnection->shouldReceive('getConnection')->once()->andReturnSelf();
+        $mockRedisConnection->shouldReceive('getEventDispatcher')->once()->andReturn($mockEventDispatcher);
+        $mockRedisConnection->shouldReceive('get')->with('key')->once()->andReturn('value');
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        $this->assertSame('value', $redis->get('key'));
+        $this->assertFalse($transformEnabled);
+    }
+
+    public function testTransformationIsDisabledAfterCommandException(): void
+    {
+        $transformEnabled = false;
+        $mockRedisConnection = Mockery::mock(RedisConnection::class);
+        $mockRedisConnection->shouldReceive('shouldTransform')
+            ->andReturnUsing(function (bool $enabled = true) use (&$transformEnabled, $mockRedisConnection) {
+                $transformEnabled = $enabled;
+
+                return $mockRedisConnection;
+            });
+        $mockRedisConnection->shouldReceive('getConnection')->once()->andReturnSelf();
+        $mockRedisConnection->shouldReceive('getEventDispatcher')->once()->andReturnNull();
+        $mockRedisConnection->shouldReceive('get')->once()->andThrow(new RuntimeException('Command failed'));
+        $mockRedisConnection->shouldReceive('release')->once();
+
+        $redis = $this->createRedis($mockRedisConnection);
+
+        try {
+            $redis->get('key');
+            $this->fail('Expected exception was not thrown');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Command failed', $exception->getMessage());
+        }
+
+        $this->assertFalse($transformEnabled);
+    }
+
+    public function testNativeHyperfCommandsUseNativeArgumentsAfterHypervelPipeline(): void
+    {
+        $nativeRedis = new NativeRedisStub();
+        $nativeRedis->execResult = [true];
+
+        $pool = Mockery::mock(RedisPool::class);
+        $pool->shouldReceive('getOption')->times(3)->andReturn(new PoolOption(events: []));
+        $pool->shouldReceive('release')->times(3);
+
+        $connection = new RedisClientConnectionStub(
+            new Container(new DefinitionSource([])),
+            $pool,
+            []
+        );
+        $connection->setActiveConnection($nativeRedis);
+        $pool->shouldReceive('get')->times(3)->andReturn($connection);
+
+        $factory = Mockery::mock(PoolFactory::class);
+        $factory->shouldReceive('getPool')->with('default')->times(3)->andReturn($pool);
+
+        $hypervel = new Redis($factory);
+        $hyperf = new HyperfRedis($factory);
+
+        $this->assertSame([true], $hypervel->pipeline(function (PhpRedis $pipe) {
+            $pipe->set('pipeline-key', 'value');
+        }));
+        $this->assertFalse($connection->getShouldTransform());
+        $this->assertFalse(Context::has('redis.connection.default'));
+
+        $this->assertTrue($hyperf->set('lock-key', 'owner', ['EX' => 10, 'NX']));
+        $this->assertSame('expected', $hyperf->eval('return ARGV[1]', ['expected'], 0));
+        $this->assertSame([
+            ['pipeline'],
+            ['set', 'pipeline-key', 'value', null],
+            ['exec'],
+            ['set', 'lock-key', 'owner', ['EX' => 10, 'NX']],
+            ['eval', 'return ARGV[1]', ['expected'], 0],
+        ], $nativeRedis->calls);
+    }
+
+    public function testNativeHyperfCommandInEventListenerSeesTransformationDisabled(): void
+    {
+        $nativeRedis = new NativeRedisStub();
+        $nativeRedis->getResult = 'value';
+
+        $pool = Mockery::mock(RedisPool::class);
+        $pool->shouldReceive('getOption')->once()->andReturn(new PoolOption(events: []));
+        $pool->shouldReceive('release')->once();
+
+        $factory = Mockery::mock(PoolFactory::class);
+        $hyperf = new HyperfRedis($factory);
+
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->twice()
+            ->andReturnUsing(function (CommandExecuted $event) use ($hyperf) {
+                if ($event->command === 'get') {
+                    $this->assertTrue($hyperf->set('lock-key', 'owner', ['EX' => 10, 'NX']));
+                }
+
+                return $event;
+            });
+
+        $connection = new RedisClientConnectionStub(
+            new Container(new DefinitionSource([])),
+            $pool,
+            []
+        );
+        $connection
+            ->setActiveConnection($nativeRedis)
+            ->setEventDispatcher($dispatcher);
+        Context::set('redis.connection.default', $connection);
+
+        $hypervel = new Redis($factory);
+
+        $this->assertSame('value', $hypervel->get('key'));
+        $this->assertFalse($connection->getShouldTransform());
+        $this->assertSame([
+            ['get', 'key'],
+            ['set', 'lock-key', 'owner', ['EX' => 10, 'NX']],
+        ], $nativeRedis->calls);
+
+        Context::destroy('redis.connection.default');
+        $connection->release();
     }
 
     public function testRegularCommandDoesNotStoreConnectionInContext(): void

--- a/tests/Redis/Stubs/NativeRedisStub.php
+++ b/tests/Redis/Stubs/NativeRedisStub.php
@@ -49,6 +49,13 @@ class NativeRedisStub extends Redis
         return $this->execResult;
     }
 
+    public function discard(): Redis|bool
+    {
+        $this->calls[] = ['discard'];
+
+        return true;
+    }
+
     public function get(string $key): mixed
     {
         $this->calls[] = ['get', $key];

--- a/tests/Redis/Stubs/NativeRedisStub.php
+++ b/tests/Redis/Stubs/NativeRedisStub.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Redis\Stubs;
+
+use Redis;
+
+class NativeRedisStub extends Redis
+{
+    public array $calls = [];
+
+    public array $execResult = [];
+
+    public mixed $getResult = null;
+
+    public function pipeline(): Redis|bool
+    {
+        $this->calls[] = ['pipeline'];
+
+        return $this;
+    }
+
+    public function multi(int $value = Redis::MULTI): Redis|bool
+    {
+        $this->calls[] = ['multi', $value];
+
+        return $this;
+    }
+
+    public function set(string $key, mixed $value, mixed $options = null): Redis|string|bool
+    {
+        $this->calls[] = ['set', $key, $value, $options];
+
+        return true;
+    }
+
+    public function eval(string $script, array $args = [], int $num_keys = 0): mixed
+    {
+        $this->calls[] = ['eval', $script, $args, $num_keys];
+
+        return $args[0] ?? null;
+    }
+
+    public function exec(): Redis|array|false
+    {
+        $this->calls[] = ['exec'];
+
+        return $this->execResult;
+    }
+
+    public function get(string $key): mixed
+    {
+        $this->calls[] = ['get', $key];
+
+        return $this->getResult;
+    }
+}

--- a/tests/Redis/Stubs/RedisClientConnectionStub.php
+++ b/tests/Redis/Stubs/RedisClientConnectionStub.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Redis\Stubs;
+
+use Hypervel\Redis\RedisConnection;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Redis;
+use Throwable;
+
+class RedisClientConnectionStub extends RedisConnection
+{
+    public function reconnect(): bool
+    {
+        return true;
+    }
+
+    public function check(): bool
+    {
+        return true;
+    }
+
+    public function getActiveConnection(): static
+    {
+        return $this;
+    }
+
+    public function setActiveConnection(Redis $connection): static
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): static
+    {
+        $this->eventDispatcher = $eventDispatcher;
+
+        return $this;
+    }
+
+    protected function retry($name, $arguments, Throwable $exception)
+    {
+        throw $exception;
+    }
+}


### PR DESCRIPTION
# Fix Redis Auto-Transform Connection-State Leak

## Summary

Update Hypervel’s Redis lifecycle so Laravel-style argument transformation is enabled only during an individual Hypervel command. Add explicit callback pipeline/transaction handling that releases connections immediately after `exec()`, matching Hyperf’s current behavior.

This prevents subsequent Hyperf cache, lock, queue, or broadcasting commands from interpreting native phpredis arguments as Hypervel arguments and eliminates the resulting warnings, reconnects, and latency.

## Implementation Changes

### Command-scoped transformation

Modify [Redis.php](/hypervel/components/tree/0.3/tests/components/src/redis/src/Redis.php):

- Keep `getConnection()` enabling transformation before each Hypervel invocation.
- In `__call()`’s `finally` block, call `shouldTransform(false)` immediately after command execution.
- Reset transformation before dispatching `CommandExecuted`, ensuring event listeners issuing native Redis commands see native mode.
- Preserve the existing result and exception capture so command exceptions are rethrown after cleanup and are not swallowed.
- Preserve current connection ownership rules:
  - Existing contextual connections remain checked out.
  - Successful `multi`, `pipeline`, and `select` calls establish contextual ownership.
  - Failed same-connection commands are released instead of stored.
  - Ordinary commands release immediately.
- Continue updating the selected database for successful `select` calls.
- Keep the reset in `RedisConnection::release()` unchanged as defense in depth.

### Callback pipeline and transaction lifecycle

Add concrete public methods to `Hypervel\Redis\Redis`:

```php
public function pipeline(?callable $callback = null): mixed;
public function transaction(?callable $callback = null): mixed;
```

Both delegate to a private multi-exec helper:

- `pipeline()` opens the native `pipeline` command.
- `transaction()` opens the native `multi` command.
- Without a callback, delegate to `__call()` and preserve manual workflows such as `multi()` → commands → `exec()`.
- With a callback:
  - Detect whether the caller already owns a contextual connection.
  - If no connection exists, mark the operation for eager release.
  - Open the pipeline/transaction through `__call()`.
  - Pass the returned native Redis instance to the callback.
  - Execute and return `$instance->exec()`.
  - In `finally`, release only connections created by this callback operation and clear the eager-release marker.
- If a connection already existed, leave its context and release responsibility unchanged.

Add private eager-release context helpers using the pool-specific key:

```text
redis.connection.{pool}.eager_release
```

When `__call()` stores a new same-connection command:

- Schedule coroutine-deferred cleanup for manual operations.
- Skip scheduling the deferred callback while eager-release mode is active, because the callback wrapper will release immediately.

### Context cleanup

Change `releaseContextConnection()` to:

- Fetch the contextual wrapper.
- Remove the key with `Context::destroy()` before releasing the connection.
- Release the wrapper exactly once.
- Leave no null-valued or eager-release entries behind.

Destroying the context first prevents re-entrant Redis work during release from observing a stale connection.

## Public Interfaces and Compatibility

- `pipeline(?callable $callback = null)` and `transaction(?callable $callback = null)` become concrete APIs instead of relying on `__call()`.
- Existing facade annotations and documented callback usage remain valid; no facade or documentation change is required.
- Callback return values remain the result of native `exec()`.
- Manual pipeline and transaction behavior remains supported.
- Laravel-style command signatures remain unchanged.
- Native Hyperf/phpredis signatures remain unchanged; transformer methods such as `callSet()` and `callEval()` will not be widened to accept both protocols.

## Test Plan

- Verify every successful Hypervel command enables transformation for dispatch and disables it afterward.
- Verify transformation is disabled before `CommandExecuted` listeners run.
- Verify exceptions still propagate while transformation cleanup and existing release rules execute.
- Verify callback `pipeline()`:
  - Queues callback commands and returns `exec()` results.
  - Removes both connection and eager-release context keys.
  - Releases the connection immediately and exactly once.
- Apply the same lifecycle assertions to callback `transaction()`.
- Verify a callback exception cleans both context keys, releases the connection, disables transformation, and rethrows the original exception.
- Verify an `exec()` exception performs the same cleanup and propagation.
- Verify a callback using a pre-existing contextual connection neither destroys nor releases that caller-owned connection.
- Preserve the existing non-callback pipeline test, confirming manual mode stores the connection and defers release.
- Exercise a manual transaction (`multi` → Laravel-style `set` → `exec`) and verify:
  - The same wrapper is used throughout.
  - Transformation is re-enabled for each Hypervel call.
  - Transformation is disabled between calls.
- Instantiate Hypervel and Hyperf Redis clients over the same mocked pool:
  - Run a Hypervel callback pipeline.
  - Run native Hyperf `SET` with an options array and assert the raw Redis client receives the native arguments.
  - Run native Hyperf `EVAL` with an argument array and key count and assert the raw signature is preserved.
  - Assert no `Redis::__call failed` warning or retry/reconnect occurs.
- Register a `CommandExecuted` listener that performs a native Hyperf Redis command on an existing contextual connection and verify it observes transformation disabled.
- Retain [RedisConnectionTest.php](/hypervel/components/tree/0.3/tests/Redis/RedisConnectionTest.php) coverage confirming `release()` always resets transformation.

Run the focused Redis tests, then the complete component test suite and static analysis to catch signature or lifecycle regressions.