### PR TITLE
feat(database): add physical session configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ The Working rules and the Avoid overengineering rules apply to all work in this 
 - **Always use `cp` to copy files and `mv` to move/rename** — never read → write new version → delete old version.
 - **Grep broadly — never assume a subdir** — when searching for any symbol, class, method, or pattern, grep across the whole `src/` (or `tests/`) tree, not a specific package subdir. Assumptions about where something lives produce false negatives.
 - **Read the source before describing behavior** — never state how code behaves from memory or Laravel assumptions. Hypervel's coroutine runtime breaks many Laravel assumptions; if you haven't read the relevant source, read it first.
+- **Match existing documentation style** — User-facing documentation must match the style and language of nearby Hypervel docs. Use simple, human-friendly prose in Laravel's documentation style, and avoid internal jargon, stiff wording, needless verbosity, and details that do not help readers use the feature correctly.
 - **Revert failed attempts immediately** — when a fix doesn't work, revert it before trying another approach. Don't leave experimental code in place.
 - **Use `composer require` for root dependencies** — the root `composer.json` has a lockfile, so dependency entries go through Composer, never hand-edits. Direct edits are fine for metadata sections no command can write (`autoload`, `replace`, `extra`, `scripts`) and for the sub-package `src/{package}/composer.json` files, which have no lockfile.
 

