### PR TITLE
Add native types to class constants

### DIFF
--- a/bin/generate-grpc-health.sh
+++ b/bin/generate-grpc-health.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+required_protoc_version="35.1"
+
+cd "$repository_root"
+
+if ! command -v protoc >/dev/null 2>&1; then
+    echo "protoc ${required_protoc_version} is required to generate the gRPC health classes." >&2
+    exit 1
+fi
+
+installed_protoc_version="$(protoc --version)"
+
+if [[ "$installed_protoc_version" != "libprotoc ${required_protoc_version}" ]]; then
+    echo "protoc ${required_protoc_version} is required; found ${installed_protoc_version}." >&2
+    exit 1
+fi
+
+generated_directory="$(mktemp -d)"
+
+cleanup() {
+    rm -rf -- "$generated_directory"
+}
+
+trap cleanup EXIT
+
+protoc \
+    --proto_path=src/grpc/resources/proto \
+    --php_out="$generated_directory" \
+    src/grpc/resources/proto/grpc/health/v1/health.proto
+
+generated_health_directory="$generated_directory/Hypervel/Grpc/Health/V1"
+
+php src/grpc/resources/proto/type-generated-constants.php \
+    "$generated_health_directory"
+
+./vendor/bin/php-cs-fixer fix \
+    --config=.php-cs-fixer.php \
+    "$generated_health_directory"
+
+rsync --archive --delete \
+    "$generated_health_directory/" \
+    src/grpc/src/Health/V1/

--- a/composer.json
+++ b/composer.json
@@ -401,6 +401,7 @@
         "lint": "php-cs-fixer fix --diff --dry-run",
         "lint:fix": "php-cs-fixer fix",
         "facade": "php -f src/facade-documenter/facade.php --",
