### PR TITLE
feat: support getPreferredLanguage in request

### DIFF
--- a/src/http/src/Contracts/RequestContract.php
+++ b/src/http/src/Contracts/RequestContract.php
@@ -333,6 +333,20 @@ interface RequestContract extends RequestInterface
     public function bearerToken(): ?string;
 
     /**
+     * Returns the preferred language.
+     *
+     * @param string[] $locales An array of ordered available locales
+     */
+    public function getPreferredLanguage(?array $locales = null): ?string;
+
+    /**
+     * Gets a list of languages acceptable by the client browser ordered in the user browser preferences.
+     *
+     * @return string[]
+     */
+    public function getLanguages(): array;
+
+    /**
      * Gets a list of content types acceptable by the client browser in preferable order.
      *
      * @return string[]

--- a/src/http/src/Request.php
+++ b/src/http/src/Request.php
@@ -31,6 +31,11 @@ use function Hyperf\Collection\data_get;
 class Request extends HyperfRequest implements RequestContract
 {
     /**
+     * The coroutine context key used to cache acceptable languages.
+     */
+    private const LANGUAGES_CONTEXT_KEY = self::class . '.properties.languages';
+
+    /**
      * The user resolver callback.
      */
     protected ?Closure $userResolver = null;
@@ -774,6 +779,137 @@ class Request extends HyperfRequest implements RequestContract
         }
 
         return null;