--- a/docs/plans/2026-07-22-physical-database-session-configuration.md
+++ b/docs/plans/2026-07-22-physical-database-session-configuration.md
@@ -1,0 +1,1470 @@
+# Physical Database Session Configuration
+
+## Status
+
+Implementation plan for a Hypervel database enhancement. The source investigation, external-reference check, and pre-plan second-opinion loop are complete. This document records the settled final design.
+
+This work adds a generic, driver-neutral way for packages and applications to keep context-sensitive database session settings synchronized with the exact physical PDO used by each operation in Hypervel's long-lived pooled workers. PostgreSQL row-level-security GUCs are the first known consumer, but neither the public API nor the database implementation is tenancy- or RLS-specific.
+
+Backward compatibility, churn, and minimizing the diff are not design constraints. The implemented result must read as though Hypervel's pooled database layer was designed with physical-session configuration from the start. That does not permit speculative machinery: every mechanism below closes a source-verified correctness, isolation, lifecycle, diagnostics, or performance requirement.
+
+## Scope
+
+Implement all of the following as one coherent database-layer change:
+
+- add a small typed public configurator contract and one Laravel-shaped boot-time registrar;
+- synchronize the complete desired state at the public PDO hand-out boundary;
+- memoize applied state by exact physical PDO, independently for read and write sessions;
+- preserve known state across clean pool release and successful commit;
+- invalidate or taint state on the transaction and failure paths that can make the memo false;
+- compose with Hypervel's existing lost-connection and transaction retry behavior;
+- prevent unknown or reentrantly configured physical sessions from reaching application SQL or returning to the pool as healthy;
+- keep transaction-control operations usable while PostgreSQL is in an aborted transaction;
+- document the public API, raw escape hatches, lifecycle, pooler constraints, and performance model;
+- add deterministic unit, pool, coroutine, all-supported-driver integration, and PostgreSQL-specific coverage;
+- remove or rewrite every touched comment, test, and documentation statement that describes the old lifecycle incompletely.
+
+The implementation does **not** add RLS policies, tenant context, tenant identifiers, package-specific GUC names, or consumer configuration. Those belong to the consuming tenancy package.
+
+## Desired final architecture
+
+| Concern | Final owner and rule |
+|---|---|
+| Configurator registration | Worker-static ordered list on `Connection`; boot-only; cleared by the existing `Connection::flushState()` test hook |
+| Desired logical state | The configurator reads current coroutine/application context lazily in `state()`; `Connection` never caches request context |
+| Applied physical state | One worker-static `WeakMap<PDO, PhysicalSessionState>`, keyed by exact PDO identity |
+| Ordinary PDO hand-out | `getPdo()` / `getReadPdo()` resolve, recover if necessary, synchronize, then return |
+| Raw escape | `getRawPdo()` / `getRawReadPdo()` remain unresolved and unsynchronized; protected raw resolvers exist only for internal control statements |
+| Transaction start | Synchronize before the outer `BEGIN`, so the established session state is outside the transaction being started |
+| Transaction control | Savepoint creation, both outer commit sites, full rollback, and savepoint rollback use the raw resolved write PDO and never invoke configurators |
+| Clean release | Reset wrapper/request state but preserve the truthful physical-session memo and server state |
+| Successful commit | Preserve the memo because session-level state survives commit |
+| Rollback or failed commit | Invalidate the memo; mark unknown only when the physical outcome is genuinely ambiguous |
+| Failed apply / reentry | Mark the exact PDO unknown; never return it; replace it when possible |
+| Unknown pooled state | Release marks the wrapper invalid; normal refresh prepares a complete replacement before disconnecting the current generation and fails invalid; shared in-memory SQLite remains fail-closed because reconnect retains the same PDO |
+| Retry | Reuse existing query/BEGIN lost-connection retry and transaction concurrency retry; add no second retry subsystem |
+
+## Finding summary
+
+| Finding | Category | Severity | Evidence |
+|---|---|---|---|
+| A coroutine retains one borrowed `Connection` while its logical context can change | Isolation gap | Critical for context-sensitive sessions | `ConnectionResolver::connection()` caches the connection in `CoroutineContext` until deferred release |
+| Pool release resets PHP wrapper state but intentionally performs no server-session reset | Missing extension point | Major | `PooledConnection::release()` calls `resetForPool()`; heartbeat is raw `SELECT 1`; no `RESET` / `DISCARD` occurs |
+| Existing `beforeExecuting()` callbacks run before reconnect and are not replayed by the direct lost-query retry | Wrong seam for this job | Critical | `Connection::run()` invokes callbacks before `reconnectIfMissingConnection()`; `tryAgainIfCausedByLostConnection()` calls `runQueryCallback()` directly |
+| Wrapper-local memoization is false when a PDO is replaced or shared | Isolation gap | Critical | read/write PDOs are distinct; reconnect swaps PDOs; shared in-memory SQLite exposes one PDO through multiple wrappers |
+| Synchronizing inside rollback can block recovery from an aborted PostgreSQL transaction | Recovery defect | Critical | rollback currently obtains PDO through `getPdo()`; a configurator SQL statement cannot run in an aborted transaction |
+| PostgreSQL rolls back session-level `SET` changes made inside an aborted transaction or after a savepoint | Memo invalidation requirement | Critical | PostgreSQL `SET` documentation and real integration behavior |
+| A failed COMMIT can be the rollback boundary without calling `rollBack()` | Memo invalidation requirement | Critical | `testTransactionRetriesOnSerializationFailure()` expects repeated BEGIN/COMMIT attempts and no explicit rollback |
+| A nested MySQL deadlock can be an automatic full rollback without calling `rollBack()` in that handler | Memo invalidation requirement | Major | `handleTransactionException()` explicitly takes this branch when a concurrency error occurs above transaction level one |
+| `disconnect()` directly rolls back and a shared PDO can outlive the wrapper | Memo invalidation requirement | Major | `Connection::disconnect()` bypasses `ManagesTransactions::rollBack()`; `DbPool` retains the shared SQLite PDO |
+| Pooled refresh disconnects the current wrapper before both fresh PDOs are ready | Failure-path lifecycle defect | Major | A failed fresh write hand-out leaves null PDOs; a failed fresh read hand-out leaves a partial write-only generation; `check()` does not inspect PDO presence |
+| Public `getPdo()->query()` is documented and supported | API boundary | Major | `src/boost/docs/database.md` documents direct PDO access |
+| Raw retained PDO handles cannot be intercepted after hand-out | Explicit escape hatch | Expected | PDO owns subsequent method calls; the framework can only synchronize at hand-out |
+
+## References checked
+
+### Hypervel source and tests
+
+- `src/database/src/Connection.php`
+- `src/database/src/ConnectionInterface.php`
+- `src/database/src/Concerns/ManagesTransactions.php`
+- `src/database/src/MySqlConnection.php`
+- `src/database/src/SQLiteConnection.php`
+- `src/database/src/DatabaseManager.php`
+- `src/database/src/ConnectionResolver.php`
+- `src/database/src/SimpleConnectionResolver.php`
+- `src/database/src/Pool/DbPool.php`
+- `src/database/src/Pool/PooledConnection.php`
+- `src/database/src/Pool/PoolFactory.php`
+- `src/database/src/Query/Processors/Processor.php`
+- `src/database/src/QueryException.php`
+- `src/database/src/DetectsLostConnections.php`
+- `src/database/src/DetectsConcurrencyErrors.php`
+- `src/queue/src/Queue.php`
+- `src/session/src/Middleware/StartSession.php`
+- `src/testing/src/PHPUnit/AfterEachTestSubscriber.php`
+- `src/foundation/src/Testing/DatabaseConnectionResolver.php`
+- `src/boost/docs/database.md`
+- `tests/Database/ConnectionTest.php`
+- `tests/Database/DatabaseConnectionTest.php`
+- `tests/Database/DatabaseTransactionsTest.php`
+- `tests/Integration/Database/PooledConnectionTest.php`
+- `tests/Integration/Database/ConnectionCoroutineSafetyTest.php`
+- the MySQL, MariaDB, PostgreSQL, and SQLite integration base classes
+- `tests/Integration/Database/Postgres/PooledConnectionStateTest.php`
+- `.github/workflows/databases.yml`
+
+Broad searches across all of `src/` and `tests/` found exactly seven database statement-execution closures that resolve a PDO: six in `Connection` and the MySQL insert override. Other direct PDO consumers are transaction control, schema import, escaping/server introspection, insert-ID retrieval, or explicit low-level access.
+
+### Laravel/Hypervel API precedents
+
+- `Queue::createPayloadUsing()` establishes the boot-only, ordered, appending `...Using()` registrar shape.
+- `StartSession::configureSessionCookieUsing()` establishes the `configure...Using` verb.
+- `Connection::getPdo()` is existing Laravel-compatible public API; this enhancement strengthens its Hypervel pooled-runtime semantics rather than inventing a parallel executor.
+- There is no Laravel physical-session configurator to port. The API is intentionally Hypervel-owned because the need comes from long-lived pooled workers.
+
+### External references
+
+- PostgreSQL `SET`: <https://www.postgresql.org/docs/current/sql-set.html>
+  - a session-level `SET` issued inside a transaction disappears if that transaction aborts;
+  - it persists after commit;
+  - rollback to an earlier savepoint cancels `SET` and `SET LOCAL` changes made after that savepoint.
+- PostgreSQL runtime settings and `set_config`: <https://www.postgresql.org/docs/current/config-setting.html> and <https://www.postgresql.org/docs/current/functions-admin.html>.
+- PostgreSQL rollback to savepoint: <https://www.postgresql.org/docs/current/sql-rollback-to.html>.
+- PHP `WeakMap`: <https://www.php.net/weakmap>. A key does not keep its object alive and its entry disappears with the key.
+- PHP weak-map RFC: <https://wiki.php.net/rfc/weak_maps>.
+- PgBouncer feature matrix: <https://www.pgbouncer.org/features.html>. Session pooling supports `SET` / `RESET`; transaction pooling does not.
+- PgBouncer reset behavior: <https://www.pgbouncer.org/config.html#server_reset_query>. Its reset query belongs to PgBouncer's external client-session release, not Hypervel's internal wrapper release.
+
+The project runtime also verified the disputed ephemeron edge directly:
+
+```bash
+php -r 'class State { public function __construct(public object $key) {} } $map = new WeakMap; $key = new stdClass; $map[$key] = new State($key); unset($key); gc_collect_cycles(); var_export(count($map));'
+# 0
+```
+
+No `WeakReference` is required. The planned state value holds no PDO reference anyway.
+
+## Current execution and lifecycle trace
+
+### Ordinary statements
+
+`Connection::run()` currently:
+
+1. invokes `beforeExecutingCallbacks`;
+2. reconnects only when the write PDO property is null;
+3. calls the operation closure through `runQueryCallback()`;
+4. catches `QueryException`;
+5. outside a transaction, reconnects and calls `runQueryCallback()` again directly when the previous exception is a lost connection.
+
+The operation closure resolves the actual PDO only after the pretend guard:
+
+| Public operation | PDO path |
+|---|---|
+| `select()`, `selectResultSets()`, `cursor()` | `getPdoForSelect()` → read or write getter |
+| `statement()`, `affectingStatement()`, `unprepared()` | write getter |
+| `MySqlConnection::insert()` | write getter |
+
+Putting synchronization in the public getters keeps all seven closures covered on first execution and direct retry. It also covers the documented immediate `getPdo()->query()` idiom without adding seven callbacks or changing `run()`.
+
+### Transaction control
+
+The current control sites are:
+
+- outer BEGIN in `Connection::executeBeginTransactionStatement()` and `SQLiteConnection::executeBeginTransactionStatement()`;
+- savepoint creation in `ManagesTransactions::createSavepoint()`;
+- inline outer commit in `transaction()`;
+- public outer commit in `commit()`;
+- the nested-concurrency branch where the driver has already rolled back the whole physical transaction;
+- full rollback and savepoint rollback in `performRollBack()`;
+- direct rollback during `Connection::disconnect()`;
+- abandoned-transaction rollback during `PooledConnection::release()`.
+
+Only outer BEGIN must synchronize. Every other control operation must use an already-resolved raw write PDO so recovery remains possible when the transaction is aborted.
+
+### Pool lifecycle
+
+`PooledConnection::release()`:
+
+- captures `errorCount`;
+- calls `Connection::resetForPool()`, which changes PHP wrapper/request state only;
+- marks high-error connections invalid;
+- rolls an abandoned transaction back;
+- optionally dispatches `ReleaseConnection`;
+- requeues the wrapper.
+
+`ping()` runs only a raw `SELECT 1`. Normal refresh/reconnect replaces the PDO. It must resolve both synchronized replacement handles before disconnecting the current wrapper and mark the pool adapter invalid if any part of refresh fails; otherwise a configurator failure can leave null or partially swapped PDOs that `check()` still treats as healthy. Shared in-memory SQLite is the deliberate exception: the pool owns one PDO and binds new wrappers back to that exact object.
+
+Therefore a clean release neither changes physical session state nor needs memo invalidation. Clearing only the PHP memo would not prevent inheritance; it would merely force a redundant configuration SQL round trip on the next same-state borrow.
+
+## Fixed public API
+
+### `SessionConfigurator`
+
+Add `src/database/src/SessionConfigurator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database;
+
+use PDO;
+
+interface SessionConfigurator
+{
+    /**
+     * Return the complete desired state identity for the connection.
+     *
+     * Return null only when this configurator does not apply to the connection.
+     * The value must completely identify the state that apply() establishes.
+     * This method runs on every synchronized PDO hand-out and must not execute
+     * database work.
+     */
+    public function state(Connection $connection): ?string;
+
+    /**
+     * Apply the complete desired state to the physical database session.
+     *
+     * Use the given PDO directly. Calling Connection query APIs from this
+     * method is reentrant and fails closed.
+     */
+    public function apply(PDO $pdo, string $state, Connection $connection): void;
+}
+```
+
+Contract details:
+
+- The state string is opaque to Hypervel and compared strictly.
+- Empty string is a valid state. Only `null` is the not-applicable sentinel.
+- `null` must never be used by a security-sensitive consumer to mean “no current context”; that consumer must return an explicit fail-closed state identity.
+- Applicability must be stable for a connection: returning `null` means the configurator does not own state on that connection at all, not that state it established earlier should be left behind for one request.
+- The state value must identify everything the configurator owns. `apply()` must establish exactly that complete state and return only after it is complete.
+- `apply()` must establish physical-session state, not transaction-local state. PostgreSQL consumers use session-level `SET` / `set_config(..., false)`, not `SET LOCAL` / `set_config(..., true)`.
+- Configurators must be stateless/worker-safe services. They may read coroutine-local context lazily, but must not capture request data in their constructor or worker-static properties.
+- `state()` is a hot-path pure computation. Consumers should precompute canonical state strings on immutable context frames rather than encode or hash on every query.
+- `apply()` uses the passed PDO directly and parameterized SQL where values are dynamic. It must not call `Connection::statement()`, `select()`, `getPdo()`, or `getReadPdo()`.
+- Different configurators own independent session settings. Registration order is deterministic, but it is not a priority/override mechanism for two configurators writing the same setting.
+
+### Registrar
+
+Add one static registrar to `Connection`:
+
+```php
+/**
+ * Register a database session configurator.
+ *
+ * Boot-only. The configurator persists in a static property for the worker
+ * lifetime and runs on every subsequent synchronized PDO hand-out across all
+ * coroutines.
+ */
+public static function configureSessionUsing(SessionConfigurator $configurator): void
+{
+    static::$sessionConfigurators[] = $configurator;
+}
+```
+
+The registrar:
+
+- appends to an ordered list;
+- returns `void`;
+- does not deduplicate;
+- does not accept names, priorities, removal callbacks, or runtime mutation;
+- is registered in a service provider during worker boot;
+- is cleared for tests through the existing `Connection::flushState()`.
+
+Do not add this method to `ConnectionInterface`: global configurator registration is a concrete Hypervel `Connection` facility, not behavior every alternate connection implementation must provide.
+
+## Exact physical-session state
+
+### Internal state object
+
+Add `src/database/src/PhysicalSessionState.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database;
+
+/**
+ * @internal
+ */
+final class PhysicalSessionState
+{
+    /**
+     * @var array<int, string>
+     */
+    public array $appliedStates = [];
+
+    public bool $configuring = false;
+
+    public bool $unknown = false;
+}
+```
+
+Each field closes one demonstrated requirement:
+
+- `appliedStates`: skip configuration SQL while every desired state still matches;
+- `configuring`: detect recursive configuration and concurrent configuration of one shared physical PDO;
+- `unknown`: prevent a partially configured or otherwise ambiguous session from being trusted.
+
+The object is final because it is a private invariant carrier, not an extension point. Its fields are public only to avoid accessor ceremony inside the owning `Connection`; the class is not documented as public API.
+
+### Worker-static storage
+
+Add to `Connection`:
+
+```php
+/**
+ * The registered database session configurators.
+ *
+ * @var list<SessionConfigurator>
+ */
+protected static array $sessionConfigurators = [];
+
+/**
+ * The state known for each live physical database session.
+ *
+ * @var null|\WeakMap<PDO, PhysicalSessionState>
+ */
+protected static ?WeakMap $physicalSessionStates = null;
+```
+
+Use a lazy nullable `WeakMap`, not an eagerly constructed map:
+
+- with no configurators, no map is allocated or touched;
+- the PDO object is the exact physical-session identity;
+- read and write PDOs naturally keep independent state;
+- clones/wrappers sharing one PDO see one state;
+- replacing or collecting a PDO naturally removes its state;
+- no object-ID reuse table, destructor hook, manual sweep, or `WeakReference` is needed.
+
+Extend the existing `flushState()`:
+
+```php
+public static function flushState(): void
+{
+    static::$sessionConfigurators = [];
+    static::$physicalSessionStates = null;
+    static::$resolvers = [];
+    static::flushMacros();
+}
+```
+
+`AfterEachTestSubscriber` already calls `Connection::flushState()`; do not add another cleanup owner.
+
+## Connection implementation
+
+### Split raw resolution from synchronized hand-out
+
+Refactor lazy PDO resolution into protected helpers:
+
+```php
+/**
+ * Resolve the current write PDO without synchronizing session state.
+ */
+protected function resolvePdo(): PDO
+{
+    if ($this->pdo instanceof Closure) {
+        return $this->pdo = call_user_func($this->pdo);
+    }
+
+    return $this->pdo;
+}
+
+/**
+ * Resolve the current read PDO without synchronizing session state.
+ */
+protected function resolveReadPdo(): PDO
+{
+    if ($this->readPdo instanceof Closure) {
+        return $this->readPdo = call_user_func($this->readPdo);
+    }
+
+    if ($this->readPdo instanceof PDO) {
+        return $this->readPdo;
+    }
+
+    $this->latestPdoTypeRetrieved = 'write';
+
+    return $this->resolvePdo();
+}
+```
+
+The public getters become the synchronized boundary:
+
+```php
+/**
+ * Get the current synchronized PDO connection.
+ */
+public function getPdo(): PDO
+{
+    $this->latestPdoTypeRetrieved = 'write';
+
+    return $this->synchronizeSession($this->resolvePdo(), read: false);
+}
+
+/**
+ * Get the current synchronized PDO connection used for reading.
+ */
+public function getReadPdo(): PDO
+{
+    if ($this->transactions > 0) {
+        return $this->getPdo();
+    }
+
+    if ($this->readOnWriteConnection
+        || ($this->recordsModified && $this->getConfig('sticky'))) {
+        return $this->getPdo();
+    }
+
+    $this->latestPdoTypeRetrieved = 'read';
+
+    return $this->synchronizeSession($this->resolveReadPdo(), read: true);
+}
+```
+
+This preserves existing read/write/sticky routing and its `latestPdoTypeRetrieved` diagnostics. When no read PDO exists, `resolveReadPdo()` falls back to the raw write PDO and records the write type just as today's `getReadPdo()` fallback reaches `getPdo()`.
+
+Keep the public raw accessors unsynchronized and update their docblocks to be explicit:
+
+```php
+/**
+ * Get the current PDO parameter without resolving, reconnecting, or
+ * synchronizing session state.
+ */
+public function getRawPdo(): PDO|Closure|null;
+
+/**
+ * Get the current read PDO parameter without resolving, reconnecting, or
+ * synchronizing session state.
+ */
+public function getRawReadPdo(): PDO|Closure|null;
+```
+
+Do not expose the protected resolver methods publicly. They exist solely so internal transaction control can resolve a lazy PDO without recursively invoking session configuration.
+
+### Synchronization algorithm
+
+Add these protected helpers to `Connection` next to the PDO accessors:
+
+```php
+/**
+ * Synchronize the desired state for a physical database session.
+ */
+protected function synchronizeSession(PDO $pdo, bool $read): PDO
+{
+    if (static::$sessionConfigurators === []) {
+        return $pdo;
+    }
+
+    $sessionState = static::physicalSessionState($pdo);
+
+    if ($sessionState->configuring) {
+        $this->markSessionStateUnknown($pdo);
+
+        throw new RuntimeException('Reentrant database session configuration is not allowed.');
+    }
+
+    if ($sessionState->unknown) {
+        $sessionState->configuring = true;
+
+        try {
+            $pdo = $this->replaceUnknownSession($read);
+        } finally {
+            $sessionState->configuring = false;
+        }
+
+        $sessionState = static::physicalSessionState($pdo);
+
+        if ($sessionState->configuring) {
+            $this->markSessionStateUnknown($pdo);
+
+            throw new RuntimeException('Reentrant database session configuration is not allowed.');
+        }
+    }
+
+    $sessionState->configuring = true;
+
+    try {
+        foreach (static::$sessionConfigurators as $index => $configurator) {
+            $desiredState = $configurator->state($this);
+
+            if ($desiredState === null
+                || ($sessionState->appliedStates[$index] ?? null) === $desiredState) {
+                continue;
+            }
+
+            try {
+                $configurator->apply($pdo, $desiredState, $this);
+
+                if ($sessionState->unknown) {
+                    throw new RuntimeException(
+                        'Database session state became unknown during configuration.'
+                    );
+                }
+            } catch (Throwable $exception) {
+                $sessionState->appliedStates = [];
+                $sessionState->unknown = true;
+
+                throw $exception;
+            }
+
+            $sessionState->appliedStates[$index] = $desiredState;
+        }
+
+        if ($sessionState->unknown) {
+            throw new RuntimeException(
+                'Database session state became unknown during configuration.'
+            );
+        }
+    } finally {
+        $sessionState->configuring = false;
+    }
+
+    return $pdo;
+}
+
+/**
+ * Replace a physical session whose state can no longer be trusted.
+ */
+protected function replaceUnknownSession(bool $read): PDO
+{
+    if ($this->transactions > 0) {
+        throw new RuntimeException(
+            'Database session state is unknown within an active transaction.'
+        );
+    }
+
+    $this->reconnect();
+
+    $replacement = $read
+        ? $this->resolveReadPdo()
+        : $this->resolvePdo();
+
+    if (static::sessionStateIsUnknown($replacement)) {
+        throw new RuntimeException(
+            'Database session state remains unknown after reconnecting.'
+        );
+    }
+
+    return $replacement;
+}
+
+/**
+ * Get the state holder for a physical database session.
+ */
+protected static function physicalSessionState(PDO $pdo): PhysicalSessionState
+{
+    $states = static::$physicalSessionStates ??= new WeakMap;
+
+    return $states[$pdo] ??= new PhysicalSessionState;
+}
+
+/**
+ * Determine whether a physical database session has unknown state.
+ */
+protected static function sessionStateIsUnknown(PDO $pdo): bool
+{
+    return static::$physicalSessionStates !== null
+        && isset(static::$physicalSessionStates[$pdo])
+        && static::$physicalSessionStates[$pdo]->unknown;
+}
+
+/**
+ * Invalidate the states remembered for a physical database session.
+ */
+protected function invalidateSessionState(PDO $pdo): void
+{
+    if (static::$physicalSessionStates !== null
+        && isset(static::$physicalSessionStates[$pdo])) {
+        static::$physicalSessionStates[$pdo]->appliedStates = [];
+    }
+}
+
+/**
+ * Mark a physical database session's state as unknown.
+ */
+protected function markSessionStateUnknown(PDO $pdo): void
+{
+    if (static::$sessionConfigurators === []) {
+        return;
+    }
+
+    $sessionState = static::physicalSessionState($pdo);
+    $sessionState->appliedStates = [];
+    $sessionState->unknown = true;
+}
+```
+
+The implementation may tune line wrapping and method placement to match the class, but not change these semantics.
+
+Important details:
+
+- The empty-list return comes before every map access and callback.
+- The map records a state only after `apply()` returns successfully.
+- A failed apply clears every configurator memo for the PDO because an earlier configurator may have succeeded before a later one failed.
+- A `state()` exception propagates without taint unless it caused a detected reentry. The contract makes `state()` pure, so a normal computation failure cannot have changed the physical session.
+- The `configuring` flag covers both same-stack recursion and concurrent access through multiple wrappers around one physical PDO.
+- If overlapping access marks a PDO unknown while another configurator call is in progress, the in-progress call checks the taint before recording success and also fails. No caller receives that PDO merely because its own `apply()` completed.
+- Unknown recovery reconnects at most once per getter call. It never recurses.
+- The old unknown PDO remains marked as configuring during its reconnect callback. A custom reconnector that re-enters a public getter before replacing the PDO therefore fails closed instead of recursively reconnecting.
+- Re-resolving after reconnect happens in the getter's original read/write route.
+- A manually constructed `Connection` without a reconnector naturally throws the existing `LostConnectionException`; no fallback connector is invented.
+- A normal pooled or manager-backed nonpooled connection already has a reconnector and replaces its PDO.
+- Shared in-memory SQLite deliberately resolves the same PDO after reconnect. The second unknown check throws, so it cannot loop or silently clear taint.
+- Do not catch and wrap the runtime failures in a new exception hierarchy.
+
+### Pool health query
+
+Add a narrow concrete method to `Connection`, consumed by `PooledConnection` at release:
+
+```php
+/**
+ * Determine whether an open PDO has unknown session state.
+ *
+ * @internal
+ */
+public function hasUnknownSessionState(): bool
+{
+    if (static::$physicalSessionStates === null) {
+        return false;
+    }
+
+    $writePdo = $this->getRawPdo();
+
+    if ($writePdo instanceof PDO
+        && static::sessionStateIsUnknown($writePdo)) {
+        return true;
+    }
+
+    $readPdo = $this->getRawReadPdo();
+
+    return $readPdo instanceof PDO
+        && static::sessionStateIsUnknown($readPdo);
+}
+```
+
+This method:
+
+- inspects only already-resolved raw PDO objects;
+- never invokes a lazy closure;
+- never reconnects or synchronizes;
+- allocates no temporary collection on the release path;
+- handles shared read/write PDO identity without needing a deduplication structure.
+
+It remains off `ConnectionInterface` because only the concrete Hypervel pool adapter consumes it.
+
+## Transaction lifecycle
+
+### Transaction-control matrix
+
+| Operation | PDO access | Memo result | Reason |
+|---|---|---|---|
+| Outer BEGIN | synchronized public write getter | current state established before BEGIN | configuration survives a later rollback |
+| BEGIN lost retry | synchronized public write getter again | fresh PDO configured | existing BEGIN retry owns reconnect |
+| Savepoint creation | raw resolved write PDO | preserve | control SQL must not configure and does not change session settings |
+| Successful inline/public commit | raw resolved write PDO | preserve | session-level state survives commit |
+| Failed commit: concurrency | raw resolved write PDO | invalidate, reusable | server abort is a known rollback; existing retry deliberately reuses PDO |
+| Failed commit: lost connection | raw resolved write PDO | invalidate old key | reconnect replaces physical session |
+| Failed commit: other | raw resolved write PDO | invalidate and mark unknown | physical outcome is ambiguous |
+| Nested concurrency error after driver auto-rollback | raw resolved write PDO | invalidate | the physical transaction and any transactional session changes are already gone |
+| Full rollback | raw resolved write PDO | invalidate in `finally` | transaction may have reverted session settings |
+| Savepoint rollback | raw resolved write PDO | invalidate in `finally` | settings after savepoint may have reverted |
+| Failed rollback: lost | raw resolved write PDO | invalidate | replacement/discard heals; do not taint merely dead old socket |
+| Failed rollback: other | raw resolved write PDO | invalidate and mark unknown | physical state is ambiguous |
+| Invalid rollback level | no PDO operation | preserve | no rollback was attempted |
+| Disconnect rollback | already-resolved raw write PDO | invalidate; unknown on failure | exact PDO may survive through shared SQLite ownership |
+
+Invalidating all configurator memos after rollback and concurrency-failed commit is deliberately conservative. A pre-BEGIN state may still be correct, but distinguishing settings applied before and after every nested boundary would require a transaction/savepoint state stack. The next synchronized hand-out safely reapplies only registered state; the error/retry path is not a hot successful path. Do not add that state stack.
+
+### Invalidate driver-owned nested rollback
+
+Keep the existing nested-concurrency behavior in `handleTransactionException()`, but invalidate the exact resolved PDO before adjusting the logical level and throwing `DeadlockException`:
+
+```php
+if ($this->causedByConcurrencyError($e)
+    && $this->transactions > 1) {
+    $this->invalidateSessionState($this->resolvePdo());
+
+    --$this->transactions;
+
+    $this->transactionsManager?->rollback(
+        $this->getName(),
+        $this->transactions
+    );
+
+    throw new DeadlockException(
+        $e->getMessage(),
+        is_int($e->getCode()) ? $e->getCode() : 0,
+        $e
+    );
+}
+```
+
+This branch already asserts that the driver rolled back the complete physical transaction, so its memo cannot be retained. A transaction level above one guarantees that the outer BEGIN already resolved the write PDO; this helper does not open a connection on the failure path. Do not mark the PDO unknown or add another rollback: the physical outcome is known and the existing transaction exception behavior is unchanged.
+
+### Keep outer BEGIN synchronized
+
+`Connection::executeBeginTransactionStatement()` and `SQLiteConnection::executeBeginTransactionStatement()` continue to call public `getPdo()`. This establishes desired state before `beginTransaction()` or `BEGIN ... TRANSACTION`.
+
+Do not move synchronization into `beforeStartingTransaction`: those callbacks are mutable per-connection request state, reset on pool release, and not the physical-session owner.
+
+### Raw savepoints and rollback
+
+Change savepoint creation to:
+
+```php
+protected function createSavepoint(): void
+{
+    $this->resolvePdo()->exec(
+        $this->queryGrammar->compileSavepoint('trans' . ($this->transactions + 1))
+    );
+}
+```
+
+Pass the exact raw PDO into rollback:
+
+```php
+public function rollBack(?int $toLevel = null): void
+{
+    $toLevel = is_null($toLevel)
+        ? $this->transactions - 1
+        : $toLevel;
+
+    if ($toLevel < 0 || $toLevel >= $this->transactions) {
+        return;
+    }
+
+    $pdo = $this->resolvePdo();
+
+    try {
+        $this->performRollBack($toLevel, $pdo);
+    } catch (Throwable $exception) {
+        if (! $this->causedByLostConnection($exception)) {
+            $this->markSessionStateUnknown($pdo);
+        }
+
+        $this->handleRollBackException($exception);
+    } finally {
+        $this->invalidateSessionState($pdo);
+    }
+
+    $this->transactions = $toLevel;
+
+    $this->transactionsManager?->rollback(
+        $this->getName(),
+        $this->transactions
+    );
+
+    $this->fireConnectionEvent('rollingBack');
+}
+
+/**
+ * Perform a rollback within the database.
+ */
+protected function performRollBack(int $toLevel, PDO $pdo): void
+{
+    if ($toLevel === 0) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+    } elseif ($this->queryGrammar->supportsSavepoints()) {
+        $pdo->exec(
+            $this->queryGrammar->compileSavepointRollBack('trans' . ($toLevel + 1))
+        );
+    }
+}
+```
+
+The level guard remains before raw resolution and invalidation. A redundant `rollBack()` at level zero remains a no-op with no state cost.
+
+The invalidation belongs in `finally`, so a failed physical rollback cannot leave a positive memo. Non-lost failure marks the exact PDO unknown before `handleRollBackException()` rethrows. The lost branch retains existing transaction-manager behavior and relies on physical replacement.
+
+### Centralize outer commit behavior
+
+Add one protected helper because both commit sites need the same nontrivial lifecycle:
+
+```php
+/**
+ * Commit the active physical transaction.
+ */
+protected function performCommit(): void
+{
+    $pdo = $this->resolvePdo();
+
+    try {
+        $pdo->commit();
+    } catch (Throwable $exception) {
+        $this->invalidateSessionState($pdo);
+
+        if (! $this->causedByLostConnection($exception)
+            && ! $this->causedByConcurrencyError($exception)) {
+            $this->markSessionStateUnknown($pdo);
+        }
+
+        throw $exception;
+    }
+}
+```
+
+Replace both:
+
+```php
+$this->getPdo()->commit();
+```
+
+with:
+
+```php
+$this->performCommit();
+```
+
+This applies to the inline outer commit inside `transaction()` and the outer branch of public `commit()`. Nested logical commits still perform no PDO commit.
+
+Recognized concurrency/serialization commit failures are explicitly reusable because Hypervel's supported retry loop expects that behavior and the failed transaction is the rollback boundary. Other non-lost failures remain unknown because the framework cannot prove the physical outcome. Tainting recognized concurrency failures would reconnect a healthy PDO on every retry without improving correctness.
+
+### Make disconnect terminal and physically truthful
+
+Refactor `Connection::disconnect()` so a throwing rollback cannot retain a half-disconnected wrapper and so a shared PDO's memo is invalidated:
+
+```php
+public function disconnect(): void
+{
+    $pdo = $this->getRawPdo();
+
+    try {
+        if ($this->transactions > 0) {
+            $this->transactions = 0;
+
+            if ($pdo instanceof PDO && $pdo->inTransaction()) {
+                try {
+                    $pdo->rollBack();
+                } finally {
+                    $this->invalidateSessionState($pdo);
+                }
+            }
+        }
+    } catch (Throwable $exception) {
+        if ($pdo instanceof PDO) {
+            $this->markSessionStateUnknown($pdo);
+        }
+
+        throw $exception;
+    } finally {
+        $this->setPdo(null)->setReadPdo(null);
+    }
+}
+```
+
+`transactions > 0` currently implies BEGIN already resolved the write closure, but keep the `instanceof PDO` boundary so disconnect never invokes a lazy connector just to close it.
+
+Dropping wrapper references in `finally` is an intentional failure-path improvement: the original exception still propagates, while the wrapper cannot retain a half-disconnected physical handle. Add a direct regression test for this behavior.
+
+### Aborted-transaction recovery
+
+The decisive PostgreSQL path is:
+
+1. an application statement aborts the transaction;
+2. logical context changes before cleanup;
+3. `rollBack()` resolves the raw PDO and runs rollback without invoking `state()` or `apply()`;
+4. rollback invalidates the memo;
+5. the next normal statement runs after the transaction, computes current desired state, reapplies it, and succeeds.
+
+Any implementation that synchronizes in `getPdo()` but forgets to route rollback/savepoint/commit through raw resolution is incorrect.
+
+## Failure, retry, and diagnostic composition
+
+### Ordinary lost-query retry
+
+No new retry code is added. Because synchronization occurs inside the operation closure through the public getter:
+
+1. `apply()` is the first SQL to touch an idle-killed PDO and throws;
+2. `runQueryCallback()` clears/taints state through the synchronizer, increments `errorCount`, and wraps the error in a `QueryException`;
+3. the wrapper names the application SQL and retains the configuration exception as `getPrevious()`;
+4. `handleQueryException()` sees no active transaction;
+5. `tryAgainIfCausedByLostConnection()` detects the previous exception, reconnects, and reruns the same operation closure;
+6. the fresh PDO has no memo, is configured, and executes the original application statement.
+
+Inside a transaction, `handleQueryException()` already refuses transparent reconnect/retry. Keep that behavior.
+
+### BEGIN lost retry
+
+`handleBeginTransactionException()` already reconnects and calls `executeBeginTransactionStatement()` again. Because outer BEGIN uses synchronized `getPdo()`, the fresh PDO is configured on the retry. Add no special BEGIN callback.
+
+### Direct getter behavior
+
+A direct `getPdo()` or `getReadPdo()` call is outside `run()`:
+
+- its current configuration failure propagates directly;
+- it gets no transparent retry for that call;
+- failed apply or detected reentry marks the exact PDO unknown, while a pure `state()` exception does not;
+- a later synchronized getter may reconnect once before use.
+
+This matches today's direct PDO semantics. Do not hide direct getter errors behind an implicit retry loop.
+
+### QueryException and error accounting
+
+Pin the intentional diagnostic shape:
+
+- a configuration `Exception` during a normal operation produces a `QueryException` whose SQL/bindings describe the requested application operation;
+- the actual configuration exception is the previous exception;
+- lost-connection detection continues to inspect that previous exception;
+- `errorCount` increments for the failed execution attempt and contributes to the pool's existing stale-connection threshold;
+- a direct getter failure outside `run()` does not increment query `errorCount`.
+
+Do not add separate prepared-statement/query instrumentation for configurator SQL. It executes directly through PDO, while its time is naturally included in the application operation's elapsed duration on a transition. Separate logging/events would require recursive query machinery and misrepresent the hot path.
+
+## Pool integration
+
+### Preserve known state across clean release
+
+`Connection::resetForPool()` continues to clear only request/wrapper state:
+
+- before-execution and before-transaction callbacks;
+- query logs and logging flag;
+- cumulative duration and handlers;
+- read-on-write routing;
+- pretend mode;
+- modified-record sticky routing;
+- error count.
+
+It must not clear physical session state or the worker-static memo. Update its docblock/comments to distinguish wrapper state from server-session state.
+
+The same-state release/reborrow path must execute zero configurator SQL. A changed context on reborrow differs in `state()` and applies before the first operation.
+
+### Reject unknown pooled sessions
+
+At the end of `PooledConnection::release()`, after abandoned rollback and the optional release event, check health in `finally` before requeue:
+
+```php
+} finally {
+    if ($this->connection?->hasUnknownSessionState()) {
+        $this->logger->warning(
+            'Database session state is unknown, marking connection as stale.'
+        );
+
+        $this->markInvalid();
+    }
+
+    $this->availableForReuse = true;
+    $this->pool->release($this);
+}
+```
+
+The final position is required:
+
+- it observes a session that was already unknown when release began, even if the application caught the originating failure;
+- it observes an apply failure a release listener caught rather than rethrew;
+- the existing outer catch still marks the wrapper invalid when release itself throws.
+
+A successful abandoned-transaction rollback invalidates the memo but does not make the session unknown. A failed release rollback is already marked unknown where appropriate and is also made stale by the existing outer catch.
+
+On the next normal borrow, `check()` fails and the existing reconnect path replaces the physical PDO. No new pool state or discard queue is needed.
+
+For shared in-memory SQLite, reconnect creates a new wrapper around the same PDO. The getter's bounded unknown check therefore throws and remains fail-closed until the owning `DbPool` is closed/recreated. Do not clear the map entry, rebuild the shared in-memory database, or invent a SQLite reset protocol.
+
+### Make normal refresh atomic and fail invalid
+
+The normal `PooledConnection::refresh()` branch must prepare the complete fresh generation before mutating the active wrapper:
+
+```php
+try {
+    $fresh = $this->factory->make(
+        $this->config,
+        $this->config['name'] ?? null
+    );
+    $writePdo = $fresh->getPdo();
+    $readPdo = $fresh->getReadPdo();
+
+    $connection->disconnect();
+    $connection->setPdo($writePdo);
+    $connection->setReadPdo($readPdo);
+} catch (Throwable $exception) {
+    $this->markInvalid();
+
+    throw $exception;
+}
+```
+
+Factory creation, both synchronized fresh hand-outs, disconnect, and both setters belong to one failure boundary. Resolving both fresh handles first means a connector or configurator failure leaves the current generation intact and inspectable rather than producing null write state or a silent read-to-write fallback. If disconnect itself fails, its own terminal cleanup may clear the handles, but the adapter is already invalid and cannot be requeued as healthy.
+
+Do not call `markValid()` after a later refresh in the same borrow or add recovery bookkeeping. A failed refresh makes that generation conservatively stale; the normal next-borrow `reconnect()` path already creates the replacement and marks it valid. The successful path performs the same factory creation, two hand-outs, disconnect, and setters in a safer order, with only two local assignments added.
+
+### Preserve the maintenance invariant
+
+Add one concise WHY comment at the raw heartbeat/release maintenance boundary:
+
+```php
+// Known session configuration is memoized by physical PDO across clean
+// releases. Built-in pool maintenance must remain session-state-neutral
+// unless it also invalidates that PDO's memo.
+```
+
+`SELECT 1` is session-neutral and remains raw. A future built-in `RESET`, `DISCARD`, `SET`, or role/search-path change must invalidate the corresponding exact PDO.
+
+Application code that deliberately mutates a configurator-owned setting through raw SQL or a retained PDO handle violates the configurator ownership contract. Do not add SQL parsing or unconditional release invalidation to defend against that escape hatch.
+
+## MySQL insert hot path
+
+`MySqlConnection::insert()` currently calls `getPdo()` once for `prepare()` and again for `lastInsertId()`. With synchronized hand-out, that would perform two state computations/map checks in one closure. Resolve once:
+
+```php
+$pdo = $this->getPdo();
+$statement = $pdo->prepare($query);
+
+$this->bindValues($statement, $this->prepareBindings($bindings));
+
+$this->recordsHaveBeenModified();
+
+$result = $statement->execute();
+
+$this->lastInsertId = $pdo->lastInsertId($sequence);
+```
+
+This is a local no-behavior-change optimization at a touched hot path, not a new cache. Do not redesign `Processor::processInsertGetId()` or store a global “last PDO”; those are separate calls and the additional known-state check is negligible.
+
+## Public documentation deliverable
+
+Update `src/boost/docs/database.md` as part of the same change. Add **Configuring Database Session State** to the table of contents and place the section immediately after **Connection Pooling**, because persistent physical sessions are the reason the API exists.
+
+The framework documentation must remain generic. Do not make tenancy, RLS, a particular GUC, or a package class the normative example. Use a small application-name configurator to show the API shape:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Database;
+
+use Hypervel\Database\Connection;
+use Hypervel\Database\SessionConfigurator;
+use PDO;
+
+final class ApplicationNameConfigurator implements SessionConfigurator
+{
+    public function __construct(
+        private readonly string $applicationName,
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        return $connection->getDriverName() === 'pgsql'
+            ? $this->applicationName
+            : null;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        $statement = $pdo->prepare(
+            "select set_config('application_name', ?, false)"
+        );
+        $statement->execute([$state]);
+        $statement->closeCursor();
+    }
+}
+```
+
+Register the worker-safe service during application boot:
+
+```php
+use App\Database\ApplicationNameConfigurator;
+use Hypervel\Database\Connection;
+
+Connection::configureSessionUsing(
+    $this->app->make(ApplicationNameConfigurator::class)
+);
+```
+
+The prose around the example must document all of these rules:
+
+- registration is boot-only, ordered, appending, and worker-static;
+- the configurator must be safe to share for the worker lifetime and must read request/coroutine context lazily rather than capture it in a constructor;
+- `state()` returns the complete opaque state identity, runs on every synchronized PDO hand-out, and must not execute database work;
+- `null` means only “this configurator does not apply to this connection”; it must not be a security-sensitive no-context shortcut;
+- that not-applicable decision is stable for the connection; it is not a way to stop managing previously applied state for one request;
+- `apply()` receives the exact physical PDO, must use it directly, and must completely establish the state represented by the string;
+- settings must be session-scoped rather than transaction-local; PostgreSQL `SET LOCAL` / `set_config(..., true)` does not satisfy this contract;
+- public `getPdo()` and `getReadPdo()` synchronize before returning; raw getters, protected framework control paths, and an already-retained PDO handle are explicit unsynchronized escape hatches;
+- Hypervel remembers state separately per physical read/write PDO, preserves it through successful commit and clean internal pool release, and rechecks it on every hand-out;
+- rollback invalidates remembered state because PostgreSQL may revert session-level settings made within the rolled-back transaction;
+- a partially configured or otherwise ambiguous PDO is not trusted or returned as healthy;
+- configuration SQL runs only when the opaque state differs, but `state()` remains a hot-path method;
+- configurator SQL runs directly through PDO and does not create its own prepared-statement event, query event, log entry, or duration callback; transition time is included in the requesting operation when configuration occurs;
+- application code must not mutate a setting owned by a configurator through raw SQL or a retained PDO without accepting that it has left the synchronization contract.
+
+Also revise the existing direct-PDO paragraph under **Using Multiple Database Connections**. `getPdo()` still returns the underlying PDO, but it is now a synchronized hand-out rather than a “raw” accessor. Point low-level framework authors to `getRawPdo()` only when they intentionally need the unresolved, unsynchronized parameter and understand that it may be a closure or `null`.
+
+Add a compact external-pooler warning:
+
+- direct server connections and session-pooling proxies preserve physical session settings for the required lifetime;
+- transaction- or statement-pooling modes are incompatible with configurators whose correctness depends on state persisting across statements;
+- Hypervel cannot reliably discover or repair the proxy's pooling mode, so it performs no automatic pooler detection.
+
+Do not add a framework configuration file, environment switch, default configurator, or automatic registration. The extension point has no behavior until a consumer explicitly registers one.
+
+## Implementation sequence and affected files
+
+Implement in this order so each layer can be tested before pool integration:
+
+1. Add `src/database/src/SessionConfigurator.php` with the public contract and complete behavioral docblocks.
+2. Add `src/database/src/PhysicalSessionState.php` as the final internal state holder.
+3. Update `src/database/src/Connection.php`:
+   - static configurator list and lazy weak map;
+   - boot-only registrar and `flushState()` cleanup;
+   - raw PDO resolvers and synchronized public getters;
+   - synchronization, bounded unknown replacement, invalidation, taint, and health helpers;
+   - direct-disconnect lifecycle;
+   - outer BEGIN remains synchronized;
+   - update docblocks/comments that describe raw PDO or reset semantics.
+4. Update `src/database/src/Concerns/ManagesTransactions.php`:
+   - memo invalidation when a nested concurrency error means the driver already rolled back the complete transaction;
+   - raw savepoint creation;
+   - centralized raw outer commit lifecycle for both commit sites;
+   - exact-PDO rollback with `finally` invalidation and non-lost taint.
+5. Update `src/database/src/MySqlConnection.php` to reuse one synchronized PDO inside its insert closure.
+6. Update `src/database/src/Pool/PooledConnection.php` to reject unknown sessions at the final release boundary, prepare normal refresh replacements atomically and fail invalid, and record the raw-maintenance invariant.
+7. Add/update the focused unit and integration tests below.
+8. Update `src/boost/docs/database.md` after the executable contract is green, then verify that every documented guarantee has a matching test.
+
+Do not modify:
+
+- `ConnectionInterface`; the registrar and pool-health inspection are concrete framework facilities;
+- `DatabaseManager`, either connection resolver, or `PoolFactory`; existing construction and reconnect wiring are sufficient;
+- `beforeExecuting()` semantics; it remains an application query callback rather than physical-session machinery;
+- `QueryException`, lost-connection detection, or concurrency detection; composition with those existing mechanisms is part of this design;
+- `AfterEachTestSubscriber`; its existing `Connection::flushState()` call owns worker-static test cleanup;
+- `.github/workflows/databases.yml`; its MySQL 8/9, MariaDB 10/11, PostgreSQL 17/18, and SQLite jobs already discover the new common integration test, while both PostgreSQL jobs also discover the driver-specific class;
+- the private tenancy package in this framework PR. It is a later consumer of this generic API.
+
+## Testing plan
+
+Tests must prove observable behavior and SQL/configurator call counts. Do not add wall-clock assertions.
+
+### Core registration, memoization, and physical identity
+
+Add `tests/Database/DatabaseSessionConfiguratorTest.php` using the repository's database test base classes and Mockery/PDO test conventions.
+
+Cover:
+
+1. **Zero-configurator fast path**
+   - `getPdo()` and `getReadPdo()` return the existing routed PDOs;
+   - no `PhysicalSessionState`/`WeakMap` is created;
+   - no extra PDO method is called;
+   - repeated hand-outs keep the same result.
+2. **Boot registration semantics**
+   - configurators run in registration order;
+   - duplicate instances are not silently deduplicated;
+   - `flushState()` removes both registrations and remembered physical state;
+   - a subsequent test starts with no callbacks or stale memo.
+3. **State semantics**
+   - `null` skips that configurator only;
+   - empty string is applied and memoized as a real state;
+   - a matching state calls `state()` but not `apply()`;
+   - a changed state calls `apply()` once and replaces the memo only after success;
+   - multiple configurators keep independent indexed states.
+4. **Physical identity**
+   - separate read and write PDOs are configured and memoized independently;
+   - read fallback to write shares one physical memo;
+   - two connection wrappers around the same PDO share one memo;
+   - a cloned wrapper around the same PDO does not reapply a matching state;
+   - after all strong PDO references are released and garbage collection runs, the weak-map entry disappears.
+5. **Public and raw access**
+   - public getters synchronize before returning;
+   - raw getters neither resolve closures nor synchronize;
+   - internal raw resolution resolves without synchronization;
+   - a previously retained PDO receives no later automatic check, pinning the documented escape-hatch boundary.
+
+Expose internal state only through purpose-built anonymous test subclasses or reflection already accepted by the local test style. Do not make production internals public merely to simplify tests.
+
+### Every normal statement path
+
+Extend `tests/Database/DatabaseConnectionTest.php` and `tests/Database/ConnectionTest.php` so every execution closure is pinned:
+
+- `select()`;
+- `selectResultSets()`;
+- `cursor()`;
+- `statement()`;
+- `affectingStatement()`;
+- `unprepared()`;
+- `MySqlConnection::insert()`.
+
+For each distinct routing family, assert synchronization occurs before prepare/query/exec. Avoid seven copy-pasted test setups: use a data provider where the assertion shape is truly identical, and keep dedicated tests for cursor/result-set and MySQL-specific behavior.
+
+Also verify:
+
+- pretend mode does not resolve a PDO, compute state, or configure because its operation closure is not entered;
+- `MySqlConnection::insert()` computes state once, prepares and retrieves the insert ID through the same PDO, and preserves existing return/ID behavior;
+- `escape()` and server-version introspection synchronize when they use public PDO getters, consistent with the public hand-out contract;
+- existing read/sticky/transaction routing and `latestPdoTypeRetrieved` diagnostics remain unchanged.
+
+### Configuration failure and reentry
+
+In `DatabaseSessionConfiguratorTest` cover:
+
+- a thrown `state()` exception propagates without marking the PDO unknown, because no physical mutation is permitted there;
+- an `apply()` failure prevents the application SQL from executing, clears every remembered configurator state for that PDO, and marks it unknown;
+- an earlier configurator succeeding before a later configurator fails does not retain a partial positive memo;
+- direct recursion through `getPdo()`, and same-PDO concurrent entry through another wrapper, throw the reentry error and mark the physical PDO unknown;
+- when overlapping same-PDO access taints a session while the first `apply()` is suspended, both callers fail and the first caller does not record success or receive the PDO after resuming;
+- unknown replacement happens once, configures the replacement, and returns only the replacement;
+- a reconnector that re-enters a public getter before replacing the unknown PDO is rejected without a recursive reconnect loop;
+- unknown recovery preserves the original route: write hand-out replaces/resolves write, read hand-out replaces/resolves read, and read fallback still uses the replacement write PDO;
+- a replacement that is the same unknown PDO fails after one reconnect without recursion;
+- an unknown PDO inside an active transaction fails closed without reconnect;
+- a manually constructed connection without a reconnector preserves the existing reconnect failure rather than inventing fallback behavior.
+
+### Query diagnostics and existing retry composition
+
+Extend `tests/Database/ConnectionTest.php` around the existing lost-connection tests:
+
+- a normal-operation configuration `Exception` is wrapped as one `QueryException` for the requested application SQL/bindings, with the configurator exception as its previous exception;
+- `errorCount` increments once for each failed execution attempt, not once for an imaginary second configuration query;
+- configuration SQL emits no separate `StatementPrepared` / query event, log entry, or duration callback;
+- a direct getter failure remains the unwrapped configurator exception and does not increment query `errorCount`;
+- when configuration is the first SQL to find a dead connection outside a transaction, existing lost-connection handling reconnects and reruns the operation closure; the replacement is configured and the original operation succeeds;
+- the same failure inside a transaction is not transparently retried;
+- when the first outer BEGIN finds a dead connection during configuration, existing BEGIN recovery reconnects, reconfigures, and begins successfully;
+- direct public getter calls receive no current-call retry.
+
+Use errors/messages already recognized by `DetectsLostConnections`; do not alter production detection rules solely to make a mock test pass.
+
+`Connection::runQueryCallback()` intentionally catches `Exception`, matching its existing contract. A non-`Exception` `Throwable` from consumer code still taints the PDO in the synchronizer and then propagates directly; do not broaden the database query wrapper as unrelated API churn.
+
+### Transaction lifecycle
+
+Extend `tests/Database/DatabaseTransactionsTest.php` and the focused connection tests:
+
+- outer BEGIN synchronizes before `beginTransaction()` / SQLite `BEGIN`;
+- nested savepoint creation uses raw resolution and invokes no configurator;
+- successful inline `transaction()` commit preserves the memo;
+- successful public `commit()` preserves the memo;
+- full rollback invalidates the memo in `finally` and the next normal hand-out reapplies;
+- rollback to savepoint invalidates the memo and the next normal hand-out reapplies;
+- invalid rollback levels perform no PDO resolution and preserve the memo;
+- a lost-connection rollback failure invalidates without marking the dead PDO newly unknown;
+- another rollback failure invalidates and marks the exact PDO unknown before existing exception handling runs;
+- a concurrency/serialization commit failure invalidates but leaves the same PDO eligible for the existing transaction retry;
+- a nested concurrency error on the driver-owned full-rollback branch invalidates before throwing `DeadlockException`, without tainting or issuing another rollback;
+- another non-lost commit failure invalidates and marks the PDO unknown;
+- a lost commit failure invalidates the old PDO's memo and composes with existing handling/replacement;
+- each transaction retry recomputes current logical state before the new BEGIN;
+- no configurator is invoked by COMMIT, ROLLBACK, or ROLLBACK TO SAVEPOINT themselves.
+
+Keep the existing serialization-retry expectation that there is no explicit `rollBack()` between failed COMMIT and the next attempt. The new assertion is that the session memo is invalidated at the failed COMMIT boundary.
+
+### Disconnect lifecycle
+
+Extend `tests/Database/DatabaseConnectionTest.php`:
+
+- disconnecting outside a transaction drops read/write references without resolving a lazy PDO;
+- successful direct rollback during disconnect invalidates the exact PDO before references are dropped;
+- a shared PDO retained elsewhere observes that invalidation;
+- failed rollback marks the PDO unknown and still drops both wrapper references in `finally`;
+- the original rollback exception is rethrown unchanged;
+- a PDO/closure boundary that is not an already-resolved PDO is never invoked merely to disconnect.
+
+### Pool lifecycle
+
+Extend `tests/Integration/Database/PooledConnectionTest.php`:
+
+- same state across clean release/reborrow performs zero additional `apply()` calls;
+- changed logical state on reborrow applies before the first application operation;
+- clean `resetForPool()` does not erase the physical memo;
+- abandoned-transaction rollback invalidates the memo and the next borrow reapplies;
+- an unknown session detected at final release marks the wrapper invalid before it is returned;
+- an unknown already-open read PDO is detected even when the write PDO is healthy, without resolving unopened closures;
+- an unknown state created by a release listener and caught by that listener is still detected;
+- a thrown release error keeps the existing invalidation/release behavior;
+- the next health check reconnects an invalid normal connection and the fresh PDO configures normally;
+- when configuration of a fresh PDO fails during unknown-session refresh, the current generation remains wholly installed, the pool adapter is marked invalid, the original exception propagates unchanged, and the next borrow recreates and configures a distinct PDO;
+- heartbeat `SELECT 1` neither computes/configures state nor invalidates a truthful memo;
+- read/write physical sessions remain independent through release/reborrow.
+
+Add a shared in-memory SQLite case through the real `DbPool`:
+
+- make the shared PDO unknown;
+- release/borrow creates or refreshes a wrapper but resolves the same physical PDO;
+- synchronized hand-out makes one reconnect attempt, sees the same unknown PDO, and throws;
+- no loop, silent taint clearing, database recreation, or application SQL occurs.
+
+### Coroutine isolation
+
+Extend `tests/Integration/Database/ConnectionCoroutineSafetyTest.php` with a worker-static configurator whose `state()` reads coroutine-local context lazily.
+
+Interleave at least two coroutines through a one-connection pool and prove:
+
+- one boot registration is shared safely;
+- each coroutine's first hand-out establishes its own current state before application SQL;
+- after release/reborrow, a changed context triggers one transition;
+- a matching context performs no configuration SQL;
+- no constructor/static property captures the first coroutine's context;
+- no callback from `resetForPool()` is needed for correctness.
+
+Use deterministic barriers/channels already present in the coroutine tests rather than sleeps.
+
+### All supported database drivers
+
+Add `tests/Integration/Database/SessionConfiguratorTest.php`, extending the common `DatabaseTestCase`, so the same behavioral contract runs in every existing database workflow job: MySQL 8/9, MariaDB 10/11, PostgreSQL 17/18, and SQLite.
+
+Use a small driver-aware test configurator and read the resulting state back from the same PDO with a native session primitive:
+
+| Driver | `apply()` primitive | Assertion primitive |
+|---|---|---|
+| PostgreSQL | `select set_config('hypervel_test.context', ?, false)` | `select current_setting('hypervel_test.context', true)` |
+| MySQL / MariaDB | `set @hypervel_test_context := ?` | `select @hypervel_test_context` |
+| SQLite | validated integer `PRAGMA cache_size = N` | `PRAGMA cache_size` |
+
+The SQLite fixture must cast/validate its test-owned state to an integer before interpolation because SQLite PRAGMA assignment does not accept a bound placeholder. No application input reaches this test SQL.
+
+Cover the cross-driver contract without duplicating four classes:
+
+1. First synchronized application SQL establishes the native session value before the application statement runs.
+2. A second hand-out with the same desired state reads the same native value and performs no second `apply()`.
+3. Changing desired state applies exactly once and the very next application statement observes the new native value.
+4. A clean release/reborrow of the same pool slot preserves a matching memo and native value with zero configuration SQL; changing state before the next borrow reconfigures before use.
+5. Full rollback invalidates the memo on every driver and causes one conservative reapply before the next statement. PostgreSQL may have reverted the setting; MySQL, MariaDB, and SQLite may still hold it, but Hypervel deliberately does not add driver-specific rollback shortcuts.
+6. Public direct PDO hand-out returns only after native state is current; raw access remains unsynchronized.
+7. Configuration SQL creates no independent prepared-statement/query event or log entry, while an application query still records its normal instrumentation.
+
+Keep call counters in the test configurator and assert exact `state()` / `apply()` counts. In `defineEnvironment()`, derive a dedicated named connection from the already-loaded default driver config and give it `pool.testing_enabled = true`, `max_connections = 1`, and heartbeats disabled before the application finishes booting. Use only that named connection for release/reborrow assertions; do not mutate connection configuration at runtime or infer physical reuse from coincidentally equal server values. The test fixture may branch only at the native SQL adapter boundary—the framework assertions remain identical.
+
+The test owns that dedicated pool. Release every borrowed wrapper in `finally` and flush the named pool during teardown so native session variables/PRAGMAs and live PDOs cannot leak to another test, including after an assertion failure. Do not duplicate `Connection::flushState()` in teardown; the existing global test subscriber remains its sole owner.
+
+Do not add separate MySQL and MariaDB copies. Running the same class in both existing workflow families verifies their native behavior and PDO drivers without maintaining parallel expectations.
+
+### Real PostgreSQL integration
+
+Add `tests/Integration/Database/Postgres/SessionConfiguratorTest.php` for PostgreSQL-only transaction and recovery semantics beyond the common cross-driver contract. Use a namespaced custom runtime parameter accepted by PostgreSQL (for example `hypervel_test.context`) and `select set_config(?, ?, false)` through the exact PDO. Clean it up explicitly where practical so failures do not confuse later assertions.
+
+Cover the facts on which the generic lifecycle depends:
+
+1. A session-level `set_config(..., false)` made outside a transaction persists after successful COMMIT.
+2. A session-level change made within a transaction is reverted by full ROLLBACK; the framework's invalidated memo causes the next synchronized statement to reapply the desired state.
+3. A change made after a savepoint is reverted by ROLLBACK TO SAVEPOINT; the framework invalidates and reapplies rather than trusting the stale memo.
+4. After an application SQL error aborts a transaction, rollback executes without calling the configurator; the next statement after rollback reconfigures and succeeds.
+5. Empty/fail-closed state values are applied as real values rather than treated as not-applicable sentinels.
+6. Kill a pooled connection's backend from an independent PostgreSQL administrative connection while the pooled PDO is idle. Change desired state so `apply()` is the first SQL to hit the dead socket, then assert the original application statement transparently reconnects, configures the fresh PDO, and succeeds outside a transaction.
+
+For the backend-kill case, use a dedicated one-slot, heartbeat-disabled pool, capture that target session's `pg_backend_pid()`, release it, and terminate only that PID through a separately created administrative PDO. This makes both physical reuse and “configuration is the first failing SQL” deterministic. Close the administrative PDO and release/flush all target-pool resources in `finally`.
+
+The test must target the existing PostgreSQL integration configuration and run in the already-defined PostgreSQL 17/18 workflow matrix. Do not repeat common first-use/matching-state cases already covered by the cross-driver class, and do not introduce a third-party proxy service merely to test the documented PgBouncer compatibility boundary.
+
+### Performance assertions
+
+Pin performance through deterministic work counts:
+
+| Path | Required work |
+|---|---|
+| No configurators | per public hand-out, one empty-list branch; per pooled release, one null-map health branch; no weak map, state object, callback, or SQL |
+| Registered, matching state | exact-PDO weak-map lookup plus `state()` and strict string comparison per configurator; no configuration SQL |
+| Changed state | same checks plus exactly one `apply()` for each changed configurator |
+| Clean same-state release/reborrow | no additional `apply()` |
+| MySQL insert closure | one synchronized PDO hand-out/state computation |
+| Rollback/failed-commit recovery | conservative reapply on next normal hand-out; no transaction-state stack |
+
+Add test-only counters for `state()` and `apply()` and assert these rows. Do not assert elapsed time in CI.
+
+Before opening the implementation PR, run a local before/after microbenchmark for the zero-configurator and matching-state paths using the same PHP process, connection, operation count, warm-up, and driver. Record the observed result in the PR description, not in production code or a permanent benchmark command. The acceptance criterion is no added SQL in steady state and no surprising regression requiring investigation; do not create a brittle numeric CI threshold.
+
+## Performance model
+
+The feature is not literally instruction-neutral when enabled: a synchronized public hand-out must ask each registered configurator for current desired state and compare it with the physical memo. It is designed to be practically negligible in the steady state and exactly neutral at the database/network layer:
+
+- applications that register nothing pay one predictable empty-array branch per synchronized hand-out plus one null-map health branch per pooled release, and allocate nothing;
+- enabled steady-state traffic performs in-process weak-map/string work only;
+- database SQL occurs only on first use of a physical PDO, a real state transition, or conservative recovery after a lifecycle invalidation;
+- preserving the memo across clean release avoids one SQL round trip per borrow for tenant-sticky workloads;
+- physical-PDO keys avoid wrapper churn and eliminate stale wrapper-local caches;
+- `state()` is consumer-controlled hot-path code, so the public contract explicitly forbids I/O and recommends a precomputed canonical value;
+- a transition is synchronized before application SQL by necessity; there is no background or deferred path that can preserve correctness;
+- failure/retry uses existing connection machinery, adding no locks, timers, queues, or retry loops.
+
+Do not describe the enabled path as “zero overhead” or “performance-neutral.” The accurate guarantee is: no additional SQL for a matching state, no allocation/map work when unused, and bounded in-process work when enabled.
+
+## Deliberately rejected designs
+
+Do not add any of the following while implementing this plan:
+
+| Rejected design | Why it is unnecessary or incorrect |
+|---|---|
+| `rlsFingerprint`, `rememberRlsFingerprint`, tenant IDs, roles, or GUC names in database | Consumer-specific vocabulary and policy do not belong in the generic physical-session extension point |
+| Public mutable session-state bag | Exposes framework invariants, invites false memos, and is unnecessary for one opaque state per configurator |
+| Named registry, priorities, replacement/removal APIs | No demonstrated runtime mutation or ownership conflict; boot-only ordered append matches existing `...Using()` APIs |
+| Closure-only registrar | A typed two-method contract states hot-path and exact-PDO responsibilities more clearly and is container-friendly |
+| One configurator singleton only | Prevents independent packages from owning independent non-overlapping settings |
+| Per-tenant or per-state connection pools | Multiplies connections and pool complexity; physical session synchronization already handles state transitions |
+| `RESET ALL`, `DISCARD ALL`, or blanket release reset | Adds a server round trip per borrow/release, interferes with driver/server facilities, and still needs exact ownership semantics |
+| Invalidate on every clean release | Does not reset server state and only creates redundant configuration SQL |
+| Read back server state on every hand-out | Adds the round trip memoization is meant to avoid and does not replace explicit ownership |
+| Parse or rewrite application SQL | Fragile, driver-specific, and unable to guard retained PDO handles reliably |
+| Transaction/savepoint memo stack | Conservatively invalidating on rollback/failure is correct and occurs off the successful hot path |
+| Automatic PgBouncer/proxy detection | Pooling topology is deployment configuration and cannot be inferred reliably from PDO |
+| Change `beforeExecuting()` | Its timing/retry semantics and request-reset lifecycle are intentionally different |
+| Expand `ConnectionInterface` | Alternate connection implementations do not need the concrete static registrar or pool-health helper |
+| Public exception hierarchy | Existing runtime, PDO, query, lost-connection, and concurrency errors already communicate the required failures |
+| `WeakReference`, object-ID maps, or destructor cleanup | `WeakMap<PDO, ...>` already models exact physical lifetime correctly |
+| Per-PDO mutex/lock service | Remote physical sessions are exclusive to one borrowed wrapper; shared in-memory SQLite executes local PDO calls without remote-I/O suspension. A configuration-only lock could not make arbitrary concurrent application use of one PDO safe anyway; the state object's reentry flag fails closed if overlap or recursion is detected |
+| PDO proxy object | Breaks established PDO type/API expectations and adds broad interception complexity for an explicit raw escape hatch |
+| A second retry subsystem | Existing query and BEGIN retry paths already replay synchronized closures correctly |
+| Feature flags or package config in the framework | No registrar means no behavior; an additional switch duplicates that fact |
+| Rebuild shared SQLite automatically | Would destroy the in-memory database to heal configuration state; bounded fail-closed behavior is safer |
+| Defend retained/raw handles after hand-out | Technically impossible without a PDO proxy; document the ownership boundary instead |
+
+This is the minimum coherent design. Removing the weak-map identity, transaction invalidation, raw control split, or unknown-state handling would reopen a verified correctness hole; adding the rejected machinery would solve no current requirement.
+
+## Stale and dead-code cleanup
+
+After implementation, perform broad searches across `src/database`, `tests`, and `src/boost/docs/database.md` for:
+
+- `resetForPool`, `server state`, `session state`, `getPdo`, `getReadPdo`, `getRawPdo`, `getRawReadPdo`;
+- direct `->commit()`, `->rollBack()`, `beginTransaction()`, savepoint SQL, and PDO-resolving transaction control;
+- every `->run(` execution closure and every direct PDO `query`, `prepare`, `exec`, or `lastInsertId` use;
+- `flushState`, resolver/static reset hooks, and pool health/release comments;
+- old test names or prose implying that clean release resets the database server session.
+
+The finished codebase must contain:
+
+- no transaction-control site that accidentally synchronizes except outer BEGIN;
+- no ordinary statement closure that bypasses synchronized hand-out;
+- no duplicate inline commit lifecycle after `performCommit()` exists;
+- no wrapper-local session memo, obsolete helper, unused import, compatibility alias, or dead branch;
+- no comment that says what the code trivially says, and no stale comment that claims wrapper reset is a server reset;
+- no temporary debug helper, benchmark code, TODO, or tenancy-specific example left in the framework;
+- no documentation promise without a matching executable behavior/test.
+
+Prefer deleting superseded comments/tests over layering contradictory caveats on them. Preserve comments only where they explain a non-obvious invariant, particularly raw transaction recovery and session-neutral pool maintenance.
+
+## Validation sequence
+
+During implementation, run the narrowest relevant test after each file or behavior change. Before review, run in this order from the components repository root:
+
+```bash
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseSessionConfiguratorTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseConnectionTest.php
+./vendor/bin/phpunit --no-progress tests/Database/ConnectionTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseTransactionsTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/PooledConnectionTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/ConnectionCoroutineSafetyTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/SessionConfiguratorTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/Postgres/SessionConfiguratorTest.php
+./vendor/bin/phpstan
+./vendor/bin/php-cs-fixer fix
+composer test:parallel
+```
+
+The PostgreSQL command requires the repository's integration-test environment. The existing database workflow provides PostgreSQL 17 and 18; verify both CI jobs rather than adding a new workflow matrix.
+
+After formatting, rerun any focused test whose production or test file changed. Then inspect:
+
+```bash
+git diff --check
+git status --short
+git diff -- src/database tests/Database tests/Integration/Database src/boost/docs/database.md
+```
+
+The final diff inspection is mandatory because formatting and transaction refactoring can expose a missed direct PDO call or stale comment even when tests pass.
+
+## Completion criteria
+
+Implementation is complete only when all of the following are true:
+
+- the public API has the exact generic naming and two-method shape in this plan;
+- registration is boot-only ordered append and is fully reset by `Connection::flushState()`;
+- unused applications allocate no session state and execute no additional SQL;
+- every public read/write PDO hand-out is synchronized and every internal post-BEGIN transaction-control operation is raw;
+- read/write/shared physical identities are memoized correctly;
+- clean release and successful commit preserve truthful memos;
+- rollback, driver-owned automatic rollback, failed commit, disconnect rollback, failed apply, and reentry follow the exact invalidation/unknown matrix;
+- unknown sessions never reach application SQL or return to a pool as healthy;
+- normal pooled refresh never leaves a null or partially swapped generation and any refresh failure marks the adapter invalid;
+- shared in-memory SQLite unknown recovery is bounded and fail-closed;
+- configuration failure composes with existing lost-connection and concurrency retry behavior without new retry machinery;
+- deterministic unit, pool, coroutine, all-supported-driver, and PostgreSQL-specific tests cover every lifecycle row and statement family;
+- the Boost database documentation fully states the public contract and deployment limits without tenancy-specific coupling;
+- all focused checks, PHPStan, formatter, parallel suite, every existing database CI job, and final diff checks pass;
+- broad searches find no stale lifecycle statement, bypass, dead helper, obsolete comment, or speculative machinery.

--- a/src/boost/docs/database.md
+++ b/src/boost/docs/database.md
@@ -4,6 +4,7 @@
     - [Configuration](#configuration)
     - [Read and Write Connections](#read-and-write-connections)
     - [Connection Pooling](#connection-pooling)
+    - [Configuring Database Session State](#configuring-database-session-state)
 - [Running SQL Queries](#running-queries)
     - [Using Multiple Database Connections](#using-multiple-database-connections)
     - [Listening for Query Events](#listening-for-query-events)
@@ -176,6 +177,75 @@ You may use `migrations_connection` on any database connection to instruct migra
 
 When you need a direct connection for migrations or schema operations, configure it as a normal connection and reference it with `migrations_connection`. Hypervel does not use Laravel's `::direct` connection suffix.
 
+<a name="configuring-database-session-state"></a>
+### Configuring Database Session State
+
+Pooled database connections keep their physical database sessions alive across requests and jobs. If an application or package relies on context-sensitive session settings, it may register a session configurator to keep those settings synchronized with the exact physical read or write PDO before Hypervel hands it out.
+
+Session configurators implement the `SessionConfigurator` contract. The following example maintains PostgreSQL's `application_name` setting:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Database;
+
+use Hypervel\Database\Connection;
+use Hypervel\Database\SessionConfigurator;
+use PDO;
+
+final class ApplicationNameConfigurator implements SessionConfigurator
+{
+    public function __construct(
+        private readonly string $applicationName,
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        return $connection->getDriverName() === 'pgsql'
+            ? $this->applicationName
+            : null;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        $statement = $pdo->prepare(
+            "select set_config('application_name', ?, false)"
+        );
+        $statement->execute([$state]);
+        $statement->closeCursor();
+    }
+}
+```
+
+Register the worker-safe configurator in a service provider's `boot` method:
+
+```php
+use App\Database\ApplicationNameConfigurator;
+use Hypervel\Database\Connection;
+
+Connection::configureSessionUsing(
+    $this->app->make(ApplicationNameConfigurator::class)
+);
+```
+
+Registration is boot-only, ordered, and appending. Registered instances remain in worker-static state and are used across every coroutine for the worker lifetime. A configurator must therefore be safe to share: it may read request or job context lazily from coroutine-local state, but it must not capture that context in its constructor or a static property.
+
+The `state` method returns an opaque string that completely identifies the desired state owned by that configurator. Hypervel calls it on every synchronized PDO hand-out, so it must be a fast, pure computation with no database or network work. Precompute the canonical string when creating an immutable context frame rather than encoding or hashing it for every query. An empty string is a real state. Return `null` only when the configurator never applies to that connection; this applicability decision must be stable for the connection. In particular, a security-sensitive configurator must represent a missing context with an explicit fail-closed state rather than `null`.
+
+The `apply` method receives the exact physical PDO and must use it directly to establish all session settings represented by the state string. Calling connection query methods or `getPdo` from `apply` is reentrant and fails closed. Dynamic values should be bound as parameters. Settings must apply to the physical session rather than only to the current transaction; for PostgreSQL, use session-level `SET` or `set_config(..., false)`, not `SET LOCAL` or `set_config(..., true)`.
+
+Hypervel remembers applied state separately for each physical read and write PDO. Matching state performs no configuration SQL. A clean internal pool release and a successful commit preserve a truthful memo, while rollback invalidates it because PostgreSQL may revert session settings established within the rolled-back transaction. A changed, newly connected, reconnected, or invalidated session is configured before the next application operation. A session left partially configured or with an ambiguous outcome is not returned as healthy.
+
+The public `getPdo` and `getReadPdo` methods synchronize session state before returning. The unresolved `getRawPdo` and `getRawReadPdo` parameters, framework transaction-control paths after `BEGIN`, and a PDO handle retained after an earlier hand-out are intentionally unsynchronized escape hatches. Application code must not mutate a setting owned by a configurator through raw SQL or a retained PDO and then expect Hypervel's memo to detect the change.
+
+Configurator SQL runs directly through PDO. It does not produce its own prepared-statement event, query event, query-log entry, or query-duration callback; when configuration is needed for an application operation, its time is included in that operation's elapsed time. With no registered configurators, hand-out adds only an empty-list branch and allocates no session state. With a matching state, it performs an in-process physical-PDO lookup, calls `state`, and compares the returned string without issuing SQL.
+
+> [!WARNING]
+> Session configuration that must persist across statements requires a direct database connection or a proxy in session-pooling mode. Transaction- and statement-pooling modes may route consecutive statements to different server sessions and are therefore incompatible with such configurators. Hypervel cannot reliably detect a proxy's pooling mode and does not attempt to repair an incompatible deployment automatically.
+
 <a name="running-queries"></a>
 ## Running SQL Queries
 
@@ -334,11 +404,13 @@ $users = DB::connection('sqlite')->select(/* ... */);
 
 Hypervel applications should define database connections in the configuration file before the worker boots. Runtime connection configuration is not supported because database pools are worker-level resources and configuration mutation would affect concurrent coroutines in the same worker.
 
-You may access the raw, underlying PDO instance of a connection using the `getPdo` method on a connection instance:
+You may access the underlying PDO instance of a connection using the `getPdo` method. This is a synchronized hand-out: registered database session configurators run before the PDO is returned.
 
 ```php
 $pdo = DB::connection()->getPdo();
 ```
+
+Low-level framework extensions may call `getRawPdo` when they intentionally need the unresolved, unsynchronized connection parameter. Its return value may be a PDO, a lazy connection closure, or `null`; normal application database work should use `getPdo` or Hypervel's query APIs instead.
 
 <a name="listening-for-query-events"></a>
 ### Listening for Query Events

--- a/src/boost/docs/database.md
+++ b/src/boost/docs/database.md
@@ -180,9 +180,9 @@ When you need a direct connection for migrations or schema operations, configure
 <a name="configuring-database-session-state"></a>
 ### Configuring Database Session State
 
-Pooled database connections keep their physical database sessions alive across requests and jobs. If an application or package relies on context-sensitive session settings, it may register a session configurator to keep those settings synchronized with the exact physical read or write PDO before Hypervel hands it out.
+Database connections may stay open and be reused across requests and jobs. If your application uses a database session setting that can change between requests or jobs, you may use a session configurator to keep it up to date.
 
-Session configurators implement the `SessionConfigurator` contract. The following example maintains PostgreSQL's `application_name` setting:
+Session configurators implement the `SessionConfigurator` contract. The following example keeps PostgreSQL's `application_name` setting up to date:
 
 ```php
 <?php
@@ -220,7 +220,7 @@ final class ApplicationNameConfigurator implements SessionConfigurator
 }
 ```
 
-Register the worker-safe configurator in a service provider's `boot` method:
+You should register the configurator in the `boot` method of a service provider:
 
 ```php
 use App\Database\ApplicationNameConfigurator;
@@ -231,20 +231,27 @@ Connection::configureSessionUsing(
 );
 ```
 
-Registration is boot-only, ordered, and appending. Registered instances remain in worker-static state and are used across every coroutine for the worker lifetime. A configurator must therefore be safe to share: it may read request or job context lazily from coroutine-local state, but it must not capture that context in its constructor or a static property.
+Registered configurators remain active for the lifetime of the worker and may be shared by several coroutines, so you should register them only during application boot. If a setting depends on the current request or job, read that context inside the `state` method. Do not store request or job data on the configurator itself. If you register more than one configurator, Hypervel runs them in registration order.
 
-The `state` method returns an opaque string that completely identifies the desired state owned by that configurator. Hypervel calls it on every synchronized PDO hand-out, so it must be a fast, pure computation with no database or network work. Precompute the canonical string when creating an immutable context frame rather than encoding or hashing it for every query. An empty string is a real state. Return `null` only when the configurator never applies to that connection; this applicability decision must be stable for the connection. In particular, a security-sensitive configurator must represent a missing context with an explicit fail-closed state rather than `null`.
+The `state` method returns a string that represents the settings the configurator wants to apply. The string should change whenever any setting managed by the configurator changes. Hypervel uses this string to determine whether the database connection needs to be updated. This method is called whenever Hypervel retrieves a PDO, so it should be fast and must not query the database or another service. If building the string takes work, compute it once when the request or job context is set instead of rebuilding it on every call.
 
-The `apply` method receives the exact physical PDO and must use it directly to establish all session settings represented by the state string. Calling connection query methods or `getPdo` from `apply` is reentrant and fails closed. Dynamic values should be bound as parameters. Settings must apply to the physical session rather than only to the current transaction; for PostgreSQL, use session-level `SET` or `set_config(..., false)`, not `SET LOCAL` or `set_config(..., true)`.
+An empty string is a valid state. Return `null` only when the configurator will never manage that database connection. Do not return `null` to represent missing request or job context when that context is required for security. Instead, return a real state that prevents the connection from receiving unintended access.
 
-Hypervel remembers applied state separately for each physical read and write PDO. Matching state performs no configuration SQL. A clean internal pool release and a successful commit preserve a truthful memo, while rollback invalidates it because PostgreSQL may revert session settings established within the rolled-back transaction. A changed, newly connected, reconnected, or invalidated session is configured before the next application operation. A session left partially configured or with an ambiguous outcome is not returned as healthy.
+The `apply` method receives the PDO that needs to be configured. Use this PDO directly and bind any dynamic values as parameters. Do not call `getPdo`, `getReadPdo`, or run queries through the database connection from `apply`. Hypervel detects this and throws an exception.
 
-The public `getPdo` and `getReadPdo` methods synchronize session state before returning. The unresolved `getRawPdo` and `getRawReadPdo` parameters, framework transaction-control paths after `BEGIN`, and a PDO handle retained after an earlier hand-out are intentionally unsynchronized escape hatches. Application code must not mutate a setting owned by a configurator through raw SQL or a retained PDO and then expect Hypervel's memo to detect the change.
+The `apply` method must apply all the settings represented by the state string to the database session. When using PostgreSQL, use session-level `SET` or `set_config(..., false)`. Do not use `SET LOCAL` or `set_config(..., true)`, since those settings last only for the current transaction.
 
-Configurator SQL runs directly through PDO. It does not produce its own prepared-statement event, query event, query-log entry, or query-duration callback; when configuration is needed for an application operation, its time is included in that operation's elapsed time. With no registered configurators, hand-out adds only an empty-list branch and allocates no session state. With a matching state, it performs an in-process physical-PDO lookup, calls `state`, and compares the returned string without issuing SQL.
+Hypervel tracks the applied state separately for read and write connections. It applies the settings when a connection is first used, when the state changes, after a reconnect, and after a rollback that may have undone a setting. Returning a connection to the pool or committing a transaction does not cause unchanged settings to be applied again. If configuration fails, Hypervel will not run the application query, and a pooled connection will not be returned as healthy.
+
+When the state has not changed, Hypervel runs no configuration SQL. The `state` method is still called, so it should remain quick. If you do not register a configurator, Hypervel stores no session state and runs no configuration SQL.
+
+The `getPdo` and `getReadPdo` methods configure the PDO before returning it. The `getRawPdo` and `getRawReadPdo` methods do not. Hypervel also cannot detect changes made through a PDO that your application kept from an earlier call. Do not manually change a setting that is owned by a configurator through one of these paths.
+
+> [!NOTE]
+> SQL executed by `apply` uses PDO directly and does not appear in Hypervel's query log or trigger query events. When a query triggers configuration, the setup time is included in that query's duration.
 
 > [!WARNING]
-> Session configuration that must persist across statements requires a direct database connection or a proxy in session-pooling mode. Transaction- and statement-pooling modes may route consecutive statements to different server sessions and are therefore incompatible with such configurators. Hypervel cannot reliably detect a proxy's pooling mode and does not attempt to repair an incompatible deployment automatically.
+> If a setting must persist across queries and your application connects through a database proxy or connection pooler, use a mode that keeps the same database session. For example, PgBouncer must use session pooling. Transaction and statement pooling may send consecutive queries to different database sessions, so the setting may be missing from the next query. Hypervel cannot detect the pooler's mode for you. Direct database connections are not affected.
 
 <a name="running-queries"></a>
 ## Running SQL Queries
@@ -404,13 +411,13 @@ $users = DB::connection('sqlite')->select(/* ... */);
 
 Hypervel applications should define database connections in the configuration file before the worker boots. Runtime connection configuration is not supported because database pools are worker-level resources and configuration mutation would affect concurrent coroutines in the same worker.
 
-You may access the underlying PDO instance of a connection using the `getPdo` method. This is a synchronized hand-out: registered database session configurators run before the PDO is returned.
+You may access the underlying PDO instance of a connection using the `getPdo` method. Hypervel applies any registered session configuration before returning the PDO.
 
 ```php
 $pdo = DB::connection()->getPdo();
 ```
 
-Low-level framework extensions may call `getRawPdo` when they intentionally need the unresolved, unsynchronized connection parameter. Its return value may be a PDO, a lazy connection closure, or `null`; normal application database work should use `getPdo` or Hypervel's query APIs instead.
+If you are building a low-level framework extension, you may use `getRawPdo` to access the connection parameter without resolving or configuring it. This value may be a PDO, a lazy connection closure, or `null`. Applications should use `getPdo` or Hypervel's query APIs instead.
 
 <a name="listening-for-query-events"></a>
 ### Listening for Query Events

--- a/src/database/src/Concerns/ManagesTransactions.php
+++ b/src/database/src/Concerns/ManagesTransactions.php
@@ -7,6 +7,7 @@ namespace Hypervel\Database\Concerns;
 use Closure;
 use Hypervel\Database\DeadlockException;
 use LogicException;
+use PDO;
 use RuntimeException;
 use Throwable;
 
@@ -53,9 +54,9 @@ trait ManagesTransactions
             $levelBeingCommitted = $this->transactions;
 
             try {
-                if ($this->transactions == 1) {
+                if ($this->transactions === 1) {
                     $this->fireConnectionEvent('committing');
-                    $this->getPdo()->commit();
+                    $this->performCommit();
                 }
 
                 $this->transactions = max(0, $this->transactions - 1);
@@ -96,6 +97,8 @@ trait ManagesTransactions
         // let the developer handle it in another way. We will decrement too.
         if ($this->causedByConcurrencyError($e)
             && $this->transactions > 1) {
+            $this->invalidateSessionState($this->resolvePdo());
+
             --$this->transactions;
 
             $this->transactionsManager?->rollback(
@@ -149,7 +152,7 @@ trait ManagesTransactions
      */
     protected function createTransaction(): void
     {
-        if ($this->transactions == 0) {
+        if ($this->transactions === 0) {
             $this->reconnectIfMissingConnection();
 
             try {
@@ -169,7 +172,7 @@ trait ManagesTransactions
      */
     protected function createSavepoint(): void
     {
-        $this->getPdo()->exec(
+        $this->resolvePdo()->exec(
             $this->queryGrammar->compileSavepoint('trans' . ($this->transactions + 1))
         );
     }
@@ -197,9 +200,9 @@ trait ManagesTransactions
      */
     public function commit(): void
     {
-        if ($this->transactionLevel() == 1) {
+        if ($this->transactionLevel() === 1) {
             $this->fireConnectionEvent('committing');
-            $this->getPdo()->commit();
+            $this->performCommit();
         }
 
         [$levelBeingCommitted, $this->transactions] = [
@@ -214,6 +217,27 @@ trait ManagesTransactions
         );
 
         $this->fireConnectionEvent('committed');
+    }
+
+    /**
+     * Commit the active physical transaction.
+     */
+    protected function performCommit(): void
+    {
+        $pdo = $this->resolvePdo();
+
+        try {
+            $pdo->commit();
+        } catch (Throwable $exception) {
+            $this->invalidateSessionState($pdo);
+
+            if (! $this->causedByLostConnection($exception)
+                && ! $this->causedByConcurrencyError($exception)) {
+                $this->markSessionStateUnknown($pdo);
+            }
+
+            throw $exception;
+        }
     }
 
     /**
@@ -257,10 +281,18 @@ trait ManagesTransactions
         // Next, we will actually perform this rollback within this database and fire the
         // rollback event. We will also set the current transaction level to the given
         // level that was passed into this method so it will be right from here out.
+        $pdo = $this->resolvePdo();
+
         try {
-            $this->performRollBack($toLevel);
-        } catch (Throwable $e) {
-            $this->handleRollBackException($e);
+            $this->performRollBack($toLevel, $pdo);
+        } catch (Throwable $exception) {
+            if (! $this->causedByLostConnection($exception)) {
+                $this->markSessionStateUnknown($pdo);
+            }
+
+            $this->handleRollBackException($exception);
+        } finally {
+            $this->invalidateSessionState($pdo);
         }
 
         $this->transactions = $toLevel;
@@ -278,16 +310,14 @@ trait ManagesTransactions
      *
      * @throws Throwable
      */
-    protected function performRollBack(int $toLevel): void
+    protected function performRollBack(int $toLevel, PDO $pdo): void
     {
-        if ($toLevel == 0) {
-            $pdo = $this->getPdo();
-
+        if ($toLevel === 0) {
             if ($pdo->inTransaction()) {
                 $pdo->rollBack();
             }
         } elseif ($this->queryGrammar->supportsSavepoints()) {
-            $this->getPdo()->exec(
+            $pdo->exec(
                 $this->queryGrammar->compileSavepointRollBack('trans' . ($toLevel + 1))
             );
         }

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -29,7 +29,9 @@ use PDO;
 use PDOStatement;
 use RuntimeException;
 use stdClass;
+use Throwable;
 use UnitEnum;
+use WeakMap;
 
 use function Hypervel\Support\enum_value;
 
@@ -192,6 +194,20 @@ class Connection implements ConnectionInterface
      * Used by connection pooling to detect and remove stale connections.
      */
     protected int $errorCount = 0;
+
+    /**
+     * The registered database session configurators.
+     *
+     * @var list<SessionConfigurator>
+     */
+    protected static array $sessionConfigurators = [];
+
+    /**
+     * The state known for each live physical database session.
+     *
+     * @var null|WeakMap<PDO, PhysicalSessionState>
+     */
+    protected static ?WeakMap $physicalSessionStates = null;
 
     /**
      * The connection resolvers.
@@ -915,23 +931,32 @@ class Connection implements ConnectionInterface
 
     /**
      * Disconnect from the underlying PDO connection.
-     *
-     * Any open transactions are rolled back before disconnecting to ensure
-     * the connection is returned to the pool in a clean state.
      */
     public function disconnect(): void
     {
-        // Roll back any open transactions before releasing the PDO.
-        // This prevents dirty state from leaking to the next pool user.
-        if ($this->transactions > 0) {
-            $this->transactions = 0;
+        $pdo = $this->getRawPdo();
 
-            if ($this->pdo?->inTransaction()) {
-                $this->pdo->rollBack();
+        try {
+            if ($this->transactions > 0) {
+                $this->transactions = 0;
+
+                if ($pdo instanceof PDO && $pdo->inTransaction()) {
+                    try {
+                        $pdo->rollBack();
+                    } finally {
+                        $this->invalidateSessionState($pdo);
+                    }
+                }
             }
-        }
+        } catch (Throwable $exception) {
+            if ($pdo instanceof PDO) {
+                $this->markSessionStateUnknown($pdo);
+            }
 
-        $this->setPdo(null)->setReadPdo(null);
+            throw $exception;
+        } finally {
+            $this->setPdo(null)->setReadPdo(null);
+        }
     }
 
     /**
@@ -965,10 +990,10 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Reset all per-request state for pool release.
+     * Reset all wrapper state for pool release.
      *
-     * Called when a connection is returned to the pool to ensure the next
-     * coroutine/request gets a clean connection without leaked state.
+     * Physical database session state is preserved and synchronized against
+     * the next coroutine's desired state when the PDO is handed out again.
      */
     public function resetForPool(): void
     {
@@ -1170,21 +1195,20 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get the current PDO connection.
+     * Get the current synchronized PDO connection.
      */
     public function getPdo(): PDO
     {
         $this->latestPdoTypeRetrieved = 'write';
+        $pdo = $this->resolvePdo();
 
-        if ($this->pdo instanceof Closure) {
-            return $this->pdo = call_user_func($this->pdo);
-        }
-
-        return $this->pdo;
+        return static::$sessionConfigurators === []
+            ? $pdo
+            : $this->synchronizeSession($pdo, read: false);
     }
 
     /**
-     * Get the current PDO connection parameter without executing any reconnect logic.
+     * Get the current PDO parameter without resolving, reconnecting, or synchronizing session state.
      */
     public function getRawPdo(): PDO|Closure|null
     {
@@ -1192,7 +1216,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Get the current PDO connection used for reading.
+     * Get the current synchronized PDO connection used for reading.
      */
     public function getReadPdo(): PDO
     {
@@ -1206,20 +1230,208 @@ class Connection implements ConnectionInterface
         }
 
         $this->latestPdoTypeRetrieved = 'read';
+        $pdo = $this->resolveReadPdo();
 
-        if ($this->readPdo instanceof Closure) {
-            return $this->readPdo = call_user_func($this->readPdo);
-        }
-
-        return $this->readPdo ?: $this->getPdo();
+        return static::$sessionConfigurators === []
+            ? $pdo
+            : $this->synchronizeSession($pdo, read: true);
     }
 
     /**
-     * Get the current read PDO connection parameter without executing any reconnect logic.
+     * Get the current read PDO parameter without resolving, reconnecting, or synchronizing session state.
      */
     public function getRawReadPdo(): PDO|Closure|null
     {
         return $this->readPdo;
+    }
+
+    /**
+     * Resolve the current write PDO without synchronizing session state.
+     */
+    protected function resolvePdo(): PDO
+    {
+        if ($this->pdo instanceof Closure) {
+            return $this->pdo = call_user_func($this->pdo);
+        }
+
+        return $this->pdo;
+    }
+
+    /**
+     * Resolve the current read PDO without synchronizing session state.
+     */
+    protected function resolveReadPdo(): PDO
+    {
+        if ($this->readPdo instanceof Closure) {
+            return $this->readPdo = call_user_func($this->readPdo);
+        }
+
+        if ($this->readPdo instanceof PDO) {
+            return $this->readPdo;
+        }
+
+        $this->latestPdoTypeRetrieved = 'write';
+
+        return $this->resolvePdo();
+    }
+
+    /**
+     * Synchronize the desired state for a physical database session.
+     */
+    protected function synchronizeSession(PDO $pdo, bool $read): PDO
+    {
+        $sessionState = static::physicalSessionState($pdo);
+
+        if ($sessionState->configuring) {
+            $this->markSessionStateUnknown($pdo);
+
+            throw new RuntimeException('Reentrant database session configuration is not allowed.');
+        }
+
+        if ($sessionState->unknown) {
+            $sessionState->configuring = true;
+
+            try {
+                $pdo = $this->replaceUnknownSession($read);
+            } finally {
+                $sessionState->configuring = false;
+            }
+
+            $sessionState = static::physicalSessionState($pdo);
+
+            if ($sessionState->configuring) {
+                $this->markSessionStateUnknown($pdo);
+
+                throw new RuntimeException('Reentrant database session configuration is not allowed.');
+            }
+        }
+
+        $sessionState->configuring = true;
+
+        try {
+            foreach (static::$sessionConfigurators as $index => $configurator) {
+                $desiredState = $configurator->state($this);
+
+                if ($desiredState === null
+                    || ($sessionState->appliedStates[$index] ?? null) === $desiredState) {
+                    continue;
+                }
+
+                try {
+                    $configurator->apply($pdo, $desiredState, $this);
+
+                    if ($sessionState->unknown) {
+                        throw new RuntimeException('Database session state became unknown during configuration.');
+                    }
+                } catch (Throwable $exception) {
+                    $sessionState->appliedStates = [];
+                    $sessionState->unknown = true;
+
+                    throw $exception;
+                }
+
+                $sessionState->appliedStates[$index] = $desiredState;
+            }
+
+            if ($sessionState->unknown) {
+                throw new RuntimeException('Database session state became unknown during configuration.');
+            }
+        } finally {
+            $sessionState->configuring = false;
+        }
+
+        return $pdo;
+    }
+
+    /**
+     * Replace a physical session whose state can no longer be trusted.
+     */
+    protected function replaceUnknownSession(bool $read): PDO
+    {
+        if ($this->transactions > 0) {
+            throw new RuntimeException('Database session state is unknown within an active transaction.');
+        }
+
+        $this->reconnect();
+
+        $replacement = $read
+            ? $this->resolveReadPdo()
+            : $this->resolvePdo();
+
+        if (static::sessionStateIsUnknown($replacement)) {
+            throw new RuntimeException('Database session state remains unknown after reconnecting.');
+        }
+
+        return $replacement;
+    }
+
+    /**
+     * Get the state holder for a physical database session.
+     */
+    protected static function physicalSessionState(PDO $pdo): PhysicalSessionState
+    {
+        $states = static::$physicalSessionStates ??= new WeakMap;
+
+        return $states[$pdo] ??= new PhysicalSessionState;
+    }
+
+    /**
+     * Determine whether a physical database session has unknown state.
+     */
+    protected static function sessionStateIsUnknown(PDO $pdo): bool
+    {
+        return static::$physicalSessionStates !== null
+            && isset(static::$physicalSessionStates[$pdo])
+            && static::$physicalSessionStates[$pdo]->unknown;
+    }
+
+    /**
+     * Invalidate the states remembered for a physical database session.
+     */
+    protected function invalidateSessionState(PDO $pdo): void
+    {
+        if (static::$physicalSessionStates !== null
+            && isset(static::$physicalSessionStates[$pdo])) {
+            static::$physicalSessionStates[$pdo]->appliedStates = [];
+        }
+    }
+
+    /**
+     * Mark a physical database session's state as unknown.
+     */
+    protected function markSessionStateUnknown(PDO $pdo): void
+    {
+        if (static::$sessionConfigurators === []) {
+            return;
+        }
+
+        $sessionState = static::physicalSessionState($pdo);
+        $sessionState->appliedStates = [];
+        $sessionState->unknown = true;
+    }
+
+    /**
+     * Determine whether an open PDO has unknown session state.
+     *
+     * @internal
+     */
+    public function hasUnknownSessionState(): bool
+    {
+        if (static::$physicalSessionStates === null) {
+            return false;
+        }
+
+        $writePdo = $this->getRawPdo();
+
+        if ($writePdo instanceof PDO
+            && static::sessionStateIsUnknown($writePdo)) {
+            return true;
+        }
+
+        $readPdo = $this->getRawReadPdo();
+
+        return $readPdo instanceof PDO
+            && static::sessionStateIsUnknown($readPdo);
     }
 
     /**
@@ -1564,6 +1776,18 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Register a database session configurator.
+     *
+     * Boot-only. The configurator persists in a static property for the worker
+     * lifetime and runs on every subsequent synchronized PDO hand-out across all
+     * coroutines.
+     */
+    public static function configureSessionUsing(SessionConfigurator $configurator): void
+    {
+        static::$sessionConfigurators[] = $configurator;
+    }
+
+    /**
      * Register a connection resolver.
      *
      * Boot-only. The resolver persists in a static property for the worker
@@ -1588,6 +1812,8 @@ class Connection implements ConnectionInterface
      */
     public static function flushState(): void
     {
+        static::$sessionConfigurators = [];
+        static::$physicalSessionStates = null;
         static::$resolvers = [];
         static::flushMacros();
     }

--- a/src/database/src/MySqlConnection.php
+++ b/src/database/src/MySqlConnection.php
@@ -40,7 +40,8 @@ class MySqlConnection extends Connection
                 return true;
             }
 
-            $statement = $this->getPdo()->prepare($query);
+            $pdo = $this->getPdo();
+            $statement = $pdo->prepare($query);
 
             $this->bindValues($statement, $this->prepareBindings($bindings));
 
@@ -48,7 +49,7 @@ class MySqlConnection extends Connection
 
             $result = $statement->execute();
 
-            $this->lastInsertId = $this->getPdo()->lastInsertId($sequence);
+            $this->lastInsertId = $pdo->lastInsertId($sequence);
 
             return $result;
         });

--- a/src/database/src/PhysicalSessionState.php
+++ b/src/database/src/PhysicalSessionState.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database;
+
+/**
+ * @internal
+ */
+final class PhysicalSessionState
+{
+    /**
+     * @var array<int, string>
+     */
+    public array $appliedStates = [];
+
+    public bool $configuring = false;
+
+    public bool $unknown = false;
+}

--- a/src/database/src/Pool/PooledConnection.php
+++ b/src/database/src/Pool/PooledConnection.php
@@ -205,6 +205,8 @@ class PooledConnection implements PoolConnectionInterface
             return false;
         }
 
+        // Known session configuration is memoized by physical PDO across clean
+        // releases. Pool maintenance must remain session-state-neutral.
         $pdos = $this->getOpenPdos();
 
         if ($pdos === []) {
@@ -260,7 +262,7 @@ class PooledConnection implements PoolConnectionInterface
             if ($this->connection instanceof Connection) {
                 $errorCount = $this->connection->getErrorCount();
 
-                // Reset all per-request state to prevent leaks between coroutines
+                // Reset wrapper state before another coroutine borrows it.
                 $this->connection->resetForPool();
 
                 // Check error count and mark as stale if too high
@@ -288,6 +290,11 @@ class PooledConnection implements PoolConnectionInterface
             // Mark as stale so it will be recreated
             $this->markInvalid();
         } finally {
+            if ($this->connection?->hasUnknownSessionState()) {
+                $this->logger->warning('Database session state is unknown, marking connection as stale.');
+                $this->markInvalid();
+            }
+
             $this->availableForReuse = true;
             $this->pool->release($this);
         }
@@ -441,12 +448,21 @@ class PooledConnection implements PoolConnectionInterface
             $connection->setPdo($sharedPdo);
             $connection->setReadPdo($sharedPdo);
         } else {
-            // Normal refresh path for other drivers
-            $fresh = $this->factory->make($this->config, $this->config['name'] ?? null);
+            try {
+                $fresh = $this->factory->make($this->config, $this->config['name'] ?? null);
+                $writePdo = $fresh->getPdo();
+                $readPdo = $fresh->getReadPdo();
 
-            $connection->disconnect();
-            $connection->setPdo($fresh->getPdo());
-            $connection->setReadPdo($fresh->getReadPdo());
+                // Keep the current generation intact until both replacement handles
+                // are ready so a failed refresh cannot leave a partial connection.
+                $connection->disconnect();
+                $connection->setPdo($writePdo);
+                $connection->setReadPdo($readPdo);
+            } catch (Throwable $exception) {
+                $this->markInvalid();
+
+                throw $exception;
+            }
 
             $this->logger->warning('Database connection refreshed.');
         }

--- a/src/database/src/SessionConfigurator.php
+++ b/src/database/src/SessionConfigurator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database;
+
+use PDO;
+
+interface SessionConfigurator
+{
+    /**
+     * Return the complete desired state identity for the connection.
+     *
+     * Return null only when this configurator does not apply to the connection.
+     * The value must completely identify the state that apply() establishes.
+     * This method runs on every synchronized PDO hand-out and must not execute
+     * database work.
+     */
+    public function state(Connection $connection): ?string;
+
+    /**
+     * Apply the complete desired state to the physical database session.
+     *
+     * Use the given PDO directly. Calling Connection query APIs from this
+     * method is reentrant and fails closed.
+     */
+    public function apply(PDO $pdo, string $state, Connection $connection): void;
+}

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -15,12 +15,14 @@ use Hypervel\Database\Events\TransactionCommitted;
 use Hypervel\Database\Events\TransactionCommitting;
 use Hypervel\Database\Events\TransactionRolledBack;
 use Hypervel\Database\MultipleColumnsSelectedException;
+use Hypervel\Database\MySqlConnection;
 use Hypervel\Database\Query\Builder as BaseBuilder;
 use Hypervel\Database\Query\Grammars\Grammar;
 use Hypervel\Database\Query\Processors\Processor;
 use Hypervel\Database\QueryException;
 use Hypervel\Database\Schema\Builder;
 use Hypervel\Database\Schema\Grammars\Grammar as SchemaGrammar;
+use Hypervel\Database\SessionConfigurator;
 use Hypervel\Testbench\TestCase;
 use Mockery as m;
 use PDO;
@@ -119,8 +121,10 @@ class DatabaseConnectionTest extends TestCase
         $this->assertIsNumeric($log[0]['time']);
     }
 
-    public function testSelectResultsetsReturnsMultipleRowset()
+    public function testSelectResultsetsReturnsMultipleRowset(): void
     {
+        $configurator = new StatementPathSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
         $pdo = $this->getMockBuilder(PDOStub::class)->onlyMethods(['prepare'])->getMock();
         $writePdo = $this->getMockBuilder(PDOStub::class)->onlyMethods(['prepare'])->getMock();
         $writePdo->expects($this->never())->method('prepare');
@@ -146,6 +150,107 @@ class DatabaseConnectionTest extends TestCase
         $this->assertSame('CALL a_procedure(?)', $log[0]['query']);
         $this->assertEquals(['foo'], $log[0]['bindings']);
         $this->assertIsNumeric($log[0]['time']);
+        $this->assertSame(1, $configurator->stateCalls);
+        $this->assertSame(1, $configurator->applyCalls);
+    }
+
+    public function testEveryOrdinaryConnectionStatementClosureSynchronizesItsPdo(): void
+    {
+        $configurator = new StatementPathSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $connection = new Connection(
+            new PDO('sqlite::memory:'),
+            ':memory:',
+            '',
+            ['name' => 'test', 'driver' => 'sqlite']
+        );
+
+        $operations = [
+            static fn () => $connection->select('select 1'),
+            static fn () => iterator_to_array($connection->cursor('select 1')),
+            static fn () => $connection->statement('create table records (id integer primary key)'),
+            static fn () => $connection->affectingStatement('insert into records (id) values (1)'),
+            static fn () => $connection->unprepared('delete from records'),
+        ];
+
+        foreach ($operations as $index => $operation) {
+            $configurator->desiredState = 'state-' . $index;
+            $operation();
+            $this->assertSame($index + 1, $configurator->applyCalls);
+        }
+
+        $this->assertSame(count($operations), $configurator->stateCalls);
+    }
+
+    public function testPretendModeDoesNotResolveOrSynchronizePdo(): void
+    {
+        $configurator = new StatementPathSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $resolutions = 0;
+        $connection = new Connection(
+            static function () use (&$resolutions): PDO {
+                ++$resolutions;
+
+                return new PDO('sqlite::memory:');
+            },
+            ':memory:',
+            '',
+            ['name' => 'test', 'driver' => 'sqlite']
+        );
+
+        $connection->pretend(static function (Connection $connection): void {
+            $connection->select('select 1');
+            $connection->statement('create table records (id integer)');
+            $connection->affectingStatement('delete from records');
+            $connection->unprepared('delete from records');
+        });
+
+        $this->assertSame(0, $resolutions);
+        $this->assertSame(0, $configurator->stateCalls);
+        $this->assertSame(0, $configurator->applyCalls);
+    }
+
+    public function testMySqlInsertUsesOneSynchronizedPdoForExecutionAndInsertId(): void
+    {
+        $configurator = new StatementPathSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pdo = $this->getMockBuilder(PDOStub::class)
+            ->onlyMethods(['prepare', 'lastInsertId'])
+            ->getMock();
+        $statement = $this->getMockBuilder(PDOStatement::class)
+            ->onlyMethods(['execute'])
+            ->getMock();
+        $pdo->expects($this->once())->method('prepare')->with('insert into records values ()')->willReturn($statement);
+        $pdo->expects($this->once())->method('lastInsertId')->with(null)->willReturn('42');
+        $statement->expects($this->once())->method('execute')->willReturn(true);
+        $connection = new MySqlConnection(
+            $pdo,
+            'test_database',
+            '',
+            ['name' => 'test', 'driver' => 'mysql']
+        );
+
+        $this->assertTrue($connection->insert('insert into records values ()'));
+        $this->assertSame('42', $connection->getLastInsertId());
+        $this->assertSame(1, $configurator->stateCalls);
+        $this->assertSame(1, $configurator->applyCalls);
+    }
+
+    public function testEscapingAndServerIntrospectionUseSynchronizedPdoHandOuts(): void
+    {
+        $configurator = new StatementPathSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $connection = new Connection(
+            new PDO('sqlite::memory:'),
+            ':memory:',
+            '',
+            ['name' => 'test', 'driver' => 'sqlite']
+        );
+
+        $this->assertSame("'value'", $connection->escape('value'));
+        $this->assertNotSame('', $connection->getServerVersion());
+        $this->assertSame(2, $configurator->stateCalls);
+        $this->assertSame(1, $configurator->applyCalls);
     }
 
     public function testInsertCallsTheStatementMethod()
@@ -924,5 +1029,26 @@ class PDOExceptionStub extends PDOException
     {
         $this->message = $message;
         $this->code = $code;
+    }
+}
+
+class StatementPathSessionConfigurator implements SessionConfigurator
+{
+    public string $desiredState = 'state';
+
+    public int $stateCalls = 0;
+
+    public int $applyCalls = 0;
+
+    public function state(Connection $connection): ?string
+    {
+        ++$this->stateCalls;
+
+        return $this->desiredState;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        ++$this->applyCalls;
     }
 }

--- a/tests/Database/DatabaseSessionConfiguratorTest.php
+++ b/tests/Database/DatabaseSessionConfiguratorTest.php
@@ -1,0 +1,1103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database\DatabaseSessionConfiguratorTest;
+
+use Closure;
+use Exception;
+use Hypervel\Database\Connection;
+use Hypervel\Database\DeadlockException;
+use Hypervel\Database\LostConnectionException;
+use Hypervel\Database\QueryException;
+use Hypervel\Database\SessionConfigurator;
+use Hypervel\Tests\TestCase;
+use PDO;
+use PDOException;
+use RuntimeException;
+use Throwable;
+
+class DatabaseSessionConfiguratorTest extends TestCase
+{
+    public function testUnconfiguredConnectionsDoNotAllocateOrSynchronizeSessionState(): void
+    {
+        $writeResolutions = 0;
+        $readResolutions = 0;
+        $writePdo = $this->pdo();
+        $readPdo = $this->pdo();
+        $connection = $this->connection(function () use (&$writeResolutions, $writePdo): PDO {
+            ++$writeResolutions;
+
+            return $writePdo;
+        });
+        $connection->setReadPdo(function () use (&$readResolutions, $readPdo): PDO {
+            ++$readResolutions;
+
+            return $readPdo;
+        });
+
+        $this->assertNull(TestSessionConnection::physicalSessionStateCount());
+        $this->assertSame($writePdo, $connection->getPdo());
+        $this->assertSame($writePdo, $connection->getPdo());
+        $this->assertSame($readPdo, $connection->getReadPdo());
+        $this->assertSame($readPdo, $connection->getReadPdo());
+        $this->assertSame(1, $writeResolutions);
+        $this->assertSame(1, $readResolutions);
+        $this->assertNull(TestSessionConnection::physicalSessionStateCount());
+    }
+
+    public function testConfiguratorsRunInRegistrationOrderWithoutDeduplication(): void
+    {
+        $calls = [];
+        $first = $this->configurator('first');
+        $second = $this->configurator('second');
+        $first->applyCallback = static function () use (&$calls): void {
+            $calls[] = 'first';
+        };
+        $second->applyCallback = static function () use (&$calls): void {
+            $calls[] = 'second';
+        };
+
+        Connection::configureSessionUsing($first);
+        Connection::configureSessionUsing($second);
+        Connection::configureSessionUsing($first);
+
+        $this->connection()->getPdo();
+
+        $this->assertSame(['first', 'second', 'first'], $calls);
+        $this->assertSame(2, $first->stateCalls);
+        $this->assertSame(2, $first->applyCalls);
+        $this->assertSame(1, $second->stateCalls);
+        $this->assertSame(1, $second->applyCalls);
+    }
+
+    public function testFlushStateRemovesConfiguratorsAndPhysicalState(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        $connection->getPdo();
+
+        $this->assertSame(1, TestSessionConnection::physicalSessionStateCount());
+
+        Connection::flushState();
+
+        $this->assertNull(TestSessionConnection::physicalSessionStateCount());
+        $connection->getPdo();
+        $this->assertSame(1, $configurator->stateCalls);
+        $this->assertSame(1, $configurator->applyCalls);
+        $this->assertNull(TestSessionConnection::physicalSessionStateCount());
+    }
+
+    public function testNullSkipsAndEmptyStringIsMemoizedAsARealState(): void
+    {
+        $skipped = $this->configurator(null);
+        $empty = $this->configurator('');
+        Connection::configureSessionUsing($skipped);
+        Connection::configureSessionUsing($empty);
+        $connection = $this->connection();
+
+        $connection->getPdo();
+        $connection->getPdo();
+
+        $this->assertSame(2, $skipped->stateCalls);
+        $this->assertSame(0, $skipped->applyCalls);
+        $this->assertSame(2, $empty->stateCalls);
+        $this->assertSame(1, $empty->applyCalls);
+        $this->assertSame([''], $empty->appliedStates);
+    }
+
+    public function testMatchingStateSkipsApplyAndChangedStateReplacesTheMemo(): void
+    {
+        $configurator = $this->configurator('first');
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        $connection->getPdo();
+        $connection->getPdo();
+        $configurator->desiredState = 'second';
+        $connection->getPdo();
+        $connection->getPdo();
+
+        $this->assertSame(4, $configurator->stateCalls);
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertSame(['first', 'second'], $configurator->appliedStates);
+    }
+
+    public function testMultipleConfiguratorsMemoizeTheirStatesIndependently(): void
+    {
+        $first = $this->configurator('first');
+        $second = $this->configurator('second');
+        Connection::configureSessionUsing($first);
+        Connection::configureSessionUsing($second);
+        $connection = $this->connection();
+
+        $connection->getPdo();
+        $second->desiredState = 'changed';
+        $connection->getPdo();
+
+        $this->assertSame(1, $first->applyCalls);
+        $this->assertSame(2, $second->applyCalls);
+        $this->assertSame(['second', 'changed'], $second->appliedStates);
+    }
+
+    public function testReadAndWritePdosAreMemoizedIndependently(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $writePdo = $this->pdo();
+        $readPdo = $this->pdo();
+        $connection = $this->connection($writePdo);
+        $connection->setReadPdo($readPdo);
+
+        $this->assertSame($writePdo, $connection->getPdo());
+        $this->assertSame($readPdo, $connection->getReadPdo());
+        $connection->getPdo();
+        $connection->getReadPdo();
+
+        $this->assertSame(4, $configurator->stateCalls);
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertSame(2, TestSessionConnection::physicalSessionStateCount());
+    }
+
+    public function testReadFallbackAndMultipleWrappersShareThePhysicalMemo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $secondConnection = $this->connection($pdo);
+
+        $this->assertSame($pdo, $connection->getReadPdo());
+        $this->assertSame($pdo, $secondConnection->getPdo());
+
+        $clonedConnection = clone $connection;
+        $this->assertSame($pdo, $clonedConnection->getPdo());
+        $this->assertSame(3, $configurator->stateCalls);
+        $this->assertSame(1, $configurator->applyCalls);
+        $this->assertSame(1, TestSessionConnection::physicalSessionStateCount());
+    }
+
+    public function testWeakMapReleasesStateWithThePhysicalPdo(): void
+    {
+        Connection::configureSessionUsing($this->configurator());
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $connection->getPdo();
+
+        $this->assertSame(1, TestSessionConnection::physicalSessionStateCount());
+
+        unset($connection, $pdo);
+        gc_collect_cycles();
+
+        $this->assertSame(0, TestSessionConnection::physicalSessionStateCount());
+    }
+
+    public function testRawAccessAndInternalResolutionDoNotSynchronize(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $writeResolutions = 0;
+        $readResolutions = 0;
+        $writePdo = $this->pdo();
+        $readPdo = $this->pdo();
+        $connection = $this->connection(function () use (&$writeResolutions, $writePdo): PDO {
+            ++$writeResolutions;
+
+            return $writePdo;
+        });
+        $connection->setReadPdo(function () use (&$readResolutions, $readPdo): PDO {
+            ++$readResolutions;
+
+            return $readPdo;
+        });
+
+        $this->assertInstanceOf(Closure::class, $connection->getRawPdo());
+        $this->assertInstanceOf(Closure::class, $connection->getRawReadPdo());
+        $this->assertSame($writePdo, $connection->resolveWritePdo());
+        $this->assertSame($readPdo, $connection->resolveReadPdoForTest());
+        $this->assertSame(1, $writeResolutions);
+        $this->assertSame(1, $readResolutions);
+        $this->assertSame(0, $configurator->stateCalls);
+        $this->assertNull(TestSessionConnection::physicalSessionStateCount());
+
+        $connection->getPdo();
+        $connection->getReadPdo();
+
+        $this->assertSame(2, $configurator->applyCalls);
+    }
+
+    public function testRetainedPdoIsAnExplicitUnsynchronizedEscapeHatch(): void
+    {
+        $configurator = $this->configurator('first');
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+        $retainedPdo = $connection->getPdo();
+
+        $configurator->desiredState = 'second';
+        $retainedPdo->query('select 1')?->closeCursor();
+
+        $this->assertSame(1, $configurator->applyCalls);
+
+        $connection->getPdo();
+
+        $this->assertSame(2, $configurator->applyCalls);
+    }
+
+    public function testStateExceptionDoesNotTaintThePhysicalSession(): void
+    {
+        $configurator = $this->configurator();
+        $exception = new Exception('State failed.');
+        $configurator->stateCallback = static fn () => throw $exception;
+        Connection::configureSessionUsing($configurator);
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected state exception was not thrown.');
+        } catch (Exception $caught) {
+            $this->assertSame($exception, $caught);
+        }
+
+        $this->assertFalse(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+        $configurator->stateCallback = null;
+        $this->assertSame($pdo, $connection->getPdo());
+        $this->assertSame(1, $configurator->applyCalls);
+    }
+
+    public function testApplyFailureClearsAllMemosAndTaintsThePhysicalSession(): void
+    {
+        $first = $this->configurator('first');
+        $second = $this->configurator('second');
+        $exception = new Exception('Apply failed.');
+        $second->applyCallback = static fn () => throw $exception;
+        Connection::configureSessionUsing($first);
+        Connection::configureSessionUsing($second);
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected apply exception was not thrown.');
+        } catch (Exception $caught) {
+            $this->assertSame($exception, $caught);
+        }
+
+        $this->assertSame(1, $first->applyCalls);
+        $this->assertSame(1, $second->applyCalls);
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+    }
+
+    public function testReentrantConfigurationFailsClosedForTheSameConnection(): void
+    {
+        $configurator = $this->configurator();
+        $configurator->applyCallback = static function (PDO $pdo, string $state, Connection $connection): void {
+            $connection->getPdo();
+        };
+        Connection::configureSessionUsing($configurator);
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected reentry exception was not thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Reentrant database session configuration is not allowed.', $exception->getMessage());
+        }
+
+        $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+    }
+
+    public function testReentrantConfigurationFailsClosedAcrossWrappersSharingAPdo(): void
+    {
+        $pdo = $this->pdo();
+        $otherConnection = $this->connection($pdo);
+        $configurator = $this->configurator();
+        $configurator->applyCallback = static function () use ($otherConnection): void {
+            $otherConnection->getPdo();
+        };
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection($pdo);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Reentrant database session configuration is not allowed.');
+
+        try {
+            $connection->getPdo();
+        } finally {
+            $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+        }
+    }
+
+    public function testUnknownWriteSessionIsReplacedOnceAndTheReplacementIsConfigured(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $oldPdo = $this->pdo();
+        $newPdo = $this->pdo();
+        $connection = $this->connection($oldPdo);
+        $connection->getPdo();
+        $connection->markSessionStateUnknownForTest($oldPdo);
+        $reconnects = 0;
+        $connection->setReconnector(static function (Connection $connection) use (&$reconnects, $newPdo): void {
+            ++$reconnects;
+            $connection->setPdo($newPdo);
+        });
+
+        $this->assertSame($newPdo, $connection->getPdo());
+        $this->assertSame(1, $reconnects);
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertFalse(TestSessionConnection::sessionStateIsUnknownForTest($newPdo));
+    }
+
+    public function testUnknownReadSessionRecoveryKeepsTheReadRoute(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $writePdo = $this->pdo();
+        $oldReadPdo = $this->pdo();
+        $newReadPdo = $this->pdo();
+        $connection = $this->connection($writePdo);
+        $connection->setReadPdo($oldReadPdo);
+        $connection->getReadPdo();
+        $connection->markSessionStateUnknownForTest($oldReadPdo);
+        $connection->setReconnector(static function (Connection $connection) use ($newReadPdo): void {
+            $connection->setReadPdo($newReadPdo);
+        });
+
+        $this->assertSame($newReadPdo, $connection->getReadPdo());
+        $this->assertSame($writePdo, $connection->getRawPdo());
+        $this->assertSame(2, $configurator->applyCalls);
+    }
+
+    public function testUnknownReadFallbackRecoveryUsesTheReplacementWritePdo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $oldPdo = $this->pdo();
+        $newPdo = $this->pdo();
+        $connection = $this->connection($oldPdo);
+        $connection->getReadPdo();
+        $connection->markSessionStateUnknownForTest($oldPdo);
+        $connection->setReconnector(static function (Connection $connection) use ($newPdo): void {
+            $connection->setPdo($newPdo);
+        });
+
+        $this->assertSame($newPdo, $connection->getReadPdo());
+        $this->assertSame($newPdo, $connection->getRawPdo());
+        $this->assertNull($connection->getRawReadPdo());
+    }
+
+    public function testUnknownSessionThatSurvivesReconnectFailsAfterOneAttempt(): void
+    {
+        Connection::configureSessionUsing($this->configurator());
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $connection->getPdo();
+        $connection->markSessionStateUnknownForTest($pdo);
+        $reconnects = 0;
+        $connection->setReconnector(static function () use (&$reconnects): void {
+            ++$reconnects;
+        });
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected unknown session exception was not thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Database session state remains unknown after reconnecting.', $exception->getMessage());
+        }
+
+        $this->assertSame(1, $reconnects);
+    }
+
+    public function testReentrantReconnectorCannotRecursivelyReplaceAnUnknownSession(): void
+    {
+        Connection::configureSessionUsing($this->configurator());
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $connection->getPdo();
+        $connection->markSessionStateUnknownForTest($pdo);
+        $reconnects = 0;
+        $connection->setReconnector(static function (Connection $connection) use (&$reconnects): void {
+            ++$reconnects;
+            $connection->getPdo();
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Reentrant database session configuration is not allowed.');
+
+        try {
+            $connection->getPdo();
+        } finally {
+            $this->assertSame(1, $reconnects);
+            $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+        }
+    }
+
+    public function testUnknownSessionInsideTransactionFailsWithoutReconnect(): void
+    {
+        Connection::configureSessionUsing($this->configurator());
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $connection->beginTransaction();
+        $connection->markSessionStateUnknownForTest($pdo);
+        $reconnects = 0;
+        $connection->setReconnector(static function () use (&$reconnects): void {
+            ++$reconnects;
+        });
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected active transaction exception was not thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Database session state is unknown within an active transaction.', $exception->getMessage());
+        } finally {
+            $connection->rollBack();
+        }
+
+        $this->assertSame(0, $reconnects);
+    }
+
+    public function testUnknownSessionWithoutAReconnectorPreservesTheExistingFailure(): void
+    {
+        Connection::configureSessionUsing($this->configurator());
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $connection->getPdo();
+        $connection->markSessionStateUnknownForTest($pdo);
+
+        $this->expectException(LostConnectionException::class);
+        $this->expectExceptionMessage('Lost connection and no reconnector available.');
+
+        $connection->getPdo();
+    }
+
+    public function testConfigurationFailureIsWrappedForTheApplicationQuery(): void
+    {
+        $configurator = $this->configurator();
+        $configurationException = new Exception('Configuration failed.');
+        $configurator->applyCallback = static fn () => throw $configurationException;
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        try {
+            $connection->statement('select ?', [1]);
+            $this->fail('Expected query exception was not thrown.');
+        } catch (QueryException $exception) {
+            $this->assertSame('select ?', $exception->getSql());
+            $this->assertSame([1], $exception->getBindings());
+            $this->assertSame($configurationException, $exception->getPrevious());
+        }
+
+        $this->assertSame(1, $connection->getErrorCount());
+        $this->assertSame([], $connection->getQueryLog());
+    }
+
+    public function testDirectGetterFailureIsUnwrappedAndDoesNotIncrementQueryErrors(): void
+    {
+        $configurator = $this->configurator();
+        $configurationException = new Exception('Configuration failed.');
+        $configurator->applyCallback = static fn () => throw $configurationException;
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected configuration exception was not thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame($configurationException, $exception);
+        }
+
+        $this->assertSame(0, $connection->getErrorCount());
+    }
+
+    public function testLostConnectionDuringConfigurationUsesTheExistingQueryRetry(): void
+    {
+        $configurator = $this->configurator();
+        $configurator->applyCallback = static function () use ($configurator): void {
+            if ($configurator->applyCalls === 1) {
+                throw new PDOException('server has gone away');
+            }
+        };
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection($this->pdo());
+        $replacement = $this->pdo();
+        $reconnects = 0;
+        $connection->setReconnector(static function (Connection $connection) use (&$reconnects, $replacement): void {
+            ++$reconnects;
+            $connection->setPdo($replacement);
+        });
+
+        $this->assertTrue($connection->statement('select 1'));
+        $this->assertSame(1, $reconnects);
+        $this->assertSame(2, $configurator->stateCalls);
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertSame(1, $connection->getErrorCount());
+    }
+
+    public function testLostConnectionDuringConfigurationIsNotRetriedInsideATransaction(): void
+    {
+        $configurator = $this->configurator('first');
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+        $connection->beginTransaction();
+        $configurator->desiredState = 'second';
+        $configurator->applyCallback = static fn () => throw new PDOException('server has gone away');
+        $reconnects = 0;
+        $connection->setReconnector(static function () use (&$reconnects): void {
+            ++$reconnects;
+        });
+
+        try {
+            $connection->statement('select 1');
+            $this->fail('Expected query exception was not thrown.');
+        } catch (QueryException $exception) {
+            $this->assertInstanceOf(PDOException::class, $exception->getPrevious());
+        } finally {
+            $connection->rollBack();
+        }
+
+        $this->assertSame(0, $reconnects);
+    }
+
+    public function testLostConnectionDuringConfigurationUsesTheExistingBeginRetry(): void
+    {
+        $configurator = $this->configurator();
+        $configurator->applyCallback = static function () use ($configurator): void {
+            if ($configurator->applyCalls === 1) {
+                throw new PDOException('server has gone away');
+            }
+        };
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection($this->pdo());
+        $replacement = $this->pdo();
+        $reconnects = 0;
+        $connection->setReconnector(static function (Connection $connection) use (&$reconnects, $replacement): void {
+            ++$reconnects;
+            $connection->setPdo($replacement);
+        });
+
+        $connection->beginTransaction();
+
+        $this->assertSame(1, $reconnects);
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertTrue($replacement->inTransaction());
+        $connection->rollBack();
+    }
+
+    public function testDirectGetterDoesNotRetryItsCurrentConfigurationFailure(): void
+    {
+        $configurator = $this->configurator();
+        $configurator->applyCallback = static fn () => throw new PDOException('server has gone away');
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+        $reconnects = 0;
+        $connection->setReconnector(static function () use (&$reconnects): void {
+            ++$reconnects;
+        });
+
+        try {
+            $connection->getPdo();
+            $this->fail('Expected PDO exception was not thrown.');
+        } catch (PDOException $exception) {
+            $this->assertSame('server has gone away', $exception->getMessage());
+        }
+
+        $this->assertSame(0, $reconnects);
+    }
+
+    public function testSuccessfulCommitPreservesThePhysicalMemo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        $connection->beginTransaction();
+        $stateCallsBeforeCommit = $configurator->stateCalls;
+        $connection->commit();
+        $connection->getPdo();
+
+        $this->assertSame($stateCallsBeforeCommit, $configurator->stateCalls - 1);
+        $this->assertSame(1, $configurator->applyCalls);
+    }
+
+    public function testSuccessfulTransactionCallbackCommitPreservesThePhysicalMemo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        $connection->transaction(static fn () => null);
+        $stateCallsAfterCommit = $configurator->stateCalls;
+        $connection->getPdo();
+
+        $this->assertSame($stateCallsAfterCommit + 1, $configurator->stateCalls);
+        $this->assertSame(1, $configurator->applyCalls);
+    }
+
+    public function testFullAndSavepointRollbackInvalidateThePhysicalMemo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $connection = $this->connection();
+
+        $connection->beginTransaction();
+        $connection->beginTransaction();
+        $this->assertSame(1, $configurator->stateCalls);
+        $connection->rollBack(1);
+        $this->assertSame(1, $configurator->stateCalls);
+        $connection->getPdo();
+        $this->assertSame(2, $configurator->applyCalls);
+        $connection->rollBack();
+        $this->assertSame(2, $configurator->stateCalls);
+        $connection->getPdo();
+        $this->assertSame(3, $configurator->applyCalls);
+    }
+
+    public function testInvalidRollbackLevelDoesNotResolveOrSynchronizeAPdo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $resolutions = 0;
+        $pdo = $this->pdo();
+        $connection = $this->connection(function () use (&$resolutions, $pdo): PDO {
+            ++$resolutions;
+
+            return $pdo;
+        });
+
+        $connection->rollBack();
+        $connection->rollBack(1);
+
+        $this->assertSame(0, $resolutions);
+        $this->assertSame(0, $configurator->stateCalls);
+        $this->assertNull(TestSessionConnection::physicalSessionStateCount());
+    }
+
+    public function testConcurrencyCommitFailureInvalidatesWithoutTaintingBeforeRetry(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new CommitRetryPdo;
+        $connection = $this->connection($pdo);
+
+        $connection->transaction(static fn () => null, 2);
+
+        $this->assertSame(2, $pdo->beginCalls);
+        $this->assertSame(2, $pdo->commitCalls);
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertFalse(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+    }
+
+    public function testNestedDriverOwnedRollbackInvalidatesWithoutIssuingAnotherRollback(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new TrackingPdo;
+        $connection = $this->connection($pdo);
+        $connection->getPdo();
+        $connection->setTransactionLevelForTest(2);
+        $exception = new QueryException('test', 'select 1', [], new Exception('Deadlock found when trying to get lock'));
+
+        try {
+            $connection->handleTransactionExceptionForTest($exception);
+            $this->fail('Expected deadlock exception was not thrown.');
+        } catch (DeadlockException $caught) {
+            $this->assertSame($exception, $caught->getPrevious());
+        }
+
+        $this->assertSame(0, $pdo->rollbackCalls);
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertFalse(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+    }
+
+    public function testNonLostCommitFailureMarksThePhysicalSessionUnknown(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new FailingCommitPdo;
+        $connection = $this->connection($pdo);
+        $connection->beginTransaction();
+
+        try {
+            $connection->commit();
+            $this->fail('Expected commit exception was not thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(FailingCommitPdo::$exception, $exception);
+        }
+
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+    }
+
+    public function testLostCommitFailureInvalidatesWithoutTaintingTheDeadPdo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new LostCommitPdo;
+        $connection = $this->connection($pdo);
+        $connection->beginTransaction();
+
+        try {
+            $connection->commit();
+            $this->fail('Expected commit exception was not thrown.');
+        } catch (PDOException $exception) {
+            $this->assertSame('server has gone away', $exception->getMessage());
+        }
+
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertFalse(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+    }
+
+    public function testNonLostRollbackFailureInvalidatesAndTaintsThePhysicalSession(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new FailingRollbackPdo;
+        $connection = $this->connection($pdo);
+        $connection->beginTransaction();
+
+        try {
+            $connection->rollBack();
+            $this->fail('Expected rollback exception was not thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(FailingRollbackPdo::$exception, $exception);
+        }
+
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+        $this->assertSame(1, $connection->transactionLevel());
+    }
+
+    public function testLostRollbackFailureInvalidatesWithoutTaintingTheDeadPdo(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new LostRollbackPdo;
+        $connection = $this->connection($pdo);
+        $connection->beginTransaction();
+
+        try {
+            $connection->rollBack();
+            $this->fail('Expected rollback exception was not thrown.');
+        } catch (PDOException $exception) {
+            $this->assertSame('server has gone away', $exception->getMessage());
+        }
+
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertFalse(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+        $this->assertSame(0, $connection->transactionLevel());
+    }
+
+    public function testDisconnectDoesNotResolveLazyPdosWithoutATransaction(): void
+    {
+        $writeResolutions = 0;
+        $readResolutions = 0;
+        $connection = $this->connection(function () use (&$writeResolutions): PDO {
+            ++$writeResolutions;
+
+            return $this->pdo();
+        });
+        $connection->setReadPdo(function () use (&$readResolutions): PDO {
+            ++$readResolutions;
+
+            return $this->pdo();
+        });
+
+        $connection->disconnect();
+
+        $this->assertSame(0, $writeResolutions);
+        $this->assertSame(0, $readResolutions);
+        $this->assertNull($connection->getRawPdo());
+        $this->assertNull($connection->getRawReadPdo());
+    }
+
+    public function testDisconnectRollbackInvalidatesStateRetainedByAnotherWrapper(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = $this->pdo();
+        $connection = $this->connection($pdo);
+        $otherConnection = $this->connection($pdo);
+        $connection->beginTransaction();
+
+        $connection->disconnect();
+        $otherConnection->getPdo();
+
+        $this->assertSame(2, $configurator->applyCalls);
+        $this->assertNull($connection->getRawPdo());
+        $this->assertNull($connection->getRawReadPdo());
+    }
+
+    public function testFailedDisconnectRollbackTaintsStateAndDropsWrapperReferences(): void
+    {
+        $configurator = $this->configurator();
+        Connection::configureSessionUsing($configurator);
+        $pdo = new FailingRollbackPdo;
+        $connection = $this->connection($pdo);
+        $connection->beginTransaction();
+        $readPdo = $this->pdo();
+        $connection->setReadPdo($readPdo);
+
+        try {
+            $connection->disconnect();
+            $this->fail('Expected rollback exception was not thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(FailingRollbackPdo::$exception, $exception);
+        }
+
+        $this->assertTrue(TestSessionConnection::sessionStateIsUnknownForTest($pdo));
+        $this->assertSame([], TestSessionConnection::appliedStatesForTest($pdo));
+        $this->assertNull($connection->getRawPdo());
+        $this->assertNull($connection->getRawReadPdo());
+    }
+
+    private function connection(PDO|Closure|null $pdo = null): TestSessionConnection
+    {
+        return new TestSessionConnection(
+            $pdo ?? $this->pdo(),
+            'test_database',
+            '',
+            ['name' => 'test', 'driver' => 'sqlite']
+        );
+    }
+
+    private function configurator(?string $state = 'state'): RecordingSessionConfigurator
+    {
+        return new RecordingSessionConfigurator($state);
+    }
+
+    private function pdo(): PDO
+    {
+        return new PDO('sqlite::memory:');
+    }
+}
+
+class RecordingSessionConfigurator implements SessionConfigurator
+{
+    public int $stateCalls = 0;
+
+    public int $applyCalls = 0;
+
+    /**
+     * @var string[]
+     */
+    public array $appliedStates = [];
+
+    public ?Closure $stateCallback = null;
+
+    public ?Closure $applyCallback = null;
+
+    public function __construct(
+        public ?string $desiredState,
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        ++$this->stateCalls;
+
+        return $this->stateCallback instanceof Closure
+            ? ($this->stateCallback)($connection)
+            : $this->desiredState;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        ++$this->applyCalls;
+        $this->appliedStates[] = $state;
+
+        if ($this->applyCallback instanceof Closure) {
+            ($this->applyCallback)($pdo, $state, $connection);
+        }
+    }
+}
+
+class TestSessionConnection extends Connection
+{
+    public function resolveWritePdo(): PDO
+    {
+        return $this->resolvePdo();
+    }
+
+    public function resolveReadPdoForTest(): PDO
+    {
+        return $this->resolveReadPdo();
+    }
+
+    public function markSessionStateUnknownForTest(PDO $pdo): void
+    {
+        $this->markSessionStateUnknown($pdo);
+    }
+
+    public static function physicalSessionStateCount(): ?int
+    {
+        return static::$physicalSessionStates === null
+            ? null
+            : count(static::$physicalSessionStates);
+    }
+
+    public static function sessionStateIsUnknownForTest(PDO $pdo): bool
+    {
+        return static::sessionStateIsUnknown($pdo);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function appliedStatesForTest(PDO $pdo): array
+    {
+        return static::$physicalSessionStates[$pdo]->appliedStates ?? [];
+    }
+
+    public function setTransactionLevelForTest(int $level): void
+    {
+        $this->transactions = $level;
+    }
+
+    public function handleTransactionExceptionForTest(Throwable $exception): void
+    {
+        $this->handleTransactionException($exception, 1, 1);
+    }
+}
+
+class CommitRetryPdo extends PDO
+{
+    public int $beginCalls = 0;
+
+    public int $commitCalls = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function beginTransaction(): bool
+    {
+        ++$this->beginCalls;
+
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        ++$this->commitCalls;
+
+        if ($this->commitCalls === 1) {
+            throw new StringCodePdoException('Serialization failure', '40001');
+        }
+
+        return true;
+    }
+}
+
+class TrackingPdo extends PDO
+{
+    public int $rollbackCalls = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function rollBack(): bool
+    {
+        ++$this->rollbackCalls;
+
+        return true;
+    }
+}
+
+class FailingCommitPdo extends PDO
+{
+    public static Exception $exception;
+
+    public function __construct()
+    {
+        static::$exception = new Exception('Commit failed.');
+    }
+
+    public function beginTransaction(): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        throw static::$exception;
+    }
+}
+
+class FailingRollbackPdo extends PDO
+{
+    public static Exception $exception;
+
+    public function __construct()
+    {
+        static::$exception = new Exception('Rollback failed.');
+    }
+
+    public function beginTransaction(): bool
+    {
+        return true;
+    }
+
+    public function inTransaction(): bool
+    {
+        return true;
+    }
+
+    public function rollBack(): bool
+    {
+        throw static::$exception;
+    }
+}
+
+class LostCommitPdo extends PDO
+{
+    public function __construct()
+    {
+    }
+
+    public function beginTransaction(): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        throw new PDOException('server has gone away');
+    }
+}
+
+class LostRollbackPdo extends PDO
+{
+    public function __construct()
+    {
+    }
+
+    public function beginTransaction(): bool
+    {
+        return true;
+    }
+
+    public function inTransaction(): bool
+    {
+        return true;
+    }
+
+    public function rollBack(): bool
+    {
+        throw new PDOException('server has gone away');
+    }
+}
+
+class StringCodePdoException extends PDOException
+{
+    public function __construct(string $message, string $code)
+    {
+        $this->message = $message;
+        $this->code = $code;
+    }
+}

--- a/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
+++ b/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Integration\Database;
 
+use Hypervel\Context\CoroutineContext;
 use Hypervel\Coroutine\WaitGroup;
 use Hypervel\Database\Connection;
 use Hypervel\Database\ConnectionResolverInterface;
 use Hypervel\Database\DatabaseManager;
 use Hypervel\Database\Eloquent\Model;
+use Hypervel\Database\Pool\DbPool;
+use Hypervel\Database\Pool\PooledConnection;
 use Hypervel\Database\Schema\Blueprint;
+use Hypervel\Database\SessionConfigurator;
 use Hypervel\Engine\Channel;
 use Hypervel\Filesystem\Filesystem;
 use Hypervel\Support\Facades\DB;
 use Hypervel\Support\Facades\Schema;
 use Hypervel\Testing\ParallelTesting;
+use PDO;
 use RuntimeException;
 use Throwable;
 
@@ -35,6 +40,8 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
 
     protected static string $writePath;
 
+    protected static string $sessionPath;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -45,8 +52,10 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
 
         static::$readPath = static::$databaseDirectory . '/read.sqlite';
         static::$writePath = static::$databaseDirectory . '/write.sqlite';
+        static::$sessionPath = static::$databaseDirectory . '/session.sqlite';
         touch(static::$readPath);
         touch(static::$writePath);
+        touch(static::$sessionPath);
     }
 
     public static function tearDownAfterClass(): void
@@ -60,6 +69,8 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
     {
         parent::defineEnvironment($app);
 
+        $app->make('config')->set('app.stdout_log.level', []);
+
         $app->make('config')->set('database.connections.sqlite_readwrite_pool', [
             'driver' => 'sqlite',
             'read' => [
@@ -71,6 +82,28 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
             'pool' => [
                 'testing_enabled' => true,
                 'max_connections' => 5,
+                'heartbeat' => -1,
+            ],
+        ]);
+
+        $app->make('config')->set('database.connections.session_context_pool', [
+            'driver' => 'sqlite',
+            'database' => static::$sessionPath,
+            'pool' => [
+                'testing_enabled' => true,
+                'min_connections' => 1,
+                'max_connections' => 1,
+                'heartbeat' => -1,
+            ],
+        ]);
+
+        $app->make('config')->set('database.connections.session_shared_pool', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'pool' => [
+                'testing_enabled' => true,
+                'min_connections' => 2,
+                'max_connections' => 2,
                 'heartbeat' => -1,
             ],
         ]);
@@ -390,6 +423,129 @@ class ConnectionCoroutineSafetyTest extends DatabaseTestCase
         $this->assertNotNull($manager, 'Pooled connection should have transaction manager configured');
     }
 
+    public function testSessionConfiguratorReadsCoroutineContextOnEachPooledHandOut(): void
+    {
+        $configurator = new CoroutineSessionConfigurator('session_context_pool');
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'session_context_pool');
+        $firstFinished = new Channel(1);
+
+        try {
+            [$firstValue, $secondValue] = parallel([
+                function () use ($pool, $firstFinished): int {
+                    CoroutineContext::set(CoroutineSessionConfigurator::CONTEXT_KEY, '101');
+
+                    /** @var PooledConnection $pooledConnection */
+                    $pooledConnection = $pool->get();
+
+                    try {
+                        return (int) $pooledConnection->getConnection()
+                            ->selectOne('PRAGMA user_version')
+                            ->user_version;
+                    } finally {
+                        $pooledConnection->release();
+                        $firstFinished->push(true);
+                    }
+                },
+                function () use ($pool, $firstFinished): int {
+                    $firstFinished->pop();
+                    CoroutineContext::set(CoroutineSessionConfigurator::CONTEXT_KEY, '202');
+
+                    /** @var PooledConnection $pooledConnection */
+                    $pooledConnection = $pool->get();
+
+                    try {
+                        return (int) $pooledConnection->getConnection()
+                            ->selectOne('PRAGMA user_version')
+                            ->user_version;
+                    } finally {
+                        $pooledConnection->release();
+                    }
+                },
+            ]);
+
+            CoroutineContext::set(CoroutineSessionConfigurator::CONTEXT_KEY, '202');
+            /** @var PooledConnection $matchingPooledConnection */
+            $matchingPooledConnection = $pool->get();
+
+            try {
+                $matchingValue = (int) $matchingPooledConnection->getConnection()
+                    ->selectOne('PRAGMA user_version')
+                    ->user_version;
+            } finally {
+                $matchingPooledConnection->release();
+            }
+
+            $this->assertSame(101, $firstValue);
+            $this->assertSame(202, $secondValue);
+            $this->assertSame(202, $matchingValue);
+            $this->assertSame(['101', '202'], $configurator->appliedStates);
+            $this->assertSame(3, $configurator->stateCalls);
+            $this->assertSame(2, $configurator->applyCalls);
+        } finally {
+            $pool->close();
+        }
+    }
+
+    public function testOverlappingConfigurationOfSharedPdoFailsClosedForBothCallers(): void
+    {
+        $configurator = new CoroutineSessionConfigurator('session_shared_pool');
+        Connection::configureSessionUsing($configurator);
+        CoroutineContext::set(CoroutineSessionConfigurator::CONTEXT_KEY, '0');
+        $pool = new DbPool($this->app, 'session_shared_pool');
+        $configurationStarted = new Channel(1);
+        $resumeConfiguration = new Channel(1);
+        $configurator->blockedState = '101';
+        $configurator->configurationStarted = $configurationStarted;
+        $configurator->resumeConfiguration = $resumeConfiguration;
+
+        try {
+            [$firstFailure, $secondFailure] = parallel([
+                function () use ($pool): string {
+                    CoroutineContext::set(CoroutineSessionConfigurator::CONTEXT_KEY, '101');
+
+                    /** @var PooledConnection $pooledConnection */
+                    $pooledConnection = $pool->get();
+
+                    try {
+                        $pooledConnection->getConnection()->getPdo();
+
+                        return 'no failure';
+                    } catch (RuntimeException $exception) {
+                        return $exception->getMessage();
+                    } finally {
+                        $pooledConnection->release();
+                    }
+                },
+                function () use ($pool, $configurationStarted, $resumeConfiguration): string {
+                    $configurationStarted->pop();
+                    CoroutineContext::set(CoroutineSessionConfigurator::CONTEXT_KEY, '202');
+
+                    /** @var PooledConnection $pooledConnection */
+                    $pooledConnection = $pool->get();
+
+                    try {
+                        $pooledConnection->getConnection()->getPdo();
+
+                        return 'no failure';
+                    } catch (RuntimeException $exception) {
+                        return $exception->getMessage();
+                    } finally {
+                        $resumeConfiguration->push(true);
+                        $pooledConnection->release();
+                    }
+                },
+            ]);
+
+            $this->assertSame('Database session state became unknown during configuration.', $firstFailure);
+            $this->assertSame('Reentrant database session configuration is not allowed.', $secondFailure);
+            $this->assertSame(['0', '101'], $configurator->appliedStates);
+            $this->assertSame(2, $configurator->applyCalls);
+        } finally {
+            $pool->close();
+        }
+    }
+
     public function testWriteSuffixDoesNotForcePlainConnectionReadsInAnotherCoroutine(): void
     {
         $this->seedReadWritePoolMarkers();
@@ -463,4 +619,51 @@ class UnguardedTestUser extends Model
     protected array $fillable = ['name', 'email'];
 
     public static array $eventLog = [];
+}
+
+class CoroutineSessionConfigurator implements SessionConfigurator
+{
+    public const CONTEXT_KEY = '__database.session_configurator_test';
+
+    public int $stateCalls = 0;
+
+    public int $applyCalls = 0;
+
+    /**
+     * @var string[]
+     */
+    public array $appliedStates = [];
+
+    public ?string $blockedState = null;
+
+    public ?Channel $configurationStarted = null;
+
+    public ?Channel $resumeConfiguration = null;
+
+    public function __construct(
+        private readonly string $connectionName,
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        ++$this->stateCalls;
+
+        return $connection->getName() === $this->connectionName
+            ? CoroutineContext::get(self::CONTEXT_KEY, '0')
+            : null;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        ++$this->applyCalls;
+        $this->appliedStates[] = $state;
+
+        if ($state === $this->blockedState) {
+            $this->configurationStarted?->push(true);
+            $this->resumeConfiguration?->pop();
+        }
+
+        $pdo->exec('PRAGMA user_version = ' . (int) $state);
+    }
 }

--- a/tests/Integration/Database/PooledConnectionTest.php
+++ b/tests/Integration/Database/PooledConnectionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Integration\Database;
 
+use Closure;
+use Exception;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Database\Connection;
@@ -11,6 +13,7 @@ use Hypervel\Database\Connectors\ConnectionFactory;
 use Hypervel\Database\Events\ConnectionEstablished;
 use Hypervel\Database\Pool\DbPool;
 use Hypervel\Database\Pool\PooledConnection;
+use Hypervel\Database\SessionConfigurator;
 use Hypervel\Database\SQLiteConnection;
 use Hypervel\Filesystem\Filesystem;
 use Hypervel\Pool\Events\ReleaseConnection;
@@ -19,6 +22,7 @@ use Hypervel\Testing\ParallelTesting;
 use InvalidArgumentException;
 use PDO;
 use ReflectionProperty;
+use RuntimeException;
 
 /**
  * Tests for PooledConnection — the adapter that wraps a database Connection
@@ -379,6 +383,377 @@ class PooledConnectionTest extends DatabaseTestCase
         $newPooledConnection->release();
     }
 
+    public function testCleanReleasePreservesMatchingPhysicalSessionState(): void
+    {
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $firstPooledConnection = $pooledConnection;
+            $connection = $firstPooledConnection->getConnection();
+            $pdo = $connection->getPdo();
+            $applyCalls = $configurator->applyCalls;
+            $pooledConnection->release();
+            $pooledConnection = null;
+
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $nextConnection = $pooledConnection->getConnection();
+
+            $this->assertSame($firstPooledConnection, $pooledConnection);
+            $this->assertSame($connection, $nextConnection);
+            $this->assertSame($pdo, $nextConnection->getPdo());
+            $this->assertSame($applyCalls, $configurator->applyCalls);
+
+            $configurator->desiredState = 'changed';
+            $nextConnection->getPdo();
+
+            $this->assertSame($applyCalls + 1, $configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
+    public function testAbandonedTransactionRollbackInvalidatesPhysicalSessionState(): void
+    {
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $connection->beginTransaction();
+            $applyCalls = $configurator->applyCalls;
+            $pooledConnection->release();
+            $pooledConnection = null;
+
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $pooledConnection->getConnection()->getPdo();
+
+            $this->assertSame($applyCalls + 1, $configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
+    public function testUnknownSessionIsMarkedInvalidAtFinalReleaseBoundary(): void
+    {
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $configurator->desiredState = 'fail';
+            $configurator->applyCallback = static fn () => throw new Exception('Configuration failed.');
+
+            try {
+                $pooledConnection->getConnection()->getPdo();
+                $this->fail('Expected configuration exception was not thrown.');
+            } catch (Exception $exception) {
+                $this->assertSame('Configuration failed.', $exception->getMessage());
+            }
+
+            $releasedConnection = $pooledConnection;
+            $pooledConnection->release();
+            $pooledConnection = null;
+
+            $this->assertTrue($this->isInvalid($releasedConnection));
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
+    public function testUnknownReadSessionIsDetectedWithoutResolvingUnopenedPdos(): void
+    {
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $readPdo = new PDO('sqlite::memory:');
+            $connection->setReadPdo($readPdo);
+            $configurator->desiredState = 'fail';
+            $configurator->applyCallback = static fn () => throw new Exception('Configuration failed.');
+
+            try {
+                $connection->getReadPdo();
+                $this->fail('Expected configuration exception was not thrown.');
+            } catch (Exception) {
+            }
+
+            $connection->setPdo(static fn () => throw new Exception('Write PDO must not be resolved.'));
+            $releasedConnection = $pooledConnection;
+            $pooledConnection->release();
+            $pooledConnection = null;
+
+            $this->assertTrue($this->isInvalid($releasedConnection));
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
+    public function testUnknownStateCaughtByReleaseListenerIsStillMarkedInvalid(): void
+    {
+        $this->app->make('config')->set('database.connections.pool_test.pool.events', [
+            ReleaseConnection::class,
+        ]);
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+        $configurator->desiredState = 'fail';
+        $configurator->applyCallback = static fn () => throw new Exception('Configuration failed.');
+        $this->app->make(Dispatcher::class)->listen(
+            ReleaseConnection::class,
+            static function (ReleaseConnection $event): void {
+                try {
+                    $event->connection->getConnection()->getPdo();
+                } catch (Exception) {
+                }
+            }
+        );
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $releasedConnection = $pooledConnection;
+            $pooledConnection->release();
+            $pooledConnection = null;
+
+            $this->assertTrue($this->isInvalid($releasedConnection));
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
+    public function testInvalidNormalConnectionReconnectsAndConfiguresAFreshPdo(): void
+    {
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('PooledConnectionTest-session-reconnect');
+        $filesystem->ensureDirectoryExists($directory);
+        $databasePath = $directory . '/database.sqlite';
+        touch($databasePath);
+        $this->app->make('config')->set('database.connections.session_reconnect_test', [
+            'driver' => 'sqlite',
+            'database' => $databasePath,
+            'prefix' => '',
+            'pool' => [
+                'min_connections' => 1,
+                'max_connections' => 1,
+                'heartbeat' => -1,
+            ],
+        ]);
+        $configurator = new PoolSessionConfigurator('session_reconnect_test');
+        $configurator->applyCallback = static fn () => throw new Exception('Configuration failed.');
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'session_reconnect_test');
+        $pooledConnection = null;
+
+        try {
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $connection = $pooledConnection->getConnection();
+
+            try {
+                $connection->getPdo();
+                $this->fail('Expected configuration exception was not thrown.');
+            } catch (Exception) {
+            }
+
+            $oldPdo = $connection->getRawPdo();
+            $firstPooledConnection = $pooledConnection;
+            $pooledConnection->release();
+            $pooledConnection = null;
+            $configurator->desiredState = 'recovered';
+            $configurator->applyCallback = null;
+
+            /** @var PooledConnection $nextPooledConnection */
+            $nextPooledConnection = $pool->get();
+            $pooledConnection = $nextPooledConnection;
+            $newPdo = $nextPooledConnection->getConnection()->getPdo();
+
+            $this->assertSame($firstPooledConnection, $nextPooledConnection);
+            $this->assertNotSame($oldPdo, $newPdo);
+            $this->assertSame(2, $configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+            $filesystem->deleteDirectory($directory);
+        }
+    }
+
+    public function testFailedRefreshPreservesTheCurrentGenerationAndMarksItInvalid(): void
+    {
+        $filesystem = new Filesystem;
+        $directory = ParallelTesting::tempDir('PooledConnectionTest-session-refresh-failure');
+        $filesystem->ensureDirectoryExists($directory);
+        $databasePath = $directory . '/database.sqlite';
+        touch($databasePath);
+        $this->app->make('config')->set('database.connections.session_refresh_failure_test', [
+            'driver' => 'sqlite',
+            'database' => $databasePath,
+            'prefix' => '',
+            'pool' => [
+                'min_connections' => 1,
+                'max_connections' => 1,
+                'heartbeat' => -1,
+            ],
+        ]);
+        $configurator = new PoolSessionConfigurator('session_refresh_failure_test');
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'session_refresh_failure_test');
+        $pooledConnection = null;
+
+        try {
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $connection = $pooledConnection->getConnection();
+            $oldPdo = $connection->getPdo();
+            $configurationException = new Exception('Replacement configuration failed.');
+            $configurator->desiredState = 'failed-refresh';
+            $configurator->applyCallback = static fn () => throw $configurationException;
+
+            try {
+                $connection->getPdo();
+                $this->fail('Expected existing-session configuration exception was not thrown.');
+            } catch (Exception $exception) {
+                $this->assertSame($configurationException, $exception);
+            }
+
+            try {
+                $connection->getPdo();
+                $this->fail('Expected replacement configuration exception was not thrown.');
+            } catch (Exception $exception) {
+                $this->assertSame($configurationException, $exception);
+            }
+
+            $this->assertSame($oldPdo, $connection->getRawPdo());
+            $this->assertNull($connection->getRawReadPdo());
+            $this->assertTrue($this->isInvalid($pooledConnection));
+
+            $firstPooledConnection = $pooledConnection;
+            $pooledConnection->release();
+            $pooledConnection = null;
+            $configurator->desiredState = 'recovered';
+            $configurator->applyCallback = null;
+
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $newPdo = $pooledConnection->getConnection()->getPdo();
+
+            $this->assertSame($firstPooledConnection, $pooledConnection);
+            $this->assertNotSame($oldPdo, $newPdo);
+            $this->assertSame(4, $configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+            $filesystem->deleteDirectory($directory);
+        }
+    }
+
+    public function testSharedInMemorySqliteUnknownRecoveryIsBoundedAndFailsClosed(): void
+    {
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $sharedPdo = $connection->getPdo();
+            $configurator->desiredState = 'fail';
+            $configurator->applyCallback = static fn () => throw new Exception('Configuration failed.');
+
+            try {
+                $connection->getPdo();
+                $this->fail('Expected configuration exception was not thrown.');
+            } catch (Exception) {
+            }
+
+            $pooledConnection->release();
+            $pooledConnection = null;
+            $configurator->applyCallback = null;
+
+            /** @var PooledConnection $pooledConnection */
+            $pooledConnection = $pool->get();
+            $replacementConnection = $pooledConnection->getConnection();
+            $connectionEstablished = 0;
+            $this->app->make(Dispatcher::class)->listen(
+                ConnectionEstablished::class,
+                static function () use (&$connectionEstablished): void {
+                    ++$connectionEstablished;
+                }
+            );
+
+            try {
+                $replacementConnection->getPdo();
+                $this->fail('Expected unknown session exception was not thrown.');
+            } catch (RuntimeException $exception) {
+                $this->assertSame('Database session state remains unknown after reconnecting.', $exception->getMessage());
+            }
+
+            $this->assertSame($sharedPdo, $replacementConnection->getRawPdo());
+            $this->assertSame(1, $connectionEstablished);
+            $this->assertSame(2, $configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
+    public function testHeartbeatDoesNotComputeOrInvalidateSessionState(): void
+    {
+        $configurator = new PoolSessionConfigurator;
+        Connection::configureSessionUsing($configurator);
+        $pool = new DbPool($this->app, 'pool_test');
+        $stateCallsAfterCreation = $configurator->stateCalls;
+        $applyCallsAfterCreation = $configurator->applyCalls;
+
+        /** @var PooledConnection $pooledConnection */
+        $pooledConnection = $pool->get();
+
+        try {
+            $pooledConnection->getConnection()->getPdo();
+            $stateCallsBeforePing = $configurator->stateCalls;
+            $applyCallsBeforePing = $configurator->applyCalls;
+
+            $this->assertGreaterThanOrEqual($stateCallsAfterCreation, $stateCallsBeforePing);
+            $this->assertSame($applyCallsAfterCreation, $applyCallsBeforePing);
+            $this->assertTrue($pooledConnection->ping(1.0));
+            $this->assertSame($stateCallsBeforePing, $configurator->stateCalls);
+            $this->assertSame($applyCallsBeforePing, $configurator->applyCalls);
+
+            $pooledConnection->getConnection()->getPdo();
+            $this->assertSame($stateCallsBeforePing + 1, $configurator->stateCalls);
+            $this->assertSame($applyCallsBeforePing, $configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+            $pool->close();
+        }
+    }
+
     public function testReleaseDispatchesReleaseEventWhenConfigured(): void
     {
         $this->app->make('config')->set('database.connections.pool_test.pool.events', [
@@ -731,5 +1106,44 @@ class PooledConnectionTest extends DatabaseTestCase
     private function ageActiveConnectionUse(PooledConnection $connection): void
     {
         (new ReflectionProperty(PooledConnection::class, 'lastUseTime'))->setValue($connection, hrtime(true) / 1e9 - 5.0);
+    }
+
+    private function isInvalid(PooledConnection $connection): bool
+    {
+        return (new ReflectionProperty(PooledConnection::class, 'invalid'))->getValue($connection);
+    }
+}
+
+class PoolSessionConfigurator implements SessionConfigurator
+{
+    public string $desiredState = 'state';
+
+    public int $stateCalls = 0;
+
+    public int $applyCalls = 0;
+
+    public ?Closure $applyCallback = null;
+
+    public function __construct(
+        private readonly string $connectionName = 'pool_test',
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        ++$this->stateCalls;
+
+        return $connection->getName() === $this->connectionName
+            ? $this->desiredState
+            : null;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        ++$this->applyCalls;
+
+        if ($this->applyCallback instanceof Closure) {
+            ($this->applyCallback)($pdo, $state, $connection);
+        }
     }
 }

--- a/tests/Integration/Database/Postgres/SessionConfiguratorTest.php
+++ b/tests/Integration/Database/Postgres/SessionConfiguratorTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Database\Postgres;
+
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Database\Connection;
+use Hypervel\Database\Connectors\ConnectionFactory;
+use Hypervel\Database\Pool\DbPool;
+use Hypervel\Database\Pool\PooledConnection;
+use Hypervel\Database\QueryException;
+use Hypervel\Database\SessionConfigurator;
+use PDO;
+use RuntimeException;
+
+class SessionConfiguratorTest extends PostgresTestCase
+{
+    private const CONNECTION_NAME = 'postgres_session_configurator_test';
+
+    private DbPool $sessionPool;
+
+    private PostgresSessionConfigurator $configurator;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $postgresConfig;
+
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        $config = $app->make('config');
+        $config->set('app.stdout_log.level', []);
+        $defaultConnection = $config->get('database.default');
+        $this->postgresConfig = $config->get("database.connections.{$defaultConnection}");
+        $connectionConfig = $this->postgresConfig;
+        $connectionConfig['pool'] = [
+            'testing_enabled' => true,
+            'min_connections' => 1,
+            'max_connections' => 1,
+            'heartbeat' => -1,
+        ];
+
+        $config->set('database.connections.' . self::CONNECTION_NAME, $connectionConfig);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new PostgresSessionConfigurator(self::CONNECTION_NAME);
+        Connection::configureSessionUsing($this->configurator);
+        $this->sessionPool = new DbPool($this->app, self::CONNECTION_NAME);
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            if (isset($this->sessionPool)) {
+                $this->sessionPool->close();
+            }
+        } finally {
+            parent::tearDown();
+        }
+    }
+
+    public function testSessionStateEstablishedBeforeTransactionPersistsAfterCommit(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $pdo = $connection->getPdo();
+            $connection->beginTransaction();
+            $connection->commit();
+
+            $this->assertSame('outside', $this->configurator->read($pdo));
+            $this->assertSame($pdo, $connection->getPdo());
+            $this->assertSame(1, $this->configurator->applyCalls);
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testFullRollbackRevertsTransactionalStateAndFrameworkReappliesIt(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $pdo = $connection->getPdo();
+            $connection->beginTransaction();
+            $this->configurator->desiredState = 'inside';
+
+            $this->assertSame('inside', $this->configurator->readThrough($connection));
+
+            $connection->rollBack();
+
+            $this->assertSame('outside', $this->configurator->read($pdo));
+            $this->assertSame('inside', $this->configurator->readThrough($connection));
+            $this->assertSame(['outside', 'inside', 'inside'], $this->configurator->appliedStates);
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testSavepointRollbackRevertsLaterStateAndFrameworkReappliesIt(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $pdo = $connection->getPdo();
+            $connection->beginTransaction();
+            $this->configurator->desiredState = 'before_savepoint';
+            $this->assertSame('before_savepoint', $this->configurator->readThrough($connection));
+            $connection->beginTransaction();
+            $this->configurator->desiredState = 'after_savepoint';
+            $this->assertSame('after_savepoint', $this->configurator->readThrough($connection));
+
+            $connection->rollBack(1);
+
+            $this->assertSame('before_savepoint', $this->configurator->read($pdo));
+            $this->assertSame('after_savepoint', $this->configurator->readThrough($connection));
+            $connection->rollBack();
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testRollbackRecoversAnAbortedTransactionWithoutInvokingConfigurator(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $pdo = $connection->getPdo();
+            $connection->beginTransaction();
+            $this->configurator->desiredState = 'inside';
+            $this->assertSame('inside', $this->configurator->readThrough($connection));
+
+            try {
+                $connection->statement('select * from hypervel_missing_session_table');
+                $this->fail('Expected query exception was not thrown.');
+            } catch (QueryException) {
+            }
+
+            $this->configurator->desiredState = 'after_rollback';
+            $stateCallsBeforeRollback = $this->configurator->stateCalls;
+            $connection->rollBack();
+
+            $this->assertSame($stateCallsBeforeRollback, $this->configurator->stateCalls);
+            $this->assertSame('outside', $this->configurator->read($pdo));
+            $this->assertSame('after_rollback', $this->configurator->readThrough($connection));
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testEmptyStateIsAppliedAsARealValue(): void
+    {
+        $this->configurator->desiredState = '';
+        $pooledConnection = $this->borrow();
+
+        try {
+            $this->assertSame('', $this->configurator->readThrough($pooledConnection->getConnection()));
+            $this->assertSame(1, $this->configurator->applyCalls);
+            $this->assertSame([''], $this->configurator->appliedStates);
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testDeadIdlePdoReconnectsWhenConfigurationIsTheFirstFailingSql(): void
+    {
+        $pooledConnection = $this->borrow();
+        $connection = $pooledConnection->getConnection();
+        $targetPdo = $connection->getPdo();
+        $targetPid = (int) $connection->scalar('select pg_backend_pid()', useReadPdo: false);
+        $pooledConnection->release();
+        $pooledConnection = null;
+
+        /** @var ConnectionFactory $factory */
+        $factory = $this->app->make('db.factory');
+        $adminConnection = $factory->make($this->postgresConfig, 'postgres_session_configurator_admin');
+        $adminPdo = $adminConnection->getPdo();
+
+        try {
+            $statement = $adminPdo->prepare('select pg_terminate_backend(?)');
+            $statement->execute([$targetPid]);
+            $this->assertTrue((bool) $statement->fetchColumn());
+            $statement->closeCursor();
+            $this->configurator->desiredState = 'after_reconnect';
+
+            $pooledConnection = $this->borrow();
+            $connection = $pooledConnection->getConnection();
+            $this->assertSame('after_reconnect', $this->configurator->readThrough($connection));
+            $replacementPdo = $connection->getRawPdo();
+            $replacementPid = (int) $connection->scalar('select pg_backend_pid()', useReadPdo: false);
+
+            $this->assertInstanceOf(PDO::class, $replacementPdo);
+            $this->assertNotSame($targetPdo, $replacementPdo);
+            $this->assertNotSame($targetPid, $replacementPid);
+            $this->assertSame(3, $this->configurator->applyCalls);
+            $this->assertSame(1, $connection->getErrorCount());
+        } finally {
+            if ($pooledConnection instanceof PooledConnection) {
+                $pooledConnection->release();
+            }
+
+            $adminConnection->disconnect();
+        }
+    }
+
+    private function borrow(): PooledConnection
+    {
+        /** @var PooledConnection $pooledConnection */
+        return $this->sessionPool->get();
+    }
+}
+
+class PostgresSessionConfigurator implements SessionConfigurator
+{
+    public string $desiredState = 'outside';
+
+    public int $stateCalls = 0;
+
+    public int $applyCalls = 0;
+
+    /**
+     * @var string[]
+     */
+    public array $appliedStates = [];
+
+    public function __construct(
+        private readonly string $connectionName,
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        if ($connection->getName() !== $this->connectionName) {
+            return null;
+        }
+
+        ++$this->stateCalls;
+
+        return $this->desiredState;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        ++$this->applyCalls;
+        $this->appliedStates[] = $state;
+        $statement = $pdo->prepare("select set_config('hypervel_test.context', ?, false)");
+        $statement->execute([$state]);
+        $statement->closeCursor();
+    }
+
+    public function readThrough(Connection $connection): string
+    {
+        return (string) $connection->scalar(
+            "select current_setting('hypervel_test.context', true)",
+            useReadPdo: false
+        );
+    }
+
+    public function read(PDO $pdo): string
+    {
+        $statement = $pdo->query("select current_setting('hypervel_test.context', true)");
+
+        if ($statement === false) {
+            throw new RuntimeException('Unable to read the PostgreSQL session state.');
+        }
+
+        try {
+            return (string) $statement->fetchColumn();
+        } finally {
+            $statement->closeCursor();
+        }
+    }
+}

--- a/tests/Integration/Database/SessionConfiguratorTest.php
+++ b/tests/Integration/Database/SessionConfiguratorTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Database;
+
+use Closure;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Database\Connection;
+use Hypervel\Database\Events\QueryExecuted;
+use Hypervel\Database\Events\StatementPrepared;
+use Hypervel\Database\Pool\DbPool;
+use Hypervel\Database\Pool\PooledConnection;
+use Hypervel\Database\SessionConfigurator;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Testing\ParallelTesting;
+use InvalidArgumentException;
+use PDO;
+
+class SessionConfiguratorTest extends DatabaseTestCase
+{
+    private const CONNECTION_NAME = 'session_configurator_test';
+
+    private DbPool $sessionPool;
+
+    private CrossDriverSessionConfigurator $configurator;
+
+    private ?string $sqliteDirectory = null;
+
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        $config = $app->make('config');
+        $defaultConnection = $config->get('database.default');
+        $connectionConfig = $config->get("database.connections.{$defaultConnection}");
+
+        if (($connectionConfig['driver'] ?? null) === 'sqlite') {
+            $filesystem = new Filesystem;
+            $this->sqliteDirectory = ParallelTesting::tempDir('SessionConfiguratorTest');
+            $filesystem->ensureDirectoryExists($this->sqliteDirectory);
+            $connectionConfig['database'] = $this->sqliteDirectory . '/session.sqlite';
+            touch($connectionConfig['database']);
+        }
+
+        $connectionConfig['pool'] = [
+            'testing_enabled' => true,
+            'min_connections' => 1,
+            'max_connections' => 1,
+            'heartbeat' => -1,
+        ];
+
+        $config->set('database.connections.' . self::CONNECTION_NAME, $connectionConfig);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new CrossDriverSessionConfigurator(self::CONNECTION_NAME, $this->driver);
+        Connection::configureSessionUsing($this->configurator);
+        $this->sessionPool = new DbPool($this->app, self::CONNECTION_NAME);
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            if (isset($this->sessionPool)) {
+                $this->sessionPool->close();
+            }
+        } finally {
+            parent::tearDown();
+
+            if ($this->sqliteDirectory !== null) {
+                (new Filesystem)->deleteDirectory($this->sqliteDirectory);
+            }
+        }
+    }
+
+    public function testFirstUseMatchingStateAndChangedStateHaveExactApplyCounts(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+
+            $this->assertSame('101', $this->configurator->readThrough($connection));
+            $this->assertSame(1, $this->configurator->stateCalls);
+            $this->assertSame(1, $this->configurator->applyCalls);
+
+            $this->assertSame('101', $this->configurator->readThrough($connection));
+            $this->assertSame(2, $this->configurator->stateCalls);
+            $this->assertSame(1, $this->configurator->applyCalls);
+
+            $this->configurator->desiredState = '202';
+
+            $this->assertSame('202', $this->configurator->readThrough($connection));
+            $this->assertSame(3, $this->configurator->stateCalls);
+            $this->assertSame(2, $this->configurator->applyCalls);
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testCleanReleasePreservesMatchingMemoAndChangedStateAppliesOnReborrow(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $firstPooledConnection = $pooledConnection;
+            $firstConnection = $firstPooledConnection->getConnection();
+            $firstPdo = $firstConnection->getPdo();
+            $this->assertSame('101', $this->configurator->read($firstPdo));
+            $pooledConnection->release();
+            $pooledConnection = null;
+
+            $pooledConnection = $this->borrow();
+            $secondConnection = $pooledConnection->getConnection();
+
+            $this->assertSame($firstPooledConnection, $pooledConnection);
+            $this->assertSame($firstConnection, $secondConnection);
+            $this->assertSame($firstPdo, $secondConnection->getPdo());
+            $this->assertSame(1, $this->configurator->applyCalls);
+
+            $pooledConnection->release();
+            $pooledConnection = null;
+            $this->configurator->desiredState = '202';
+            $pooledConnection = $this->borrow();
+            $secondConnection = $pooledConnection->getConnection();
+
+            $this->assertSame('202', $this->configurator->readThrough($secondConnection));
+            $this->assertSame(2, $this->configurator->applyCalls);
+        } finally {
+            $pooledConnection?->release();
+        }
+    }
+
+    public function testFullRollbackConservativelyInvalidatesAndReappliesState(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $connection->beginTransaction();
+            $this->assertSame('101', $this->configurator->readThrough($connection));
+            $this->assertSame(1, $this->configurator->applyCalls);
+
+            $connection->rollBack();
+
+            $this->assertSame('101', $this->configurator->readThrough($connection));
+            $this->assertSame(2, $this->configurator->applyCalls);
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testPublicPdoHandOutSynchronizesAndRawAccessDoesNot(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+
+            $this->assertInstanceOf(Closure::class, $connection->getRawPdo());
+            $this->assertSame(0, $this->configurator->stateCalls);
+            $this->assertSame(0, $this->configurator->applyCalls);
+
+            $pdo = $connection->getPdo();
+            $this->assertSame('101', $this->configurator->read($pdo));
+            $this->assertSame(1, $this->configurator->applyCalls);
+
+            $this->configurator->desiredState = '202';
+            $this->assertSame('101', $this->configurator->read($connection->getRawPdo()));
+            $this->assertSame(1, $this->configurator->applyCalls);
+
+            $this->assertSame('202', $this->configurator->read($connection->getPdo()));
+            $this->assertSame(2, $this->configurator->applyCalls);
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    public function testConfigurationSqlDoesNotCreateIndependentFrameworkInstrumentation(): void
+    {
+        $pooledConnection = $this->borrow();
+
+        try {
+            $connection = $pooledConnection->getConnection();
+            $preparedStatements = 0;
+            $executedQueries = 0;
+            $events = $connection->getEventDispatcher();
+            $events?->listen(StatementPrepared::class, static function () use (&$preparedStatements): void {
+                ++$preparedStatements;
+            });
+            $events?->listen(QueryExecuted::class, static function () use (&$executedQueries): void {
+                ++$executedQueries;
+            });
+            $connection->enableQueryLog();
+
+            $this->assertSame('101', $this->configurator->readThrough($connection));
+
+            $this->assertSame(1, $this->configurator->applyCalls);
+            $this->assertSame(1, $preparedStatements);
+            $this->assertSame(1, $executedQueries);
+            $this->assertCount(1, $connection->getQueryLog());
+        } finally {
+            $pooledConnection->release();
+        }
+    }
+
+    private function borrow(): PooledConnection
+    {
+        /** @var PooledConnection $pooledConnection */
+        return $this->sessionPool->get();
+    }
+}
+
+class CrossDriverSessionConfigurator implements SessionConfigurator
+{
+    public string $desiredState = '101';
+
+    public int $stateCalls = 0;
+
+    public int $applyCalls = 0;
+
+    public function __construct(
+        private readonly string $connectionName,
+        private readonly string $driver,
+    ) {
+    }
+
+    public function state(Connection $connection): ?string
+    {
+        if ($connection->getName() !== $this->connectionName) {
+            return null;
+        }
+
+        ++$this->stateCalls;
+
+        return $this->desiredState;
+    }
+
+    public function apply(PDO $pdo, string $state, Connection $connection): void
+    {
+        ++$this->applyCalls;
+
+        match ($this->driver) {
+            'pgsql' => $this->execute($pdo, "select set_config('hypervel_test.context', ?, false)", $state),
+            'mysql', 'mariadb' => $this->execute($pdo, 'set @hypervel_test_context := ?', $state),
+            'sqlite' => $this->configureSqlite($pdo, $state),
+            default => throw new InvalidArgumentException("Unsupported test database driver [{$this->driver}]."),
+        };
+    }
+
+    public function readThrough(Connection $connection): string
+    {
+        return match ($this->driver) {
+            'pgsql' => (string) $connection->scalar(
+                "select current_setting('hypervel_test.context', true)",
+                useReadPdo: false
+            ),
+            'mysql', 'mariadb' => (string) $connection->scalar(
+                'select @hypervel_test_context',
+                useReadPdo: false
+            ),
+            'sqlite' => (string) $connection->scalar('PRAGMA cache_size', useReadPdo: false),
+            default => throw new InvalidArgumentException("Unsupported test database driver [{$this->driver}]."),
+        };
+    }
+
+    public function read(PDO|Closure|null $pdo): string
+    {
+        if (! $pdo instanceof PDO) {
+            throw new InvalidArgumentException('Expected an already-resolved PDO.');
+        }
+
+        $statement = $pdo->query(match ($this->driver) {
+            'pgsql' => "select current_setting('hypervel_test.context', true)",
+            'mysql', 'mariadb' => 'select @hypervel_test_context',
+            'sqlite' => 'PRAGMA cache_size',
+            default => throw new InvalidArgumentException("Unsupported test database driver [{$this->driver}]."),
+        });
+
+        if ($statement === false) {
+            throw new InvalidArgumentException('Unable to read the native database session state.');
+        }
+
+        try {
+            return (string) $statement->fetchColumn();
+        } finally {
+            $statement->closeCursor();
+        }
+    }
+
+    private function execute(PDO $pdo, string $query, string $state): void
+    {
+        $statement = $pdo->prepare($query);
+        $statement->execute([$state]);
+        $statement->closeCursor();
+    }
+
+    private function configureSqlite(PDO $pdo, string $state): void
+    {
+        $value = filter_var($state, FILTER_VALIDATE_INT);
+
+        if ($value === false) {
+            throw new InvalidArgumentException('SQLite session test state must be an integer.');
+        }
+
+        $pdo->exec("PRAGMA cache_size = {$value}");
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a generic database session configuration API for Hypervel's long-lived pooled workers. Packages and applications can now declare the complete session state required by the current coroutine, and Hypervel applies that state to the exact physical PDO before it is handed to application code.

For more details, see: docs/plans/2026-07-22-physical-database-session-configuration.md

The implementation is driver-neutral. PostgreSQL row-level-security settings are the first known consumer, but the database layer has no tenancy, role, or GUC-specific behavior.

## Motivation

A pooled `Connection` wrapper and a physical database session have different lifetimes. One coroutine can retain a wrapper while its logical context changes, and the same physical PDO can later be reused by another request or job. Session settings therefore cannot be treated as request state or cached on the wrapper.

The existing query hooks are not a safe boundary for this work. They run before reconnect and are not replayed by the direct lost-connection retry path. They also do not cover the supported `getPdo()->query()` form.

This change puts synchronization at the public PDO hand-out boundary instead. Every normal database operation already resolves its PDO there, including retried operations.

## Design

### Configurator contract

`SessionConfigurator` has two methods:

- `state(Connection): ?string` returns an opaque identity for the complete desired state. `null` means the configurator does not apply to that connection.
- `apply(PDO, string, Connection): void` establishes that complete state directly on the given physical PDO.

Configurators are registered during worker boot with `Connection::configureSessionUsing()`. Registration is ordered and appending, matching Hypervel's existing `...Using()` APIs. Configurators may read coroutine-local context lazily, but they must remain safe to share for the worker lifetime.

### Physical session identity

Applied state is stored in a lazy `WeakMap` keyed by exact PDO identity. This gives read and write sessions independent state, lets wrappers that share a PDO share one memo, and removes state automatically when a PDO is collected.

The map is never allocated when no configurator is registered.

### Execution boundary

`getPdo()` and `getReadPdo()` now return synchronized PDOs. Internal raw resolvers handle transaction control without invoking configurators.

Outer `BEGIN` remains synchronized so session state is established before the transaction starts. Commit, rollback, savepoint creation, and rollback to savepoint use the raw resolved PDO. This is required for PostgreSQL recovery: configuration SQL cannot run while a transaction is aborted.

Raw getters and already-retained PDO handles remain explicit escape hatches. Hypervel does not proxy PDO or parse application SQL.

### Transaction lifecycle

Successful commit preserves the memo because session-level state survives commit. Rollback and failed commit invalidate it because PostgreSQL can revert session settings at transaction or savepoint boundaries.

Ambiguous failures mark the exact PDO as unknown. Failed configuration and reentrant or overlapping configuration also mark it unknown. Unknown sessions are never returned to application code or released back to the pool as healthy.

The implementation composes with the existing lost-connection and concurrency retry paths. It does not add another retry system.

### Pool lifecycle

Clean pool release resets wrapper state but preserves truthful physical-session state. A same-state release and reborrow therefore adds no configuration SQL.

Pool release checks resolved read and write PDOs for unknown state and marks the adapter stale when needed. Heartbeat SQL remains raw and session-state-neutral.

Normal refresh now prepares both replacement PDOs before disconnecting or mutating the active wrapper. Connector or configurator failure leaves the current generation intact, marks the adapter invalid, and rethrows the original error. This also closes an existing path that could leave a wrapper with null or partially swapped PDOs.

Shared in-memory SQLite remains deliberately fail-closed when reconnect returns the same unknown PDO. Hypervel does not destroy and recreate the in-memory database to hide that state.

## Performance

With no configurators, the public hand-out path adds one predictable empty-list check and allocates no session-state objects.

With configurators enabled and matching state, the steady-state work is an in-process weak-map lookup, state computation, and strict string comparison. No database SQL runs. Configuration SQL runs only on first use, a real state change, or conservative recovery after lifecycle invalidation.

The memo is preserved across clean release to avoid a round trip per borrow. The MySQL insert path also reuses one synchronized PDO for prepare, execute, and insert-ID retrieval.

## Testing

Coverage includes:

- registration, state semantics, exact PDO identity, read/write routing, weak-map cleanup, and raw access;
- every normal statement family and the MySQL insert path;
- failed apply, reentry, overlapping shared-PDO access, unknown replacement, and direct getter behavior;
- commit, rollback, savepoint, disconnect, lost-connection, and concurrency retry lifecycles;
- clean release, changed-state reborrow, abandoned transactions, unknown release state, heartbeat neutrality, atomic refresh failure, and shared SQLite behavior;
- coroutine isolation through a one-slot pool;
- common integration behavior across MySQL, MariaDB, PostgreSQL, and SQLite;
- PostgreSQL commit, rollback, savepoint rollback, aborted-transaction recovery, empty state, and killed-backend reconnect behavior.

The formatter, static analysis, focused database suites, full parallel suite, Testbench suite, and package dogfood checks pass.

## Deployment notes

Direct database connections and session-pooling proxies preserve the physical session lifetime this API requires. Transaction- and statement-pooling proxy modes are not compatible with settings that must persist across statements. Hypervel does not attempt to infer proxy pooling mode.

The feature has no behavior until a configurator is explicitly registered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable database session state synchronization for pooled and long-lived connections.
  * Session settings are applied consistently when connections are handed out and preserved efficiently across reuse.
  * Added safeguards for stale, failed, or reentrant session configuration, including recovery and invalidation handling.
  * Raw PDO access remains available as an explicitly unsynchronized escape hatch.

* **Documentation**
  * Added guidance and examples for configuring database session state and using synchronized versus raw PDO access.

* **Tests**
  * Added broad coverage across pooled connections, coroutines, PostgreSQL, MySQL/MariaDB, and SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->