+        "generate:grpc-health": "bash bin/generate-grpc-health.sh",
         "check": [
             "@test",
             "@test:testbench",

--- a/src/cache/src/ArrayStore.php
+++ b/src/cache/src/ArrayStore.php
@@ -12,12 +12,12 @@ class ArrayStore extends AbstractArrayStore
     /**
      * The context key prefix for stored values.
      */
-    protected const STORAGE_CONTEXT_KEY_PREFIX = '__cache.array.storage.';
+    protected const string STORAGE_CONTEXT_KEY_PREFIX = '__cache.array.storage.';
 
     /**
      * The context key prefix for lock records.
      */
-    protected const LOCKS_CONTEXT_KEY_PREFIX = '__cache.array.locks.';
+    protected const string LOCKS_CONTEXT_KEY_PREFIX = '__cache.array.locks.';
 
     /**
      * The sequence used to build unique per-instance context keys.

--- a/src/cache/src/CacheManager.php
+++ b/src/cache/src/CacheManager.php
@@ -38,7 +38,7 @@ class CacheManager implements FactoryContract
     /**
      * The context key prefix for memoized cache repositories.
      */
-    protected const MEMOIZED_CONTEXT_KEY_PREFIX = '__cache.memoized.';
+    protected const string MEMOIZED_CONTEXT_KEY_PREFIX = '__cache.memoized.';
 
     /**
      * The array of resolved cache stores.

--- a/src/cache/src/FileStore.php
+++ b/src/cache/src/FileStore.php
@@ -22,7 +22,7 @@ class FileStore implements CanFlushLocks, LockProvider, Store
     /**
      * The expiration timestamp stored for items cached forever.
      */
-    protected const PERMANENT_TIMESTAMP = 9999999999;
+    protected const int PERMANENT_TIMESTAMP = 9999999999;
 
     /**
      * The Filesystem instance.

--- a/src/cache/src/NullSentinel.php
+++ b/src/cache/src/NullSentinel.php
@@ -32,7 +32,7 @@ final class NullSentinel
     /**
      * Sentinel value stored in place of null by the nullable cache methods.
      */
-    public const VALUE = ['__hypervel_cache_null_sentinel' => true];
+    public const array VALUE = ['__hypervel_cache_null_sentinel' => true];
 
     /**
      * Unwrap a value read from the cache — sentinel becomes null; anything else passes through.

--- a/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
+++ b/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
@@ -26,7 +26,7 @@ class BenchmarkContext
      * Key prefix for benchmark-generated cache entries.
      * Matches the pattern used by DoctorContext (_doctor:test:).
      */
-    public const KEY_PREFIX = '_bench:';
+    public const string KEY_PREFIX = '_bench:';
 
     /**
      * Memory usage threshold (percentage) before throwing exception.

--- a/src/cache/src/Redis/Console/Doctor/Checks/LargeDatasetCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/LargeDatasetCheck.php
@@ -14,7 +14,7 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class LargeDatasetCheck implements CheckInterface
 {
-    private const ITEM_COUNT = 500;
+    private const int ITEM_COUNT = 500;
 
     public function name(): string
     {

--- a/src/cache/src/Redis/Console/Doctor/Checks/PhpRedisCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/PhpRedisCheck.php
@@ -13,7 +13,7 @@ use Hypervel\Cache\Redis\Console\Doctor\CheckResult;
  */
 final class PhpRedisCheck implements EnvironmentCheckInterface
 {
-    private const REQUIRED_VERSION = '6.3.0';
+    private const string REQUIRED_VERSION = '6.3.0';
 
     private ?string $installedVersion = null;
 

--- a/src/cache/src/Redis/Console/Doctor/Checks/RedisVersionCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/RedisVersionCheck.php
@@ -17,9 +17,9 @@ use Throwable;
  */
 final class RedisVersionCheck implements EnvironmentCheckInterface
 {
-    private const REDIS_REQUIRED_VERSION = '8.0.0';
+    private const string REDIS_REQUIRED_VERSION = '8.0.0';
 
-    private const VALKEY_REQUIRED_VERSION = '9.0.0';
+    private const string VALKEY_REQUIRED_VERSION = '9.0.0';
 
     private ?string $serviceName = null;
 

--- a/src/cache/src/Redis/Console/Doctor/DoctorContext.php
+++ b/src/cache/src/Redis/Console/Doctor/DoctorContext.php
@@ -24,7 +24,7 @@ final class DoctorContext
      * Unique prefix to prevent collision with production data.
      * Mode-agnostic - just identifies doctor test data.
      */
-    private const TEST_PREFIX = '_doctor:test:';
+    private const string TEST_PREFIX = '_doctor:test:';
 
     /**
      * Create a new doctor context instance.

--- a/src/cache/src/Redis/Console/DoctorCommand.php
+++ b/src/cache/src/Redis/Console/DoctorCommand.php
@@ -67,7 +67,7 @@ class DoctorCommand extends Command
      * Unique prefix to prevent collision with production data.
      * Mode-agnostic - just identifies doctor test data.
      */
-    private const TEST_PREFIX = '_doctor:test:';
+    private const string TEST_PREFIX = '_doctor:test:';
 
     /**
      * Execute the console command.

--- a/src/cache/src/Redis/Operations/AllTag/Decrement.php
+++ b/src/cache/src/Redis/Operations/AllTag/Decrement.php
@@ -21,7 +21,7 @@ class Decrement
     /**
      * Score for decrement operations (no TTL - persists until deleted).
      */
-    private const FOREVER_SCORE = -1;
+    private const int FOREVER_SCORE = -1;
 
     public function __construct(
         private readonly StoreContext $context,

--- a/src/cache/src/Redis/Operations/AllTag/Flush.php
+++ b/src/cache/src/Redis/Operations/AllTag/Flush.php
@@ -9,7 +9,7 @@ use Hypervel\Redis\RedisConnection;
 
 class Flush
 {
-    private const CHUNK_SIZE = 1000;
+    private const int CHUNK_SIZE = 1000;
 
     public function __construct(
         private readonly StoreContext $context,

--- a/src/cache/src/Redis/Operations/AllTag/Forever.php
+++ b/src/cache/src/Redis/Operations/AllTag/Forever.php
@@ -19,7 +19,7 @@ use Hypervel\Redis\RedisConnection;
  */
 class Forever
 {
-    private const FOREVER_SCORE = -1;
+    private const int FOREVER_SCORE = -1;
 
     public function __construct(
         private readonly StoreContext $context,

--- a/src/cache/src/Redis/Operations/AllTag/Increment.php
+++ b/src/cache/src/Redis/Operations/AllTag/Increment.php
@@ -21,7 +21,7 @@ class Increment
     /**
      * Score for increment operations (no TTL - persists until deleted).
      */
-    private const FOREVER_SCORE = -1;
+    private const int FOREVER_SCORE = -1;
 
     public function __construct(
         private readonly StoreContext $context,

--- a/src/cache/src/Redis/Operations/AllTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AllTag/Prune.php
@@ -30,7 +30,7 @@ class Prune
     /**
      * Default number of keys to process per SCAN iteration.
      */
-    private const DEFAULT_SCAN_COUNT = 1000;
+    private const int DEFAULT_SCAN_COUNT = 1000;
 
     /**
      * Create a new prune operation instance.

--- a/src/cache/src/Redis/Operations/AnyTag/Flush.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Flush.php
@@ -23,7 +23,7 @@ use Hypervel\Redis\RedisConnection;
  */
 class Flush
 {
-    private const CHUNK_SIZE = 1000;
+    private const int CHUNK_SIZE = 1000;
 
     /**
      * Create a new flush operation instance.

--- a/src/cache/src/Redis/Operations/AnyTag/GetTagItems.php
+++ b/src/cache/src/Redis/Operations/AnyTag/GetTagItems.php
@@ -17,7 +17,7 @@ use Hypervel\Redis\RedisConnection;
  */
 class GetTagItems
 {
-    private const CHUNK_SIZE = 1000;
+    private const int CHUNK_SIZE = 1000;
 
     /**
      * Create a new tag items query instance.

--- a/src/cache/src/Redis/Operations/AnyTag/GetTaggedKeys.php
+++ b/src/cache/src/Redis/Operations/AnyTag/GetTaggedKeys.php
@@ -22,7 +22,7 @@ class GetTaggedKeys
      * Default threshold for switching from HKEYS to HSCAN.
      * Above this number of fields, use HSCAN for memory efficiency.
      */
-    private const DEFAULT_SCAN_THRESHOLD = 1000;
+    private const int DEFAULT_SCAN_THRESHOLD = 1000;
 
     /**
      * Create a new get tagged keys query instance.

--- a/src/cache/src/Redis/Operations/AnyTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Prune.php
@@ -29,7 +29,7 @@ class Prune
     /**
      * Default number of hash fields to process per HSCAN iteration.
      */
-    private const DEFAULT_SCAN_COUNT = 1000;
+    private const int DEFAULT_SCAN_COUNT = 1000;
 
     /**
      * Create a new prune operation instance.

--- a/src/cache/src/Redis/Operations/AnyTag/PutMany.php
+++ b/src/cache/src/Redis/Operations/AnyTag/PutMany.php
@@ -16,7 +16,7 @@ use Hypervel\Redis\RedisConnection;
  */
 class PutMany
 {
-    private const CHUNK_SIZE = 1000;
+    private const int CHUNK_SIZE = 1000;
 
     /**
      * Create a new put many with tags operation instance.

--- a/src/cache/src/Redis/Support/StoreContext.php
+++ b/src/cache/src/Redis/Support/StoreContext.php
@@ -18,13 +18,13 @@ class StoreContext
      * The maximum expiry timestamp (Year 9999) for "forever" items.
      * Used in the tag registry to represent items with no expiration.
      */
-    public const MAX_EXPIRY = 253402300799;
+    public const int MAX_EXPIRY = 253402300799;
 
     /**
      * The value stored in tag hash fields.
      * We only need to track membership, so we use a minimal placeholder value.
      */
-    public const TAG_FIELD_VALUE = '1';
+    public const string TAG_FIELD_VALUE = '1';
 
     private readonly TagKeyBuilder $tagKeyBuilder;
 

--- a/src/cache/src/Repository.php
+++ b/src/cache/src/Repository.php
@@ -61,7 +61,7 @@ class Repository implements ArrayAccess, CacheContract, RawReadable
     /**
      * The cache key prefix used to track when a flexible cache value was last refreshed.
      */
-    public const FLEXIBLE_CREATED_KEY_PREFIX = 'hypervel:cache:flexible:created:';
+    public const string FLEXIBLE_CREATED_KEY_PREFIX = 'hypervel:cache:flexible:created:';
 
     /**
      * The cache store implementation.

--- a/src/cache/src/StorageStore.php
+++ b/src/cache/src/StorageStore.php
@@ -17,7 +17,7 @@ class StorageStore implements Store
     /**
      * The expiration timestamp stored for items cached forever.
      */
-    protected const PERMANENT_TIMESTAMP = 9999999999;
+    protected const int PERMANENT_TIMESTAMP = 9999999999;
 
     /**
      * The filesystem disk instance.

--- a/src/cache/src/SwooleStore.php
+++ b/src/cache/src/SwooleStore.php
@@ -18,30 +18,30 @@ use Throwable;
 
 class SwooleStore implements CanFlushLocks, LockProvider, Store
 {
-    public const EVICTION_POLICY_LRU = 'lru';
+    public const string EVICTION_POLICY_LRU = 'lru';
 
-    public const EVICTION_POLICY_LFU = 'lfu';
+    public const string EVICTION_POLICY_LFU = 'lfu';
 
-    public const EVICTION_POLICY_TTL = 'ttl';
+    public const string EVICTION_POLICY_TTL = 'ttl';
 
-    public const EVICTION_POLICY_NOEVICTION = 'noeviction';
+    public const string EVICTION_POLICY_NOEVICTION = 'noeviction';
 
-    protected const USER_PREFIX = 'u:';
+    protected const string USER_PREFIX = 'u:';
 
-    protected const INTERVAL_PREFIX = 'i:';
+    protected const string INTERVAL_PREFIX = 'i:';
 
-    protected const INTERVAL_INDEX_PREFIX = 'x:';
+    protected const string INTERVAL_INDEX_PREFIX = 'x:';
 
-    protected const INTERVAL_INDEX_SHARDS = 64;
+    protected const int INTERVAL_INDEX_SHARDS = 64;
 
     /*
      * This timeout must stay comfortably above normal resolver runtimes. If a
      * worker crashes after claiming an interval, another process can reclaim it
      * after this window instead of freezing refreshes until restart.
      */
-    protected const INTERVAL_REFRESH_CLAIM_TIMEOUT = 300.0;
+    protected const float INTERVAL_REFRESH_CLAIM_TIMEOUT = 300.0;
 
-    protected const LOCK_PREFIX = 'l:';
+    protected const string LOCK_PREFIX = 'l:';
 
     protected SwooleTable $table;
 

--- a/src/collections/src/Traits/EnumeratesValues.php
+++ b/src/collections/src/Traits/EnumeratesValues.php
@@ -72,7 +72,7 @@ trait EnumeratesValues
     /**
      * The default methods that can be proxied.
      */
-    protected const DEFAULT_PROXIES = [
+    protected const array DEFAULT_PROXIES = [
         'average',
         'avg',
         'contains',

--- a/src/concurrency/src/Console/InvokeSerializedClosureCommand.php
+++ b/src/concurrency/src/Console/InvokeSerializedClosureCommand.php
@@ -15,7 +15,7 @@ use Throwable;
 #[AsCommand(name: 'invoke-serialized-closure')]
 class InvokeSerializedClosureCommand extends Command
 {
-    private const JSON_FLAGS = JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PRESERVE_ZERO_FRACTION;
+    private const int JSON_FLAGS = JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PRESERVE_ZERO_FRACTION;
 
     protected ?string $signature = 'invoke-serialized-closure {code? : The serialized closure}';
 

--- a/src/console/src/Application.php
+++ b/src/console/src/Application.php
@@ -36,7 +36,7 @@ class Application extends SymfonyApplication implements ConsoleApplicationContra
     /**
      * The CoroutineContext key holding the output from the previous command.
      */
-    protected const LAST_OUTPUT_CONTEXT_KEY = '__console.last_output';
+    protected const string LAST_OUTPUT_CONTEXT_KEY = '__console.last_output';
 
     /**
      * The console application bootstrappers.

--- a/src/console/src/Scheduling/CallbackEvent.php
+++ b/src/console/src/Scheduling/CallbackEvent.php
@@ -18,7 +18,7 @@ class CallbackEvent extends Event
     /**
      * Context key prefix for the current callback invocation.
      */
-    protected const CALLBACK_CONTEXT_KEY_PREFIX = '__console.scheduling_callback.';
+    protected const string CALLBACK_CONTEXT_KEY_PREFIX = '__console.scheduling_callback.';
 
     /**
      * The callback to call.

--- a/src/console/src/Scheduling/Event.php
+++ b/src/console/src/Scheduling/Event.php
@@ -43,17 +43,17 @@ class Event
     /**
      * Context key prefix for the current run's exit code.
      */
-    protected const EXIT_CODE_CONTEXT_KEY_PREFIX = '__console.scheduling_exit_code.';
+    protected const string EXIT_CODE_CONTEXT_KEY_PREFIX = '__console.scheduling_exit_code.';
 
     /**
      * Context key prefix for the current run's process.
      */
-    protected const PROCESS_CONTEXT_KEY_PREFIX = '__console.scheduling_process.';
+    protected const string PROCESS_CONTEXT_KEY_PREFIX = '__console.scheduling_process.';
 
     /**
      * Context key prefix for the current run's overlap skip state.
      */
-    protected const SKIPPED_BECAUSE_OVERLAPPING_CONTEXT_KEY_PREFIX = '__console.scheduling_skipped_because_overlapping.';
+    protected const string SKIPPED_BECAUSE_OVERLAPPING_CONTEXT_KEY_PREFIX = '__console.scheduling_skipped_because_overlapping.';
 
     /**
      * The command string.

--- a/src/console/src/Scheduling/PendingEventAttributes.php
+++ b/src/console/src/Scheduling/PendingEventAttributes.php
@@ -17,7 +17,7 @@ class PendingEventAttributes
      *
      * @var array<int, string>
      */
-    public const DEFERRED_EVENT_METHODS = [
+    public const array DEFERRED_EVENT_METHODS = [
         'before',
         'after',
         'then',

--- a/src/console/src/Scheduling/Schedule.php
+++ b/src/console/src/Scheduling/Schedule.php
@@ -38,19 +38,19 @@ class Schedule
         __call as macroCall;
     }
 
-    public const SUNDAY = 0;
+    public const int SUNDAY = 0;
 
-    public const MONDAY = 1;
+    public const int MONDAY = 1;
 
-    public const TUESDAY = 2;
+    public const int TUESDAY = 2;
 
-    public const WEDNESDAY = 3;
+    public const int WEDNESDAY = 3;
 
-    public const THURSDAY = 4;
+    public const int THURSDAY = 4;
 
-    public const FRIDAY = 5;
+    public const int FRIDAY = 5;
 
-    public const SATURDAY = 6;
+    public const int SATURDAY = 6;
 
     /**
      * All of the events on the schedule.

--- a/src/container/src/Container.php
+++ b/src/container/src/Container.php
@@ -37,12 +37,12 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Context key for the coroutine-local build stack.
      */
-    protected const BUILD_STACK_CONTEXT_KEY = '__container.build_stack';
+    protected const string BUILD_STACK_CONTEXT_KEY = '__container.build_stack';
 
     /**
      * Context key for the coroutine-local resolution depth counter.
      */
-    public const DEPTH_CONTEXT_KEY = '__container.depth';
+    public const string DEPTH_CONTEXT_KEY = '__container.depth';
 
     /**
      * Context key for the coroutine-local resolving stack.
@@ -53,7 +53,7 @@ class Container implements ArrayAccess, ContainerContract
      * positives when call() pushes a class name that is then re-resolved
      * inside the method body.
      */
-    protected const RESOLVING_STACK_CONTEXT_KEY = '__container.resolving_stack';
+    protected const string RESOLVING_STACK_CONTEXT_KEY = '__container.resolving_stack';
 
     /**
      * Maximum resolution depth before assuming a circular dependency.
@@ -62,17 +62,17 @@ class Container implements ArrayAccess, ContainerContract
      * abstract names differ from the concretes pushed by build(), making
      * the direct in_array check insufficient.
      */
-    protected const MAX_RESOLUTION_DEPTH = 500;
+    protected const int MAX_RESOLUTION_DEPTH = 500;
 
     /**
      * Context key for the coroutine-local parameter override stack.
      */
-    protected const PARAMETER_OVERRIDES_CONTEXT_KEY = '__container.parameter_overrides';
+    protected const string PARAMETER_OVERRIDES_CONTEXT_KEY = '__container.parameter_overrides';
 
     /**
      * Context key prefix for coroutine-local scoped instances.
      */
-    protected const SCOPED_CONTEXT_PREFIX = '__container.scoped.';
+    protected const string SCOPED_CONTEXT_PREFIX = '__container.scoped.';
 
     /**
      * The current globally available container (if any).

--- a/src/contracts/src/Engine/Http/Http.php
+++ b/src/contracts/src/Engine/Http/Http.php
@@ -8,7 +8,7 @@ use Stringable;
 
 interface Http
 {
-    public const DEFAULT_PROTOCOL_VERSION = '1.1';
+    public const string DEFAULT_PROTOCOL_VERSION = '1.1';
 
     /**
      * Pack an HTTP request.

--- a/src/contracts/src/Engine/WebSocket/WebSocketInterface.php
+++ b/src/contracts/src/Engine/WebSocket/WebSocketInterface.php
@@ -6,9 +6,9 @@ namespace Hypervel\Contracts\Engine\WebSocket;
 
 interface WebSocketInterface
 {
-    public const ON_MESSAGE = 'message';
+    public const string ON_MESSAGE = 'message';
 
-    public const ON_CLOSE = 'close';
+    public const string ON_CLOSE = 'close';
 
     /**
      * Register an event callback.

--- a/src/contracts/src/Filesystem/Filesystem.php
+++ b/src/contracts/src/Filesystem/Filesystem.php
@@ -13,17 +13,13 @@ interface Filesystem
 {
     /**
      * The public visibility setting.
-     *
-     * @var string
      */
-    public const VISIBILITY_PUBLIC = 'public';
+    public const string VISIBILITY_PUBLIC = 'public';
 
     /**
      * The private visibility setting.
-     *
-     * @var string
      */
-    public const VISIBILITY_PRIVATE = 'private';
+    public const string VISIBILITY_PRIVATE = 'private';
 
     /**
      * Get the full path to the file that exists at the given relative path.

--- a/src/cookie/src/CookieJar.php
+++ b/src/cookie/src/CookieJar.php
@@ -23,7 +23,7 @@ class CookieJar implements JarContract
     /**
      * Context key for the queued cookies.
      */
-    protected const QUEUE_CONTEXT_KEY = '__cookie.queue';
+    protected const string QUEUE_CONTEXT_KEY = '__cookie.queue';
 
     /**
      * The default path (if specified).

--- a/src/coordinator/src/Constants.php
+++ b/src/coordinator/src/Constants.php
@@ -9,10 +9,10 @@ class Constants
     /**
      * Swoole onWorkerStart event.
      */
-    public const WORKER_START = 'workerStart';
+    public const string WORKER_START = 'workerStart';
 
     /**
      * Swoole onWorkerExit event.
      */
-    public const WORKER_EXIT = 'workerExit';
+    public const string WORKER_EXIT = 'workerExit';
 }

--- a/src/coordinator/src/Timer.php
+++ b/src/coordinator/src/Timer.php
@@ -12,7 +12,7 @@ use function Hypervel\Coroutine\go;
 
 class Timer
 {
-    public const STOP = 'stop';
+    public const string STOP = 'stop';
 
     /**
      * Timer IDs mapped to coroutine IDs, or zero until creation publishes the ID.

--- a/src/core/src/Logger/StdoutLogger.php
+++ b/src/core/src/Logger/StdoutLogger.php
@@ -27,13 +27,13 @@ class StdoutLogger implements StdoutLoggerInterface
 {
     use LoggerTrait;
 
-    private const JSON_FLAGS = JSON_UNESCAPED_SLASHES
+    private const int JSON_FLAGS = JSON_UNESCAPED_SLASHES
         | JSON_UNESCAPED_UNICODE
         | JSON_PRESERVE_ZERO_FRACTION
         | JSON_INVALID_UTF8_SUBSTITUTE
         | JSON_PARTIAL_OUTPUT_ON_ERROR;
 
-    private const STANDARD_LEVELS = [
+    private const array STANDARD_LEVELS = [
         LogLevel::EMERGENCY => true,
         LogLevel::ALERT => true,
         LogLevel::CRITICAL => true,

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -12,5 +12,6 @@ Documentation: https://hypervel.org/docs/database
 - Laravel's remaining directly deprecated Database compatibility forwarders are intentionally not ported. Use the current class-keyed factory resolver, schema blueprint and grammar APIs, and correctly named PostgreSQL truncation method instead.
 - `make:migration` omits Laravel's deprecated `--fullpath` option and obsolete Composer constructor dependency because migration creation no longer dumps autoload files.
 - `Blueprint::dropForeign()` widens Laravel's method signature with an optional constraint name when columns are supplied, allowing explicitly named foreign keys to be dropped portably across SQLite and the server databases. Custom `Blueprint` subclasses that override this method must accept the optional second argument.
+- Eloquent models that override `CREATED_AT` or `UPDATED_AT` must declare the compatible `?string` constant type, such as `public const ?string UPDATED_AT = null;`. Laravel's constants are untyped, but omitting the type from an override in Hypervel causes a fatal error.
 
 Ported from: https://github.com/laravel/framework

--- a/src/database/src/Connection.php
+++ b/src/database/src/Connection.php
@@ -125,7 +125,7 @@ class Connection implements ConnectionInterface
      */
     protected ?DatabaseTransactionsManager $transactionsManager = null;
 
-    public const READ_WRITE_TYPE_CONFIG_KEY = 'read_write_type';
+    public const string READ_WRITE_TYPE_CONFIG_KEY = 'read_write_type';
 
     /**
      * Indicates if changes have been made to the database.

--- a/src/database/src/ConnectionName.php
+++ b/src/database/src/ConnectionName.php
@@ -8,9 +8,9 @@ use InvalidArgumentException;
 
 final readonly class ConnectionName
 {
-    public const READ = 'read';
+    public const string READ = 'read';
 
-    public const WRITE = 'write';
+    public const string WRITE = 'write';
 
     /**
      * Create a new parsed connection name instance.

--- a/src/database/src/ConnectionResolver.php
+++ b/src/database/src/ConnectionResolver.php
@@ -28,7 +28,7 @@ class ConnectionResolver implements ConnectionResolverInterface
      * Shared with DatabaseManager::usingConnection() to ensure all access
      * paths respect the override.
      */
-    public const DEFAULT_CONNECTION_CONTEXT_KEY = '__database.default_connection';
+    public const string DEFAULT_CONNECTION_CONTEXT_KEY = '__database.default_connection';
 
     /**
      * The config-derived default connection name, captured at construction.

--- a/src/database/src/Console/Migrations/TableGuesser.php
+++ b/src/database/src/Console/Migrations/TableGuesser.php
@@ -6,12 +6,12 @@ namespace Hypervel\Database\Console\Migrations;
 
 class TableGuesser
 {
-    public const CREATE_PATTERNS = [
+    public const array CREATE_PATTERNS = [
         '/^create_(\w+)_table$/',
         '/^create_(\w+)$/',
     ];
 
-    public const CHANGE_PATTERNS = [
+    public const array CHANGE_PATTERNS = [
         '/.+_(to|from|in)_(\w+)_table$/',
         '/.+_(to|from|in)_(\w+)$/',
     ];

--- a/src/database/src/DatabaseManager.php
+++ b/src/database/src/DatabaseManager.php
@@ -41,7 +41,7 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Context key for query duration handlers that have run in the current coroutine.
      */
-    public const QUERY_DURATION_HANDLERS_CONTEXT_KEY = '__database.query_duration_handlers';
+    public const string QUERY_DURATION_HANDLERS_CONTEXT_KEY = '__database.query_duration_handlers';
 
     /**
      * The active connection instances.

--- a/src/database/src/DatabaseTransactionsManager.php
+++ b/src/database/src/DatabaseTransactionsManager.php
@@ -16,11 +16,11 @@ use Throwable;
  */
 class DatabaseTransactionsManager
 {
-    protected const COMMITTED_CONTEXT_KEY = '__database.transactions.committed';
+    protected const string COMMITTED_CONTEXT_KEY = '__database.transactions.committed';
 
-    protected const PENDING_CONTEXT_KEY = '__database.transactions.pending';
+    protected const string PENDING_CONTEXT_KEY = '__database.transactions.pending';
 
-    protected const CURRENT_CONTEXT_KEY = '__database.transactions.current';
+    protected const string CURRENT_CONTEXT_KEY = '__database.transactions.current';
 
     /**
      * Get all committed transactions for the current coroutine.

--- a/src/database/src/Eloquent/Concerns/HasTimestamps.php
+++ b/src/database/src/Eloquent/Concerns/HasTimestamps.php
@@ -17,7 +17,7 @@ trait HasTimestamps
     /**
      * Context key for storing models that should ignore timestamps.
      */
-    protected const IGNORE_TIMESTAMPS_CONTEXT_KEY = '__database.model.ignore_timestamps';
+    protected const string IGNORE_TIMESTAMPS_CONTEXT_KEY = '__database.model.ignore_timestamps';
 
     /**
      * Indicates if the model should be timestamped.

--- a/src/database/src/Eloquent/Concerns/PreventsCircularRecursion.php
+++ b/src/database/src/Eloquent/Concerns/PreventsCircularRecursion.php
@@ -14,7 +14,7 @@ trait PreventsCircularRecursion
     /**
      * The context key for the recursion cache.
      */
-    protected const RECURSION_CACHE_CONTEXT_KEY = '__database.model.recursion_cache';
+    protected const string RECURSION_CACHE_CONTEXT_KEY = '__database.model.recursion_cache';
 
     /**
      * Prevent a method from being called multiple times on the same object within the same call stack.

--- a/src/database/src/Eloquent/Model.php
+++ b/src/database/src/Eloquent/Model.php
@@ -71,22 +71,22 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Context key for storing models that should ignore touch.
      */
-    protected const IGNORE_ON_TOUCH_CONTEXT_KEY = '__database.model.ignore_on_touch';
+    protected const string IGNORE_ON_TOUCH_CONTEXT_KEY = '__database.model.ignore_on_touch';
 
     /**
      * Context key for storing whether broadcasting is enabled.
      */
-    protected const BROADCASTING_CONTEXT_KEY = '__database.model.broadcasting';
+    protected const string BROADCASTING_CONTEXT_KEY = '__database.model.broadcasting';
 
     /**
      * Context key for storing whether events are disabled.
      */
-    protected const EVENTS_DISABLED_CONTEXT_KEY = '__database.model.events_disabled';
+    protected const string EVENTS_DISABLED_CONTEXT_KEY = '__database.model.events_disabled';
 
     /**
      * Context key for storing whether mass assignment is unguarded.
      */
-    public const UNGUARDED_CONTEXT_KEY = '__database.model.unguarded';
+    public const string UNGUARDED_CONTEXT_KEY = '__database.model.unguarded';
 
     /**
      * The connection name for the model.
@@ -320,17 +320,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
     /**
      * The name of the "created at" column.
-     *
-     * @var null|string
      */
-    public const CREATED_AT = 'created_at';
+    public const ?string CREATED_AT = 'created_at';
 
     /**
      * The name of the "updated at" column.
-     *
-     * @var null|string
      */
-    public const UPDATED_AT = 'updated_at';
+    public const ?string UPDATED_AT = 'updated_at';
 
     /**
      * Create a new Eloquent model instance.

--- a/src/database/src/Eloquent/Relations/Relation.php
+++ b/src/database/src/Eloquent/Relations/Relation.php
@@ -60,7 +60,7 @@ abstract class Relation implements BuilderContract
     /**
      * The context key for storing whether constraints are enabled.
      */
-    protected const CONSTRAINTS_CONTEXT_KEY = '__database.relation.constraints';
+    protected const string CONSTRAINTS_CONTEXT_KEY = '__database.relation.constraints';
 
     /**
      * An array to map morph names to their class names in the database.

--- a/src/database/src/Migrations/MigrationCreator.php
+++ b/src/database/src/Migrations/MigrationCreator.php
@@ -15,7 +15,7 @@ use RuntimeException;
 
 class MigrationCreator
 {
-    protected const CURRENT_MIGRATION_PATH_CONTEXT_KEY_PREFIX = '__database.migration_creator.current_path.';
+    protected const string CURRENT_MIGRATION_PATH_CONTEXT_KEY_PREFIX = '__database.migration_creator.current_path.';
 
     /**
      * The registered post create hooks.

--- a/src/database/src/Pool/PooledConnection.php
+++ b/src/database/src/Pool/PooledConnection.php
@@ -35,7 +35,7 @@ class PooledConnection implements PoolConnectionInterface
     /**
      * Maximum allowed errors before marking connection as stale.
      */
-    protected const MAX_ERROR_COUNT = 100;
+    protected const int MAX_ERROR_COUNT = 100;
 
     protected ?Connection $connection = null;
 

--- a/src/di/src/Aop/ProxyCallVisitor.php
+++ b/src/di/src/Aop/ProxyCallVisitor.php
@@ -50,13 +50,13 @@ use PhpParser\NodeVisitorAbstract;
 
 class ProxyCallVisitor extends NodeVisitorAbstract
 {
-    private const ARGUMENT_FUNCTIONS = [
+    private const array ARGUMENT_FUNCTIONS = [
         'func_get_arg',
         'func_get_args',
         'func_num_args',
     ];
 
-    private const INDIRECT_CALL_FUNCTIONS = [
+    private const array INDIRECT_CALL_FUNCTIONS = [
         'call_user_func',
         'call_user_func_array',
     ];

--- a/src/di/src/Aop/ProxyManager.php
+++ b/src/di/src/Aop/ProxyManager.php
@@ -13,7 +13,7 @@ use Throwable;
 
 class ProxyManager
 {
-    private const FINGERPRINT_HEADER = '// Hypervel AOP fingerprint: ';
+    private const string FINGERPRINT_HEADER = '// Hypervel AOP fingerprint: ';
 
     /**
      * The classes that have been rewritten as proxies.

--- a/src/di/src/Aop/RewriteCollection.php
+++ b/src/di/src/Aop/RewriteCollection.php
@@ -6,9 +6,9 @@ namespace Hypervel\Di\Aop;
 
 class RewriteCollection
 {
-    public const CLASS_LEVEL = 1;
+    public const int CLASS_LEVEL = 1;
 
-    public const METHOD_LEVEL = 2;
+    public const int METHOD_LEVEL = 2;
 
     /**
      * Which methods can be rewritten.

--- a/src/docs/eloquent.md
+++ b/src/docs/eloquent.md
@@ -360,17 +360,13 @@ class Flight extends Model
 {
     /**
      * The name of the "created at" column.
-     *
-     * @var string|null
      */
-    public const CREATED_AT = 'creation_date';
+    public const ?string CREATED_AT = 'creation_date';
 
     /**
      * The name of the "updated at" column.
-     *
-     * @var string|null
      */
-    public const UPDATED_AT = 'updated_date';
+    public const ?string UPDATED_AT = 'updated_date';
 }
 ```
 

--- a/src/engine/src/Constant.php
+++ b/src/engine/src/Constant.php
@@ -6,5 +6,5 @@ namespace Hypervel\Engine;
 
 class Constant
 {
-    public const ENGINE = 'Swoole';
+    public const string ENGINE = 'Swoole';
 }

--- a/src/engine/src/Constants/SocketType.php
+++ b/src/engine/src/Constants/SocketType.php
@@ -6,15 +6,15 @@ namespace Hypervel\Engine\Constants;
 
 class SocketType
 {
-    public const TCP = SWOOLE_SOCK_TCP;
+    public const int TCP = SWOOLE_SOCK_TCP;
 
-    public const TCP6 = SWOOLE_SOCK_TCP6;
+    public const int TCP6 = SWOOLE_SOCK_TCP6;
 
-    public const UDP = SWOOLE_SOCK_UDP;
+    public const int UDP = SWOOLE_SOCK_UDP;
 
-    public const UDP6 = SWOOLE_SOCK_UDP6;
+    public const int UDP6 = SWOOLE_SOCK_UDP6;
 
-    public const UNIX_STREAM = SWOOLE_SOCK_UNIX_STREAM;
+    public const int UNIX_STREAM = SWOOLE_SOCK_UNIX_STREAM;
 
-    public const UNIX_DGRAM = SWOOLE_SOCK_UNIX_DGRAM;
+    public const int UNIX_DGRAM = SWOOLE_SOCK_UNIX_DGRAM;
 }

--- a/src/engine/src/WebSocket/Opcode.php
+++ b/src/engine/src/WebSocket/Opcode.php
@@ -6,15 +6,15 @@ namespace Hypervel\Engine\WebSocket;
 
 class Opcode
 {
-    public const CONTINUATION = 0;
+    public const int CONTINUATION = 0;
 
-    public const TEXT = 1;
+    public const int TEXT = 1;
 
-    public const BINARY = 2;
+    public const int BINARY = 2;
 
-    public const CLOSE = 8;
+    public const int CLOSE = 8;
 
-    public const PING = 9;
+    public const int PING = 9;
 
-    public const PONG = 10;
+    public const int PONG = 10;
 }

--- a/src/events/src/Dispatcher.php
+++ b/src/events/src/Dispatcher.php
@@ -57,22 +57,22 @@ class Dispatcher implements DispatcherContract
     /**
      * Context key for whether event deferral is active.
      */
-    public const DEFERRING_CONTEXT_KEY = '__events.deferring';
+    public const string DEFERRING_CONTEXT_KEY = '__events.deferring';
 
     /**
      * Context key for the queue of deferred events.
      */
-    public const DEFERRED_EVENTS_CONTEXT_KEY = '__events.deferred_events';
+    public const string DEFERRED_EVENTS_CONTEXT_KEY = '__events.deferred_events';
 
     /**
      * Context key for the list of event classes to defer.
      */
-    public const EVENTS_TO_DEFER_CONTEXT_KEY = '__events.events_to_defer';
+    public const string EVENTS_TO_DEFER_CONTEXT_KEY = '__events.events_to_defer';
 
     /**
      * Context key for events queued via push() and dispatched via flush().
      */
-    public const PUSHED_EVENTS_CONTEXT_KEY = '__events.pushed';
+    public const string PUSHED_EVENTS_CONTEXT_KEY = '__events.pushed';
 
     /**
      * The IoC container instance.

--- a/src/filesystem/src/FileResponseBuilder.php
+++ b/src/filesystem/src/FileResponseBuilder.php
@@ -19,7 +19,7 @@ use Throwable;
 
 class FileResponseBuilder
 {
-    private const CHUNK_SIZE = 64 * 1024;
+    private const int CHUNK_SIZE = 64 * 1024;
 
     /**
      * Build and stream a range-aware file response.

--- a/src/filesystem/src/FilesystemManager.php
+++ b/src/filesystem/src/FilesystemManager.php
@@ -56,12 +56,12 @@ class FilesystemManager implements FactoryContract
     /**
      * The logical name used while resolving on-demand disks.
      */
-    protected const ON_DEMAND_DISK_NAME = 'ondemand';
+    protected const string ON_DEMAND_DISK_NAME = 'ondemand';
 
     /**
      * Google Cloud Storage client constructor options supported by the installed SDK.
      */
-    protected const GCS_CLIENT_OPTIONS = [
+    protected const array GCS_CLIENT_OPTIONS = [
         'apiEndpoint',
         'projectId',
         'authCache',

--- a/src/filesystem/src/GoogleCloudStorageAdapter.php
+++ b/src/filesystem/src/GoogleCloudStorageAdapter.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class GoogleCloudStorageAdapter extends FilesystemAdapter
 {
-    public const DEFAULT_API_ENDPOINT = 'https://storage.googleapis.com';
+    public const string DEFAULT_API_ENDPOINT = 'https://storage.googleapis.com';
 
     public function __construct(
         FilesystemOperator $driver,

--- a/src/filesystem/src/LeasedStream.php
+++ b/src/filesystem/src/LeasedStream.php
@@ -12,7 +12,7 @@ use Throwable;
 
 final class LeasedStream
 {
-    public const PROTOCOL = 'hypervel-leased';
+    public const string PROTOCOL = 'hypervel-leased';
 
     /** @var resource */
     public $context;

--- a/src/fortify/src/Fortify.php
+++ b/src/fortify/src/Fortify.php
@@ -29,21 +29,21 @@ use RuntimeException;
 
 class Fortify
 {
-    public const PASSWORD_UPDATED = 'password-updated';
+    public const string PASSWORD_UPDATED = 'password-updated';
 
-    public const PROFILE_INFORMATION_UPDATED = 'profile-information-updated';
+    public const string PROFILE_INFORMATION_UPDATED = 'profile-information-updated';
 
-    public const RECOVERY_CODES_GENERATED = 'recovery-codes-generated';
+    public const string RECOVERY_CODES_GENERATED = 'recovery-codes-generated';
 
-    public const TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
+    public const string TWO_FACTOR_AUTHENTICATION_CONFIRMED = 'two-factor-authentication-confirmed';
 
-    public const TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
+    public const string TWO_FACTOR_AUTHENTICATION_DISABLED = 'two-factor-authentication-disabled';
 
-    public const TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
+    public const string TWO_FACTOR_AUTHENTICATION_ENABLED = 'two-factor-authentication-enabled';
 
-    public const VERIFICATION_LINK_SENT = 'verification-link-sent';
+    public const string VERIFICATION_LINK_SENT = 'verification-link-sent';
 
-    private const DEFAULT_REGISTERS_ROUTES = true;
+    private const bool DEFAULT_REGISTERS_ROUTES = true;
 
     private static ?Closure $authenticateThroughCallback = null;
 

--- a/src/foundation/src/Application.php
+++ b/src/foundation/src/Application.php
@@ -46,10 +46,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
     /**
      * The Hypervel framework version.
-     *
-     * @var string
      */
-    public const VERSION = '0.4';
+    public const string VERSION = '0.4';
 
     /**
      * The base path for the Hypervel installation.

--- a/src/foundation/src/Console/CliDumper.php
+++ b/src/foundation/src/Console/CliDumper.php
@@ -18,7 +18,7 @@ class CliDumper extends BaseCliDumper
 {
     use ResolvesDumpSource;
 
-    protected const DUMPING_CONTEXT_KEY = '__foundation.cli_dumper.dumping';
+    protected const string DUMPING_CONTEXT_KEY = '__foundation.cli_dumper.dumping';
 
     /**
      * Create a new CLI dumper instance.

--- a/src/foundation/src/Console/VendorPublishCommand.php
+++ b/src/foundation/src/Console/VendorPublishCommand.php
@@ -29,7 +29,7 @@ class VendorPublishCommand extends Command
     /**
      * The migration filename pattern.
      */
-    protected const MIGRATION_NAME_PATTERN = '/^\d{4}_\d{2}_\d{2}_\d{6}_(.+)$/';
+    protected const string MIGRATION_NAME_PATTERN = '/^\d{4}_\d{2}_\d{2}_\d{6}_(.+)$/';
 
     /**
      * The console command signature.

--- a/src/foundation/src/Exceptions/Handler.php
+++ b/src/foundation/src/Exceptions/Handler.php
@@ -74,17 +74,17 @@ class Handler implements ExceptionHandlerContract
     /**
      * Context key for the per-request reported exception deduplication map.
      */
-    public const REPORTED_EXCEPTION_MAP_CONTEXT_KEY = '__foundation.errors.reported_exception_map';
+    public const string REPORTED_EXCEPTION_MAP_CONTEXT_KEY = '__foundation.errors.reported_exception_map';
 
     /**
      * Context key for after-response callbacks.
      */
-    public const AFTER_RESPONSE_CONTEXT_KEY = '__foundation.errors.after_response';
+    public const string AFTER_RESPONSE_CONTEXT_KEY = '__foundation.errors.after_response';
 
     /**
      * Context key for the exception currently being reported.
      */
-    public const CURRENTLY_REPORTING_CONTEXT_KEY = '__foundation.errors.currently_reporting';
+    public const string CURRENTLY_REPORTING_CONTEXT_KEY = '__foundation.errors.currently_reporting';
 
     /**
      * A list of the exception types that are not reported.

--- a/src/foundation/src/Exceptions/Renderer/Listener.php
+++ b/src/foundation/src/Exceptions/Renderer/Listener.php
@@ -13,12 +13,12 @@ class Listener
     /**
      * The Context key for storing executed queries.
      */
-    protected const QUERIES_CONTEXT_KEY = '__foundation.exception_renderer.queries';
+    protected const string QUERIES_CONTEXT_KEY = '__foundation.exception_renderer.queries';
 
     /**
      * The maximum number of queries to store.
      */
-    protected const MAX_QUERIES = 100;
+    protected const int MAX_QUERIES = 100;
 
     /**
      * Register the appropriate listeners on the given event dispatcher.

--- a/src/foundation/src/Exceptions/Renderer/Renderer.php
+++ b/src/foundation/src/Exceptions/Renderer/Renderer.php
@@ -16,7 +16,7 @@ class Renderer
     /**
      * The path to the renderer's distribution files.
      */
-    protected const DIST = __DIR__ . '/../../../resources/exceptions/renderer/dist/';
+    protected const string DIST = __DIR__ . '/../../../resources/exceptions/renderer/dist/';
 
     /**
      * Create a new exception renderer instance.

--- a/src/foundation/src/Http/HtmlDumper.php
+++ b/src/foundation/src/Http/HtmlDumper.php
@@ -18,19 +18,15 @@ class HtmlDumper extends BaseHtmlDumper
 
     /**
      * Where the source should be placed on "expanded" kind of dumps.
-     *
-     * @var string
      */
-    public const EXPANDED_SEPARATOR = 'class=sf-dump-expanded>';
+    public const string EXPANDED_SEPARATOR = 'class=sf-dump-expanded>';
 
     /**
      * Where the source should be placed on "non expanded" kind of dumps.
-     *
-     * @var string
      */
-    public const NON_EXPANDED_SEPARATOR = "\n</pre><script>";
+    public const string NON_EXPANDED_SEPARATOR = "\n</pre><script>";
 
-    protected const DUMPING_CONTEXT_KEY = '__foundation.html_dumper.dumping';
+    protected const string DUMPING_CONTEXT_KEY = '__foundation.html_dumper.dumping';
 
     /**
      * Create a new HTML dumper instance.

--- a/src/foundation/src/Http/Kernel.php
+++ b/src/foundation/src/Http/Kernel.php
@@ -88,7 +88,7 @@ class Kernel implements KernelContract
      * and an instance property would be overwritten by whichever coroutine
      * called handle() most recently.
      */
-    protected const REQUEST_STARTED_AT_CONTEXT_KEY = '__http.kernel.request_started_at';
+    protected const string REQUEST_STARTED_AT_CONTEXT_KEY = '__http.kernel.request_started_at';
 
     /**
      * The priority-sorted list of middleware.

--- a/src/foundation/src/Vite.php
+++ b/src/foundation/src/Vite.php
@@ -22,17 +22,17 @@ class Vite implements Htmlable
     /**
      * The Content Security Policy nonce context key.
      */
-    protected const NONCE_CONTEXT_KEY = '__foundation.vite.nonce';
+    protected const string NONCE_CONTEXT_KEY = '__foundation.vite.nonce';
 
     /**
      * The entry points context key.
      */
-    protected const ENTRY_POINTS_CONTEXT_KEY = '__foundation.vite.entry_points';
+    protected const string ENTRY_POINTS_CONTEXT_KEY = '__foundation.vite.entry_points';
 
     /**
      * The preloaded assets context key.
      */
-    protected const PRELOADED_ASSETS_CONTEXT_KEY = '__foundation.vite.preloaded_assets';
+    protected const string PRELOADED_ASSETS_CONTEXT_KEY = '__foundation.vite.preloaded_assets';
 
     /**
      * The key to check for integrity hashes within the manifest.

--- a/src/grpc/README.md
+++ b/src/grpc/README.md
@@ -1,3 +1,6 @@
 # gRPC for Hypervel
 
 Documentation: https://hypervel.org/docs/grpc
+
+Maintainers: see [`resources/proto/README.md`](resources/proto/README.md) for the
+pinned health protocol generation workflow.

--- a/src/grpc/resources/proto/README.md
+++ b/src/grpc/resources/proto/README.md
@@ -6,32 +6,32 @@ beside this file. The only schema changes are the PHP namespace generation
 options required by this package.
 
 Generation requires the official `protoc` v35.1 release, matching the
-`google/protobuf` 5.35 runtime used by the package. Run this command from the
-components repository root:
+`google/protobuf` 5.35 runtime used by the package. Run the complete generation
+workflow from the components repository root:
 
 ```bash
-grpc_health_out="$(mktemp -d)"
-trap 'rm -rf "$grpc_health_out"' EXIT
-
-protoc \
-  --proto_path=src/grpc/resources/proto \
-  --php_out="$grpc_health_out" \
-  src/grpc/resources/proto/grpc/health/v1/health.proto
-
-rsync --archive --delete \
-  "$grpc_health_out/Hypervel/Grpc/Health/V1/" \
-  src/grpc/src/Health/V1/
-
-./vendor/bin/php-cs-fixer fix \
-  --config=.php-cs-fixer.php \
-  src/grpc/src/Health/V1
+composer generate:grpc-health
 ```
 
-The canonical checked-in form is the pinned protoc output followed by the
-Composer-locked repository fixer. The generated `DO NOT EDIT` marker prohibits
-hand edits; regeneration means running both steps above.
+The Composer command runs the pinned `protoc`, adds Hypervel's native PHP 8.4
+constant types, runs the Composer-locked repository fixer, and then replaces
+the generated health classes. The canonical checked-in form is the result of
+that complete workflow. The generated `DO NOT EDIT` marker prohibits hand
+edits. Native constant types are the only Hypervel typing adaptation; generated
+properties and method signatures intentionally remain as `protoc` emits them.
 
-Running the complete protoc, copy, and fixer workflow a second time must leave
-the generated directory unchanged. A protoc or fixer update is accepted only
-after `tests/Grpc`, `tests/Integration/Grpc`, both plaintext and TLS grpc-go
-client runs, and the repository-wide verification suite remain green.
+To update the generated health protocol:
+
+1. Copy `grpc/health/v1/health.proto` from the chosen `grpc/grpc-proto`
+   revision, retain the Hypervel PHP namespace options, and update the pinned
+   revision at the top of this file.
+2. When changing the protobuf runtime, update the `google/protobuf` Composer
+   requirement through Composer. When changing `protoc`, update the required
+   version in `bin/generate-grpc-health.sh` and the version documented above.
+3. Run `composer generate:grpc-health` and review the generated changes before
+   committing them.
+
+Running `composer generate:grpc-health` a second time must leave the generated
+directory unchanged. A protocol, protoc, runtime, or fixer update is accepted
+only after `tests/Grpc`, `tests/Integration/Grpc`, both plaintext and TLS
+grpc-go client runs, and the repository-wide verification suite remain green.

--- a/src/grpc/resources/proto/type-generated-constants.php
+++ b/src/grpc/resources/proto/type-generated-constants.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+// Protoc emits enum constants without native types. The gRPC health generation
+// workflow runs this adaptation before formatting and committing its PHP output.
+
+/**
+ * Report a generated constant typing failure.
+ */
+function failGeneratedConstantTyping(string $message): never
+{
+    fwrite(STDERR, $message . PHP_EOL);
+
+    exit(1);
+}
+
+if ($argc !== 2) {
+    failGeneratedConstantTyping('Usage: php type-generated-constants.php <generated-directory>');
+}
+
+$generatedDirectory = $argv[1];
+
+if (! is_dir($generatedDirectory)) {
+    failGeneratedConstantTyping("Generated directory [{$generatedDirectory}] does not exist.");
+}
+
+$files = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($generatedDirectory, FilesystemIterator::SKIP_DOTS)
+);
+
+$typedConstants = 0;
+
+foreach ($files as $file) {
+    if (! $file->isFile() || $file->getExtension() !== 'php') {
+        continue;
+    }
+
+    $path = $file->getPathname();
+    $contents = file_get_contents($path);
+
+    if ($contents === false) {
+        failGeneratedConstantTyping("Unable to read generated file [{$path}].");
+    }
+
+    $updatedContents = preg_replace(
+        '/^(\s*(?:(?:final|public|protected|private)\s+)*const )([A-Z][A-Z0-9_]*) = (-?\d+);$/m',
+        '${1}int ${2} = ${3};',
+        $contents,
+        -1,
+        $replacementCount
+    );
+
+    if ($updatedContents === null) {
+        failGeneratedConstantTyping("Unable to type constants in generated file [{$path}].");
+    }
+
+    if (preg_match('/^\s*(?:(?:final|public|protected|private)\s+)*const [A-Z][A-Z0-9_]* = /m', $updatedContents) === 1) {
+        failGeneratedConstantTyping("Generated file [{$path}] contains a class constant without a supported type.");
+    }
+
+    if ($replacementCount === 0) {
+        continue;
+    }
+
+    if (file_put_contents($path, $updatedContents) === false) {
+        failGeneratedConstantTyping("Unable to update generated file [{$path}].");
+    }
+
+    $typedConstants += $replacementCount;
+}
+
+fwrite(STDOUT, "Typed {$typedConstants} generated protobuf constants." . PHP_EOL);

--- a/src/grpc/src/GrpcServiceProvider.php
+++ b/src/grpc/src/GrpcServiceProvider.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 class GrpcServiceProvider extends ServiceProvider
 {
     /** @var list<string> */
-    private const TLS_KEYS = [
+    private const array TLS_KEYS = [
         'local_cert',
         'local_pk',
         'passphrase',
@@ -37,7 +37,7 @@ class GrpcServiceProvider extends ServiceProvider
     ];
 
     /** @var list<string> */
-    private const OWNED_SERVER_SETTINGS = [
+    private const array OWNED_SERVER_SETTINGS = [
         'open_http_protocol',
         'open_http2_protocol',
         'open_websocket_protocol',

--- a/src/grpc/src/Health/V1/HealthCheckResponse/ServingStatus.php
+++ b/src/grpc/src/Health/V1/HealthCheckResponse/ServingStatus.php
@@ -17,24 +17,24 @@ class ServingStatus
     /**
      * Generated from protobuf enum <code>UNKNOWN = 0;</code>.
      */
-    public const UNKNOWN = 0;
+    public const int UNKNOWN = 0;
 
     /**
      * Generated from protobuf enum <code>SERVING = 1;</code>.
      */
-    public const SERVING = 1;
+    public const int SERVING = 1;
 
     /**
      * Generated from protobuf enum <code>NOT_SERVING = 2;</code>.
      */
-    public const NOT_SERVING = 2;
+    public const int NOT_SERVING = 2;
 
     /**
      * Used only by the Watch method.
      *
      * Generated from protobuf enum <code>SERVICE_UNKNOWN = 3;</code>
      */
-    public const SERVICE_UNKNOWN = 3;
+    public const int SERVICE_UNKNOWN = 3;
 
     private static $valueToName = [
         self::UNKNOWN => 'UNKNOWN',

--- a/src/grpc/src/Metadata.php
+++ b/src/grpc/src/Metadata.php
@@ -13,7 +13,7 @@ use Traversable;
 final class Metadata implements Countable, IteratorAggregate
 {
     /** @internal */
-    public const OWNED_KEYS = [
+    public const array OWNED_KEYS = [
         'host',
         'content-type',
         'content-length',

--- a/src/grpc/src/Protocol/MediaType.php
+++ b/src/grpc/src/Protocol/MediaType.php
@@ -9,7 +9,7 @@ namespace Hypervel\Grpc\Protocol;
  */
 final readonly class MediaType
 {
-    public const PROTOBUF = 'application/grpc+proto';
+    public const string PROTOBUF = 'application/grpc+proto';
 
     private function __construct(private ?string $subtype)
     {

--- a/src/grpc/src/Protocol/Timeout.php
+++ b/src/grpc/src/Protocol/Timeout.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  */
 class Timeout
 {
-    private const MAXIMUM_VALUE = 99_999_999;
+    private const int MAXIMUM_VALUE = 99_999_999;
 
     /**
      * Encode seconds as a gRPC timeout header value.

--- a/src/grpc/src/Server/CallContextStore.php
+++ b/src/grpc/src/Server/CallContextStore.php
@@ -12,7 +12,7 @@ use LogicException;
  */
 class CallContextStore
 {
-    private const CALL_CONTEXT_KEY = '__grpc.call';
+    private const string CALL_CONTEXT_KEY = '__grpc.call';
 
     /**
      * Store the active server call context.

--- a/src/grpc/src/Server/ResponseFactory.php
+++ b/src/grpc/src/Server/ResponseFactory.php
@@ -34,16 +34,16 @@ use UnexpectedValueException;
 class ResponseFactory
 {
     /** @internal */
-    public const COMPRESSION_ATTRIBUTE = '_grpc.response_compression';
+    public const string COMPRESSION_ATTRIBUTE = '_grpc.response_compression';
 
     /** @var list<string> */
-    private const STATUS_TRAILER_NAMES = [
+    private const array STATUS_TRAILER_NAMES = [
         'grpc-status',
         'grpc-message',
         'grpc-status-details-bin',
     ];
 
-    private const MAX_SERVER_FIELD_NAME_LENGTH = 127;
+    private const int MAX_SERVER_FIELD_NAME_LENGTH = 127;
 
     private readonly FrameEncoder $frames;
 

--- a/src/horizon/src/Horizon.php
+++ b/src/horizon/src/Horizon.php
@@ -52,7 +52,7 @@ class Horizon
     /**
      * The context key for Horizon's CSP nonce attribute.
      */
-    protected const CSP_NONCE_CONTEXT_KEY = '__horizon.csp_nonce';
+    protected const string CSP_NONCE_CONTEXT_KEY = '__horizon.csp_nonce';
 
     /**
      * Determine if the given request can access the Horizon dashboard.

--- a/src/horizon/src/ListensForSignals.php
+++ b/src/horizon/src/ListensForSignals.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 trait ListensForSignals
 {
-    protected const HANDLED_SIGNALS = [
+    protected const array HANDLED_SIGNALS = [
         SIGTERM,
         SIGUSR1,
         SIGUSR2,

--- a/src/horizon/src/RedisQueue.php
+++ b/src/horizon/src/RedisQueue.php
@@ -23,7 +23,7 @@ use Override;
 
 class RedisQueue extends BaseQueue
 {
-    public const LAST_PUSHED_CONTEXT_KEY = '__horizon.queue.last_pushed';
+    public const string LAST_PUSHED_CONTEXT_KEY = '__horizon.queue.last_pushed';
 
     /**
      * Get the number of queue jobs that are ready to process.

--- a/src/horizon/src/SupervisorCommandString.php
+++ b/src/horizon/src/SupervisorCommandString.php
@@ -9,7 +9,7 @@ class SupervisorCommandString
     /**
      * The default base supervisor command.
      */
-    protected const DEFAULT_COMMAND = 'exec @php artisan horizon:supervisor';
+    protected const string DEFAULT_COMMAND = 'exec @php artisan horizon:supervisor';
 
     /**
      * The base worker command.

--- a/src/horizon/src/SupervisorProcess.php
+++ b/src/horizon/src/SupervisorProcess.php
@@ -17,7 +17,7 @@ class SupervisorProcess extends WorkerProcess
     /**
      * Signals handled by a supervisor after its application boots.
      */
-    protected const STARTUP_SIGNALS = [
+    protected const array STARTUP_SIGNALS = [
         SIGTERM,
         SIGUSR1,
         SIGUSR2,

--- a/src/horizon/src/SystemProcessCounter.php
+++ b/src/horizon/src/SystemProcessCounter.php
@@ -11,7 +11,7 @@ class SystemProcessCounter
     /**
      * The default base command.
      */
-    protected const DEFAULT_COMMAND = 'horizon:work';
+    protected const string DEFAULT_COMMAND = 'horizon:work';
 
     /**
      * The base command to search for.

--- a/src/horizon/src/Tags.php
+++ b/src/horizon/src/Tags.php
@@ -18,7 +18,7 @@ use stdClass;
 
 class Tags
 {
-    protected const CONTEXT_KEY = '__horizon.tags';
+    protected const string CONTEXT_KEY = '__horizon.tags';
 
     /**
      * Determine the tags for the given job.

--- a/src/horizon/src/WorkerCommandString.php
+++ b/src/horizon/src/WorkerCommandString.php
@@ -9,7 +9,7 @@ class WorkerCommandString
     /**
      * The default base worker command.
      */
-    protected const DEFAULT_COMMAND = 'exec @php artisan horizon:work';
+    protected const string DEFAULT_COMMAND = 'exec @php artisan horizon:work';
 
     /**
      * The base worker command.

--- a/src/horizon/src/WorkerProcess.php
+++ b/src/horizon/src/WorkerProcess.php
@@ -22,7 +22,7 @@ class WorkerProcess
     /**
      * Signals handled by a queue worker after its application boots.
      */
-    protected const STARTUP_SIGNALS = [
+    protected const array STARTUP_SIGNALS = [
         SIGQUIT,
         SIGTERM,
         SIGINT,

--- a/src/http-server/src/ResponseBridge.php
+++ b/src/http-server/src/ResponseBridge.php
@@ -23,7 +23,7 @@ class ResponseBridge
      *
      * @var list<string>
      */
-    protected const FORBIDDEN_TRAILER_NAMES = [
+    protected const array FORBIDDEN_TRAILER_NAMES = [
         'host',
         'content-length',
         'transfer-encoding',

--- a/src/http/src/Client/RequestException.php
+++ b/src/http/src/Client/RequestException.php
@@ -11,7 +11,7 @@ class RequestException extends HttpClientException
     /**
      * The default truncation length for exception messages.
      */
-    public const DEFAULT_TRUNCATE_AT = 120;
+    public const int DEFAULT_TRUNCATE_AT = 120;
 
     /**
      * The current truncation length for the exception message.

--- a/src/http/src/Middleware/TrustHosts.php
+++ b/src/http/src/Middleware/TrustHosts.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 class TrustHosts
 {
     // Never matches; keeps trusted-host validation enabled when no hosts are trusted.
-    private const REJECT_ALL_HOST_PATTERN = '(?!)';
+    private const string REJECT_ALL_HOST_PATTERN = '(?!)';
 
     /**
      * The application instance.

--- a/src/http/src/Request.php
+++ b/src/http/src/Request.php
@@ -48,7 +48,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Forwarded-header parameter mapping.
      */
-    protected const FORWARDED_PARAMS = [
+    protected const array FORWARDED_PARAMS = [
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
         self::HEADER_X_FORWARDED_PROTO => 'proto',
@@ -58,7 +58,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Mapping of trusted-header bitmask flags to header names.
      */
-    protected const TRUSTED_HEADERS = [
+    protected const array TRUSTED_HEADERS = [
         self::HEADER_FORWARDED => 'FORWARDED',
         self::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
         self::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',

--- a/src/inertia/src/InertiaState.php
+++ b/src/inertia/src/InertiaState.php
@@ -22,7 +22,7 @@ class InertiaState implements ReplicableContext
     /**
      * The coroutine Context key for this state.
      */
-    public const CONTEXT_KEY = '__inertia.state';
+    public const string CONTEXT_KEY = '__inertia.state';
 
     /**
      * The root Blade template name.

--- a/src/inertia/src/Support/Header.php
+++ b/src/inertia/src/Support/Header.php
@@ -9,55 +9,55 @@ class Header
     /**
      * The main Inertia request header.
      */
-    public const INERTIA = 'X-Inertia';
+    public const string INERTIA = 'X-Inertia';
 
     /**
      * Header for specifying which error bag to use for validation errors.
      */
-    public const ERROR_BAG = 'X-Inertia-Error-Bag';
+    public const string ERROR_BAG = 'X-Inertia-Error-Bag';
 
     /**
      * Header for external redirects.
      */
-    public const LOCATION = 'X-Inertia-Location';
+    public const string LOCATION = 'X-Inertia-Location';
 
     /**
      * Header for hash fragment redirects.
      */
-    public const REDIRECT = 'X-Inertia-Redirect';
+    public const string REDIRECT = 'X-Inertia-Redirect';
 
     /**
      * Header for the current asset version.
      */
-    public const VERSION = 'X-Inertia-Version';
+    public const string VERSION = 'X-Inertia-Version';
 
     /**
      * Header specifying the component for partial reloads.
      */
-    public const PARTIAL_COMPONENT = 'X-Inertia-Partial-Component';
+    public const string PARTIAL_COMPONENT = 'X-Inertia-Partial-Component';
 
     /**
      * Header specifying which props to include in partial reloads.
      */
-    public const PARTIAL_ONLY = 'X-Inertia-Partial-Data';
+    public const string PARTIAL_ONLY = 'X-Inertia-Partial-Data';
 
     /**
      * Header specifying which props to exclude from partial reloads.
      */
-    public const PARTIAL_EXCEPT = 'X-Inertia-Partial-Except';
+    public const string PARTIAL_EXCEPT = 'X-Inertia-Partial-Except';
 
     /**
      * Header for resetting the page state.
      */
-    public const RESET = 'X-Inertia-Reset';
+    public const string RESET = 'X-Inertia-Reset';
 
     /**
      * Header for specifying the merge intent when paginating on infinite scroll.
      */
-    public const INFINITE_SCROLL_MERGE_INTENT = 'X-Inertia-Infinite-Scroll-Merge-Intent';
+    public const string INFINITE_SCROLL_MERGE_INTENT = 'X-Inertia-Infinite-Scroll-Merge-Intent';
 
     /**
      * Header specifying which once props to exclude from the response.
      */
-    public const EXCEPT_ONCE_PROPS = 'X-Inertia-Except-Once-Props';
+    public const string EXCEPT_ONCE_PROPS = 'X-Inertia-Except-Once-Props';
 }

--- a/src/inertia/src/Support/SessionKey.php
+++ b/src/inertia/src/Support/SessionKey.php
@@ -9,15 +9,15 @@ class SessionKey
     /**
      * Session key for clearing the Inertia history.
      */
-    public const CLEAR_HISTORY = 'inertia.clear_history';
+    public const string CLEAR_HISTORY = 'inertia.clear_history';
 
     /**
      * Session key for flash data.
      */
-    public const FLASH_DATA = 'inertia.flash_data';
+    public const string FLASH_DATA = 'inertia.flash_data';
 
     /**
      * Session key for preserving the URL fragment.
      */
-    public const PRESERVE_FRAGMENT = 'inertia.preserve_fragment';
+    public const string PRESERVE_FRAGMENT = 'inertia.preserve_fragment';
 }

--- a/src/json-schema/src/Deserializer.php
+++ b/src/json-schema/src/Deserializer.php
@@ -14,7 +14,7 @@ class Deserializer
      *
      * @var array<int, string>
      */
-    protected const TYPE_SPECIFIC_KEYWORDS = [
+    protected const array TYPE_SPECIFIC_KEYWORDS = [
         'minLength', 'maxLength', 'pattern', 'format',
         'minimum', 'maximum', 'multipleOf',
         'items', 'minItems', 'maxItems', 'uniqueItems',
@@ -26,7 +26,7 @@ class Deserializer
      *
      * @var array<int, string>
      */
-    protected const UNSUPPORTED_ASSERTION_KEYWORDS = [
+    protected const array UNSUPPORTED_ASSERTION_KEYWORDS = [
         'const', 'not', 'allOf', 'if', 'dependentSchemas', 'dependentRequired',
         'prefixItems', 'contains', 'patternProperties', 'propertyNames',
         'unevaluatedItems', 'unevaluatedProperties',
@@ -37,12 +37,12 @@ class Deserializer
     /**
      * The maximum number of schema fragments that may be expanded.
      */
-    protected const MAX_NODES = 20000;
+    protected const int MAX_NODES = 20000;
 
     /**
      * The maximum number of distinct references on one active path.
      */
-    protected const MAX_REFERENCE_DEPTH = 256;
+    protected const int MAX_REFERENCE_DEPTH = 256;
 
     /**
      * The number of schema fragments expanded so far.

--- a/src/json-schema/src/Types/UnionType.php
+++ b/src/json-schema/src/Types/UnionType.php
@@ -13,7 +13,7 @@ class UnionType extends Type
      *
      * @var array<int, string>
      */
-    public const SUPPORTED = ['string', 'integer', 'number', 'boolean', 'object', 'array'];
+    public const array SUPPORTED = ['string', 'integer', 'number', 'boolean', 'object', 'array'];
 
     /**
      * The union's member type names.

--- a/src/jwt/src/Providers/Provider.php
+++ b/src/jwt/src/Providers/Provider.php
@@ -8,23 +8,23 @@ use Hypervel\Support\Arr;
 
 abstract class Provider
 {
-    public const ALGO_HS256 = 'HS256';
+    public const string ALGO_HS256 = 'HS256';
 
-    public const ALGO_HS384 = 'HS384';
+    public const string ALGO_HS384 = 'HS384';
 
-    public const ALGO_HS512 = 'HS512';
+    public const string ALGO_HS512 = 'HS512';
 
-    public const ALGO_RS256 = 'RS256';
+    public const string ALGO_RS256 = 'RS256';
 
-    public const ALGO_RS384 = 'RS384';
+    public const string ALGO_RS384 = 'RS384';
 
-    public const ALGO_RS512 = 'RS512';
+    public const string ALGO_RS512 = 'RS512';
 
-    public const ALGO_ES256 = 'ES256';
+    public const string ALGO_ES256 = 'ES256';
 
-    public const ALGO_ES384 = 'ES384';
+    public const string ALGO_ES384 = 'ES384';
 
-    public const ALGO_ES512 = 'ES512';
+    public const string ALGO_ES512 = 'ES512';
 
     /**
      * Constructor.

--- a/src/jwt/src/Storage/TaggedCache.php
+++ b/src/jwt/src/Storage/TaggedCache.php
@@ -17,7 +17,7 @@ class TaggedCache implements StorageContract
      * of the cache; in any mode keys are plain, so the prefix provides
      * that isolation instead.
      */
-    private const DIRECT_KEY_PREFIX = 'jwt_blacklist:';
+    private const string DIRECT_KEY_PREFIX = 'jwt_blacklist:';
 
     protected string $tag = 'jwt_blacklist';
 

--- a/src/log/src/Context/Repository.php
+++ b/src/log/src/Context/Repository.php
@@ -26,7 +26,7 @@ class Repository implements ReplicableContext
     use Macroable;
     use SerializesAndRestoresModelIdentifiers;
 
-    public const CONTEXT_KEY = '__log.context_repository';
+    public const string CONTEXT_KEY = '__log.context_repository';
 
     /**
      * The contextual data that flows to logs and jobs.

--- a/src/log/src/LogManager.php
+++ b/src/log/src/LogManager.php
@@ -52,7 +52,7 @@ class LogManager implements LoggerInterface
     /**
      * Context key for shared log context across channels.
      */
-    protected const SHARED_CONTEXT_KEY = '__log.shared_context';
+    protected const string SHARED_CONTEXT_KEY = '__log.shared_context';
 
     /**
      * The array of resolved channels.

--- a/src/log/src/Logger.php
+++ b/src/log/src/Logger.php
@@ -24,7 +24,7 @@ class Logger implements LoggerInterface
     /**
      * The CoroutineContext key prefix for per-channel logger context.
      */
-    protected const CONTEXT_KEY_PREFIX = '__log.logger_state.';
+    protected const string CONTEXT_KEY_PREFIX = '__log.logger_state.';
 
     /**
      * The next worker-unique logger family identifier.

--- a/src/mail/src/MailManager.php
+++ b/src/mail/src/MailManager.php
@@ -54,7 +54,7 @@ class MailManager implements FactoryContract
     /**
      * Mailer-level keys that do not affect built-in transport construction.
      */
-    protected const TRANSPORT_PRESENTATION_KEYS = [
+    protected const array TRANSPORT_PRESENTATION_KEYS = [
         'from', 'reply_to', 'return_path', 'to', 'name', 'pool',
     ];
 

--- a/src/nested-set/src/NodeContext.php
+++ b/src/nested-set/src/NodeContext.php
@@ -13,7 +13,7 @@ class NodeContext
     /**
      * Context key prefix for structural freshness state.
      */
-    protected const FRESHNESS_CONTEXT_KEY_PREFIX = '__nested_set.freshness.';
+    protected const string FRESHNESS_CONTEXT_KEY_PREFIX = '__nested_set.freshness.';
 
     /**
      * Determine whether the model is current for the logical tree revision.

--- a/src/notifications/src/ChannelManager.php
+++ b/src/notifications/src/ChannelManager.php
@@ -27,12 +27,12 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     /**
      * Context key for the per-request default channel override.
      */
-    protected const DEFAULT_CHANNEL_CONTEXT_KEY = '__notifications.default_channel';
+    protected const string DEFAULT_CHANNEL_CONTEXT_KEY = '__notifications.default_channel';
 
     /**
      * Context key for the per-request default locale override.
      */
-    protected const DEFAULT_LOCALE_CONTEXT_KEY = '__notifications.default_locale';
+    protected const string DEFAULT_LOCALE_CONTEXT_KEY = '__notifications.default_locale';
 
     /**
      * The default channel used to deliver messages.

--- a/src/notifications/src/Channels/SlackWebApiChannel.php
+++ b/src/notifications/src/Channels/SlackWebApiChannel.php
@@ -15,7 +15,7 @@ use RuntimeException;
 
 class SlackWebApiChannel
 {
-    protected const SLACK_API_URL = 'https://slack.com/api/chat.postMessage';
+    protected const string SLACK_API_URL = 'https://slack.com/api/chat.postMessage';
 
     /**
      * Create a new Slack channel instance.

--- a/src/notifications/src/NotificationSender.php
+++ b/src/notifications/src/NotificationSender.php
@@ -43,7 +43,7 @@ class NotificationSender
      * listener would leak into the persistent $listeners array. The boot-time listener
      * marks an active attempt when its channel dispatches NotificationFailed before throwing.
      */
-    public const FAILED_EVENT_DISPATCHED_CONTEXT_KEY = '__notifications.failed_dispatched';
+    public const string FAILED_EVENT_DISPATCHED_CONTEXT_KEY = '__notifications.failed_dispatched';
 
     /**
      * Create a new notification sender instance.

--- a/src/object-pool/src/PoolOptions.php
+++ b/src/object-pool/src/PoolOptions.php
@@ -8,17 +8,17 @@ use InvalidArgumentException;
 
 final readonly class PoolOptions
 {
-    public const DEFAULT_IDLE_TTL = 300.0;
+    public const float DEFAULT_IDLE_TTL = 300.0;
 
-    private const DEFAULT_MIN_RETAINED_OBJECTS = 1;
+    private const int DEFAULT_MIN_RETAINED_OBJECTS = 1;
 
-    private const DEFAULT_MAX_OBJECTS = 10;
+    private const int DEFAULT_MAX_OBJECTS = 10;
 
-    private const DEFAULT_WAIT_TIMEOUT = 3.0;
+    private const float DEFAULT_WAIT_TIMEOUT = 3.0;
 
-    private const DEFAULT_MAX_LIFETIME = 60.0;
+    private const float DEFAULT_MAX_LIFETIME = 60.0;
 
-    private const DEFAULT_MAX_IDLE_TIME = 0.0;
+    private const float DEFAULT_MAX_IDLE_TIME = 0.0;
 
     /**
      * Create normalized pool options.

--- a/src/pagination/src/AbstractPaginator.php
+++ b/src/pagination/src/AbstractPaginator.php
@@ -121,12 +121,12 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
     /**
      * The default pagination view name.
      */
-    protected const DEFAULT_VIEW = 'pagination::tailwind';
+    protected const string DEFAULT_VIEW = 'pagination::tailwind';
 
     /**
      * The default simple pagination view name.
      */
-    protected const DEFAULT_SIMPLE_VIEW = 'pagination::simple-tailwind';
+    protected const string DEFAULT_SIMPLE_VIEW = 'pagination::simple-tailwind';
 
     /**
      * The default pagination view.

--- a/src/passkeys/src/Passkeys.php
+++ b/src/passkeys/src/Passkeys.php
@@ -16,9 +16,9 @@ use RuntimeException;
 
 class Passkeys
 {
-    private const DEFAULT_PASSKEY_MODEL = Passkey::class;
+    private const string DEFAULT_PASSKEY_MODEL = Passkey::class;
 
-    private const DEFAULT_REGISTERS_ROUTES = true;
+    private const bool DEFAULT_REGISTERS_ROUTES = true;
 
     /** @var class-string<Passkey> */
     private static string $passkeyModel = self::DEFAULT_PASSKEY_MODEL;

--- a/src/permission/src/DefaultTeamResolver.php
+++ b/src/permission/src/DefaultTeamResolver.php
@@ -11,7 +11,7 @@ use Hypervel\Permission\Contracts\PermissionsTeamResolver;
 
 final class DefaultTeamResolver implements PermissionsTeamResolver
 {
-    public const TEAM_ID_CONTEXT_KEY = '__permission.team_id';
+    public const string TEAM_ID_CONTEXT_KEY = '__permission.team_id';
 
     /**
      * Set the current permissions team id.

--- a/src/permission/src/PermissionRegistrar.php
+++ b/src/permission/src/PermissionRegistrar.php
@@ -42,17 +42,17 @@ use function Hypervel\Support\enum_value;
 
 class PermissionRegistrar
 {
-    public const MODEL_ROLES_CACHE_KEY_PREFIX = 'hypervel.permission.cache.model.roles';
+    public const string MODEL_ROLES_CACHE_KEY_PREFIX = 'hypervel.permission.cache.model.roles';
 
-    public const MODEL_PERMISSIONS_CACHE_KEY_PREFIX = 'hypervel.permission.cache.model.permissions';
+    public const string MODEL_PERMISSIONS_CACHE_KEY_PREFIX = 'hypervel.permission.cache.model.permissions';
 
-    public const MODEL_CACHE_TOKEN_KEY = 'hypervel.permission.cache.model.token';
+    public const string MODEL_CACHE_TOKEN_KEY = 'hypervel.permission.cache.model.token';
 
-    public const PERMISSION_CATALOG_CONTEXT_KEY = '__permission.catalog';
+    public const string PERMISSION_CATALOG_CONTEXT_KEY = '__permission.catalog';
 
-    public const WILDCARD_PERMISSION_INDEX_CONTEXT_KEY = '__permission.wildcard_index';
+    public const string WILDCARD_PERMISSION_INDEX_CONTEXT_KEY = '__permission.wildcard_index';
 
-    public const MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY = '__permission.model_via_role_permissions';
+    public const string MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY = '__permission.model_via_role_permissions';
 
     protected static ?string $partitionColumn = null;
 

--- a/src/permission/src/Support/Config.php
+++ b/src/permission/src/Support/Config.php
@@ -16,9 +16,9 @@ use Hypervel\Permission\PermissionRegistrar;
 class Config
 {
     // Eloquent derives the morph-type column from the relation name.
-    public const MORPH_NAME = 'model';
+    public const string MORPH_NAME = 'model';
 
-    public const MORPH_TYPE = self::MORPH_NAME . '_type';
+    public const string MORPH_TYPE = self::MORPH_NAME . '_type';
 
     /**
      * Get the config repository.

--- a/src/permission/src/WildcardPermission.php
+++ b/src/permission/src/WildcardPermission.php
@@ -12,11 +12,11 @@ use Hypervel\Support\Str;
 
 class WildcardPermission implements Wildcard
 {
-    public const WILDCARD_TOKEN = '*';
+    public const string WILDCARD_TOKEN = '*';
 
-    public const PART_DELIMITER = '.';
+    public const string PART_DELIMITER = '.';
 
-    public const SUBPART_DELIMITER = ',';
+    public const string SUBPART_DELIMITER = ',';
 
     /**
      * Create a new wildcard permission matcher.

--- a/src/pool/src/PoolOption.php
+++ b/src/pool/src/PoolOption.php
@@ -15,12 +15,12 @@ class PoolOption implements PoolOptionInterface
     /**
      * Lowest max_lifetime fraction assigned to a connection generation.
      */
-    public const MIN_LIFETIME_JITTER_BASIS = 9000;
+    public const int MIN_LIFETIME_JITTER_BASIS = 9000;
 
     /**
      * Scale used for jitter basis values.
      */
-    public const LIFETIME_JITTER_SCALE = 10000;
+    public const int LIFETIME_JITTER_SCALE = 10000;
 
     /**
      * @param int $minConnections Managed-connection floor when trimming excess idle connections

--- a/src/prompts/src/Concerns/Fallback.php
+++ b/src/prompts/src/Concerns/Fallback.php
@@ -14,12 +14,12 @@ trait Fallback
     /**
      * Context key for the fallback condition.
      */
-    protected const SHOULD_FALLBACK_CONTEXT_KEY = '__prompts.should_fallback';
+    protected const string SHOULD_FALLBACK_CONTEXT_KEY = '__prompts.should_fallback';
 
     /**
      * Context key for the fallback implementations.
      */
-    protected const FALLBACKS_CONTEXT_KEY = '__prompts.fallbacks';
+    protected const string FALLBACKS_CONTEXT_KEY = '__prompts.fallbacks';
 
     /**
      * Whether to fallback to a custom implementation.

--- a/src/prompts/src/Concerns/Interactivity.php
+++ b/src/prompts/src/Concerns/Interactivity.php
@@ -13,7 +13,7 @@ trait Interactivity
     /**
      * Context key for the interactive mode override.
      */
-    protected const INTERACTIVE_CONTEXT_KEY = '__prompts.interactive';
+    protected const string INTERACTIVE_CONTEXT_KEY = '__prompts.interactive';
 
     /**
      * Whether to render the prompt interactively.

--- a/src/prompts/src/Concerns/Themes.php
+++ b/src/prompts/src/Concerns/Themes.php
@@ -58,14 +58,14 @@ trait Themes
     /**
      * The default theme name.
      */
-    protected const DEFAULT_THEME = 'default';
+    protected const string DEFAULT_THEME = 'default';
 
     /**
      * The default theme registry.
      *
      * @var array<string, array<class-string<\Hypervel\Prompts\Prompt>, class-string<callable&object>>>
      */
-    protected const DEFAULT_THEMES = [
+    protected const array DEFAULT_THEMES = [
         self::DEFAULT_THEME => [
             TextPrompt::class => TextPromptRenderer::class,
             NumberPrompt::class => NumberPromptRenderer::class,

--- a/src/prompts/src/Key.php
+++ b/src/prompts/src/Key.php
@@ -6,99 +6,99 @@ namespace Hypervel\Prompts;
 
 class Key
 {
-    public const UP = "\e[A";
+    public const string UP = "\e[A";
 
-    public const SHIFT_UP = "\e[1;2A";
+    public const string SHIFT_UP = "\e[1;2A";
 
-    public const PAGE_UP = "\e[5~";
+    public const string PAGE_UP = "\e[5~";
 
-    public const DOWN = "\e[B";
+    public const string DOWN = "\e[B";
 
-    public const SHIFT_DOWN = "\e[1;2B";
+    public const string SHIFT_DOWN = "\e[1;2B";
 
-    public const PAGE_DOWN = "\e[6~";
+    public const string PAGE_DOWN = "\e[6~";
 
-    public const RIGHT = "\e[C";
+    public const string RIGHT = "\e[C";
 
-    public const LEFT = "\e[D";
+    public const string LEFT = "\e[D";
 
-    public const UP_ARROW = "\eOA";
+    public const string UP_ARROW = "\eOA";
 
-    public const DOWN_ARROW = "\eOB";
+    public const string DOWN_ARROW = "\eOB";
 
-    public const RIGHT_ARROW = "\eOC";
+    public const string RIGHT_ARROW = "\eOC";
 
-    public const LEFT_ARROW = "\eOD";
+    public const string LEFT_ARROW = "\eOD";
 
-    public const ESCAPE = "\e";
+    public const string ESCAPE = "\e";
 
-    public const DELETE = "\e[3~";
+    public const string DELETE = "\e[3~";
 
-    public const BACKSPACE = "\177";
+    public const string BACKSPACE = "\177";
 
-    public const ENTER = "\n";
+    public const string ENTER = "\n";
 
-    public const SPACE = ' ';
+    public const string SPACE = ' ';
 
-    public const TAB = "\t";
+    public const string TAB = "\t";
 
-    public const SHIFT_TAB = "\e[Z";
+    public const string SHIFT_TAB = "\e[Z";
 
-    public const HOME = ["\e[1~", "\eOH", "\e[H", "\e[7~"];
+    public const array HOME = ["\e[1~", "\eOH", "\e[H", "\e[7~"];
 
-    public const END = ["\e[4~", "\eOF", "\e[F", "\e[8~"];
+    public const array END = ["\e[4~", "\eOF", "\e[F", "\e[8~"];
 
     /**
      * Cancel/SIGINT.
      */
-    public const CTRL_C = "\x03";
+    public const string CTRL_C = "\x03";
 
     /**
      * Previous/Up.
      */
-    public const CTRL_P = "\x10";
+    public const string CTRL_P = "\x10";
 
     /**
      * Next/Down.
      */
-    public const CTRL_N = "\x0E";
+    public const string CTRL_N = "\x0E";
 
     /**
      * Forward/Right.
      */
-    public const CTRL_F = "\x06";
+    public const string CTRL_F = "\x06";
 
     /**
      * Back/Left.
      */
-    public const CTRL_B = "\x02";
+    public const string CTRL_B = "\x02";
 
     /**
      * Backspace.
      */
-    public const CTRL_H = "\x08";
+    public const string CTRL_H = "\x08";
 
     /**
      * Home.
      */
-    public const CTRL_A = "\x01";
+    public const string CTRL_A = "\x01";
 
     /**
      * EOF.
      */
-    public const CTRL_D = "\x04";
+    public const string CTRL_D = "\x04";
 
     /**
      * End.
      */
-    public const CTRL_E = "\x05";
+    public const string CTRL_E = "\x05";
 
     /**
      * Negative affirmation.
      */
-    public const CTRL_U = "\x15";
+    public const string CTRL_U = "\x15";
 
-    public const OPTION_BACKSPACE = "\e\177";
+    public const string OPTION_BACKSPACE = "\e\177";
 
     /**
      * Checks for the constant values for the given match and returns the match.

--- a/src/prompts/src/Prompt.php
+++ b/src/prompts/src/Prompt.php
@@ -28,12 +28,12 @@ abstract class Prompt
     /**
      * Context key for the output instance override.
      */
-    protected const OUTPUT_CONTEXT_KEY = '__prompts.output';
+    protected const string OUTPUT_CONTEXT_KEY = '__prompts.output';
 
     /**
      * Context key for the custom validation callback override.
      */
-    protected const VALIDATE_USING_CONTEXT_KEY = '__prompts.validate_using';
+    protected const string VALIDATE_USING_CONTEXT_KEY = '__prompts.validate_using';
 
     /**
      * The current state of the prompt.

--- a/src/prompts/src/Task.php
+++ b/src/prompts/src/Task.php
@@ -23,19 +23,19 @@ class Task extends Prompt
      *
      * This must remain well above the public render interval.
      */
-    protected const LOGGER_WRITE_TIMEOUT_SECONDS = 10;
+    protected const int LOGGER_WRITE_TIMEOUT_SECONDS = 10;
 
     /**
      * Scheduling margin added to one complete renderer frame interval.
      *
      * Reset can arrive while the renderer is sleeping between frames.
      */
-    protected const RENDERER_SETTLEMENT_MARGIN_MILLISECONDS = 1000;
+    protected const int RENDERER_SETTLEMENT_MARGIN_MILLISECONDS = 1000;
 
     /**
      * The renderer settlement acknowledgement byte.
      */
-    protected const RENDERER_ACKNOWLEDGEMENT = "\x06";
+    protected const string RENDERER_ACKNOWLEDGEMENT = "\x06";
 
     /**
      * The minimum width for the longest line calculation.

--- a/src/queue/src/Console/WorkCommand.php
+++ b/src/queue/src/Console/WorkCommand.php
@@ -31,9 +31,9 @@ class WorkCommand extends Command
 {
     use InteractsWithTime;
 
-    protected const CURRENT_COMMAND_CONTEXT_KEY = '__queue.worker.current_command';
+    protected const string CURRENT_COMMAND_CONTEXT_KEY = '__queue.worker.current_command';
 
-    protected const LATEST_STARTED_AT_CONTEXT_KEY = '__queue.worker.latest_started_at';
+    protected const string LATEST_STARTED_AT_CONTEXT_KEY = '__queue.worker.latest_started_at';
 
     /**
      * The console command name.

--- a/src/queue/src/SqsQueue.php
+++ b/src/queue/src/SqsQueue.php
@@ -28,19 +28,19 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * The maximum SQS payload size in bytes (1 MB).
      */
-    public const MAX_SQS_PAYLOAD_SIZE = 1048576;
+    public const int MAX_SQS_PAYLOAD_SIZE = 1048576;
 
     /**
      * The maximum number of messages allowed per SendMessageBatch request.
      */
-    public const MAX_MESSAGES_PER_BATCH = 10;
+    public const int MAX_MESSAGES_PER_BATCH = 10;
 
     /**
      * The cache key prefix for extended SQS payloads.
      *
      * IMPORTANT: Uses Laravel's prefix for cross-framework queue interoperability.
      */
-    public const EXTENDED_PAYLOAD_CACHE_PREFIX = 'laravel:sqs-payloads:';
+    public const string EXTENDED_PAYLOAD_CACHE_PREFIX = 'laravel:sqs-payloads:';
 
     /**
      * The overflow storage options for large payload offloading.

--- a/src/queue/src/Worker.php
+++ b/src/queue/src/Worker.php
@@ -40,23 +40,23 @@ class Worker
 {
     use DetectsLostConnections;
 
-    public const EXIT_SUCCESS = 0;
+    public const int EXIT_SUCCESS = 0;
 
-    public const EXIT_ERROR = 1;
+    public const int EXIT_ERROR = 1;
 
-    public const EXIT_MEMORY_LIMIT = 12;
+    public const int EXIT_MEMORY_LIMIT = 12;
 
     /**
      * The cache key for the restart signal.
      *
      * IMPORTANT: Uses Laravel's key for cross-framework queue interoperability.
      */
-    public const RESTART_SIGNAL_CACHE_KEY = 'illuminate:queue:restart';
+    public const string RESTART_SIGNAL_CACHE_KEY = 'illuminate:queue:restart';
 
     /**
      * Signals installed when the worker daemon starts.
      */
-    protected const HANDLED_SIGNALS = [
+    protected const array HANDLED_SIGNALS = [
         SIGQUIT,
         SIGTERM,
         SIGINT,

--- a/src/redis/src/Operations/FlushByPattern.php
+++ b/src/redis/src/Operations/FlushByPattern.php
@@ -52,7 +52,7 @@ final class FlushByPattern
      * Number of keys to buffer before executing a batch delete.
      * Balances memory usage vs. number of Redis round-trips.
      */
-    private const BUFFER_SIZE = 1000;
+    private const int BUFFER_SIZE = 1000;
 
     /**
      * Create a new pattern flush instance.

--- a/src/redis/src/PhpRedis.php
+++ b/src/redis/src/PhpRedis.php
@@ -6,7 +6,7 @@ namespace Hypervel\Redis;
 
 final class PhpRedis
 {
-    private const NULL_INITIAL_CURSOR_VERSION = '6.1.0';
+    private const string NULL_INITIAL_CURSOR_VERSION = '6.1.0';
 
     /**
      * Determine if phpredis uses null as the initial SCAN-family cursor.

--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -333,7 +333,7 @@ abstract class RedisConnection extends BaseConnection
     /**
      * Top-level connection config keys that should be applied through setOption.
      */
-    private const CONNECTION_LEVEL_PHPREDIS_OPTIONS = [
+    private const array CONNECTION_LEVEL_PHPREDIS_OPTIONS = [
         'read_timeout',
         'max_retries',
         'backoff_algorithm',

--- a/src/redis/src/RedisProxy.php
+++ b/src/redis/src/RedisProxy.php
@@ -40,19 +40,19 @@ class RedisProxy implements ConnectionContract
     /**
      * Context key prefix for per-connection pool state.
      */
-    public const CONNECTION_CONTEXT_PREFIX = '__redis.connection.';
+    public const string CONNECTION_CONTEXT_PREFIX = '__redis.connection.';
 
     /**
      * Context key prefix for the coroutine owning deferred pool cleanup.
      */
-    private const DEFERRED_RELEASE_OWNER_CONTEXT_KEY_PREFIX = '__redis.deferred_release_owner.';
+    private const string DEFERRED_RELEASE_OWNER_CONTEXT_KEY_PREFIX = '__redis.deferred_release_owner.';
 
     /**
      * Methods that must be called while explicitly holding a pool connection.
      *
      * These methods must remain excluded from Redis facade generation.
      */
-    private const CONNECTION_BOUND_METHODS = [
+    private const array CONNECTION_BOUND_METHODS = [
         'auth',
         'check',
         'client',

--- a/src/redis/src/Subscriber/Constants.php
+++ b/src/redis/src/Subscriber/Constants.php
@@ -6,5 +6,5 @@ namespace Hypervel\Redis\Subscriber;
 
 class Constants
 {
-    public const CRLF = "\r\n";
+    public const string CRLF = "\r\n";
 }

--- a/src/routing/src/ResourceRegistrar.php
+++ b/src/routing/src/ResourceRegistrar.php
@@ -11,7 +11,7 @@ class ResourceRegistrar
     /**
      * The default verbs used in resource URIs.
      */
-    protected const DEFAULT_VERBS = [
+    protected const array DEFAULT_VERBS = [
         'create' => 'create',
         'edit' => 'edit',
     ];

--- a/src/routing/src/Route.php
+++ b/src/routing/src/Route.php
@@ -59,17 +59,17 @@ class Route
      * mutable state (parameters, controller instances) must be stored in
      * coroutine-local Context rather than on the Route instance.
      */
-    private const PARAMS_CONTEXT_KEY_PREFIX = '__routing.parameters.';
+    private const string PARAMS_CONTEXT_KEY_PREFIX = '__routing.parameters.';
 
     /**
      * Context key for coroutine-local original route parameters.
      */
-    private const ORIGINAL_PARAMS_CONTEXT_KEY_PREFIX = '__routing.original_parameters.';
+    private const string ORIGINAL_PARAMS_CONTEXT_KEY_PREFIX = '__routing.original_parameters.';
 
     /**
      * Context key prefix for coroutine-local controller instances.
      */
-    private const CONTROLLER_CONTEXT_KEY_PREFIX = '__routing.controller.';
+    private const string CONTROLLER_CONTEXT_KEY_PREFIX = '__routing.controller.';
 
     /**
      * The URI pattern the route responds to.

--- a/src/routing/src/Router.php
+++ b/src/routing/src/Router.php
@@ -46,9 +46,9 @@ class Router implements BindingRegistrar, RegistrarContract
     }
     use Tappable;
 
-    private const CURRENT_ROUTE_CONTEXT_KEY = '__routing.current_route';
+    private const string CURRENT_ROUTE_CONTEXT_KEY = '__routing.current_route';
 
-    private const CURRENT_REQUEST_CONTEXT_KEY = '__routing.current_request';
+    private const string CURRENT_REQUEST_CONTEXT_KEY = '__routing.current_request';
 
     /**
      * The event dispatcher instance.

--- a/src/routing/src/UrlGenerator.php
+++ b/src/routing/src/UrlGenerator.php
@@ -30,27 +30,27 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Context key for the cached URL scheme.
      */
-    protected const CACHED_SCHEME_CONTEXT_KEY = '__routing.url.cached_scheme';
+    protected const string CACHED_SCHEME_CONTEXT_KEY = '__routing.url.cached_scheme';
 
     /**
      * Context key for the cached root URL.
      */
-    protected const CACHED_ROOT_CONTEXT_KEY = '__routing.url.cached_root';
+    protected const string CACHED_ROOT_CONTEXT_KEY = '__routing.url.cached_root';
 
     /**
      * Context key for the forced root URL override.
      */
-    protected const FORCED_ROOT_CONTEXT_KEY = '__routing.url.forced_root';
+    protected const string FORCED_ROOT_CONTEXT_KEY = '__routing.url.forced_root';
 
     /**
      * Context key for the forced asset root URL override.
      */
-    protected const FORCED_ASSET_ROOT_CONTEXT_KEY = '__routing.url.forced_asset_root';
+    protected const string FORCED_ASSET_ROOT_CONTEXT_KEY = '__routing.url.forced_asset_root';
 
     /**
      * Context key for request-scoped default route parameters.
      */
-    protected const DEFAULT_PARAMETERS_CONTEXT_KEY = '__routing.url.default_parameters';
+    protected const string DEFAULT_PARAMETERS_CONTEXT_KEY = '__routing.url.default_parameters';
 
     /**
      * The route collection.

--- a/src/scout/src/Engines/MeilisearchEngine.php
+++ b/src/scout/src/Engines/MeilisearchEngine.php
@@ -35,12 +35,12 @@ class MeilisearchEngine extends Engine implements DeletesByFilter, UpdatesIndexS
     /**
      * The maximum time to wait for a filtered deletion task.
      */
-    protected const FILTER_DELETE_TIMEOUT_IN_MS = 500_000;
+    protected const int FILTER_DELETE_TIMEOUT_IN_MS = 500_000;
 
     /**
      * The interval between filtered deletion task checks.
      */
-    protected const FILTER_DELETE_INTERVAL_IN_MS = 5_000;
+    protected const int FILTER_DELETE_INTERVAL_IN_MS = 5_000;
 
     /**
      * Create a new MeilisearchEngine instance.

--- a/src/scout/src/Engines/MeilisearchRetryPolicy.php
+++ b/src/scout/src/Engines/MeilisearchRetryPolicy.php
@@ -24,7 +24,7 @@ class MeilisearchRetryPolicy
     /**
      * Status codes that indicate transient failures and should be retried.
      */
-    private const RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
+    private const array RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
 
     /**
      * Determine whether a response or exception should trigger a retry.

--- a/src/scout/src/ModelObserver.php
+++ b/src/scout/src/ModelObserver.php
@@ -23,12 +23,12 @@ class ModelObserver
     /**
      * Context key prefix for storing whether syncing is disabled per model class.
      */
-    protected const SYNCING_DISABLED_CONTEXT_KEY_PREFIX = '__scout.syncing_disabled.';
+    protected const string SYNCING_DISABLED_CONTEXT_KEY_PREFIX = '__scout.syncing_disabled.';
 
     /**
      * Context key for storing whether the current coroutine is forcing a search update.
      */
-    protected const FORCE_SAVING_CONTEXT_KEY = '__scout.force_saving';
+    protected const string FORCE_SAVING_CONTEXT_KEY = '__scout.force_saving';
 
     /**
      * Indicates if Scout will dispatch the observer's events after the open parent database transactions have committed.

--- a/src/scout/src/Scout.php
+++ b/src/scout/src/Scout.php
@@ -29,12 +29,12 @@ class Scout
     /**
      * The default job class that makes models searchable.
      */
-    protected const DEFAULT_MAKE_SEARCHABLE_JOB = MakeSearchable::class;
+    protected const string DEFAULT_MAKE_SEARCHABLE_JOB = MakeSearchable::class;
 
     /**
      * The default job class that removes models from the search index.
      */
-    protected const DEFAULT_REMOVE_FROM_SEARCH_JOB = RemoveFromSearch::class;
+    protected const string DEFAULT_REMOVE_FROM_SEARCH_JOB = RemoveFromSearch::class;
 
     /**
      * Coroutine-local context key indicating that scout:import is currently running.
@@ -42,12 +42,12 @@ class Scout
      * Coroutine-local rather than process-global so concurrent coroutines in the
      * same process don't leak the import flag into each other.
      */
-    public const IMPORTING_CONTEXT_KEY = '__scout.importing';
+    public const string IMPORTING_CONTEXT_KEY = '__scout.importing';
 
     /**
      * Coroutine-local context key for the active scout:import progress reporter.
      */
-    public const IMPORT_PROGRESS_CONTEXT_KEY = '__scout.import_progress';
+    public const string IMPORT_PROGRESS_CONTEXT_KEY = '__scout.import_progress';
 
     /**
      * The job class that makes models searchable.

--- a/src/scout/src/Searchable.php
+++ b/src/scout/src/Searchable.php
@@ -35,7 +35,7 @@ trait Searchable
      * Coroutine-local rather than a static property so concurrent coroutines in
      * the same process don't share or overwrite each other's runner instances.
      */
-    public const SCOUT_RUNNER_CONTEXT_KEY = '__scout.runner';
+    public const string SCOUT_RUNNER_CONTEXT_KEY = '__scout.runner';
 
     /**
      * Additional metadata attributes managed by Scout.

--- a/src/sentry/src/Features/CacheFeature.php
+++ b/src/sentry/src/Features/CacheFeature.php
@@ -45,7 +45,7 @@ class CacheFeature extends Feature
      */
     public bool $detectSessionKeyOnConsole = false;
 
-    private const FEATURE_KEY = 'cache';
+    private const string FEATURE_KEY = 'cache';
 
     public function isApplicable(): bool
     {

--- a/src/sentry/src/Features/Concerns/ResolvesSessionKey.php
+++ b/src/sentry/src/Features/Concerns/ResolvesSessionKey.php
@@ -11,9 +11,9 @@ use Throwable;
 
 trait ResolvesSessionKey
 {
-    private const SESSION_KEY_RESOLUTION_CONTEXT_KEY = '__sentry.session_key.resolving';
+    private const string SESSION_KEY_RESOLUTION_CONTEXT_KEY = '__sentry.session_key.resolving';
 
-    private const SESSION_KEY_PLACEHOLDER = '{sessionKey}';
+    private const string SESSION_KEY_PLACEHOLDER = '{sessionKey}';
 
     /**
      * Retrieve the current session key if available.

--- a/src/sentry/src/Features/Concerns/TracksPushedScopesAndSpans.php
+++ b/src/sentry/src/Features/Concerns/TracksPushedScopesAndSpans.php
@@ -149,7 +149,7 @@ trait TracksPushedScopesAndSpans
     /**
      * Context key prefix for per-class span tracking state.
      */
-    public const SPANS_CONTEXT_PREFIX = '__sentry.spans.';
+    public const string SPANS_CONTEXT_PREFIX = '__sentry.spans.';
 
     /**
      * Build a coroutine Context key scoped to this class.

--- a/src/sentry/src/Features/ConsoleIntegration.php
+++ b/src/sentry/src/Features/ConsoleIntegration.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class ConsoleIntegration extends Feature
 {
-    private const FEATURE_KEY = 'command_info';
+    private const string FEATURE_KEY = 'command_info';
 
     public function isApplicable(): bool
     {

--- a/src/sentry/src/Features/NotificationsFeature.php
+++ b/src/sentry/src/Features/NotificationsFeature.php
@@ -21,7 +21,7 @@ class NotificationsFeature extends Feature
 {
     use TracksPushedScopesAndSpans;
 
-    private const FEATURE_KEY = 'notifications';
+    private const string FEATURE_KEY = 'notifications';
 
     public function isApplicable(): bool
     {

--- a/src/sentry/src/Features/QueueFeature.php
+++ b/src/sentry/src/Features/QueueFeature.php
@@ -37,15 +37,15 @@ class QueueFeature extends Feature
         pushScope as private pushScopeTrait;
     }
 
-    private const QUEUE_SPAN_OP_QUEUE_PUBLISH = 'queue.publish';
+    private const string QUEUE_SPAN_OP_QUEUE_PUBLISH = 'queue.publish';
 
-    private const QUEUE_PAYLOAD_BAGGAGE_DATA = 'sentry_baggage_data';
+    private const string QUEUE_PAYLOAD_BAGGAGE_DATA = 'sentry_baggage_data';
 
-    private const QUEUE_PAYLOAD_TRACE_PARENT_DATA = 'sentry_trace_parent_data';
+    private const string QUEUE_PAYLOAD_TRACE_PARENT_DATA = 'sentry_trace_parent_data';
 
-    private const QUEUE_PAYLOAD_PUBLISH_TIME = 'sentry_publish_time';
+    private const string QUEUE_PAYLOAD_PUBLISH_TIME = 'sentry_publish_time';
 
-    private const QUEUE_PAYLOAD_DESTINATION_NAME = 'sentry_destination_name';
+    private const string QUEUE_PAYLOAD_DESTINATION_NAME = 'sentry_destination_name';
 
     public function isApplicable(): bool
     {

--- a/src/sentry/src/Features/Storage/Integration.php
+++ b/src/sentry/src/Features/Storage/Integration.php
@@ -15,9 +15,9 @@ use RuntimeException;
 
 class Integration extends Feature
 {
-    private const FEATURE_KEY = 'storage';
+    private const string FEATURE_KEY = 'storage';
 
-    private const STORAGE_DRIVER_NAME = 'sentry';
+    private const string STORAGE_DRIVER_NAME = 'sentry';
 
     public function isApplicable(): bool
     {

--- a/src/sentry/src/Hub.php
+++ b/src/sentry/src/Hub.php
@@ -29,9 +29,9 @@ use function sprintf;
 
 class Hub implements HubInterface
 {
-    public const CONTEXT_STACK_KEY = '__sentry.stack';
+    public const string CONTEXT_STACK_KEY = '__sentry.stack';
 
-    public const CONTEXT_LAST_EVENT_ID_KEY = '__sentry.last_event_id';
+    public const string CONTEXT_LAST_EVENT_ID_KEY = '__sentry.last_event_id';
 
     public function __construct(protected ?ClientInterface $client = null, protected ?Scope $scope = null)
     {

--- a/src/sentry/src/Integration.php
+++ b/src/sentry/src/Integration.php
@@ -32,7 +32,7 @@ use const SWOOLE_VERSION;
 
 class Integration implements IntegrationInterface
 {
-    private const CONTEXT_TRANSACTION_KEY = '__sentry.transaction';
+    private const string CONTEXT_TRANSACTION_KEY = '__sentry.transaction';
 
     public function setupOnce(): void
     {

--- a/src/sentry/src/Integration/ModelViolations/ModelViolationReporter.php
+++ b/src/sentry/src/Integration/ModelViolations/ModelViolationReporter.php
@@ -22,7 +22,7 @@ abstract class ModelViolationReporter
 {
     use ResolvesEventOrigin;
 
-    private const CONTEXT_REPORTED_PREFIX = '__sentry.model_violations.reported.';
+    private const string CONTEXT_REPORTED_PREFIX = '__sentry.model_violations.reported.';
 
     private ?Closure $callback;
 

--- a/src/sentry/src/SentryServiceProvider.php
+++ b/src/sentry/src/SentryServiceProvider.php
@@ -55,7 +55,7 @@ class SentryServiceProvider extends ServiceProvider
     /**
      * Configuration options that are Hypervel-specific and should not be sent to the base PHP SDK.
      */
-    protected const HYPERVEL_SPECIFIC_OPTIONS = [
+    protected const array HYPERVEL_SPECIFIC_OPTIONS = [
         // These settings are Hypervel-specific and the PHP SDK will throw errors if it receives them
         'tracing',
         'breadcrumbs',
@@ -70,7 +70,7 @@ class SentryServiceProvider extends ServiceProvider
     /**
      * Options that should be resolved from the container instead of being passed directly to the SDK.
      */
-    protected const OPTIONS_TO_RESOLVE_FROM_CONTAINER = [
+    protected const array OPTIONS_TO_RESOLVE_FROM_CONTAINER = [
         'logger',
     ];
 

--- a/src/sentry/src/Tracing/EventHandler.php
+++ b/src/sentry/src/Tracing/EventHandler.php
@@ -38,11 +38,11 @@ class EventHandler
         DatabaseEvents\TransactionRolledBack::class => 'transactionRolledBack',
     ];
 
-    private const CONTEXT_RESPONSE_SPANS_KEY = '__sentry.tracing.response_spans';
+    private const string CONTEXT_RESPONSE_SPANS_KEY = '__sentry.tracing.response_spans';
 
-    public const CONTEXT_TRANSACTION_SPANS_KEY = '__sentry.tracing.transaction_spans';
+    public const string CONTEXT_TRANSACTION_SPANS_KEY = '__sentry.tracing.transaction_spans';
 
-    private const CONTEXT_CLEANUP_REGISTERED_KEY = '__sentry.tracing.cleanup_registered';
+    private const string CONTEXT_CLEANUP_REGISTERED_KEY = '__sentry.tracing.cleanup_registered';
 
     private readonly bool $traceSqlQueries;
 

--- a/src/sentry/src/Tracing/ViewEngineDecorator.php
+++ b/src/sentry/src/Tracing/ViewEngineDecorator.php
@@ -11,7 +11,7 @@ use Sentry\Tracing\SpanContext;
 
 final class ViewEngineDecorator implements Engine
 {
-    public const CONTEXT_KEY = '__sentry.view_name';
+    public const string CONTEXT_KEY = '__sentry.view_name';
 
     /**
      * Create a new view engine decorator instance.

--- a/src/sentry/src/Version.php
+++ b/src/sentry/src/Version.php
@@ -10,9 +10,9 @@ use Hypervel\Foundation\PackageManifest;
 
 final class Version
 {
-    public const SDK_IDENTIFIER = 'sentry.php.hypervel';
+    public const string SDK_IDENTIFIER = 'sentry.php.hypervel';
 
-    public const SDK_VERSION = Application::VERSION;
+    public const string SDK_VERSION = Application::VERSION;
 
     public static function getSdkIdentifier(): string
     {

--- a/src/server/src/Event.php
+++ b/src/server/src/Event.php
@@ -9,102 +9,102 @@ class Event
     /**
      * Swoole onStart event.
      */
-    public const ON_START = 'start';
+    public const string ON_START = 'start';
 
     /**
      * Swoole onWorkerStart event.
      */
-    public const ON_WORKER_START = 'workerStart';
+    public const string ON_WORKER_START = 'workerStart';
 
     /**
      * Swoole onWorkerStop event.
      */
-    public const ON_WORKER_STOP = 'workerStop';
+    public const string ON_WORKER_STOP = 'workerStop';
 
     /**
      * Swoole onWorkerExit event.
      */
-    public const ON_WORKER_EXIT = 'workerExit';
+    public const string ON_WORKER_EXIT = 'workerExit';
 
     /**
      * Swoole onWorkerError event.
      */
-    public const ON_WORKER_ERROR = 'workerError';
+    public const string ON_WORKER_ERROR = 'workerError';
 
     /**
      * Swoole onPipeMessage event.
      */
-    public const ON_PIPE_MESSAGE = 'pipeMessage';
+    public const string ON_PIPE_MESSAGE = 'pipeMessage';
 
     /**
      * Swoole onRequest event.
      */
-    public const ON_REQUEST = 'request';
+    public const string ON_REQUEST = 'request';
 
     /**
      * Swoole onReceive event.
      */
-    public const ON_RECEIVE = 'receive';
+    public const string ON_RECEIVE = 'receive';
 
     /**
      * Swoole onConnect event.
      */
-    public const ON_CONNECT = 'connect';
+    public const string ON_CONNECT = 'connect';
 
     /**
      * Swoole onHandshake event.
      */
-    public const ON_HANDSHAKE = 'handshake';
+    public const string ON_HANDSHAKE = 'handshake';
 
     /**
      * Swoole onOpen event.
      */
-    public const ON_OPEN = 'open';
+    public const string ON_OPEN = 'open';
 
     /**
      * Swoole onMessage event.
      */
-    public const ON_MESSAGE = 'message';
+    public const string ON_MESSAGE = 'message';
 
     /**
      * Swoole onClose event.
      */
-    public const ON_CLOSE = 'close';
+    public const string ON_CLOSE = 'close';
 
     /**
      * Swoole onTask event.
      */
-    public const ON_TASK = 'task';
+    public const string ON_TASK = 'task';
 
     /**
      * Swoole onFinish event.
      */
-    public const ON_FINISH = 'finish';
+    public const string ON_FINISH = 'finish';
 
     /**
      * Swoole onShutdown event.
      */
-    public const ON_SHUTDOWN = 'shutdown';
+    public const string ON_SHUTDOWN = 'shutdown';
 
     /**
      * Swoole onPacket event.
      */
-    public const ON_PACKET = 'packet';
+    public const string ON_PACKET = 'packet';
 
     /**
      * Swoole onManagerStart event.
      */
-    public const ON_MANAGER_START = 'managerStart';
+    public const string ON_MANAGER_START = 'managerStart';
 
     /**
      * Swoole onManagerStop event.
      */
-    public const ON_MANAGER_STOP = 'managerStop';
+    public const string ON_MANAGER_STOP = 'managerStop';
 
     /**
      * Before server start, it's not a swoole event.
      */
-    public const ON_BEFORE_START = 'beforeStart';
+    public const string ON_BEFORE_START = 'beforeStart';
 
     /**
      * Determine if the given event is a native Swoole event.

--- a/src/server/src/ServerInterface.php
+++ b/src/server/src/ServerInterface.php
@@ -8,11 +8,11 @@ use Swoole\Server as SwooleServer;
 
 interface ServerInterface
 {
-    public const SERVER_HTTP = 1;
+    public const int SERVER_HTTP = 1;
 
-    public const SERVER_WEBSOCKET = 2;
+    public const int SERVER_WEBSOCKET = 2;
 
-    public const SERVER_BASE = 3;
+    public const int SERVER_BASE = 3;
 
     /**
      * Initialize the server with the given configuration.

--- a/src/session/src/CookieSessionHandler.php
+++ b/src/session/src/CookieSessionHandler.php
@@ -17,7 +17,7 @@ class CookieSessionHandler implements SessionHandlerInterface
     /**
      * Context key prefix for the current request.
      */
-    protected const REQUEST_CONTEXT_KEY_PREFIX = '__session.cookie.request.';
+    protected const string REQUEST_CONTEXT_KEY_PREFIX = '__session.cookie.request.';
 
     /**
      * Create a new cookie driven handler instance.

--- a/src/session/src/DatabaseSessionHandler.php
+++ b/src/session/src/DatabaseSessionHandler.php
@@ -27,7 +27,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      * Suffixed with the handler's object ID so multiple handler instances
      * within the same coroutine maintain independent existence state.
      */
-    protected const DATABASE_EXISTS_CONTEXT_KEY_PREFIX = '__session.database.exists.';
+    protected const string DATABASE_EXISTS_CONTEXT_KEY_PREFIX = '__session.database.exists.';
 
     /**
      * Create a new database session handler instance.

--- a/src/session/src/Store.php
+++ b/src/session/src/Store.php
@@ -36,32 +36,32 @@ class Store implements Session
     /**
      * The context key used to store the active session for the current request.
      */
-    public const CONTEXT_KEY = '__session.store';
+    public const string CONTEXT_KEY = '__session.store';
 
     /**
      * Context key for whether the session has been started.
      */
-    public const STARTED_CONTEXT_KEY_PREFIX = '__session.store.started.';
+    public const string STARTED_CONTEXT_KEY_PREFIX = '__session.store.started.';
 
     /**
      * Context key for the session attributes.
      */
-    public const ATTRIBUTES_CONTEXT_KEY_PREFIX = '__session.store.attributes.';
+    public const string ATTRIBUTES_CONTEXT_KEY_PREFIX = '__session.store.attributes.';
 
     /**
      * Context key for the session ID.
      */
-    public const ID_CONTEXT_KEY_PREFIX = '__session.store.id.';
+    public const string ID_CONTEXT_KEY_PREFIX = '__session.store.id.';
 
     /**
      * The supported session serialization strategies.
      */
-    protected const SUPPORTED_SERIALIZATIONS = ['json', 'php'];
+    protected const array SUPPORTED_SERIALIZATIONS = ['json', 'php'];
 
     /**
      * The length of session ID strings.
      */
-    protected const SESSION_ID_LENGTH = 40;
+    protected const int SESSION_ID_LENGTH = 40;
 
     /**
      * The context key for whether this session has been started.

--- a/src/support/src/Base62.php
+++ b/src/support/src/Base62.php
@@ -8,9 +8,9 @@ use InvalidArgumentException;
 
 class Base62
 {
-    public const CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+    public const string CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
-    public const BASE = 62;
+    public const int BASE = 62;
 
     /**
      * Encode the given number to a base62 string.

--- a/src/support/src/ConfigurationUrlParser.php
+++ b/src/support/src/ConfigurationUrlParser.php
@@ -11,7 +11,7 @@ class ConfigurationUrlParser
     /**
      * The default driver aliases map.
      */
-    protected const DEFAULT_DRIVER_ALIASES = [
+    protected const array DEFAULT_DRIVER_ALIASES = [
         'mssql' => 'sqlsrv',
         'mysql2' => 'mysql', // RDS
         'postgres' => 'pgsql',

--- a/src/support/src/DataObject.php
+++ b/src/support/src/DataObject.php
@@ -29,7 +29,7 @@ abstract class DataObject implements ArrayAccess, JsonSerializable
     /**
      * The default date format for DateTime properties.
      */
-    protected const DEFAULT_DATE_FORMAT = 'Y-m-d H:i:s';
+    protected const string DEFAULT_DATE_FORMAT = 'Y-m-d H:i:s';
 
     /**
      * Reflection parameters cache (class name => [ReflectionParameter]).

--- a/src/support/src/EncodedHtmlString.php
+++ b/src/support/src/EncodedHtmlString.php
@@ -16,7 +16,7 @@ class EncodedHtmlString extends HtmlString
     /**
      * Context key for temporarily scoped encoder callbacks.
      */
-    protected const ENCODER_CONTEXT_KEY = '__support.encoded_html.encoder';
+    protected const string ENCODER_CONTEXT_KEY = '__support.encoded_html.encoder';
 
     /**
      * The callback that should be used to encode the HTML strings.

--- a/src/support/src/Facades/Date.php
+++ b/src/support/src/Facades/Date.php
@@ -110,7 +110,7 @@ use Hypervel\Support\DateFactory;
  */
 class Date extends Facade
 {
-    public const DEFAULT_FACADE = DateFactory::class;
+    public const string DEFAULT_FACADE = DateFactory::class;
 
     /**
      * Get the registered name of the component.

--- a/src/support/src/FileinfoMimeTypeGuesser.php
+++ b/src/support/src/FileinfoMimeTypeGuesser.php
@@ -26,7 +26,7 @@ use RuntimeException;
  */
 class FileinfoMimeTypeGuesser
 {
-    public const FINFO_CONTEXT_KEY_PREFIX = '__support.finfo_mime_type_guesser.';
+    public const string FINFO_CONTEXT_KEY_PREFIX = '__support.finfo_mime_type_guesser.';
 
     /**
      * @param null|string $magicFile A magic file to use with the finfo instance

--- a/src/support/src/Js.php
+++ b/src/support/src/Js.php
@@ -21,10 +21,8 @@ class Js implements Htmlable, Stringable
 
     /**
      * Flags that should be used when encoding to JSON.
-     *
-     * @var int
      */
-    protected const REQUIRED_FLAGS = JSON_HEX_TAG
+    protected const int REQUIRED_FLAGS = JSON_HEX_TAG
         | JSON_HEX_APOS
         | JSON_HEX_AMP
         | JSON_HEX_QUOT

--- a/src/support/src/MimeTypeExtensionGuesser.php
+++ b/src/support/src/MimeTypeExtensionGuesser.php
@@ -11,7 +11,7 @@ class MimeTypeExtensionGuesser
      *
      * @see https://github.com/symfony/mime/blob/7.1/MimeTypes.php
      */
-    protected const MAP = [
+    protected const array MAP = [
         'application/acrobat' => ['pdf'],
         'application/andrew-inset' => ['ez'],
         'application/annodex' => ['anx'],
@@ -1770,7 +1770,7 @@ class MimeTypeExtensionGuesser
         'zz-application/zz-winassoc-xls' => ['xls', 'xlc', 'xll', 'xlm', 'xlw', 'xla', 'xlt', 'xld'],
     ];
 
-    protected const REVERSE_MAP = [
+    protected const array REVERSE_MAP = [
         '123' => ['application/lotus123', 'application/vnd.lotus-1-2-3', 'application/wk1', 'application/x-123', 'application/x-lotus123', 'zz-application/zz-winassoc-123'],
         '1km' => ['application/vnd.1000minds.decision-model+xml'],
         '32x' => ['application/x-genesis-32x-rom'],

--- a/src/support/src/Number.php
+++ b/src/support/src/Number.php
@@ -17,12 +17,12 @@ class Number
     /**
      * Context key for the per-request locale override.
      */
-    public const LOCALE_CONTEXT_KEY = '__support.number.locale';
+    public const string LOCALE_CONTEXT_KEY = '__support.number.locale';
 
     /**
      * Context key for the per-request currency override.
      */
-    public const CURRENCY_CONTEXT_KEY = '__support.number.currency';
+    public const string CURRENCY_CONTEXT_KEY = '__support.number.currency';
 
     /**
      * The current default locale.

--- a/src/support/src/Once.php
+++ b/src/support/src/Once.php
@@ -12,12 +12,12 @@ class Once
     /**
      * The context key for the current once instance.
      */
-    protected const INSTANCE_CONTEXT_KEY = '__support.once.instance';
+    protected const string INSTANCE_CONTEXT_KEY = '__support.once.instance';
 
     /**
      * The context key for the once enabled flag.
      */
-    protected const ENABLED_CONTEXT_KEY = '__support.once.enabled';
+    protected const string ENABLED_CONTEXT_KEY = '__support.once.enabled';
 
     /**
      * Create a new once instance.

--- a/src/support/src/Pluralizer.php
+++ b/src/support/src/Pluralizer.php
@@ -15,7 +15,7 @@ class Pluralizer
      *
      * @var list<string>
      */
-    protected const DEFAULT_UNCOUNTABLE = [
+    protected const array DEFAULT_UNCOUNTABLE = [
         'recommended',
         'related',
     ];

--- a/src/support/src/Str.php
+++ b/src/support/src/Str.php
@@ -29,7 +29,7 @@ class Str
     /**
      * The list of characters that are considered "invisible" in strings.
      */
-    public const INVISIBLE_CHARACTERS = '\x{0009}\x{0020}\x{00A0}\x{00AD}\x{034F}\x{061C}\x{115F}\x{1160}\x{17B4}\x{17B5}\x{180E}\x{2000}\x{2001}\x{2002}\x{2003}\x{2004}\x{2005}\x{2006}\x{2007}\x{2008}\x{2009}\x{200A}\x{200B}\x{200C}\x{200D}\x{200E}\x{200F}\x{202F}\x{205F}\x{2060}\x{2061}\x{2062}\x{2063}\x{2064}\x{2065}\x{206A}\x{206B}\x{206C}\x{206D}\x{206E}\x{206F}\x{3000}\x{2800}\x{3164}\x{FEFF}\x{FFA0}\x{1D159}\x{1D173}\x{1D174}\x{1D175}\x{1D176}\x{1D177}\x{1D178}\x{1D179}\x{1D17A}\x{E0020}';
+    public const string INVISIBLE_CHARACTERS = '\x{0009}\x{0020}\x{00A0}\x{00AD}\x{034F}\x{061C}\x{115F}\x{1160}\x{17B4}\x{17B5}\x{180E}\x{2000}\x{2001}\x{2002}\x{2003}\x{2004}\x{2005}\x{2006}\x{2007}\x{2008}\x{2009}\x{200A}\x{200B}\x{200C}\x{200D}\x{200E}\x{200F}\x{202F}\x{205F}\x{2060}\x{2061}\x{2062}\x{2063}\x{2064}\x{2065}\x{206A}\x{206B}\x{206C}\x{206D}\x{206E}\x{206F}\x{3000}\x{2800}\x{3164}\x{FEFF}\x{FFA0}\x{1D159}\x{1D173}\x{1D174}\x{1D175}\x{1D176}\x{1D177}\x{1D178}\x{1D179}\x{1D17A}\x{E0020}';
 
     /**
      * The callback that should be used to generate UUIDs.

--- a/src/telescope/src/EntryType.php
+++ b/src/telescope/src/EntryType.php
@@ -6,41 +6,41 @@ namespace Hypervel\Telescope;
 
 class EntryType
 {
-    public const BATCH = 'batch';
+    public const string BATCH = 'batch';
 
-    public const CACHE = 'cache';
+    public const string CACHE = 'cache';
 
-    public const COMMAND = 'command';
+    public const string COMMAND = 'command';
 
-    public const DUMP = 'dump';
+    public const string DUMP = 'dump';
 
-    public const EVENT = 'event';
+    public const string EVENT = 'event';
 
-    public const EXCEPTION = 'exception';
+    public const string EXCEPTION = 'exception';
 
-    public const JOB = 'job';
+    public const string JOB = 'job';
 
-    public const LOG = 'log';
+    public const string LOG = 'log';
 
-    public const MAIL = 'mail';
+    public const string MAIL = 'mail';
 
-    public const MODEL = 'model';
+    public const string MODEL = 'model';
 
-    public const NOTIFICATION = 'notification';
+    public const string NOTIFICATION = 'notification';
 
-    public const QUERY = 'query';
+    public const string QUERY = 'query';
 
-    public const REDIS = 'redis';
+    public const string REDIS = 'redis';
 
-    public const REVERB = 'reverb';
+    public const string REVERB = 'reverb';
 
-    public const REQUEST = 'request';
+    public const string REQUEST = 'request';
 
-    public const SCHEDULED_TASK = 'schedule';
+    public const string SCHEDULED_TASK = 'schedule';
 
-    public const GATE = 'gate';
+    public const string GATE = 'gate';
 
-    public const VIEW = 'view';
+    public const string VIEW = 'view';
 
-    public const CLIENT_REQUEST = 'client_request';
+    public const string CLIENT_REQUEST = 'client_request';
 }

--- a/src/telescope/src/ListensForStorageOpportunities.php
+++ b/src/telescope/src/ListensForStorageOpportunities.php
@@ -20,7 +20,7 @@ use Hypervel\Telescope\Contracts\EntriesRepository;
 
 trait ListensForStorageOpportunities
 {
-    public const PROCESSING_JOBS_CONTEXT_KEY = '__telescope.processing_jobs';
+    public const string PROCESSING_JOBS_CONTEXT_KEY = '__telescope.processing_jobs';
 
     /**
      * The callback that determines if Telescope should start recording.

--- a/src/telescope/src/Storage/DatabaseEntriesRepository.php
+++ b/src/telescope/src/Storage/DatabaseEntriesRepository.php
@@ -27,7 +27,7 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
     /**
      * Context key for the per-request monitored tags cache.
      */
-    protected const MONITORED_TAGS_CONTEXT_KEY = '__telescope.monitored_tags';
+    protected const string MONITORED_TAGS_CONTEXT_KEY = '__telescope.monitored_tags';
 
     /**
      * The database connection name that should be used.

--- a/src/telescope/src/Storage/EntryModel.php
+++ b/src/telescope/src/Storage/EntryModel.php
@@ -21,10 +21,8 @@ class EntryModel extends Model
 
     /**
      * The name of the "updated at" column.
-     *
-     * @var null|string
      */
-    public const UPDATED_AT = null;
+    public const ?string UPDATED_AT = null;
 
     /**
      * The attributes that should be cast to native types.

--- a/src/telescope/src/Telescope.php
+++ b/src/telescope/src/Telescope.php
@@ -34,29 +34,29 @@ class Telescope
     use ListensForStorageOpportunities;
     use RegistersWatchers;
 
-    protected const DEFAULT_HIDDEN_REQUEST_HEADERS = [
+    protected const array DEFAULT_HIDDEN_REQUEST_HEADERS = [
         'authorization',
         'php-auth-pw',
     ];
 
-    protected const DEFAULT_HIDDEN_REQUEST_PARAMETERS = [
+    protected const array DEFAULT_HIDDEN_REQUEST_PARAMETERS = [
         'password',
         'password_confirmation',
     ];
 
-    public const ENTRIES_QUEUE_CONTEXT_KEY = '__telescope.entries_queue';
+    public const string ENTRIES_QUEUE_CONTEXT_KEY = '__telescope.entries_queue';
 
-    public const UPDATES_QUEUE_CONTEXT_KEY = '__telescope.updates_queue';
+    public const string UPDATES_QUEUE_CONTEXT_KEY = '__telescope.updates_queue';
 
-    public const SHOULD_RECORD_CONTEXT_KEY = '__telescope.should_record';
+    public const string SHOULD_RECORD_CONTEXT_KEY = '__telescope.should_record';
 
-    public const IS_RECORDING_CONTEXT_KEY = '__telescope.is_recording';
+    public const string IS_RECORDING_CONTEXT_KEY = '__telescope.is_recording';
 
-    public const HAS_STORED_CONTEXT_KEY = '__telescope.has_stored';
+    public const string HAS_STORED_CONTEXT_KEY = '__telescope.has_stored';
 
-    public const BATCH_ID_CONTEXT_KEY = '__telescope.batch_id';
+    public const string BATCH_ID_CONTEXT_KEY = '__telescope.batch_id';
 
-    protected const CSP_NONCE_CONTEXT_KEY = '__telescope.csp_nonce';
+    protected const string CSP_NONCE_CONTEXT_KEY = '__telescope.csp_nonce';
 
     /**
      * The callbacks that filter the entries that should be recorded.

--- a/src/telescope/src/Watchers/DumpWatcher.php
+++ b/src/telescope/src/Watchers/DumpWatcher.php
@@ -15,7 +15,7 @@ use Throwable;
 
 class DumpWatcher extends Watcher
 {
-    protected const DEFAULT_INSTALLED = false;
+    protected const bool DEFAULT_INSTALLED = false;
 
     /**
      * Whether the Telescope dump handler is installed.

--- a/src/telescope/src/Watchers/LogWatcher.php
+++ b/src/telescope/src/Watchers/LogWatcher.php
@@ -18,7 +18,7 @@ class LogWatcher extends Watcher
     /**
      * The available log level priorities.
      */
-    protected const PRIORITIES = [
+    protected const array PRIORITIES = [
         LogLevel::DEBUG => 100,
         LogLevel::INFO => 200,
         LogLevel::NOTICE => 250,

--- a/src/telescope/src/Watchers/ModelWatcher.php
+++ b/src/telescope/src/Watchers/ModelWatcher.php
@@ -18,7 +18,7 @@ use Hypervel\Telescope\Telescope;
 
 class ModelWatcher extends Watcher
 {
-    public const HYDRATIONS_CONTEXT_KEY = '__telescope.watcher.model.hydrations';
+    public const string HYDRATIONS_CONTEXT_KEY = '__telescope.watcher.model.hydrations';
 
     /**
      * Register the watcher.

--- a/src/telescope/src/Watchers/ScheduleWatcher.php
+++ b/src/telescope/src/Watchers/ScheduleWatcher.php
@@ -15,7 +15,7 @@ use Hypervel\Telescope\Telescope;
 
 class ScheduleWatcher extends Watcher
 {
-    protected const LAST_RECORDED_TASK_CONTEXT_KEY = '__telescope.schedule_watcher.last_recorded_task';
+    protected const string LAST_RECORDED_TASK_CONTEXT_KEY = '__telescope.schedule_watcher.last_recorded_task';
 
     /**
      * The application instance.

--- a/src/testbench/src/Bootstrapper.php
+++ b/src/testbench/src/Bootstrapper.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class Bootstrapper
 {
-    protected const RUNTIME_PROCESS_MARKER = '.testbench-process';
+    protected const string RUNTIME_PROCESS_MARKER = '.testbench-process';
 
     protected static ?ConfigContract $configuration = null;
 

--- a/src/translation/src/Translator.php
+++ b/src/translation/src/Translator.php
@@ -26,12 +26,12 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Context key for the per-request locale override.
      */
-    protected const LOCALE_CONTEXT_KEY = '__translation.locale';
+    protected const string LOCALE_CONTEXT_KEY = '__translation.locale';
 
     /**
      * Context key for suppressing missing-key callbacks in the current coroutine.
      */
-    protected const MISSING_KEY_HANDLING_CONTEXT_KEY = '__translation.handle_missing_keys';
+    protected const string MISSING_KEY_HANDLING_CONTEXT_KEY = '__translation.handle_missing_keys';
 
     /**
      * The fallback locale used by the translator.

--- a/src/validation/src/BatchDatabaseChecker.php
+++ b/src/validation/src/BatchDatabaseChecker.php
@@ -18,7 +18,7 @@ use Stringable;
  */
 final class BatchDatabaseChecker
 {
-    private const CHUNK_SIZE = 1000;
+    private const int CHUNK_SIZE = 1000;
 
     /**
      * Build a PrecomputedPresenceVerifier from grouped rules.

--- a/src/validation/src/Rule.php
+++ b/src/validation/src/Rule.php
@@ -48,7 +48,7 @@ class Rule
      * Set by ValidationRuleParser::explodeWildcardRulesCompilable() to avoid
      * repeated Arr::undot() calls when Rule::forEach expands wildcard items.
      */
-    public const UNDOTTED_DATA_CONTEXT_KEY = '__validation.rule_compile_undotted_data';
+    public const string UNDOTTED_DATA_CONTEXT_KEY = '__validation.rule_compile_undotted_data';
 
     /**
      * Get a can constraint builder instance.

--- a/src/validation/src/RulePlanCache.php
+++ b/src/validation/src/RulePlanCache.php
@@ -18,7 +18,7 @@ use InvalidArgumentException;
  */
 final class RulePlanCache
 {
-    private const DEFAULT_MAX_SIZE = 2048;
+    private const int DEFAULT_MAX_SIZE = 2048;
 
     private static int $maxSize = self::DEFAULT_MAX_SIZE;
 

--- a/src/view/src/Compilers/BladeCompiler.php
+++ b/src/view/src/Compilers/BladeCompiler.php
@@ -48,22 +48,22 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * Temporarily store the raw blocks found in the template.
      */
-    protected const RAW_BLOCKS_CONTEXT_KEY = '__view.raw_blocks';
+    protected const string RAW_BLOCKS_CONTEXT_KEY = '__view.raw_blocks';
 
     /**
      * Footer lines to be added to the template.
      */
-    protected const FOOTER_CONTEXT_KEY = '__view.footer';
+    protected const string FOOTER_CONTEXT_KEY = '__view.footer';
 
     /**
      * The file currently being compiled.
      */
-    protected const PATH_CONTEXT_KEY = '__view.path';
+    protected const string PATH_CONTEXT_KEY = '__view.path';
 
     /**
      * The temporary echo format override for the current coroutine.
      */
-    protected const ECHO_FORMAT_CONTEXT_KEY = '__view.echo_format';
+    protected const string ECHO_FORMAT_CONTEXT_KEY = '__view.echo_format';
 
     /**
      * All of the registered extensions.

--- a/src/view/src/Compilers/ComponentTagCompiler.php
+++ b/src/view/src/Compilers/ComponentTagCompiler.php
@@ -22,7 +22,7 @@ class ComponentTagCompiler
     /**
      * The "bind:" attributes that have been compiled for the current component.
      */
-    protected const BOUND_ATTRIBUTES_CONTEXT_KEY = '__view.bound_attributes';
+    protected const string BOUND_ATTRIBUTES_CONTEXT_KEY = '__view.bound_attributes';
 
     /**
      * The Blade compiler instance.

--- a/src/view/src/Compilers/Concerns/CompilesComponents.php
+++ b/src/view/src/Compilers/Concerns/CompilesComponents.php
@@ -15,7 +15,7 @@ trait CompilesComponents
     /**
      * The component name hash stack.
      */
-    protected const COMPONENT_HASH_STACK_CONTEXT_KEY = '__view.component_hash_stack';
+    protected const string COMPONENT_HASH_STACK_CONTEXT_KEY = '__view.component_hash_stack';
 
     /**
      * Compile the component statements into valid PHP.

--- a/src/view/src/Compilers/Concerns/CompilesConditionals.php
+++ b/src/view/src/Compilers/Concerns/CompilesConditionals.php
@@ -12,7 +12,7 @@ trait CompilesConditionals
     /**
      * Identifier for the first case in the switch statement.
      */
-    protected const FIRST_CASE_IN_SWITCH_CONTEXT_KEY = '__view.first_case_in_switch';
+    protected const string FIRST_CASE_IN_SWITCH_CONTEXT_KEY = '__view.first_case_in_switch';
 
     /**
      * Compile the if-auth statements into valid PHP.

--- a/src/view/src/Compilers/Concerns/CompilesLayouts.php
+++ b/src/view/src/Compilers/Concerns/CompilesLayouts.php
@@ -11,7 +11,7 @@ trait CompilesLayouts
     /**
      * The name of the last section started during the current compile pass.
      */
-    protected const LAST_SECTION_CONTEXT_KEY = '__view.last_section';
+    protected const string LAST_SECTION_CONTEXT_KEY = '__view.last_section';
 
     /**
      * Compile the extends statements into valid PHP.

--- a/src/view/src/Compilers/Concerns/CompilesLoops.php
+++ b/src/view/src/Compilers/Concerns/CompilesLoops.php
@@ -12,7 +12,7 @@ trait CompilesLoops
     /**
      * Counter to keep track of nested forelse statements.
      */
-    protected const FOR_ELSE_COUNTER_CONTEXT_KEY = '__view.for_else_counter';
+    protected const string FOR_ELSE_COUNTER_CONTEXT_KEY = '__view.for_else_counter';
 
     protected function incrementForElseCounter(): int
     {

--- a/src/view/src/Concerns/ManagesComponents.php
+++ b/src/view/src/Concerns/ManagesComponents.php
@@ -16,27 +16,27 @@ trait ManagesComponents
     /**
      * Context key for the components being rendered.
      */
-    protected const COMPONENT_STACK_CONTEXT_KEY = '__view.component_stack';
+    protected const string COMPONENT_STACK_CONTEXT_KEY = '__view.component_stack';
 
     /**
      * Context key for the original data passed to the component.
      */
-    protected const COMPONENT_DATA_CONTEXT_KEY = '__view.component_data';
+    protected const string COMPONENT_DATA_CONTEXT_KEY = '__view.component_data';
 
     /**
      * Context key for the component data for the component that is currently being rendered.
      */
-    protected const CURRENT_COMPONENT_DATA_CONTEXT_KEY = '__view.current_component_data';
+    protected const string CURRENT_COMPONENT_DATA_CONTEXT_KEY = '__view.current_component_data';
 
     /**
      * Context key for the slot contents for the component.
      */
-    protected const SLOTS_CONTEXT_KEY = '__view.slots';
+    protected const string SLOTS_CONTEXT_KEY = '__view.slots';
 
     /**
      * Context key for the names of the slots being rendered.
      */
-    protected const SLOT_STACK_CONTEXT_KEY = '__view.slot_stack';
+    protected const string SLOT_STACK_CONTEXT_KEY = '__view.slot_stack';
 
     /**
      * Start a component rendering process.

--- a/src/view/src/Concerns/ManagesFragments.php
+++ b/src/view/src/Concerns/ManagesFragments.php
@@ -12,12 +12,12 @@ trait ManagesFragments
     /**
      * All of the captured, rendered fragments.
      */
-    protected const FRAGMENTS_CONTEXT_KEY = '__view.fragments';
+    protected const string FRAGMENTS_CONTEXT_KEY = '__view.fragments';
 
     /**
      * The stack of in-progress fragment renders.
      */
-    protected const FRAGMENT_STACK_CONTEXT_KEY = '__view.fragment_stack';
+    protected const string FRAGMENT_STACK_CONTEXT_KEY = '__view.fragment_stack';
 
     /**
      * Start injecting content into a fragment.

--- a/src/view/src/Concerns/ManagesLayouts.php
+++ b/src/view/src/Concerns/ManagesLayouts.php
@@ -14,12 +14,12 @@ trait ManagesLayouts
     /**
      * Context key for finished, captured sections.
      */
-    protected const SECTIONS_CONTEXT_KEY = '__view.sections';
+    protected const string SECTIONS_CONTEXT_KEY = '__view.sections';
 
     /**
      * Context key for the stack of in-progress sections.
      */
-    protected const SECTION_STACK_CONTEXT_KEY = '__view.section_stack';
+    protected const string SECTION_STACK_CONTEXT_KEY = '__view.section_stack';
 
     /**
      * The parent placeholder salt for the worker.

--- a/src/view/src/Concerns/ManagesLoops.php
+++ b/src/view/src/Concerns/ManagesLoops.php
@@ -13,7 +13,7 @@ trait ManagesLoops
     /**
      * The context key for loops stack.
      */
-    protected const LOOPS_STACK_CONTEXT_KEY = '__view.loops_stack';
+    protected const string LOOPS_STACK_CONTEXT_KEY = '__view.loops_stack';
 
     /**
      * Add new loop to the stack.

--- a/src/view/src/Concerns/ManagesStacks.php
+++ b/src/view/src/Concerns/ManagesStacks.php
@@ -12,17 +12,17 @@ trait ManagesStacks
     /**
      * Context key for finished, captured push sections.
      */
-    protected const PUSHES_CONTEXT_KEY = '__view.pushes';
+    protected const string PUSHES_CONTEXT_KEY = '__view.pushes';
 
     /**
      * Context key for finished, captured prepend sections.
      */
-    protected const PREPENDS_CONTEXT_KEY = '__view.prepends';
+    protected const string PREPENDS_CONTEXT_KEY = '__view.prepends';
 
     /**
      * Context key for the stack of in-progress push sections.
      */
-    protected const PUSH_STACK_CONTEXT_KEY = '__view.push_stack';
+    protected const string PUSH_STACK_CONTEXT_KEY = '__view.push_stack';
 
     /**
      * Start injecting content into a push section.

--- a/src/view/src/Concerns/ManagesTranslations.php
+++ b/src/view/src/Concerns/ManagesTranslations.php
@@ -11,7 +11,7 @@ trait ManagesTranslations
     /**
      * Context key for translation replacements.
      */
-    protected const TRANSLATION_REPLACEMENTS_CONTEXT_KEY = '__view.translation_replacements';
+    protected const string TRANSLATION_REPLACEMENTS_CONTEXT_KEY = '__view.translation_replacements';
 
     /**
      * Start a translation block.

--- a/src/view/src/Engines/CompilerEngine.php
+++ b/src/view/src/Engines/CompilerEngine.php
@@ -20,7 +20,7 @@ class CompilerEngine extends PhpEngine
     /**
      * The context key for a stack of the compiled template path.
      */
-    public const COMPILED_PATH_CONTEXT_KEY = '__view.compiled_path';
+    public const string COMPILED_PATH_CONTEXT_KEY = '__view.compiled_path';
 
     /**
      * The view paths that were compiled or are not expired, keyed by the path.

--- a/src/view/src/Factory.php
+++ b/src/view/src/Factory.php
@@ -31,12 +31,12 @@ class Factory implements FactoryContract
     /**
      * The number of active rendering operations.
      */
-    protected const RENDER_COUNT_CONTEXT_KEY = '__view.render_count';
+    protected const string RENDER_COUNT_CONTEXT_KEY = '__view.render_count';
 
     /**
      * The "once" block IDs that have been rendered.
      */
-    protected const RENDERED_ONCE_CONTEXT_KEY = '__view.rendered_once';
+    protected const string RENDERED_ONCE_CONTEXT_KEY = '__view.rendered_once';
 
     /**
      * The IoC container instance.

--- a/src/view/src/RequestSharedData.php
+++ b/src/view/src/RequestSharedData.php
@@ -12,7 +12,7 @@ class RequestSharedData
     /**
      * The coroutine context key for request-scoped shared view data.
      */
-    protected const CONTEXT_KEY = '__view.request_shared_data';
+    protected const string CONTEXT_KEY = '__view.request_shared_data';
 
     /**
      * Get the shared data for the current request.

--- a/src/view/src/ViewFinderInterface.php
+++ b/src/view/src/ViewFinderInterface.php
@@ -9,7 +9,7 @@ interface ViewFinderInterface
     /**
      * Hint path delimiter value.
      */
-    public const HINT_PATH_DELIMITER = '::';
+    public const string HINT_PATH_DELIMITER = '::';
 
     /**
      * Get the fully qualified location of the view.

--- a/src/wayfinder/src/GenerateCommand.php
+++ b/src/wayfinder/src/GenerateCommand.php
@@ -29,7 +29,7 @@ use function Hypervel\Prompts\info;
 #[AsCommand(name: 'wayfinder:generate')]
 class GenerateCommand extends Command
 {
-    private const GENERATED_IDENTIFIERS = [
+    private const array GENERATED_IDENTIFIERS = [
         'queryParams',
         'applyUrlDefaults',
         'validateParameters',

--- a/src/websocket-server/src/Constants/Opcode.php
+++ b/src/websocket-server/src/Constants/Opcode.php
@@ -6,15 +6,15 @@ namespace Hypervel\WebSocketServer\Constants;
 
 class Opcode
 {
-    public const CONTINUATION = 0x0;
+    public const int CONTINUATION = 0x0;
 
-    public const TEXT = 0x1;
+    public const int TEXT = 0x1;
 
-    public const BINARY = 0x2;
+    public const int BINARY = 0x2;
 
-    public const CLOSE = 0x8;
+    public const int CLOSE = 0x8;
 
-    public const PING = 0x9;
+    public const int PING = 0x9;
 
-    public const PONG = 0xA;
+    public const int PONG = 0xA;
 }

--- a/src/websocket-server/src/Context.php
+++ b/src/websocket-server/src/Context.php
@@ -10,7 +10,7 @@ use Hypervel\Support\Arr;
 
 class Context
 {
-    public const FD = 'ws.fd';
+    public const string FD = 'ws.fd';
 
     protected static array $storage = [];
 

--- a/src/websocket-server/src/Security.php
+++ b/src/websocket-server/src/Security.php
@@ -6,15 +6,15 @@ namespace Hypervel\WebSocketServer;
 
 class Security
 {
-    public const VERSION = '13';
+    public const string VERSION = '13';
 
-    public const PATTERN = '#^[+/0-9A-Za-z]{21}[AQgw]==$#';
+    public const string PATTERN = '#^[+/0-9A-Za-z]{21}[AQgw]==$#';
 
-    public const KEY = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+    public const string KEY = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
-    public const SEC_WEBSOCKET_KEY = 'sec-websocket-key';
+    public const string SEC_WEBSOCKET_KEY = 'sec-websocket-key';
 
-    public const SEC_WEBSOCKET_PROTOCOL = 'sec-websocket-protocol';
+    public const string SEC_WEBSOCKET_PROTOCOL = 'sec-websocket-protocol';
 
     /**
      * Determine if the given key is an invalid WebSocket security key.

--- a/tests/Cache/CacheSwooleStoreConcurrencyTest.php
+++ b/tests/Cache/CacheSwooleStoreConcurrencyTest.php
@@ -18,9 +18,9 @@ use Throwable;
 
 class CacheSwooleStoreConcurrencyTest extends TestCase
 {
-    private const FRAME_HEADER_BYTES = 4;
+    private const int FRAME_HEADER_BYTES = 4;
 
-    private const MAX_FRAME_BYTES = 1_048_576;
+    private const int MAX_FRAME_BYTES = 1_048_576;
 
     protected bool $runTestsInCoroutine = false;
 

--- a/tests/Console/ConsoleApplicationProgrammaticTest.php
+++ b/tests/Console/ConsoleApplicationProgrammaticTest.php
@@ -279,7 +279,7 @@ class ConsoleApplicationProgrammaticTest extends TestCase
 
 class ProgrammaticParityCommand extends Command
 {
-    public const EXIT_CODE = 17;
+    public const int EXIT_CODE = 17;
 
     protected ?string $signature = 'test:programmatic-parity {argument=default} {--flag=}';
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -3436,7 +3436,7 @@ class ModelSelfRelatedStub extends Model
 
 class StubWithoutTimestamp extends Model
 {
-    public const UPDATED_AT = null;
+    public const ?string UPDATED_AT = null;
 
     protected ?string $table = 'table';
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -5141,7 +5141,7 @@ class ModelWithUpdatedAtNull extends Model
 {
     protected ?string $table = 'stub';
 
-    public const UPDATED_AT = null;
+    public const ?string UPDATED_AT = null;
 }
 
 class UnsavedModel extends Model

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -312,7 +312,7 @@ class UserWithCreatedAndUpdated extends Eloquent
 
 class UserWithCreated extends Eloquent
 {
-    public const UPDATED_AT = null;
+    public const ?string UPDATED_AT = null;
 
     protected ?string $table = 'users_created_at';
 
@@ -323,7 +323,7 @@ class UserWithCreated extends Eloquent
 
 class UserWithUpdated extends Eloquent
 {
-    public const CREATED_AT = null;
+    public const ?string CREATED_AT = null;
 
     protected ?string $table = 'users_updated_at';
 

--- a/tests/FacadeDocumenter/ConstFetchResolutionTest.php
+++ b/tests/FacadeDocumenter/ConstFetchResolutionTest.php
@@ -314,6 +314,8 @@ class ConstFetchResolutionTest extends FacadeDocumenterTestCase
 
     /**
      * Resolve relative constant owners from the declaring and selected classes.
+     *
+     * The generated fixtures intentionally use untyped constants to cover userland code.
      */
     public function testRelativeConstantOwnersUsePhpSemantics(): void
     {

--- a/tests/Filesystem/FileResponseBuilderTest.php
+++ b/tests/Filesystem/FileResponseBuilderTest.php
@@ -568,7 +568,7 @@ class FileResponseBuilderStreamState
 
 class FileResponseBuilderStreamWrapper
 {
-    public const PROTOCOL = 'hypervel-file-response-test';
+    public const string PROTOCOL = 'hypervel-file-response-test';
 
     /** @var resource */
     public $context;

--- a/tests/Filesystem/LeasedStreamTest.php
+++ b/tests/Filesystem/LeasedStreamTest.php
@@ -332,7 +332,7 @@ PHP;
 
 class RecordingStreamWrapper
 {
-    public const PROTOCOL = 'hypervel-leased-options-inner';
+    public const string PROTOCOL = 'hypervel-leased-options-inner';
 
     /** @var resource */
     public $context;

--- a/tests/Filesystem/LockableFileTest.php
+++ b/tests/Filesystem/LockableFileTest.php
@@ -17,7 +17,7 @@ use Swoole\Coroutine\CanceledException;
 
 class LockableFileTest extends TestCase
 {
-    private const STREAM_SCHEME = 'hypervel-lockable-file-test';
+    private const string STREAM_SCHEME = 'hypervel-lockable-file-test';
 
     private string $tempDir;
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -626,7 +626,7 @@ class ProductStub extends Model
 
 class CustomProductStub extends ProductStub
 {
-    public const DELETED_AT = 'trashed_at';
+    public const string DELETED_AT = 'trashed_at';
 }
 
 class OrderStub extends Model

--- a/tests/Foundation/Testing/Concerns/ExternalServiceOptInTest.php
+++ b/tests/Foundation/Testing/Concerns/ExternalServiceOptInTest.php
@@ -34,7 +34,7 @@ class ExternalServiceOptInTest extends TestCase
      *
      * @var list<string>
      */
-    private const ENVIRONMENT_KEYS = [
+    private const array ENVIRONMENT_KEYS = [
         'REDIS_HOST',
         'MEILISEARCH_HOST',
         'TYPESENSE_HOST',

--- a/tests/Foundation/Testing/Concerns/InteractsWithRedisParallelTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithRedisParallelTest.php
@@ -19,7 +19,7 @@ class InteractsWithRedisParallelTest extends TestCase
      *
      * @var list<string>
      */
-    private const REDIS_ENVIRONMENT_KEYS = [
+    private const array REDIS_ENVIRONMENT_KEYS = [
         'REDIS_HOST',
         'REDIS_DB',
         'REDIS_TEST_DB_MIN',

--- a/tests/Grpc/GrpcServiceProviderTest.php
+++ b/tests/Grpc/GrpcServiceProviderTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class GrpcServiceProviderTest extends TestCase
 {
-    private const ROUTES = __DIR__ . '/../../src/grpc/stubs/grpc.php';
+    private const string ROUTES = __DIR__ . '/../../src/grpc/stubs/grpc.php';
 
     public function testClientOnlyConfigurationDoesNotAppendAListener(): void
     {

--- a/tests/Grpc/TypeGeneratedConstantsTest.php
+++ b/tests/Grpc/TypeGeneratedConstantsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Grpc;
+
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Testing\ParallelTesting;
+use Hypervel\Tests\TestCase;
+use Symfony\Component\Process\Process;
+
+class TypeGeneratedConstantsTest extends TestCase
+{
+    protected string $temporaryDirectory;
+
+    protected Filesystem $filesystem;
+
+    /**
+     * Prepare the generated-code fixture directory.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+        $this->temporaryDirectory = ParallelTesting::tempDir('TypeGeneratedConstantsTest');
+        $this->filesystem->deleteDirectory($this->temporaryDirectory);
+        mkdir($this->temporaryDirectory, 0777, true);
+    }
+
+    /**
+     * Remove the generated-code fixture directory.
+     */
+    protected function tearDown(): void
+    {
+        $this->filesystem->deleteDirectory($this->temporaryDirectory);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Type raw protoc constants without changing already typed declarations.
+     */
+    public function testItTypesRawProtocConstantsIdempotently(): void
+    {
+        $fixturePath = $this->temporaryDirectory . '/ServingStatus.php';
+
+        file_put_contents($fixturePath, <<<'PHP'
+            <?php
+
+            class ServingStatus
+            {
+                const UNKNOWN = 0;
+                const NEGATIVE = -3;
+                public const PUBLIC_VALUE = 7;
+                protected const LEVEL = 3;
+                private const INTERNAL = 4;
+                final const FINAL_VALUE = 5;
+                public final const PUBLIC_FINAL_VALUE = 8;
+                public const int ALREADY_TYPED = 6;
+            }
+            PHP);
+
+        $process = $this->runTransformer();
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+        $this->assertSame('Typed 7 generated protobuf constants.' . PHP_EOL, $process->getOutput());
+
+        $expectedContents = <<<'PHP'
+            <?php
+
+            class ServingStatus
+            {
+                const int UNKNOWN = 0;
+                const int NEGATIVE = -3;
+                public const int PUBLIC_VALUE = 7;
+                protected const int LEVEL = 3;
+                private const int INTERNAL = 4;
+                final const int FINAL_VALUE = 5;
+                public final const int PUBLIC_FINAL_VALUE = 8;
+                public const int ALREADY_TYPED = 6;
+            }
+            PHP;
+
+        $this->assertSame($expectedContents, file_get_contents($fixturePath));
+
+        $secondProcess = $this->runTransformer();
+
+        $this->assertTrue($secondProcess->isSuccessful(), $secondProcess->getErrorOutput());
+        $this->assertSame('Typed 0 generated protobuf constants.' . PHP_EOL, $secondProcess->getOutput());
+        $this->assertSame($expectedContents, file_get_contents($fixturePath));
+    }
+
+    /**
+     * Reject generated constants whose types cannot be inferred safely.
+     */
+    public function testItRejectsUnsupportedUntypedConstants(): void
+    {
+        $fixturePath = $this->temporaryDirectory . '/Unsupported.php';
+        $fixtureContents = <<<'PHP'
+            <?php
+
+            class Unsupported
+            {
+                const NAME = 'unknown';
+            }
+            PHP;
+
+        file_put_contents($fixturePath, $fixtureContents);
+
+        $process = $this->runTransformer();
+
+        $this->assertFalse($process->isSuccessful());
+        $this->assertSame('', $process->getOutput());
+        $this->assertStringContainsString(
+            "Generated file [{$fixturePath}] contains a class constant without a supported type.",
+            $process->getErrorOutput()
+        );
+        $this->assertSame($fixtureContents, file_get_contents($fixturePath));
+    }
+
+    /**
+     * Run the generated constant transformer.
+     */
+    protected function runTransformer(): Process
+    {
+        $process = new Process([
+            PHP_BINARY,
+            dirname(__DIR__, 2) . '/src/grpc/resources/proto/type-generated-constants.php',
+            $this->temporaryDirectory,
+        ]);
+        $process->run();
+
+        return $process;
+    }
+}

--- a/tests/Inertia/TestCase.php
+++ b/tests/Inertia/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends Testbench
      *
      * @var array<string, mixed>
      */
-    protected const EXAMPLE_PAGE_OBJECT = [
+    protected const array EXAMPLE_PAGE_OBJECT = [
         'component' => 'Foo/Bar',
         'props' => ['foo' => 'bar'],
         'url' => '/test',

--- a/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
+++ b/tests/Integration/Database/ConnectionCoroutineSafetyTest.php
@@ -606,7 +606,7 @@ class UnguardedTestUser extends Model
 
 class CoroutineSessionConfigurator implements SessionConfigurator
 {
-    public const CONTEXT_KEY = '__database.session_configurator_test';
+    public const string CONTEXT_KEY = '__database.session_configurator_test';
 
     public int $stateCalls = 0;
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -172,7 +172,7 @@ class TestModel2 extends Model
 {
     public ?string $table = 'test_model2';
 
-    public const UPDATED_AT = null;
+    public const ?string UPDATED_AT = null;
 
     protected array $guarded = [];
 

--- a/tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
@@ -15,13 +15,13 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMariaDbConnectionTest extends MariaDbTestCase
 {
-    public const TABLE = 'player';
+    public const string TABLE = 'player';
 
-    public const FLOAT_COL = 'float_col';
+    public const string FLOAT_COL = 'float_col';
 
-    public const JSON_COL = 'json_col';
+    public const string JSON_COL = 'json_col';
 
-    public const FLOAT_VAL = 0.2;
+    public const float FLOAT_VAL = 0.2;
 
     protected function afterRefreshingDatabase(): void
     {

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -16,13 +16,13 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 #[RequiresPhpExtension('pdo_mysql')]
 class DatabaseMySqlConnectionTest extends MySqlTestCase
 {
-    public const TABLE = 'player';
+    public const string TABLE = 'player';
 
-    public const FLOAT_COL = 'float_col';
+    public const string FLOAT_COL = 'float_col';
 
-    public const JSON_COL = 'json_col';
+    public const string JSON_COL = 'json_col';
 
-    public const FLOAT_VAL = 0.2;
+    public const float FLOAT_VAL = 0.2;
 
     protected function afterRefreshingDatabase(): void
     {

--- a/tests/Integration/Database/Postgres/SessionConfiguratorTest.php
+++ b/tests/Integration/Database/Postgres/SessionConfiguratorTest.php
@@ -16,7 +16,7 @@ use RuntimeException;
 
 class SessionConfiguratorTest extends PostgresTestCase
 {
-    private const CONNECTION_NAME = 'postgres_session_configurator_test';
+    private const string CONNECTION_NAME = 'postgres_session_configurator_test';
 
     private DbPool $sessionPool;
 

--- a/tests/Integration/Database/SessionConfiguratorTest.php
+++ b/tests/Integration/Database/SessionConfiguratorTest.php
@@ -19,7 +19,7 @@ use PDO;
 
 class SessionConfiguratorTest extends DatabaseTestCase
 {
-    private const CONNECTION_NAME = 'session_configurator_test';
+    private const string CONNECTION_NAME = 'session_configurator_test';
 
     private DbPool $sessionPool;
 

--- a/tests/Integration/Grpc/Fixtures/TestService.php
+++ b/tests/Integration/Grpc/Fixtures/TestService.php
@@ -17,7 +17,7 @@ use Hypervel\Tests\Grpc\Fixtures\TestRequest;
 
 class TestService
 {
-    private const MAX_TEST_RESPONSE_SIZE = 5 * 1024 * 1024;
+    private const int MAX_TEST_RESPONSE_SIZE = 5 * 1024 * 1024;
 
     /**
      * Handle the integration fixture's unary call.

--- a/tests/Integration/Horizon/Feature/SupervisorCommandTest.php
+++ b/tests/Integration/Horizon/Feature/SupervisorCommandTest.php
@@ -12,7 +12,7 @@ use Hypervel\Tests\Integration\Horizon\IntegrationTestCase;
 
 class SupervisorCommandTest extends IntegrationTestCase
 {
-    public const OPTIONS = [
+    public const array OPTIONS = [
         'name' => 'foo',
         'connection' => 'redis',
         '--workers-name' => 'default',

--- a/tests/Integration/Horizon/IntegrationTestCase.php
+++ b/tests/Integration/Horizon/IntegrationTestCase.php
@@ -19,7 +19,7 @@ abstract class IntegrationTestCase extends TestCase
 {
     use InteractsWithRedis;
 
-    public const HORIZON_PREFIX = 'hypervel_test_horizon:';
+    public const string HORIZON_PREFIX = 'hypervel_test_horizon:';
 
     protected array $originalQueueConfig = [];
 

--- a/tests/Integration/HttpServer/ResponseStreamingTest.php
+++ b/tests/Integration/HttpServer/ResponseStreamingTest.php
@@ -9,7 +9,7 @@ use Hypervel\Engine\Http\V2\Request as Http2Request;
 
 class ResponseStreamingTest extends HttpServerIntegrationTestCase
 {
-    protected const BINARY_CONTENTS = '0123456789abcdefghijklmnopqrstuvwxyz';
+    protected const string BINARY_CONTENTS = '0123456789abcdefghijklmnopqrstuvwxyz';
 
     public function testCallbackAndIterableStreamsPassThroughOutboundMiddleware(): void
     {

--- a/tests/JsonSchema/DeserializerTest.php
+++ b/tests/JsonSchema/DeserializerTest.php
@@ -1884,10 +1884,10 @@ class DeserializerTest extends TestCase
 
 class JsonSchemaDepthLimitedDeserializer extends Deserializer
 {
-    protected const MAX_REFERENCE_DEPTH = 1;
+    protected const int MAX_REFERENCE_DEPTH = 1;
 }
 
 class JsonSchemaNodeLimitedDeserializer extends Deserializer
 {
-    protected const MAX_NODES = 1;
+    protected const int MAX_NODES = 1;
 }

--- a/tests/Log/StreamHandlerTest.php
+++ b/tests/Log/StreamHandlerTest.php
@@ -16,7 +16,7 @@ use function Hypervel\Coroutine\parallel;
 
 class StreamHandlerTest extends TestCase
 {
-    private const STREAM_SCHEME = 'hypervel-log-test';
+    private const string STREAM_SCHEME = 'hypervel-log-test';
 
     protected function setUp(): void
     {

--- a/tests/Permission/Fixtures/Models/WildcardPermission.php
+++ b/tests/Permission/Fixtures/Models/WildcardPermission.php
@@ -8,12 +8,11 @@ use Hypervel\Permission\WildcardPermission as BaseWildcardPermission;
 
 class WildcardPermission extends BaseWildcardPermission
 {
-    /** @var string */
-    public const WILDCARD_TOKEN = '@';
+    public const string WILDCARD_TOKEN = '@';
 
     /** @var non-empty-string */
-    public const PART_DELIMITER = ':';
+    public const string PART_DELIMITER = ':';
 
     /** @var non-empty-string */
-    public const SUBPART_DELIMITER = ';';
+    public const string SUBPART_DELIMITER = ';';
 }

--- a/tests/RateLimiter/SwooleStoreConcurrencyTest.php
+++ b/tests/RateLimiter/SwooleStoreConcurrencyTest.php
@@ -21,9 +21,9 @@ use Throwable;
 
 class SwooleStoreConcurrencyTest extends TestCase
 {
-    private const FRAME_HEADER_BYTES = 4;
+    private const int FRAME_HEADER_BYTES = 4;
 
-    private const MAX_FRAME_BYTES = 1_048_576;
+    private const int MAX_FRAME_BYTES = 1_048_576;
 
     protected bool $runTestsInCoroutine = false;
 

--- a/tests/Sanctum/PersonalAccessTokenCacheTest.php
+++ b/tests/Sanctum/PersonalAccessTokenCacheTest.php
@@ -1437,7 +1437,7 @@ class TimestampDisabledPersonalAccessToken extends PersonalAccessToken
 
 class CustomTimestampPersonalAccessToken extends PersonalAccessToken
 {
-    public const UPDATED_AT = 'modified_at';
+    public const ?string UPDATED_AT = 'modified_at';
 }
 
 class SecondaryConnectionPersonalAccessToken extends PersonalAccessToken

--- a/tests/Sentry/Features/StrictTraceContinuationIntegrationTest.php
+++ b/tests/Sentry/Features/StrictTraceContinuationIntegrationTest.php
@@ -11,11 +11,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class StrictTraceContinuationIntegrationTest extends SentryTestCase
 {
-    private const INCOMING_TRACE_ID = '566e3688a61d4bc888951642d6f14a19';
+    private const string INCOMING_TRACE_ID = '566e3688a61d4bc888951642d6f14a19';
 
-    private const INCOMING_PARENT_SPAN_ID = '566e3688a61d4bc8';
+    private const string INCOMING_PARENT_SPAN_ID = '566e3688a61d4bc8';
 
-    private const INCOMING_SENTRY_TRACE_HEADER = self::INCOMING_TRACE_ID . '-' . self::INCOMING_PARENT_SPAN_ID . '-1';
+    private const string INCOMING_SENTRY_TRACE_HEADER = self::INCOMING_TRACE_ID . '-' . self::INCOMING_PARENT_SPAN_ID . '-1';
 
     private function registerRoutes(): void
     {

--- a/tests/Sentry/IntegrationMetaTagTest.php
+++ b/tests/Sentry/IntegrationMetaTagTest.php
@@ -13,7 +13,7 @@ use function Sentry\configureScope;
 
 class IntegrationMetaTagTest extends SentryTestCase
 {
-    private const DANGEROUS_PAYLOAD = '</meta><script>alert("owned")</script>';
+    private const string DANGEROUS_PAYLOAD = '</meta><script>alert("owned")</script>';
 
     protected function tearDown(): void
     {

--- a/tests/Support/EnvTest.php
+++ b/tests/Support/EnvTest.php
@@ -12,9 +12,9 @@ use RuntimeException;
 
 class EnvTest extends TestCase
 {
-    private const ARRAY_KEY = 'TEST_ENV_ARRAY';
+    private const string ARRAY_KEY = 'TEST_ENV_ARRAY';
 
-    private const REQUIRED_KEY = 'TEST_REQUIRED_ENV';
+    private const string REQUIRED_KEY = 'TEST_REQUIRED_ENV';
 
     protected function setUp(): void
     {

--- a/tests/Testbench/Foundation/Console/ServeCommandTest.php
+++ b/tests/Testbench/Foundation/Console/ServeCommandTest.php
@@ -24,7 +24,7 @@ use function Hypervel\Testbench\package_path;
 
 class ServeCommandTest extends TestCase
 {
-    private const WORKING_PATH_ENV = 'TESTBENCH_WORKING_PATH';
+    private const string WORKING_PATH_ENV = 'TESTBENCH_WORKING_PATH';
 
     /** @var array{process: false|string, environment_exists: bool, environment: mixed, server_exists: bool, server: mixed} */
     private array $workingPathState;

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -16,9 +16,9 @@ use PHPUnit\Framework\Attributes\TestWith;
 
 class ValidationEmailRuleTest extends TestCase
 {
-    private const ATTRIBUTE = 'my_email';
+    private const string ATTRIBUTE = 'my_email';
 
-    private const ATTRIBUTE_REPLACED = 'my email';
+    private const string ATTRIBUTE_REPLACED = 'my email';
 
     protected function setUp(): void
     {

--- a/tests/Watcher/Driver/FswatchDriverTest.php
+++ b/tests/Watcher/Driver/FswatchDriverTest.php
@@ -503,7 +503,7 @@ class FswatchDriverStreamState
 
 class FswatchDriverStreamWrapper
 {
-    public const PROTOCOL = 'hypervel-fswatch-driver-test';
+    public const string PROTOCOL = 'hypervel-fswatch-driver-test';
 
     /** @var resource */
     public $context;


### PR DESCRIPTION
## Summary

This change adds native PHP 8.4 types to class constants throughout the framework, optional packages, tests, and integration fixtures.

Class constant declarations now follow the same native-typing standard as parameters, return values, and properties. Existing constant values, visibility, ordering, and runtime behavior remain unchanged.

## Framework and test constants

The declarations use `string`, `int`, `float`, `bool`, `array`, and `?string` according to each constant's value and contract.

PHPDoc annotations that only repeated the native type have been removed. Annotations that still add information—such as array shapes, non-empty strings, and class strings—remain in place.

Facade document generation still tests untyped application and third-party constants. Those declarations are input fixtures held in nowdoc strings, rather than Hypervel class declarations, and are intentionally unchanged.

## Eloquent timestamp overrides

`Model::CREATED_AT` and `Model::UPDATED_AT` use `?string` because a model can disable either timestamp by setting its constant to `null`.

PHP requires an overriding constant to declare a compatible type. The Eloquent documentation and Database package README now show and explain the required declarations for custom timestamp column names.

## Generated gRPC health classes

The checked-in protobuf health enum now uses typed integer constants.

A new `composer generate:grpc-health` command provides the complete maintainer workflow for future updates. It verifies the pinned `protoc` version, generates into a temporary directory, applies native types to generated enum constants, formats the output, and only then replaces the committed files.

The transformer fails on unsupported untyped declarations instead of silently leaving incomplete output. Its tests cover raw `protoc` declarations, constant modifiers, repeat runs, and failure behavior. Generated properties and methods are left as emitted by `protoc`.

## Compatibility

Hypervel already requires PHP 8.4, so these declarations do not change the supported runtime range.

Constant values and visibility are unchanged. Applications that override the timestamp constants must now include the compatible `?string` type; the documentation calls this out directly.

Global constants are unchanged because PHP does not support native types on them.

## Verification

The full repository formatting, static analysis, test, Testbench, and dogfood suite passes. The gRPC generation workflow also has focused subprocess coverage, and a final class-constant inventory found no untyped Hypervel declarations.