+    }
+
+    /**
+     * Returns the preferred language.
+     *
+     * @param string[] $locales An array of ordered available locales
+     */
+    public function getPreferredLanguage(?array $locales = null): ?string
+    {
+        $preferredLanguages = $this->getLanguages();
+
+        if (! $locales) {
+            return $preferredLanguages[0] ?? null;
+        }
+
+        $locales = array_map($this->formatLocale(...), $locales);
+        if (! $preferredLanguages) {
+            return $locales[0];
+        }
+
+        $combinations = array_merge(...array_map($this->getLanguageCombinations(...), $preferredLanguages));
+        foreach ($combinations as $combination) {
+            foreach ($locales as $locale) {
+                if (str_starts_with($locale, $combination)) {
+                    return $locale;
+                }
+            }
+        }
+
+        return $locales[0];
+    }
+
+    /**
+     * Gets a list of languages acceptable by the client browser ordered in the user browser preferences.
+     *
+     * @return string[]
+     */
+    public function getLanguages(): array
+    {
+        if (Context::has(self::LANGUAGES_CONTEXT_KEY)) {
+            return Context::get(self::LANGUAGES_CONTEXT_KEY);
+        }
+
+        $languages = AcceptHeader::fromString($this->header('Accept-Language'))->all();
+        $preferredLanguages = [];
+        foreach ($languages as $acceptHeaderItem) {
+            $preferredLanguages[] = self::formatLocale($acceptHeaderItem->getValue());
+        }
+
+        return Context::set(
+            self::LANGUAGES_CONTEXT_KEY,
+            array_unique($preferredLanguages)
+        );
+    }
+
+    /**
+     * Strips the locale to only keep the canonicalized language value.
+     *
+     * Depending on the $locale value, this method can return values like:
+     * - language_Script_REGION: "fr_Latn_FR", "zh_Hans_TW"
+     * - language_Script: "fr_Latn", "zh_Hans"
+     * - language_REGION: "fr_FR", "zh_TW"
+     * - language: "fr", "zh"
+     *
+     * Invalid locale values are returned as is.
+     *
+     * @see https://wikipedia.org/wiki/IETF_language_tag
+     * @see https://datatracker.ietf.org/doc/html/rfc5646
+     */
+    private static function formatLocale(string $locale): string
+    {
+        [$language, $script, $region] = self::getLanguageComponents($locale);
+
+        return implode('_', array_filter([$language, $script, $region]));
+    }
+
+    /**
+     * Returns an array of all possible combinations of the language components.
+     *
+     * For instance, if the locale is "fr_Latn_FR", this method will return:
+     * - "fr_Latn_FR"
+     * - "fr_Latn"
+     * - "fr_FR"
+     * - "fr"
+     *
+     * @return string[]
+     */
+    private static function getLanguageCombinations(string $locale): array
+    {
+        [$language, $script, $region] = self::getLanguageComponents($locale);
+
+        return array_unique([
+            implode('_', array_filter([$language, $script, $region])),
+            implode('_', array_filter([$language, $script])),
+            implode('_', array_filter([$language, $region])),
+            $language,
+        ]);
+    }
+
+    /**
+     * Returns an array with the language components of the locale.
+     *
+     * For example:
+     * - If the locale is "fr_Latn_FR", this method will return "fr", "Latn", "FR"
+     * - If the locale is "fr_FR", this method will return "fr", null, "FR"
+     * - If the locale is "zh_Hans", this method will return "zh", "Hans", null
+     *
+     * @see https://wikipedia.org/wiki/IETF_language_tag
+     * @see https://datatracker.ietf.org/doc/html/rfc5646
+     *
+     * @return array{string, null|string, null|string}
+     */
+    private static function getLanguageComponents(string $locale): array
+    {
+        $locale = str_replace('_', '-', strtolower($locale));
+        $pattern = '/^([a-zA-Z]{2,3}|i-[a-zA-Z]{5,})(?:-([a-zA-Z]{4}))?(?:-([a-zA-Z]{2}))?(?:-(.+))?$/';
+        if (! preg_match($pattern, $locale, $matches)) {
+            return [$locale, null, null];
+        }
+        if (str_starts_with($matches[1], 'i-')) {
+            // Language not listed in ISO 639 that are not variants
+            // of any listed language, which can be registered with the
+            // i-prefix, such as i-cherokee.
+            $matches[1] = substr($matches[1], 2);
+        }
+
+        return [
+            $matches[1],
+            isset($matches[2]) ? ucfirst(strtolower($matches[2])) : null,
+            isset($matches[3]) ? strtoupper($matches[3]) : null,
+        ];
     }
 
     /**

--- a/src/support/src/Facades/Request.php
+++ b/src/support/src/Facades/Request.php
@@ -63,6 +63,8 @@ use Hypervel\Http\Contracts\RequestContract;
  * @method static \Hypervel\Support\Uri uri()
  * @method static array headers()
  * @method static string|null bearerToken()
+ * @method static string|null getPreferredLanguage(string[]|null $locales = null)
+ * @method static string[] getLanguages()
  * @method static string[] getAcceptableContentTypes()
  * @method static string|null getMimeType(string $format)
  * @method static string[] getMimeTypes(string $format)

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Hyperf\Collection\Collection;
 use Hyperf\Context\ApplicationContext;
 use Hyperf\Context\Context;
+use Hyperf\HttpMessage\Server\Request as Psr7ServerRequest;
 use Hyperf\HttpMessage\Upload\UploadedFile;
 use Hyperf\HttpMessage\Uri\Uri as HyperfUri;
 use Hyperf\HttpServer\Request as HyperfRequest;
@@ -27,6 +28,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Swow\Psr7\Message\ServerRequestPlusInterface;
 
+use function Hypervel\Coroutine\parallel;
+use function Hypervel\Coroutine\run;
+
 /**
  * @internal
  * @coversNothing
@@ -40,6 +44,7 @@ class RequestTest extends TestCase
         Context::destroy('http.request.parsedData');
         Context::destroy(HyperfRequest::class . '.properties.requestUri');
         Context::destroy(HyperfRequest::class . '.properties.pathInfo');
+        Context::destroy(Request::class . '.properties.languages');
     }
 
     public function testAllFiles()
@@ -345,6 +350,75 @@ class RequestTest extends TestCase
         $request = new Request();
 
         $this->assertTrue($request->isJson());
+    }
+
+    public function testGetLanguages()
+    {
+        Context::set(ServerRequestInterface::class, new Psr7ServerRequest(
+            'GET',
+            '/',
+            ['Accept-Language' => 'zh-hans-tw;q=0.8, fr-latn-fr, en-US;q=0.9, i-cherokee;q=0.7, INVALID;q=0.6']
+        ));
+
+        $this->assertSame(
+            ['fr_Latn_FR', 'en_US', 'zh_Hans_TW', 'cherokee', 'invalid'],
+            (new Request())->getLanguages()
+        );
+    }
+
+    public function testGetPreferredLanguage()
+    {
+        Context::set(ServerRequestInterface::class, new Psr7ServerRequest(
+            'GET',
+            '/',
+            ['Accept-Language' => 'zh-Hant-HK, fr-FR;q=0.8']
+        ));
+        $request = new Request();
+
+        $this->assertSame('zh_Hant_TW', $request->getPreferredLanguage([
+            'zh-Hans-CN',
+            'zh-Hant-TW',
+            'fr-fr',
+        ]));
+        $this->assertSame('zh_Hant_HK', $request->getPreferredLanguage());
+    }
+
+    public function testGetPreferredLanguageFallsBackToFirstAvailableLocale()
+    {
+        Context::set(ServerRequestInterface::class, new Psr7ServerRequest('GET', '/'));
+
+        $this->assertSame('en_US', (new Request())->getPreferredLanguage(['en-us', 'fr-FR']));
+    }
+
+    public function testLanguagesAreIsolatedByCoroutineContext()
+    {
+        $request = new Request();
+        $results = [];
+
+        run(function () use ($request, &$results) {
+            $results = parallel([
+                function () use ($request) {
+                    Context::set(ServerRequestInterface::class, new Psr7ServerRequest(
+                        'GET',
+                        '/',
+                        ['Accept-Language' => 'en-US']
+                    ));
+
+                    return $request->getLanguages();
+                },
+                function () use ($request) {
+                    Context::set(ServerRequestInterface::class, new Psr7ServerRequest(
+                        'GET',
+                        '/',
+                        ['Accept-Language' => 'fr-FR']
+                    ));
+
+                    return $request->getLanguages();
+                },
+            ]);
+        });
+
+        $this->assertSame([['en_US'], ['fr_FR']], $results);
     }
 
     public function testIsNotFilled()


### PR DESCRIPTION
## Summary

This PR ports Symfony’s `getPreferredLanguage()` and `getLanguages()` request methods to Hypervel.

It adds `Accept-Language` parsing, locale canonicalization, language/script/region fallback matching, and coroutine-safe caching. The new methods are also exposed through the request contract and request facade.

## Motivation

Hypervel currently provides content negotiation helpers for the `Accept` header, but it does not provide an equivalent API for negotiating languages from the `Accept-Language` header.

Applications therefore need to manually:

- Parse quality values from `Accept-Language`.
- Normalize locale separators and casing.
- Match language, script, and region variants.
- Handle fallback behavior.
- Ensure cached request state does not leak between concurrent requests.

This PR provides a framework-level implementation compatible with Symfony’s current language negotiation behavior.

## Changes

### Added `Request::getLanguages()`

`getLanguages()` parses the current request’s `Accept-Language` header and returns the accepted languages in browser preference order.

The order respects the quality values defined in the header.

For example:

```http
Accept-Language: zh-Hans-TW;q=0.8, fr-Latn-FR, en-US;q=0.9
```

Returns:

```php
[
    'fr_Latn_FR',
    'en_US',
    'zh_Hans_TW',
]
```

The returned locales are canonicalized using the following formats:

```text
language_Script_REGION
language_Script
language_REGION
language
```

Examples:

```text
fr-latn-fr -> fr_Latn_FR
zh-hans    -> zh_Hans
en-us      -> en_US
fr         -> fr
```

Registered languages using the legacy `i-` prefix are also supported:

```text
i-cherokee -> cherokee
```

Invalid locale values are normalized to lowercase but otherwise returned as-is.

Duplicate languages produced after canonicalization are removed.

### Added `Request::getPreferredLanguage()`

`getPreferredLanguage()` returns the locale that best matches the client’s language preferences.

When available locales are supplied, both the accepted languages and available locales are canonicalized before matching.

```php
$locale = $request->getPreferredLanguage([
    'en-US',
    'fr-FR',
    'zh-Hant-TW',
]);
```

The matching algorithm considers progressively broader combinations of the preferred language.

For a preferred language such as:

```text
zh_Hant_HK
```

The following combinations are considered in order:

```text
zh_Hant_HK
zh_Hant
zh_HK
zh
```

This allows a client requesting `zh-Hant-HK` to match an available `zh-Hant-TW` locale through the shared `zh_Hant` language and script combination.

For example:

```http
Accept-Language: zh-Hant-HK, fr-FR;q=0.8
```

```php
$request->getPreferredLanguage([
    'zh-Hans-CN',
    'zh-Hant-TW',
    'fr-FR',
]);
```

Returns:

```text
zh_Hant_TW
```

### Fallback behavior

The method follows these fallback rules:

- When no available locales are provided, return the client’s most preferred language.
- When the request has no accepted languages, return the first available locale.
- When no accepted language matches, return the first available locale.
- When neither accepted languages nor available locales exist, return `null`.

Available locales are returned in canonicalized form.

For example:

```php
$request->getPreferredLanguage(['en-us', 'fr-fr']);
```

Returns:

```text
en_US
```

when the request contains no `Accept-Language` header.

## Coroutine safety

Hypervel’s `Request` service can be shared while the underlying PSR-7 request is stored in coroutine context. Caching accepted languages in a normal object property would therefore risk leaking one request’s language preferences into another concurrent request.

This implementation stores the parsed languages using Hyperf’s coroutine-local `Context`:

```text
Hypervel\Http\Request.properties.languages
```

As a result:

- Repeated calls within the same request reuse the parsed language list.
- Concurrent requests maintain independent language caches.
- A shared `Request` instance does not share language state between coroutines.
- No mutable process-level request state is introduced.

## Public API

The following methods were added to `RequestContract`:

```php
public function getPreferredLanguage(?array $locales = null): ?string;

public function getLanguages(): array;
```

The request facade annotations were also updated, allowing the methods to be used through the facade:

```php
use Hypervel\Support\Facades\Request;

$languages = Request::getLanguages();

$locale = Request::getPreferredLanguage([
    'en-US',
    'fr-FR',
]);
```

## Testing

The request test suite now covers:

- Parsing `Accept-Language`.
- Ordering languages by quality value.
- Canonicalizing language, script, and region components.
- Legacy `i-` language tags.
- Preferred-language matching.
- Script-based fallback matching.
- Returning the most preferred language when no locale list is supplied.
- Falling back to the first available locale.
- Canonicalizing available locales.
- Isolating cached language state between concurrent coroutines sharing the same `Request` instance.


## Backward compatibility

This change is additive and does not alter existing request behavior.

Existing request methods and public APIs remain unchanged. The only interface change is the addition of the two new language negotiation methods to `RequestContract`.