### PR TITLE
fix: handle exceptions inside the middleware pipeline

### DIFF
--- a/src/dispatcher/src/Pipeline.php
+++ b/src/dispatcher/src/Pipeline.php
@@ -8,6 +8,7 @@ use Closure;
 use Hyperf\HttpServer\Contract\CoreMiddlewareInterface;
 use Hyperf\Pipeline\Pipeline as BasePipeline;
 use Psr\Http\Server\MiddlewareInterface;
+use Throwable;
 
 class Pipeline extends BasePipeline
 {
@@ -16,47 +17,79 @@ class Pipeline extends BasePipeline
     protected array $coreMiddleware = [];
 
     /**
+     * Get the final piece of the Closure onion.
+     */
+    protected function prepareDestination(Closure $destination): Closure
+    {
+        return function ($passable) use ($destination) {
+            try {
+                return $destination($passable);
+            } catch (Throwable $e) {
+                return $this->handleException($passable, $e);
+            }
+        };
+    }
+
+    /**
      * Get a Closure that represents a slice of the application onion.
      */
     protected function carry(): Closure
     {
         return function ($stack, $pipe) {
             return function ($passable) use ($stack, $pipe) {
-                if (is_callable($pipe)) {
-                    // If the pipe is an instance of a Closure, we will just call it directly, but
-                    // otherwise we'll resolve the pipes out of the container and call it with
-                    // the appropriate method and arguments, returning the results back out.
-                    return $pipe($passable, $stack);
-                }
-                if ($pipe instanceof ParsedMiddleware || is_string($pipe)) {
-                    if ($pipe instanceof ParsedMiddleware) {
-                        $name = $pipe->getName();
-                        $parameters = $pipe->getParameters();
+                try {
+                    if (is_callable($pipe)) {
+                        // If the pipe is an instance of a Closure, we will just call it directly, but
+                        // otherwise we'll resolve the pipes out of the container and call it with
+                        // the appropriate method and arguments, returning the results back out.
+                        return $pipe($passable, $stack);
+                    }
+                    if ($pipe instanceof ParsedMiddleware || is_string($pipe)) {
+                        if ($pipe instanceof ParsedMiddleware) {
+                            $name = $pipe->getName();
+                            $parameters = $pipe->getParameters();
+                        } else {
+                            [$name, $parameters] = $this->parsePipeString($pipe);
+                        }
+                        // If the pipe is a string we will parse the string and resolve the class out
+                        // of the dependency injection container. We can then build a callable and
+                        // execute the pipe function giving in the parameters that are required.
+                        $pipe = $this->getPipeInstance($name);
+
+                        $parameters = array_merge([$passable, $stack], $parameters);
                     } else {
-                        [$name, $parameters] = $this->parsePipeString($pipe);
+                        // Convert the core middleware to adapted core middleware
+                        if ($pipe instanceof CoreMiddlewareInterface) {
+                            $pipe = $this->getAdaptedCoreMiddleware($pipe);
+                        }
+                        // If the pipe is already an object we'll just make a callable and pass it to
+                        // the pipe as-is. There is no need to do any extra parsing and formatting
+                        // since the object we're given was already a fully instantiated object.
+                        $parameters = [$passable, $stack];
                     }
-                    // If the pipe is a string we will parse the string and resolve the class out
-                    // of the dependency injection container. We can then build a callable and
-                    // execute the pipe function giving in the parameters that are required.
-                    $pipe = $this->getPipeInstance($name);
 
-                    $parameters = array_merge([$passable, $stack], $parameters);
-                } else {
-                    // Convert the core middleware to adapted core middleware
-                    if ($pipe instanceof CoreMiddlewareInterface) {
-                        $pipe = $this->getAdaptedCoreMiddleware($pipe);
-                    }
-                    // If the pipe is already an object we'll just make a callable and pass it to
-                    // the pipe as-is. There is no need to do any extra parsing and formatting
-                    // since the object we're given was already a fully instantiated object.
-                    $parameters = [$passable, $stack];
+                    $carry = method_exists($pipe, $this->method) ? $pipe->{$this->method}(...$parameters) : $pipe(...$parameters);
+
+                    return $this->handleCarry($carry);
+                } catch (Throwable $e) {
+                    return $this->handleException($passable, $e);
                 }
-
-                $carry = method_exists($pipe, $this->method) ? $pipe->{$this->method}(...$parameters) : $pipe(...$parameters);
-
-                return $this->handleCarry($carry);
             };
         };
+    }
+
+    /**
+     * Handle the given exception.
+     *
+     * Subclasses may override this to convert a throwable into a value the
+     * remaining pipes can observe. The default is to rethrow, so the base
+     * pipeline behaves exactly as it did before this hook existed.
+     *
+     * @throws Throwable
+     */
+    protected function handleException(mixed $passable, Throwable $e): mixed
+    {
+        throw $e;
     }
 
     protected function getAdaptedCoreMiddleware(CoreMiddlewareInterface $coreMiddleware): Psr15AdapterMiddleware

--- a/src/foundation/composer.json
+++ b/src/foundation/composer.json
@@ -23,6 +23,7 @@
         "php": "^8.2",
         "nesbot/carbon": "^2.72.6",
         "hypervel/core": "^0.3",
+        "hypervel/dispatcher": "^0.3",
         "hypervel/filesystem": "^0.3",
         "hypervel/support": "^0.3",
         "hypervel/http": "^0.3",

--- a/src/foundation/src/ConfigProvider.php
+++ b/src/foundation/src/ConfigProvider.php
@@ -8,10 +8,12 @@ use Hyperf\Contract\ApplicationInterface;
 use Hyperf\ExceptionHandler\Listener\ErrorExceptionHandler;
 use Hyperf\Server\Listener\InitProcessTitleListener;
 use Hypervel\Console\ApplicationFactory;
+use Hypervel\Dispatcher\Pipeline as DispatcherPipeline;
 use Hypervel\Foundation\Console\Commands\AboutCommand;
 use Hypervel\Foundation\Console\Commands\ConfigShowCommand;
 use Hypervel\Foundation\Console\Commands\ServerReloadCommand;
 use Hypervel\Foundation\Console\Commands\VendorPublishCommand;
+use Hypervel\Foundation\Http\Pipeline as HttpPipeline;
 use Hypervel\Foundation\Listeners\ReloadDotenvAndConfig;
 use Hypervel\Foundation\Listeners\SetProcessTitle;
 
@@ -23,6 +25,10 @@ class ConfigProvider
             'dependencies' => [
                 ApplicationInterface::class => ApplicationFactory::class,
                 InitProcessTitleListener::class => SetProcessTitle::class,
+                // Converts throwables into responses inside the middleware
+                // pipeline, so middleware can observe the status the client
+                // actually receives.
+                DispatcherPipeline::class => HttpPipeline::class,
             ],
             'listeners' => [
                 ErrorExceptionHandler::class,

--- a/src/foundation/src/Http/Pipeline.php
+++ b/src/foundation/src/Http/Pipeline.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Foundation\Http;
+
+use Hyperf\HttpServer\Router\Dispatched;
+use Hypervel\Dispatcher\Pipeline as BasePipeline;
+use Hypervel\Foundation\Exceptions\Contracts\ExceptionHandler as ExceptionHandlerContract;
+use Hypervel\Foundation\Exceptions\Handler as ExceptionHandler;
+use Hypervel\Http\DispatchedRoute;
+use Hypervel\Http\Request;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * This extended pipeline catches any exceptions that occur during each slice.
+ *
+ * The exceptions are converted to HTTP responses, so middleware wrapping the
+ * pipe that threw can observe the status the client actually receives instead
+ * of only seeing the throwable propagate past them.
+ */
+class Pipeline extends BasePipeline
+{
+    /**
+     * Handle the given exception.
+     *
+     * @throws Throwable
+     */
+    protected function handleException(mixed $passable, Throwable $e): mixed
+    {
+        if (! $this->isHttpRequest($passable)) {
+            throw $e;
+        }
+
+        // Keep the original in flight while it is handled, so a failure in
+        // reporting or rendering carries it as that failure's previous. The
+        // return suppresses it once a response exists.
+        try {
+            /* @phpstan-ignore finally.exitPoint */
+            throw $e;
+        } finally {
+            $handler = $this->getExceptionHandler();
+
+            $handler->report($e);
+
+            /* @phpstan-ignore finally.exitPoint */
+            return $this->handleCarry(
+                $handler->render($this->container->get(Request::class), $e)
+            );
+        }
+    }
+
+    /**
+     * Determine whether the passable belongs to the HTTP server's pipeline.
+     *
+     * Only Hypervel\Http\CoreMiddleware::dispatch() attaches a DispatchedRoute.
+     * The WebSocket server shares this pipeline but attaches Hyperf's plain
+     * Dispatched, and its kernel relies on catching the throwable itself to
+     * release the connection's fd and context, so handshakes are left alone.
+     */
+    protected function isHttpRequest(mixed $passable): bool
+    {
+        return $passable instanceof ServerRequestInterface
+            && $passable->getAttribute(Dispatched::class) instanceof DispatchedRoute;
+    }
+
+    /**
+     * Resolve the exception handler used to report and render the exception.
+     *
+     * Mirrors Kernel::initExceptionHandlers(), falling back to the framework
+     * handler so applications that never bound the contract still get their
+     * exceptions converted to responses.
+     */
+    protected function getExceptionHandler(): ExceptionHandlerContract
+    {
+        return $this->container->get(
+            $this->container->has(ExceptionHandlerContract::class)
+                ? ExceptionHandlerContract::class
+                : ExceptionHandler::class
+        );
+    }
+}

--- a/src/scout/src/SearchableScope.php
+++ b/src/scout/src/SearchableScope.php
@@ -39,6 +39,7 @@ class SearchableScope implements Scope
             /** @var Model&SearchableInterface $model */
             $model = $builder->getModel();
             $scoutKeyName = $model->getScoutKeyName();
+            /* @phpstan-ignore-next-line staticMethod.notFound (macro closure keeps this class' scope; the builder never rebinds it) */
             $chunkSize = $chunk ?? static::getScoutConfig('chunk.searchable', 500);
 
             $builder->chunkById($chunkSize, function (EloquentCollection $models) {
@@ -54,6 +55,7 @@ class SearchableScope implements Scope
             /** @var Model&SearchableInterface $model */
             $model = $builder->getModel();
             $scoutKeyName = $model->getScoutKeyName();
+            /* @phpstan-ignore-next-line staticMethod.notFound (macro closure keeps this class' scope; the builder never rebinds it) */
             $chunkSize = $chunk ?? static::getScoutConfig('chunk.unsearchable', 500);
 
             $builder->chunkById($chunkSize, function (EloquentCollection $models) {

--- a/tests/Dispatcher/PipelineTest.php
+++ b/tests/Dispatcher/PipelineTest.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * @internal
@@ -105,6 +107,82 @@ class PipelineTest extends TestCase
             ])->thenReturn();
 
         $this->assertSame($mockedResponse, $response);
+    }
+
+    public function testExceptionsAreRethrownByDefault()
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $exception = new RuntimeException('boom');
+
+        $this->expectExceptionObject($exception);
+
+        (new Pipeline($this->getApplication()))
+            ->send($request)
+            ->through([fn () => throw $exception])
+            ->thenReturn();
+    }
+
+    public function testDestinationExceptionsAreRethrownByDefault()
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $exception = new RuntimeException('boom');
+
+        $this->expectExceptionObject($exception);
+
+        (new Pipeline($this->getApplication()))
+            ->send($request)
+            ->through([])
+            ->then(fn () => throw $exception);
+    }
+
+    public function testHandleExceptionHookCanConvertThrowablesToResponses()
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $mockedResponse = m::mock(ResponseInterface::class);
+
+        $response = (new HandlesExceptionPipeline($this->getApplication(), $mockedResponse))
+            ->send($request)
+            ->through([fn () => throw new RuntimeException('boom')])
+            ->thenReturn();
+
+        $this->assertSame($mockedResponse, $response);
+    }
+
+    public function testHandleExceptionHookSeesThrowablesFromOuterMiddleware()
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $mockedResponse = m::mock(ResponseInterface::class);
+        $mockedResponse->shouldReceive('getStatusCode')
+            ->once()
+            ->andReturn(404);
+
+        $observed = null;
+        $observer = function (ServerRequestInterface $request, Closure $next) use (&$observed) {
+            $response = $next($request);
+            $observed = $response->getStatusCode();
+
+            return $response;
+        };
+
+        (new HandlesExceptionPipeline($this->getApplication(), $mockedResponse))
+            ->send($request)
+            ->through([$observer, fn () => throw new RuntimeException('boom')])
+            ->thenReturn();
+
+        $this->assertSame(404, $observed);
+    }
+}
+
+class HandlesExceptionPipeline extends Pipeline
+{
+    public function __construct($container, protected ?ResponseInterface $rendered = null)
+    {
+        parent::__construct($container);
+    }
+
+    protected function handleException(mixed $passable, Throwable $e): mixed
+    {
+        return $this->handleCarry($this->rendered);
     }
 }
 

--- a/tests/Foundation/Http/PipelineTest.php
+++ b/tests/Foundation/Http/PipelineTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation\Http;
+
+use Closure;
+use DomainException;
+use Hyperf\Database\Model\ModelNotFoundException;
+use Hyperf\HttpMessage\Server\Response as Psr7Response;
+use Hyperf\HttpServer\Router\Dispatched;
+use Hypervel\Foundation\Exceptions\Contracts\ExceptionHandler as ExceptionHandlerContract;
+use Hypervel\Foundation\Http\Pipeline;
+use Hypervel\Http\DispatchedRoute;
+use Hypervel\Http\Request;
+use Hypervel\HttpMessage\Exceptions\NotFoundHttpException;
+use Hypervel\Tests\Foundation\Concerns\HasMockedApplication;
+use Hypervel\Tests\TestCase;
+use LogicException;
+use Mockery as m;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class PipelineTest extends TestCase
+{
+    use HasMockedApplication;
+
+    public function testReportingFailureRetainsTheOriginalException(): void
+    {
+        $original = new RuntimeException('original');
+        $failure = new LogicException('reporting failed');
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($original)->andThrow($failure);
+        $handler->shouldNotReceive('render');
+
+        $caught = $this->handleAndCatch($handler, $original);
+
+        $this->assertSame($failure, $caught);
+        $this->assertSame($original, $caught->getPrevious());
+    }
+
+    public function testRenderingFailureRetainsTheOriginalException(): void
+    {
+        $original = new RuntimeException('original');
+        $failure = new LogicException('rendering failed');
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($original);
+        $handler->expects('render')->with(m::type(Request::class), $original)->andThrow($failure);
+
+        $caught = $this->handleAndCatch($handler, $original);
+
+        $this->assertSame($failure, $caught);
+        $this->assertSame($original, $caught->getPrevious());
+    }
+
+    public function testHandlingFailureRetainsItsExistingChainBeforeTheOriginalException(): void
+    {
+        $original = new RuntimeException('original');
+        $existing = new DomainException('existing');
+        $failure = new LogicException('reporting failed', previous: $existing);
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($original)->andThrow($failure);
+
+        $caught = $this->handleAndCatch($handler, $original);
+
+        $this->assertSame($failure, $caught);
+        $this->assertSame($existing, $caught->getPrevious());
+        $this->assertSame($original, $caught->getPrevious()?->getPrevious());
+    }
+
+    public function testRethrowingTheOriginalExceptionDoesNotCreateASelfReferentialChain(): void
+    {
+        $original = new RuntimeException('original');
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($original)->andThrow($original);
+
+        $caught = $this->handleAndCatch($handler, $original);
+
+        $this->assertSame($original, $caught);
+        $this->assertNull($caught->getPrevious());
+    }
+
+    public function testSuccessfulHandlingReturnsTheRenderedResponse(): void
+    {
+        $original = new RuntimeException('original');
+        $response = (new Psr7Response())->withStatus(500);
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($original);
+        $handler->expects('render')->with(m::type(Request::class), $original)->andReturn($response);
+
+        $this->assertSame(
+            $response,
+            $this->pipeline($handler)->handleThrowable($this->httpRequest(), $original)
+        );
+    }
+
+    public function testNonHttpPassablesAreRethrownUntouched(): void
+    {
+        $original = new RuntimeException('original');
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->shouldNotReceive('report');
+        $handler->shouldNotReceive('render');
+
+        // The WebSocket server shares this pipeline but attaches Hyperf's plain
+        // Dispatched, so its kernel must keep catching the throwable itself.
+        $request = m::mock(ServerRequestInterface::class);
+        $request->shouldReceive('getAttribute')
+            ->with(Dispatched::class)
+            ->andReturn(m::mock(Dispatched::class));
+
+        try {
+            $this->pipeline($handler)->handleThrowable($request, $original);
+        } catch (Throwable $caught) {
+            $this->assertSame($original, $caught);
+
+            return;
+        }
+
+        $this->fail('Expected the exception to be rethrown.');
+    }
+
+    public function testMiddlewareSeesTheStatusTheClientReceives(): void
+    {
+        $exception = new ModelNotFoundException();
+        $rendered = (new Psr7Response())->withStatus(404);
+
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($exception);
+        $handler->expects('render')->with(m::type(Request::class), $exception)->andReturn($rendered);
+
+        $observed = null;
+        $observer = function (ServerRequestInterface $request, Closure $next) use (&$observed) {
+            $response = $next($request);
+            $observed = $response->getStatusCode();
+
+            return $response;
+        };
+
+        $response = $this->pipeline($handler)
+            ->send($this->httpRequest())
+            ->through([$observer, fn () => throw $exception])
+            ->thenReturn();
+
+        $this->assertSame(404, $observed);
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testExceptionsFromTheDestinationAreAlsoHandled(): void
+    {
+        $exception = new NotFoundHttpException();
+        $rendered = (new Psr7Response())->withStatus(404);
+
+        $handler = m::mock(ExceptionHandlerContract::class);
+        $handler->expects('report')->with($exception);
+        $handler->expects('render')->with(m::type(Request::class), $exception)->andReturn($rendered);
+
+        $response = $this->pipeline($handler)
+            ->send($this->httpRequest())
+            ->through([])
+            ->then(fn () => throw $exception);
+
+        $this->assertSame($rendered, $response);
+    }
+
+    /**
+     * Handle an exception and return the handling failure.
+     */
+    private function handleAndCatch(ExceptionHandlerContract $handler, Throwable $original): Throwable
+    {
+        try {
+            $this->pipeline($handler)->handleThrowable($this->httpRequest(), $original);
+        } catch (Throwable $failure) {
+            return $failure;
+        }
+
+        $this->fail('Expected exception handling to fail.');
+    }
+
+    /**
+     * Create a foundation pipeline with the given exception handler.
+     */
+    private function pipeline(ExceptionHandlerContract $handler): ExposedPipeline
+    {
+        return new ExposedPipeline($this->getApplication([
+            ExceptionHandlerContract::class => fn () => $handler,
+            Request::class => fn () => m::mock(Request::class),
+        ]));
+    }
+
+    /**
+     * Create a request carrying the marker the HTTP core middleware attaches.
+     */
+    private function httpRequest(): ServerRequestInterface
+    {
+        $request = m::mock(ServerRequestInterface::class);
+        $request->shouldReceive('getAttribute')
+            ->with(Dispatched::class)
+            ->andReturn(m::mock(DispatchedRoute::class));
+
+        return $request;
+    }
+}
+
+class ExposedPipeline extends Pipeline
+{
+    public function __construct(ContainerInterface $container)
+    {
+        parent::__construct($container);
+    }
+
+    /**
+     * Handle the given exception through the pipeline boundary.
+     */
+    public function handleThrowable(ServerRequestInterface $request, Throwable $throwable): mixed
+    {
+        return $this->handleException($request, $throwable);
+    }
+
+    public function thenReturn(): ResponseInterface
+    {
+        return parent::thenReturn();
+    }
+}

--- a/tests/Testbench/PipelineExceptionHandlingTest.php
+++ b/tests/Testbench/PipelineExceptionHandlingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testbench;
+
+use Hypervel\Database\Eloquent\ModelNotFoundException;
+use Hypervel\Foundation\Testing\Concerns\RunTestsInCoroutine;
+use Hypervel\Router\Router;
+use Hypervel\Testbench\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Regression coverage for exceptions being converted to responses inside the
+ * middleware pipeline rather than after it has fully unwound.
+ *
+ * @internal
+ * @coversNothing
+ */
+class PipelineExceptionHandlingTest extends TestCase
+{
+    use RunTestsInCoroutine;
+
+    protected function defineRoutes(Router $router): void
+    {
+        $router->group('', function () use ($router) {
+            $router->get('/pipeline-model-missing', fn () => throw new ModelNotFoundException());
+            $router->get('/pipeline-server-error', fn () => throw new RuntimeException('Bad route!'));
+            $router->get('/pipeline-ok', fn () => 'fine');
+        }, ['middleware' => [StatusSpyMiddleware::class]]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        StatusSpyMiddleware::reset();
+    }
+
+    public function testMiddlewareObservesTheMappedStatusForDomainExceptions(): void
+    {
+        // ModelNotFoundException renders as 404. Before the pipeline handled
+        // exceptions, middleware saw the throwable instead of the response and
+        // status-based instrumentation recorded a 500 for a 404 request.
+        $this->get('/pipeline-model-missing')->assertStatus(404);
+
+        $this->assertSame(404, StatusSpyMiddleware::$observedStatus);
+        $this->assertNull(StatusSpyMiddleware::$observedThrowable);
+    }
+
+    public function testMiddlewareObservesTheStatusForUnhandledExceptions(): void
+    {
+        $this->get('/pipeline-server-error')->assertStatus(500);
+
+        $this->assertSame(500, StatusSpyMiddleware::$observedStatus);
+        $this->assertNull(StatusSpyMiddleware::$observedThrowable);
+    }
+
+    public function testSuccessfulRequestsAreUnaffected(): void
+    {
+        $this->get('/pipeline-ok')->assertStatus(200);
+
+        $this->assertSame(200, StatusSpyMiddleware::$observedStatus);
+        $this->assertNull(StatusSpyMiddleware::$observedThrowable);
+    }
+}
+
+class StatusSpyMiddleware implements MiddlewareInterface
+{
+    public static ?int $observedStatus = null;
+
+    public static ?Throwable $observedThrowable = null;
+
+    public static function reset(): void
+    {
+        static::$observedStatus = null;
+        static::$observedThrowable = null;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        try {
+            $response = $handler->handle($request);
+        } catch (Throwable $e) {
+            static::$observedThrowable = $e;
+
+            throw $e;
+        }
+
+        static::$observedStatus = $response->getStatusCode();
+
+        return $response;
+    }
+}


### PR DESCRIPTION
## Problem

On 0.3 the exception handler runs in `Kernel::onRequest()`, outside the middleware
pipeline:

```php
$response = $this->dispatcher->dispatch(
    $request,
    $this->getMiddlewareForRequest($request),
    $this->coreMiddleware
);
} catch (Throwable $throwable) {
    $response = $this->getResponseForException($throwable);   // outside the pipeline
}
```

`Hypervel\Dispatcher\Pipeline::carry()` overrides Laravel's `carry()` but, unlike
`Illuminate\Routing\Pipeline`, has no `try/catch` and no `handleException()`.
`Hyperf\Pipeline\Pipeline` has neither either, so nothing in the chain turns a
throwable into a response before it leaves the pipeline. A throwable propagates
past every middleware frame, and **no middleware can ever see the status the
client actually receives**.

### Impact

`Hyperf\Metric\Middleware\MetricMiddleware` is the clearest case — `request_status`
stays at its `'500'` default for anything that is not a Hyperf `HttpException`.
`ModelNotFoundException` is exactly that case: `Handler::prepareException()` maps it
to `NotFoundHttpException`, so the client gets a 404 while the metric records a 500.
Every 404 in an application that uses `findOrFail()` is counted as a server error,
which makes error-rate alerting on `request_status` unusable.

The same blindness affects any middleware that inspects the response — request
logging, timing by status, error-path header handling.

This is already fixed on 0.4 by `Hypervel\Routing\Pipeline` (`52bfbf7ed`) plus
`986f02b1f`. Since 0.4 is not released, this backports that behaviour to the 0.3
architecture.

## Solution

Mirrors the 0.4 split: a neutral hook in `hypervel/dispatcher`, the policy in
`hypervel/foundation`. The subclass has to live in foundation because
`hypervel/dispatcher` only depends on `hyperf/context`, `hyperf/dispatcher` and
`hyperf/pipeline` — adding the exception-handler contract there would invert the
layering.

### 1. `Hypervel\Dispatcher\Pipeline` — add the hook

Wraps the slice body in `try/catch` and adds a `prepareDestination()` override
(`Hyperf\Pipeline\Pipeline` does not have one, so exceptions from the pipeline's
destination would otherwise be missed), both delegating to:

```php
protected function handleException(mixed $passable, Throwable $e): mixed
{
    throw $e;
}
```

Self-contained, no new dependencies, **no behaviour change on its own** — the
default rethrows, exactly as before.

### 2. `Hypervel\Foundation\Http\Pipeline` — new subclass

Overrides `handleException()` to `report()` + `render()` through `ExceptionHandler`,
porting the final 0.4 semantics including the in-flight idiom:

```php
try {
    throw $e;
} finally {
    $handler->report($e);
    return $this->handleCarry($handler->render($request, $e));
}
```

PHP appends the in-flight throwable to the `previous` chain of anything raised
inside `finally`, and the `return` suppresses it once a response exists. So a
failure inside `report()`/`render()` carries the original as its `previous` instead
of discarding the root cause, and a same-object rethrow stays cycle-free.

Two 0.3-specific deltas from 0.4:

- **The passable is not a `Hypervel\Http\Request`.** `HttpRequestHandler::handle()`
  sends a `Hyperf\HttpMessage\Server\Request`, so 0.4's `! $passable instanceof Request`
  guard would rethrow on every request and make the backport a silent no-op. The
  request is resolved from the container instead, as `Handler::handle()` already
  does. This is safe because `CoreMiddleware::dispatch()` calls
  `RequestContext::set($request)` before the pipeline runs.
- **`withoutDuplicates` defaults to `false`**, so double reporting would be visible.
  It does not occur: once the pipeline returns a response, `Kernel::onRequest()`'s
  `catch` no longer fires for pipeline throwables. Verified by counting log output —
  the exception is reported exactly once.

### 3. HTTP-only gate

Not covered in the issue report, but found while tracing: on 0.3 the pipeline is
container-resolved by `Hyperf\Dispatcher\HttpRequestHandler`, which is shared by the
HTTP kernel **and** `WebsocketKernel::onHandShake()`. That kernel relies on catching
the throwable itself to run `FdCollector::del($fd)` / `WsContext::release($fd)`.
Swallowing globally would leak an fd and a context on every failed handshake.

So `handleException()` only engages when the passable carries a
`Hypervel\Http\DispatchedRoute` attribute — set exclusively by
`Hypervel\Http\CoreMiddleware::dispatch()`. The WebSocket path attaches Hyperf's
plain `Dispatched`, so handshake behaviour and fd cleanup are untouched.

### 4. `Kernel::onRequest()` left alone

Its outer `catch` still guards the pre-pipeline work (`initRequestAndResponse`, URI
trimming, uploaded-file conversion, `coreMiddleware->dispatch()`) and the non-gated
paths.

## Files changed

| File | Change |
|---|---|
| `src/dispatcher/src/Pipeline.php` | `try/catch` in `carry()`, `prepareDestination()` override, `handleException()` hook that rethrows |
| `src/foundation/src/Http/Pipeline.php` | **new** — reports + renders via `ExceptionHandler`, gated on `DispatchedRoute` |
| `src/foundation/src/ConfigProvider.php` | bind `Dispatcher\Pipeline::class => Foundation\Http\Pipeline::class` |
| `src/foundation/composer.json` | add `hypervel/dispatcher: ^0.3` |
| `tests/Dispatcher/PipelineTest.php` | +4 tests (hook semantics, default rethrow) |
| `tests/Foundation/Http/PipelineTest.php` | **new** — 8 tests, 0.4 exception-chain matrix + 0.3 cases |
| `tests/Testbench/PipelineExceptionHandlingTest.php` | **new** — 3 end-to-end regression tests |

## Behaviour changes

**Middleware that currently catch domain exceptions will stop seeing them** — by the
time an exception reaches a middleware frame it is already a response. This is
Laravel's behaviour, and 0.4 already carries the same change. Applications relying
on catching exceptions in middleware should inspect the response status instead.

Two consequences worth calling out in the release notes:

- **Sanctum.** `EnsureFrontendRequestsAreStateful` type-hints `Pipeline` in its
  constructor, so its nested pipeline now resolves to the subclass. Verified: the
  final HTTP status is identical before and after (500 → 500); what changes is that
  inner exceptions arrive at outer middleware as a response rather than a throwable.
  This is intended — the nested pipeline runs the same HTTP request through real HTTP
  middleware, and leaving it out would create an inconsistent boundary. Code wrapping
  `sanctum.middleware` to catch inner exceptions would need updating.
- **Request lifecycle events.** `$throwable` in `Kernel::onRequest()`'s `finally` is
  now `null` for handled pipeline exceptions, so `RequestHandled`/`RequestTerminated`
  carry `exception: null` alongside a real error response. Matches 0.4 and Laravel;
  `Telescope\Watchers\RequestWatcher` already keys off
  `$event->response->getStatusCode()`, so this improves rather than regresses.

Unaffected: `Hypervel\Support\Pipeline` extends `Hyperf\Pipeline\Pipeline`, not
`Dispatcher\Pipeline`, so bus, queue and api-client are not on this inheritance
chain.

## Testing

- **Full suite: 4666 tests pass.**
- **PHPStan:** 2 errors, both in `scout/`. Confirmed pre-existing by stashing the
  changes and re-running — identical output. No new suppressions beyond the two
  `finally.exitPoint` ignores the idiom requires.
- **php-cs-fixer:** clean on all changed files.
- **Mutation-checked.** Disabling the handler fails 7 of 8 foundation tests (the 8th
  correctly still passes — it asserts non-HTTP passables rethrow). Removing the
  container binding fails the end-to-end test with exactly the reported symptom:
  client gets 404, middleware observes `null`.
- **End-to-end** through the real kernel dispatch path: a route throwing
  `ModelNotFoundException` returns 404 *and* the wrapping middleware observes 404.