### PR TITLE
Fix framework audit findings

### DIFF
--- a/docs/plans/2026-08-21-1100-hypervel-audit-correctness-cleanup-and-typing.md
+++ b/docs/plans/2026-08-21-1100-hypervel-audit-correctness-cleanup-and-typing.md
@@ -1,0 +1,405 @@
+# Hypervel Audit Correctness, Cleanup, and Typing
+
+## Goal
+
+Resolve every verified finding from the supplied framework audit, including the broader local inconsistencies exposed by each sampled finding. Fix the two adjacent command/validation bugs found while tracing the code. Leave no compatibility shim, dead branch, stale comment, false success, or half-typed family behind.
+
+This is framework bug-fix and source-quality work. Laravel remains the public API reference for the Laravel-ported packages; Hypervel-specific Redis console code keeps its stronger concrete requirements and Swoole-aware design. Implementation remains serial and file-by-file. Re-read this plan and `AGENTS.md` after compaction, and re-read the relevant package source before each implementation slice.
+
+## Confirmed design
+
+### Correctness fixes
+
+1. `BenchmarkCommand` must clean up after success, `BenchmarkMemoryException`, and every other throwable from a benchmark suite. Cleanup failure must be visible and make a successful run fail, but it must never replace an active suite exception. Its best-effort cache-service display must also report a failure without aborting the benchmark.
+2. `DoctorCommand` must keep cleanup best-effort across every tag, pattern, and registry operation while reporting each thrown cleanup failure. A failed silent preflight does not stop the functional diagnostics, but it makes the command fail because stale state can affect their reliability. Functional assertion totals and cleanup health remain separate. Its best-effort system-information display must catch every throwable and retain its visible connection-failure result.
+3. `Rules\Email` must let its nested validator reject non-string values. The current early return leaves its message list empty, so `Validator::validateUsingCustomRule()` falls back to the rule class name. `ValidatesAttributes::validateEmail()` already rejects the value safely and supplies the translated email message.
+4. Nested class-string command calls must execute a fresh clone. `Command::resolveCommand()` currently clones name-resolved commands and supplied command objects, but executes a container-resolved class string directly. Hypervel auto-singletons that unbound concrete, so repeated or concurrent `$this->call(CommandClass::class)` invocations otherwise share mutable command state.
+
+### Type and source-quality fixes
+
+- `BenchmarkContext::getStore()` returns the concrete `Hypervel\Cache\Repository`. Every benchmark scenario obtains its repository here, and the tagged scenarios plus `cleanup()` call concrete-only `tags()`, while `Hypervel\Contracts\Cache\Repository` does not declare that method. Keep the local `@var Repository` refinement because `CacheContract::store()` is contract-typed; remove the contradictory `@return` and fully qualified native type.
+- Add all missing native types that the audited call paths prove: 22 array-backed `Container` properties, the two known arrow-function parameters, the View bound-attribute parameter, affected test methods/providers/callbacks, and precise array shapes that native PHP cannot express.
+- Add Laravel-style imperative method documentation to the complete audited families, not only the sampled files.
+- Remove unused imports and catch bindings. Correct ordinary all-caps emphasis in Cache Redis comments while preserving real identifiers, acronyms, boolean operators, and intentional console banners.
+- Correct Telescope's protected `countExceptionOccurences()` spelling cleanly, with no alias or deprecated wrapper. The owner explicitly chose correct Hypervel code over retaining the upstream typo.
+
+### Verified non-findings and guardrails
+
+- `Repository::rememberForever()` has one `@template TCacheValue`; no source docblock contains a duplicate template name. Do not edit it.
+- gRPC regeneration already runs `type-generated-constants.php`, rejects surviving untyped constants, formats the result, and only then replaces the generated health classes. Do not add another generator check or test.
+- Keep `Container::$environmentResolver` docblock-only. PHP forbids `callable` as a property type, and narrowing the public `?callable` resolver API to `?Closure` would be wrong. `Container::$instance`, `$sharedResolutions`, `$sharedResolutionWaits`, and `$buildRecipes` are already correctly typed.
+- Keep `BenchmarkContext::cleanup()` fail-fast. Twelve scenario call sites rely on cleanup failure aborting meaningless benchmark work; aggregation belongs only in the command's final cleanup boundary.
+- Keep `DoctorCommand::cleanup()` as `void`. The runtime failure list records thrown failures only. Existing `CleanupVerificationCheck` owns silent incompleteness by scanning cache-value patterns, tag-storage patterns, and any-mode registry orphans after cleanup.
+- Do not reset Doctor counters or failure lists in `handle()`. The lazy loader and auto-singleton container intentionally cache command prototypes. `Application::freshCommandForRun()` already clones top-level CLI and `Artisan::call()` executions, and section 5 closes the omitted clone in nested class-string `$this->call()` execution. Invocation state belongs on those per-run clones, not behind command-specific reset machinery.
+- Do not add validation cases for an absent attribute or an empty string here. Those paths are outer `Validator` applicability rules, and the current helper always creates a present attribute. The explicit `nullable` case is the relevant contrast for the Email rule change.
+- Do not add a Telescope upgrade-guide entry. `src/docs/upgrade.md` is the completed 0.3-to-0.4 guide, and this narrow protected spelling correction does not belong in the Laravel porting guide. No user documentation changes are needed.
+
+## Implementation
+
+### 1. Make Benchmark cleanup exception-safe
+
+Files:
+
+- `tests/Cache/Redis/Console/BenchmarkCommandTest.php`
+- `src/cache/src/Redis/Console/BenchmarkCommand.php`
+- `src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php`
+
+First extend `BenchmarkCommandTest` with a subclass that retains the production `handle()`. Its `createContext()` override returns an injected Mockery `BenchmarkContext`; its `runComparison()` override either returns normally or throws an injected prebuilt `Throwable`. Do not reuse `TestableBenchmarkCommand`, whose `handle()` tests setup only, and do not construct a real `BenchmarkContext` for this control-flow test. Run the command with explicit `--scale=small`, `--runs=1`, `--compare-tag-modes`, and `--force` options. The comparison branch reaches the real try/catch/finally boundary without calling `BenchmarkContext::getStoreInstance()`; the context double's complete production expectation is therefore one `cleanup()` call, configured to return or throw for the matrix row.
+
+Give these full-handle tests their own cache mock builder. Do not relax the existing `mockCacheStore()` helper: its exact two-call expectation correctly protects the setup-only tests. The new builder expects `CacheContract::store()` exactly three times (twice in `setup()` and once in `displaySystemInfo()`), `Repository::getStore()` twice, and `Repository::get('test')` once; it also supplies the Redis context/info and tag mode needed by the successful display path. This keeps both seams strict and prevents the first full-handle test from failing on an unrelated Mockery count.
+
+Cover these paths:
+
+| Suite path | Cleanup path | Required result |
+|---|---|---|
+| returns | returns | `SUCCESS`, cleanup once |
+| returns | throws | class and message reported, `FAILURE` |
+| throws `BenchmarkMemoryException` | returns | memory guidance shown, cleanup once, `FAILURE` |
+| throws `BenchmarkMemoryException` | throws | both failures reported, `FAILURE` |
+| throws another prebuilt exception | throws | cleanup reported and the exact suite exception remains top-level |
+
+Then wrap the existing suite branch as follows:
+
+```php
+$cleanupFailed = false;
+
+try {
+    // Existing comparison or selected-mode suite.
+} catch (BenchmarkMemoryException $exception) {
+    $this->displayMemoryError($exception);
+
+    return self::FAILURE;
+} finally {
+    $this->newLine();
+    $this->info('Cleaning up benchmark data...');
+
+    try {
+        $context->cleanup();
+    } catch (Throwable $exception) {
+        $cleanupFailed = true;
+        $this->error('Benchmark cleanup failed (' . $exception::class . '): ' . $exception->getMessage());
+    }
+}
+
+return $cleanupFailed ? self::FAILURE : self::SUCCESS;
+```
+
+The inner catch stays `Throwable`: a cleanup `Error` or `TypeError` must not displace an active suite exception. Do not change `BenchmarkContext::cleanup()` or any scenario caller.
+
+Also import `Throwable`, replace `displaySystemInfo()`'s silent `Exception` catch with `catch (Throwable $exception)`, and emit a non-fatal diagnostic containing `Cache Service: Connection failed`, the throwable class, and its message. Add a real-handle regression in which the third `CacheContract::store()` call returns the repository but the repository's second `getStore()` call throws an `Error`; setup's first `getStore()` call still succeeds, so the strict 3/2/1 fixture counts remain valid. Assert the diagnostic and prove the controlled comparison suite still runs. This is a best-effort header path, so inability to retrieve the optional service/version details must be visible but must not prevent the actual benchmark. Keep the `Exception` import because mandatory setup still catches ordinary connection exceptions separately.
+
+In `BenchmarkContext`, change `getStore()` to the imported concrete `Repository`. While editing the cleanup method's comments, type its connection callback as `RedisConnection`, rename its registry filter parameter to `string $member`, and type both callback returns. In `BenchmarkCommand`, rename local catch variables and the protected `displayMemoryError(BenchmarkMemoryException $exception)` parameter consistently; update its positional test-subclass call as needed. Replace the now-false `Cleanup skipped to avoid further memory exhaustion.` guidance with wording that automatic cleanup runs next and the listed commands are fallback recovery if benchmark keys remain. There is no in-tree named-argument caller to preserve.
+
+### 2. Make Doctor cleanup truthful and independently reportable
+
+Files:
+
+- `tests/Cache/Redis/Console/DoctorCommandTest.php`
+- `src/cache/src/Redis/Console/DoctorCommand.php`
+
+Add focused regressions through the real cleanup and handle flow:
+
+- the first cache-store lookup, inside system-information display, throws an `Error` and prints the existing `Service: Connection failed` result; the second lookup returns the controlled Redis repository so store validation and diagnostics demonstrably continue;
+- a thrown failure in each cleanup category is reported with its operation, class, and message, and later cleanup work is still attempted;
+- silent preflight failure is visible, functional checks still run, and the eventual command status is `FAILURE` even when all functional assertions pass;
+- the summary presents functional failures and cleanup failures as separate groups and never counts cleanup as a test assertion;
+- a cleanup `Throwable` during an active prebuilt functional exception is reported without replacing that exact functional exception;
+- `Cleanup complete.` appears only when that cleanup invocation had no thrown failure.
+
+Add the runtime-only state and one shared reporter because four cleanup branches call it:
+
+```php
+/** @var list<string> */
+private array $cleanupFailures = [];
+
+/**
+ * Record and report a cleanup failure.
+ */
+private function recordCleanupFailure(string $operation, Throwable $exception): void
+{
+    $failure = $operation . ' failed (' . $exception::class . '): ' . $exception->getMessage();
+
+    $this->cleanupFailures[] = $failure;
+    $this->error($failure);
+}
+```
+
+Catch `Throwable` around each known-tag flush, cache-value pattern, tag-storage pattern, and any-mode registry cleanup. Derive `$phase = $silent ? 'Preflight cleanup' : 'Cleanup'` once at method entry, then begin every reported operation with that phase and include its tag or pattern, for example `Preflight cleanup: flush tag '_doctor:test:products'`. This makes otherwise identical preflight and final failures distinguishable both inline and in the summary without adding state or a phase abstraction. Track the failure-list count at method entry so a non-silent invocation only prints `Cleanup complete.` when that invocation added no failure. Keep reporting active in silent mode so a preflight problem is never hidden, and assert the phase distinction in the cleanup regressions.
+
+Widen `displaySystemInformation()`'s remaining `catch (Exception)` to `catch (Throwable $exception)`. Once the four cleanup catches are widened too, replace the now-unused `Exception` import with `Throwable`. Report the throwable class and message after `Service: Connection failed`: this optional display step must identify the cause and allow the command's substantive checks to continue even when the failure is an `Error` or `TypeError`.
+
+`displaySummary()` keeps assertion counts unchanged and adds its own cleanup-failures heading/list when needed. The callback returns success only when both conditions hold:
+
+```php
+return $this->testsFailed === 0 && $this->cleanupFailures === []
+    ? self::SUCCESS
+    : self::FAILURE;
+```
+
+Import the concrete Cache `Repository` for the local `@var` in `handle()`. Rename the cleanup registry filter parameter to `string $member` and type its return as `bool`. Do not create cleanup result objects, registries, retries, or return-value protocols.
+
+### 3. Complete Cache Redis method documentation
+
+Add imperative title docblocks to every undocumented named method in the concrete Doctor checks: 68 additions across 22 classes.
+
+- Functional checks: `AddOperationsCheck`, `BasicOperationsCheck`, `BulkOperationsCheck`, `CleanupVerificationCheck`, `ConcurrencyCheck`, `EdgeCasesCheck`, `ExpirationCheck`, `FlushBehaviorCheck`, `ForeverStorageCheck`, `HashStructuresCheck`, `IncrementDecrementCheck`, `LargeDatasetCheck`, `MemoryLeakPreventionCheck`, `MultipleTagsCheck`, `SequentialOperationsCheck`, `SharedTagFlushCheck`, `TaggedOperationsCheck`, and `TaggedRememberCheck`.
+- Environment checks: `CacheStoreCheck`, `HashFieldExpirationCheck`, `PhpRedisCheck`, and `RedisVersionCheck`.
+- Document all 48 `name()` / `run()` / `getFixInstructions()` implementations and the constructors of `CacheStoreCheck`, `HashFieldExpirationCheck`, and `RedisVersionCheck`.
+- Document the 17 currently bare helpers: `ConcurrencyCheck::setOutput()`, `testAtomicAdd()`, `testConcurrentFlush()`; `ExpirationCheck::setOutput()`, `testAnyModeExpiration()`, `testAllModeExpiration()`; both mode helpers on `FlushBehaviorCheck`, `ForeverStorageCheck`, `IncrementDecrementCheck`, `MemoryLeakPreventionCheck`, and `TaggedOperationsCheck`; plus `SharedTagFlushCheck::testAnyMode()`.
+- Add missing title lines to the existing type-only docblocks on both `MultipleTagsCheck` mode helpers and `SharedTagFlushCheck::testAllMode()`. Keep their useful array annotations.
+- While these methods are open, complete the proven local callback typing: type the five atomic-add closures and two concurrent-flush closures as returning `bool`; change the existing `array_filter` arrow to `fn (bool $succeeded): bool => $succeeded === true`; change `CleanupVerificationCheck`'s registry filter to `fn (string $member): bool => ...`; rename the three local `Throwable $e` bindings in `ConcurrencyCheck` and `RedisVersionCheck` to `$exception`. These are local variables only and do not change an extension signature.
+- Replace `ExpirationCheck`'s raw `sleep(2)` with `Sleep::sleep(2)` so the source delay uses the framework's fakeable timing primitive while retaining the same real delay by default.
+- Remove `ForeverStorageCheck::testAllMode()`'s unused private `$key` parameter and its sole call-site argument.
+
+Use short titles that state the method's purpose; do not repeat signatures, inventory class members, or add bodies where the code is clear. The new Doctor cleanup reporter also receives its title docblock as shown above.
+
+Add constructor titles to the complete 15-file Cache Redis gap:
+
+- `Operations/AllTag/{Add,AddEntry,Decrement,Flush,FlushStale,Forever,GetEntries,Increment,Put,PutMany}.php`
+- `Operations/AllTagOperations.php`
+- `Operations/AnyTagOperations.php`
+- `Support/MonitoringDetector.php`
+- `Support/StoreContext.php`
+- `Support/TagKeyBuilder.php`
+
+Match the established sibling wording, such as `Create a new touch operation instance.` Complete the directly proven callback returns in these files: `void` for `AddEntry`, `Flush`, and `FlushStale`; `int|false` for `Decrement` and `Increment`; `bool` for `Forever`, `Put`, and `PutMany`; `Generator` for `GetEntries`' lazy source; and `string` for `StoreContext::optPrefix()`. Replace `TagKeyBuilder`'s historical move narration with its current architectural role so the comment reads as designed this way from the start.
+
+### 4. Finish Cache Redis comment, import, and callback cleanup
+
+Normalize every ordinary all-caps emphasis found in the scoped Cache Redis scan:
+
+| File group | Ordinary emphasis to normalize |
+|---|---|
+| `Support/Serialization.php` | `IMPORTANT`, `NOT`, `AND` |
+| `Console/Doctor/DoctorContext.php` | `ANY`, `ALL`, two `BOTH` occurrences |
+| `Console/DoctorCommand.php` | `BOTH` |
+| Doctor check interface/classes | `BEFORE`, `AFTER`, `ANY`, `ALL`, and two `NOT` occurrences |
+| `Console/Benchmark/BenchmarkContext.php` | three `BOTH` occurrences and `NOT` before `OPT_PREFIX` |
+| `AnyTagSet.php` | `ANY` |
+| `Operations/AllTag/PutMany.php` | two `ONE` occurrences |
+| `Operations/AnyTag/Forever.php` | `WITHOUT` |
+| `Operations/Flush.php` | `ALL` |
+
+Preserve `OR` and `AND` in `FlushBehaviorCheck` where they name boolean operators. Preserve identifiers/acronyms such as `ARGV`, `OPT_PREFIX`, `ZSET`, `SCAN`, `KEYS`, `TTL`, and Redis command names. Preserve intentional console banners and warnings. Keep useful performance/ownership explanations; rewrite `IMPORTANT:` as a clear sentence-case ownership lead rather than deleting it.
+
+Also:
+
+- remove the unused global `Redis` import from `Operations/AllTag/Prune.php`;
+- type `AnyTag/GetTagItems::fetchValues()`'s `array_map` key as `string` and its connection callback return as `array`;
+- rename `Serialization`'s abbreviated `RedisConnection $conn` parameters to `$connection`; all in-tree calls are positional, and this Hypervel Redis helper is not a Laravel API;
+- complete directly known operation callback returns and descriptive local names in the edited files, without changing command structure or result handling;
+- correct `AnyTagSet`'s stale key-builder ownership comment to match the `StoreContext` → `TagKeyBuilder` call chain;
+- retain every operation's behavior and network-round-trip structure.
+
+### 5. Clone nested class-string commands per execution
+
+Files:
+
+- `tests/Integration/Console/CallCommandsTest.php`
+- `src/console/src/Command.php`
+
+Laravel's `Command::resolveCommand()` can execute a container-resolved class directly because its unbound concrete resolution is transient. Hypervel's container deliberately auto-singletons unbound concretes, so the ported class-string branch returns a worker-lived command prototype. The two sibling branches already clone a command resolved by name or supplied as an object, and top-level execution uses `Application::freshCommandForRun()` for the same input/output and coroutine-isolation reason.
+
+Add an integration regression with a stateful child command whose typed instance counter increments and is printed by `handle()`. Have a parent command invoke `$this->call(StatefulChildCommand::class)` twice. Before the fix the output progresses from `1` to `2`; require two independent `1` results and no `2`, proving sequential class-string calls do not share the container prototype. Retaining per-instance state in the fixture also tests the behavior directly without relying on recyclable object IDs. While this test file is open, add `: void` to its existing test methods and to every no-return Artisan command closure; keep every command `handle()` return typed as `int`.
+
+Then clone the container result in the existing class-string branch:
+
+```php
+$command = clone $this->hypervel->make($command);
+```
+
+Keep the shared post-resolution `setApplication()` and `setHypervel()` calls unchanged so the clone receives the current parent command's execution context. This is an intentional Hypervel adaptation of the Laravel source: Laravel does not need this clone under its transient unbound-resolution semantics. Do not reset individual command properties, opt commands into `SelfBuilding`, change container lifetime rules, or add a command run-state abstraction.
+
+### 6. Complete safe framework source typing and constructor documentation
+
+Apply these direct changes one file at a time:
+
+- `src/console/src/Application.php`: add `Create a new console application instance.` above the constructor; type the `getDefaultInputDefinition()` tap callback as `function (InputDefinition $definition): void`; type `getEnvironmentOption(): InputOption` and remove its redundant `@return`. Native typing protected Laravel methods is an established approved Hypervel port adaptation throughout this class and package.
+- `src/console/src/Commands/ScheduleListCommand.php`: type `handle(): void`; its only explicit return is bare and all other paths fall through.
+- `src/console/src/Commands/ScheduleClearCacheCommand.php`: type `handle(Schedule $schedule): void`; the method has no return value. This completes the directly related scheduling-command family.
+- `src/console/src/Commands/ScheduleTestCommand.php`: replace the live `return $this->info(...)` suppression with current Laravel's component-rendered info call followed by `return;`, type `handle(): void`, and type the directly known predicate/value callbacks. This deliberately makes the empty-schedule output consistent with the command's existing component-rendered no-match message.
+- `tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php`: add `: void` to the existing empty-schedule regression and run the test file immediately.
+- `src/coordinator/src/Timer.php`: add `Create a new timer instance.` above the constructor.
+- `src/core/src/Logger/StdoutLogger.php`: add `Create a new stdout logger instance.` above the constructor.
+- `src/database/src/ConnectionResolver.php`: add `Create a new connection resolver instance.` above the constructor.
+- `src/database/src/Pool/PooledConnection.php`: add `Create a new pooled connection instance.` above the constructor.
+- `src/database/src/Eloquent/Concerns/PreventsCircularRecursion.php`: change the `tap()` arrow parameter to `array &$stack`.
+- `src/view/src/Compilers/ComponentTagCompiler.php`: type `setBoundAttribute(string $attribute)`, remove its stale `mixed` annotation, and add `@return array<string, true>` to `getBoundAttributes()`.
+
+In `src/container/src/Container.php`, add native `array` to these 22 properties while keeping PHPDocs that describe their elements:
+
+`$resolved`, `$bindings`, `$methodBindings`, `$instances`, `$autoSingletons`, `$scopedInstances`, `$aliases`, `$abstractAliases`, `$extenders`, `$tags`, `$contextual`, `$contextualAttributes`, `$checkedForAttributeBindings`, `$checkedForSingletonOrScopedAttributes`, `$reboundCallbacks`, `$globalBeforeResolvingCallbacks`, `$globalResolvingCallbacks`, `$globalAfterResolvingCallbacks`, `$beforeResolvingCallbacks`, `$resolvingCallbacks`, `$afterResolvingCallbacks`, and `$afterResolvingAttributeCallbacks`.
+
+All initialize to arrays, all mutation/reset paths preserve arrays, and the only in-tree production subclass (`Foundation\Application`) does not redeclare them. Do not touch the already typed properties or `$environmentResolver`.
+
+### 7. Finish Database test typing and strict assertions
+
+#### Eloquent timestamps
+
+In `tests/Database/DatabaseEloquentTimestampsTest.php`:
+
+- import `ConnectionInterface`, `Schema\Builder`, and `Schema\Blueprint`;
+- type `createSchema(): void`, all seven test methods `: void`, `connection(): ConnectionInterface`, and `schema(): Builder`;
+- type the three schema callbacks as `function (Blueprint $table): void` and every no-return timestamp-suppression callback as `: void`; retain the existing throwing callback's `: never`;
+- remove the stale Illuminate return annotations now represented natively;
+- replace the four exact timestamp-string `assertEquals()` calls with `assertSame()`;
+- change `Setup the database schema.` to `Set up the database schema.`;
+- remove the method-attached, contentless `Tests...` docblock;
+- retain the useful fixture boundary, but convert the apparent class docblock into a normal `// Eloquent models.` section comment. It marks the three inline fixture models without attaching an inventory-style docblock to the first model class.
+
+These comment edits are narrow applications of the explicit no-stale/dead-comment requirement, not a general precedent for stripping useful upstream comments.
+
+#### MySQL and MariaDB connection tests
+
+Make the two files structurally consistent:
+
+- type test methods `: void` and callback returns `: void`;
+- type float-comparison inputs as `float`, `string`, and `bool`;
+- type JSON null inputs as `bool`, `string`, and `array`;
+- type JSON-key count inputs as `int` and `string`;
+- type every provider `: array`; add an imperative provider title and keep the precise shape beneath it:
+
+```php
+/**
+ * Provide JSON float comparisons.
+ *
+ * @return list<array{0: float, 1: string, 2: bool}>
+ */
+
+/**
+ * Provide JSON null comparisons.
+ *
+ * @return array<string, array{0: bool, 1: string, 2?: array<array-key, mixed>}>
+ */
+
+/**
+ * Provide JSON paths and their expected match counts.
+ *
+ * @return array<string, array{0: int, 1: string}>
+ */
+```
+
+The optional JSON payload uses `array-key`, not `string`, because the providers include list and explicitly integer-keyed arrays. Replace both float `assertEquals()` calls and MySQL's insert-ID `assertEquals()` with `assertSame()`. Replace MySQL's unnecessary static local `$callbackExecuted` with an ordinary local initialized to `false`, so a repeated invocation cannot inherit a passing listener state. This deliberately fixes the same static-local defect still present in the Laravel reference test; record the intentional upstream divergence in the implementation/commit context so a future re-port does not restore it as apparent parity. PDO's configured `ATTR_STRINGIFY_FETCHES => false` returns the tested float on both local engines, and `MySqlProcessor::processInsertGetId()` casts numeric IDs to `int`.
+
+### 8. Correct Telescope spelling and unused catches
+
+In `src/telescope/src/Storage/DatabaseEntriesRepository.php`:
+
+- rename `countExceptionOccurences()` to `countExceptionOccurrences()` and update its sole in-tree call;
+- change the title to `Count the occurrences of an exception.`;
+- remove the unused binding from both `UniqueConstraintViolationException` catches and the `Throwable` catch in `loadMonitoredTags()`;
+- retain both `JsonException $exception` bindings because their codes are used.
+
+Do not retain the misspelled method as a shim and do not add migration prose. Run the repository storage test to protect the surrounding exception-family aggregation and tag behavior.
+
+### 9. Restore Email validation messages and fully type its test
+
+Files:
+
+- `tests/Validation/ValidationEmailRuleTest.php`
+- `src/validation/src/Rules/Email.php`
+
+Make the regression fail first by changing integer expectations from `[Email::class]` to the translated Laravel-compatible email message and by making null cases execute. Then remove the redundant non-string guard from `Email::passes()`. The nested validator's existing email rule rejects integers and null, fills `$messages`, and returns `false`; the outer custom-rule path then uses that translated message instead of the class fallback.
+
+Complete the test file's native typing in the same pass:
+
+- add `: void` to every test and helper;
+- type every `#[TestWith]` email argument as `string`;
+- type the translator closure as `function (): Translator` and Email-producing macro/default callbacks as `function (): Email`;
+- type helper rules as `Email`, values as `array|int|string|null`, expected messages as `array`, the expected result as `bool`, and custom messages as `?string`;
+- retain PHPDocs only for useful list element shapes, with imperative titles on `fails()`, `assertValidationRules()`, and `passes()` rather than type-only docblocks;
+- replace `Arr::wrap()` with `is_array($values) ? $values : [$values]` so scalar null becomes one exercised value, then remove the unused `Arr` import;
+- replace the dead `is_object()` branch with `clone $rule`;
+- rename local `$v` to `$validator`;
+- use `var_export($value, true)` in assertion diagnostics so null and strings remain readable;
+- change both bare present-null cases to failure expectations with the translated message;
+- add one direct Validator case showing `['nullable', Rule::email()]` accepts present null without errors;
+- restore Laravel's direct `strict()` alias regression, which was missing even though Hypervel exposes the method.
+
+Do not add absent-key or empty-string cases to this Email-owned test.
+
+### 10. Remove every stale PHPStan suppression
+
+Keep `reportUnmatchedIgnoredErrors: true` temporarily while performing this audit. Full PHPStan 2.2.8 reports no ordinary source-analysis errors: all failures are stale suppression metadata. It reports 195 inline findings at 189 source locations—124 unmatched identifiers and 71 bare line ignores—plus five unmatched global patterns in `phpstan.neon.dist`.
+
+Inspect each reported source location and remove only the unmatched directive or identifier. All six multi-identifier locations report every listed identifier as unmatched. Preserve an accompanying explanation only when it remains useful without the suppression; remove analyzer-only narration with the stale directive. Do not mechanically alter the 531 inline suppression lines that still match a real PHPStan error.
+
+Remove these five unmatched global patterns:
+
+- undefined method calls on `ColumnDefinition`;
+- undefined method calls on `IndexDefinition`;
+- undefined method calls on `ForeignKeyDefinition`;
+- undefined method calls on the generic `TPivotModel`;
+- the invariant `Collection` array-shape return pattern.
+
+Run full PHPStan with unmatched-ignore reporting still enabled and require a clean result. Then restore `reportUnmatchedIgnoredErrors: false` and run full PHPStan again. Do not add a targeted config or alternate developer command: partial analyses otherwise report required global patterns belonging to packages outside the selected path, but making developers and agents remember two configurations adds permanent friction for a periodic maintenance check. Temporarily enable the setting again during future stale-suppression audits.
+
+## API, performance, and complexity assessment
+
+- No Laravel API behavior or named surface is removed. Email behavior moves back to Laravel's message contract; nested class-string commands retain the Laravel API while gaining the per-execution identity Hypervel's container semantics require; native types enforce proven existing shapes under Hypervel's approved porting adaptation, and the remaining Laravel-ported changes are grammar, test correctness, or unused-binding cleanup.
+- The Telescope correction intentionally breaks callers/overrides of the misspelled Hypervel method, with no shim. Renaming `BenchmarkCommand::displayMemoryError()`'s protected `$e` parameter can likewise affect a Hypervel subclass that calls it by named argument. Both are Hypervel-only corrections, not Laravel API breaks. The concrete `BenchmarkContext::getStore()` return and typed protected View parameter also make existing real extension requirements explicit; neither class is a Laravel public surface.
+- The cleanup changes add one local boolean to Benchmark and one runtime list plus one four-caller helper to Doctor. There is no target registry, result hierarchy, retry policy, cleanup protocol, run-state object, command-lifetime change, or extra verification layer.
+- No application hot path gains network calls, loops, or shared state. Nested class-string command execution gains one shallow clone, matching the cloning already performed for top-level, name-resolved, and object-supplied executions. Command-only failure paths gain reporting. Invalid non-string Email values now run the existing nested validator to produce the correct message; valid Email validation is unchanged.
+- Native property/parameter types and PHPDocs have no algorithmic cost. Cache operation pipelines, batching, and Redis round trips remain unchanged.
+- Removing stale PHPStan directives and patterns has no runtime or API effect. Restoring unmatched-ignore reporting to `false` preserves one standard PHPStan command for full and targeted analysis.
+
+## Testing and verification
+
+### Red/green bug cadence
+
+Run each changed test file immediately after its test edit to confirm the regression, then again after its source fix:
+
+```bash
+./vendor/bin/phpunit --no-progress tests/Cache/Redis/Console/BenchmarkCommandTest.php
+./vendor/bin/phpunit --no-progress tests/Cache/Redis/Console/DoctorCommandTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Console/CallCommandsTest.php
+./vendor/bin/phpunit --no-progress tests/Validation/ValidationEmailRuleTest.php
+```
+
+Run each Database test file immediately after editing it:
+
+```bash
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseEloquentTimestampsTest.php
+
+DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_DATABASE=testing DB_USERNAME=root DB_PASSWORD=password \
+  ./vendor/bin/phpunit --no-progress tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+
+DB_CONNECTION=mariadb DB_HOST=127.0.0.1 DB_PORT=3307 DB_DATABASE=testing DB_USERNAME=root DB_PASSWORD=password \
+  ./vendor/bin/phpunit --no-progress tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
+```
+
+### Focused source checks
+
+After each related source slice, run:
+
+```bash
+./vendor/bin/phpunit --no-progress tests/Cache/Redis
+./vendor/bin/phpunit --no-progress tests/Console/CommandTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Console/CallCommandsTest.php
+./vendor/bin/phpunit --no-progress tests/Container/ContainerTest.php
+./vendor/bin/phpunit --no-progress tests/Coordinator/TimerTest.php
+./vendor/bin/phpunit --no-progress tests/Core/StdoutLoggerTest.php
+./vendor/bin/phpunit --no-progress tests/Database/ConnectionResolverTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseConcernsPreventsCircularRecursionTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/PooledConnectionTest.php
+./vendor/bin/phpunit --no-progress tests/Telescope/Storage/DatabaseEntriesRepositoryTest.php
+./vendor/bin/phpunit --no-progress tests/View/Blade/BladeComponentTagCompilerTest.php
+```
+
+### Search and review gates
+
+- Confirm `countExceptionOccurences` has no source/test references and the corrected name has the intended definition/caller.
+- Confirm the three Telescope catches have no unused binding and the used JSON catches retain theirs.
+- Confirm all 22 listed Container properties are natively `array` and `$environmentResolver` is unchanged.
+- Confirm every `Command::resolveCommand()` branch produces a per-execution command: clone the name-resolved command, clone the container result for an existing class string, and clone a supplied command object; keep both execution-context setters after those branches.
+- Confirm `DoctorCommand` has no remaining `catch (Exception`, has removed `use Exception;`, and imports `Throwable`; confirm `BenchmarkCommand` imports both `Exception` for mandatory setup and `Throwable` for best-effort display/final cleanup.
+- Confirm no `fn ($m)` remains in `DoctorCommand`, `CleanupVerificationCheck`, or `BenchmarkContext`, and each registry filter uses `string $member` with a `bool` return.
+- Re-run the Doctor-method scan: no named method in the 22 concrete check classes may lack a docblock or have a type-only docblock without an imperative title.
+- Re-run the Cache Redis ordinary-emphasis scan. Only real operators/identifiers and approved console banners may remain capitalized.
+- Confirm the named Database files contain no `assertEquals()`, no untyped test/provider method, and no stale Illuminate return annotation.
+- Confirm `ValidationEmailRuleTest` no longer imports or calls `Arr`, every null assertion executes, and the production guard is gone.
+- Confirm `Repository::rememberForever()` and the gRPC generation workflow remain unchanged.
+- With unmatched-ignore reporting temporarily enabled, confirm full PHPStan reports neither ordinary errors nor unmatched suppressions; then restore the setting to `false` and confirm the standard full run remains clean.
+- Inspect every changed file for stale imports, dead branches/comments, unplanned API changes, avoidable hot-path work, and formatter-driven collateral edits.
+
+At the final checkpoint, run `composer fix` once from the worktree root. If it fails, follow the repository workflow: fix with targeted checks, then run the failed check and every remaining `fix` script entry. Finish with `git diff --check`, `git status --short`, and a full diff review against this plan, Laravel references, and all caller/callee invariants above.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -45,15 +45,12 @@ parameters:
     # Framework traits provided for userland - not used internally but intentionally available
     - '#Trait Hypervel\\[A-Za-z\\\\]+ is used zero times and is not analysed\.#'
 
-    # Fluent class uses magic __get/__set/__call for dynamic properties and methods (ColumnDefinition, IndexDefinition, etc.)
+    # Schema definitions use Fluent's dynamic properties; Fluent and ForeignIdColumnDefinition also expose dynamic methods.
     - '#Access to an undefined property Hypervel\\Support\\Fluent::\$#'
     - '#Access to an undefined property Hypervel\\Database\\Schema\\ColumnDefinition::\$#'
     - '#Access to an undefined property Hypervel\\Database\\Schema\\IndexDefinition::\$#'
     - '#Access to an undefined property Hypervel\\Database\\Schema\\ForeignKeyDefinition::\$#'
     - '#Call to an undefined method Hypervel\\Support\\Fluent::#'
-    - '#Call to an undefined method Hypervel\\Database\\Schema\\ColumnDefinition::#'
-    - '#Call to an undefined method Hypervel\\Database\\Schema\\IndexDefinition::#'
-    - '#Call to an undefined method Hypervel\\Database\\Schema\\ForeignKeyDefinition::#'
     - '#Access to an undefined property Hypervel\\Database\\Schema\\ForeignIdColumnDefinition::\$#'
     - '#Call to an undefined method Hypervel\\Database\\Schema\\ForeignIdColumnDefinition::#'
 
@@ -67,7 +64,6 @@ parameters:
     # Generic template type limitations - PHPStan can't resolve methods through generic TModel/TRelatedModel
     - '#Call to an undefined method TModel of Hypervel\\Database\\Eloquent\\Model::#'
     - '#Call to an undefined method TRelatedModel of Hypervel\\Database\\Eloquent\\Model::#'
-    - '#Call to an undefined method TPivotModel of Hypervel\\Database\\Eloquent\\Relations\\Pivot::#'
 
     # Deep generic template limitations - PHPStan can't fully resolve complex generic type relationships
     - identifier: generics.lessTypes
@@ -93,10 +89,6 @@ parameters:
     # PHPStan sees Builder return type but the actual return is $this (the Relation)
     - message: '#should return \$this\(Hypervel\\Database\\Eloquent\\Relations\\.+\) but returns Hypervel\\Database\\(Query|Eloquent)\\Builder#'
       path: src/database/*
-
-    # Collection template covariance - specific array shapes are subtypes of array<string, mixed>
-    # but Collection<TValue> is invariant, so PHPStan rejects the more specific return type
-    - message: '#should return Hypervel\\Support\\Collection<.+, array<.+>> but returns Hypervel\\Support\\Collection<.+, array\{#'
 
     # BelongsToMany pivot intersection type - PHPDoc uses object{pivot: ...}&TRelatedModel
     # to document that models get a pivot property attached, but PHPStan can't track dynamic attachment

--- a/src/api-client/src/PendingRequest.php
+++ b/src/api-client/src/PendingRequest.php
@@ -178,7 +178,7 @@ class PendingRequest
      */
     public function withResource(string $resource): static
     {
-        if (! is_a($resource, ApiResource::class, true)) { // @phpstan-ignore function.alreadyNarrowedType (validates PHPDoc contract at runtime)
+        if (! is_a($resource, ApiResource::class, true)) {
             throw new InvalidArgumentException(
                 sprintf('Resource class `%s` must be `%s` or a subclass.', $resource, ApiResource::class)
             );

--- a/src/auth/src/AuthManager.php
+++ b/src/auth/src/AuthManager.php
@@ -278,7 +278,7 @@ class AuthManager implements FactoryContract
             return;
         }
 
-        $provider = $guardInstance->getProvider(); /* @phpstan-ignore method.notFound (getProvider() is on GuardHelpers trait, not the Guard contract) */
+        $provider = $guardInstance->getProvider();
 
         if ($provider instanceof EloquentUserProvider) {
             $provider->clearUserCache($identifier);
@@ -408,7 +408,7 @@ class AuthManager implements FactoryContract
 
             $keys = [
                 ...$keys,
-                ...$guard->getAuthContextKeys(), /* @phpstan-ignore method.notFound */
+                ...$guard->getAuthContextKeys(),
             ];
         }
 

--- a/src/auth/src/EloquentUserProvider.php
+++ b/src/auth/src/EloquentUserProvider.php
@@ -442,7 +442,7 @@ class EloquentUserProvider implements UserProvider
         $effectiveTags = $this->effectiveCacheTags();
 
         if ($effectiveTags === []) {
-            return $this->cache; /* @phpstan-ignore return.type */
+            return $this->cache;
         }
 
         return $this->cache->tags($effectiveTags); /* @phpstan-ignore method.notFound (tags() is on Repository concrete, not the Repository contract) */

--- a/src/cache/src/Redis/AnyTagSet.php
+++ b/src/cache/src/Redis/AnyTagSet.php
@@ -36,7 +36,7 @@ class AnyTagSet extends TagSet
     /**
      * Get the hash key for a tag.
      *
-     * Delegates to StoreContext which delegates to TagMode (single source of truth).
+     * Delegates to StoreContext and its shared TagKeyBuilder source of truth.
      * Format: "{prefix}_any:tag:{tag}:entries"
      */
     public function tagHashKey(string $name): string
@@ -78,7 +78,7 @@ class AnyTagSet extends TagSet
     /**
      * Flush all tags in this set.
      *
-     * Deletes all cache items that have ANY of the specified tags
+     * Deletes all cache items that have any of the specified tags
      * (union semantics), along with their reverse indexes and tag hashes.
      */
     public function flush(): void

--- a/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
+++ b/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
@@ -58,10 +58,8 @@ class BenchmarkContext
 
     /**
      * Get the cache repository for this context.
-     *
-     * @return Repository
      */
-    public function getStore(): \Hypervel\Contracts\Cache\Repository
+    public function getStore(): Repository
     {
         /** @var Repository */
         return $this->cacheManager->store($this->storeName);
@@ -122,7 +120,7 @@ class BenchmarkContext
     /**
      * Get patterns to match all tag storage structures with a given tag name prefix.
      *
-     * Returns patterns for BOTH tag modes to ensure complete cleanup
+     * Returns patterns for both tag modes to ensure complete cleanup
      * regardless of current mode (important for --compare-tag-modes):
      * - Any mode: {cachePrefix}_any:tag:{tagNamePrefix}*
      * - All mode: {cachePrefix}_all:tag:{tagNamePrefix}*
@@ -145,7 +143,7 @@ class BenchmarkContext
     /**
      * Get patterns to match all cache value keys with a given key prefix.
      *
-     * Returns patterns for BOTH tag modes to ensure complete cleanup
+     * Returns patterns for both tag modes to ensure complete cleanup
      * regardless of current mode (important for --compare-tag-modes):
      * - Untagged keys: {cachePrefix}{keyPrefix}* (same in both modes)
      * - Tagged keys in all mode: {cachePrefix}{xxh128}:{keyPrefix}* (namespaced)
@@ -274,7 +272,7 @@ class BenchmarkContext
         }
 
         // 3. Clean up any remaining tag storage structures matching benchmark prefix
-        // Uses patterns for BOTH modes to ensure complete cleanup after --compare-tag-modes
+        // Uses patterns for both modes to ensure complete cleanup after --compare-tag-modes
         foreach ($this->getTagStoragePatterns(self::KEY_PREFIX) as $pattern) {
             $this->flushKeysByPattern($storeInstance, $pattern);
         }
@@ -282,15 +280,15 @@ class BenchmarkContext
         // 4. Any mode: clean up benchmark entries from the tag registry
         if ($this->isAnyMode()) {
             $context = $storeInstance->getContext();
-            $context->withConnection(function ($connection) use ($context) {
+            $context->withConnection(function (RedisConnection $connection) use ($context): void {
                 $registryKey = $context->registryKey();
                 $members = $connection->zRange($registryKey, 0, -1);
-                $benchMembers = array_filter(
+                $benchmarkMembers = array_filter(
                     $members,
-                    fn ($m) => str_starts_with($m, self::KEY_PREFIX)
+                    fn (string $member): bool => str_starts_with($member, self::KEY_PREFIX)
                 );
-                if (! empty($benchMembers)) {
-                    $connection->zrem($registryKey, ...$benchMembers);
+                if (! empty($benchmarkMembers)) {
+                    $connection->zrem($registryKey, ...$benchmarkMembers);
                 }
             });
         }
@@ -300,12 +298,12 @@ class BenchmarkContext
      * Flush keys by pattern using RedisConnection::flushByPattern().
      *
      * @param RedisStore $store The Redis store instance
-     * @param string $pattern The pattern to match (should include cache prefix, NOT OPT_PREFIX)
+     * @param string $pattern The pattern to match (should include cache prefix, not OPT_PREFIX)
      */
     private function flushKeysByPattern(RedisStore $store, string $pattern): void
     {
         $store->getContext()->withConnection(
-            fn (RedisConnection $connection) => $connection->flushByPattern($pattern)
+            fn (RedisConnection $connection): int => $connection->flushByPattern($pattern)
         );
     }
 }

--- a/src/cache/src/Redis/Console/BenchmarkCommand.php
+++ b/src/cache/src/Redis/Console/BenchmarkCommand.php
@@ -28,6 +28,7 @@ use Hypervel\Redis\RedisConnection;
 use Hypervel\Support\SystemInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
 
 #[AsCommand(name: 'cache:redis-benchmark')]
 class BenchmarkCommand extends Command
@@ -141,6 +142,7 @@ class BenchmarkCommand extends Command
 
         $cacheManager = $this->hypervel->make(CacheContract::class);
         $context = $this->createContext($config, $cacheManager);
+        $cleanupFailed = false;
 
         try {
             // Run Benchmark(s)
@@ -152,17 +154,23 @@ class BenchmarkCommand extends Command
                 $tagMode = $tagModeOption ?? $store->getTagMode()->value;
                 $this->runSuiteWithRuns($tagMode, $context, $runs);
             }
-        } catch (BenchmarkMemoryException $e) {
-            $this->displayMemoryError($e);
+        } catch (BenchmarkMemoryException $exception) {
+            $this->displayMemoryError($exception);
 
             return self::FAILURE;
+        } finally {
+            $this->newLine();
+            $this->info('Cleaning up benchmark data...');
+
+            try {
+                $context->cleanup();
+            } catch (Throwable $exception) {
+                $cleanupFailed = true;
+                $this->error('Benchmark cleanup failed (' . $exception::class . '): ' . $exception->getMessage());
+            }
         }
 
-        $this->newLine();
-        $this->info('Cleaning up benchmark data...');
-        $context->cleanup();
-
-        return self::SUCCESS;
+        return $cleanupFailed ? self::FAILURE : self::SUCCESS;
     }
 
     /**
@@ -228,8 +236,8 @@ class BenchmarkCommand extends Command
 
             // Test connection
             $cacheManager->store($this->storeName)->get('test');
-        } catch (Exception $e) {
-            $this->error("Could not connect to Redis store '{$this->storeName}': " . $e->getMessage());
+        } catch (Exception $exception) {
+            $this->error("Could not connect to Redis store '{$this->storeName}': " . $exception->getMessage());
 
             return false;
         }
@@ -520,8 +528,11 @@ class BenchmarkCommand extends Command
 
                 $this->line('  Tag Mode: <fg=cyan>' . $store->getTagMode()->value . '</>');
             }
-        } catch (Exception) {
-            // Silently skip if Redis connection fails
+        } catch (Throwable $exception) {
+            $this->line(
+                '  Cache Service: <fg=red>Connection failed ('
+                . $exception::class . '): ' . $exception->getMessage() . '</>'
+            );
         }
 
         $this->newLine();
@@ -551,17 +562,17 @@ class BenchmarkCommand extends Command
     /**
      * Display memory exhaustion error with recovery guidance.
      */
-    protected function displayMemoryError(BenchmarkMemoryException $e): void
+    protected function displayMemoryError(BenchmarkMemoryException $exception): void
     {
         $config = $this->hypervel->make('config');
 
         $this->newLine();
         $this->error('Benchmark aborted due to memory constraints.');
         $this->newLine();
-        $this->line($e->getMessage());
+        $this->line($exception->getMessage());
         $this->newLine();
-        $this->warn('Cleanup skipped to avoid further memory exhaustion.');
-        $this->line('   After fixing memory issues, clean up leftover benchmark keys:');
+        $this->warn('Automatic cleanup will run next.');
+        $this->line('   If benchmark keys remain, clean them up after fixing the memory issue:');
         $this->newLine();
         $this->line('   Option 1 - Clear all cache (simple):');
         $this->line('   <fg=cyan>php artisan cache:clear ' . $this->storeName . '</>');

--- a/src/cache/src/Redis/Console/Doctor/Checks/AddOperationsCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/AddOperationsCheck.php
@@ -15,11 +15,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class AddOperationsCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Add Operations (Only If Not Exists)';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;

--- a/src/cache/src/Redis/Console/Doctor/Checks/BasicOperationsCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/BasicOperationsCheck.php
@@ -14,11 +14,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class BasicOperationsCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Basic Cache Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -60,14 +66,14 @@ final class BasicOperationsCheck implements CheckInterface
         // Remember
         $value = $context->cache->remember($context->prefixed('basic:remember'), 60, fn (): string => 'remembered');
         $result->assert(
-            $value === 'remembered' && $context->cache->get($context->prefixed('basic:remember')) === 'remembered', // @phpstan-ignore identical.alwaysTrue (diagnostic assertion)
+            $value === 'remembered' && $context->cache->get($context->prefixed('basic:remember')) === 'remembered',
             'remember() stores and returns closure result'
         );
 
         // RememberForever
         $value = $context->cache->rememberForever($context->prefixed('basic:forever'), fn (): string => 'permanent');
         $result->assert(
-            $value === 'permanent', // @phpstan-ignore identical.alwaysTrue (diagnostic assertion)
+            $value === 'permanent',
             'rememberForever() stores without expiration'
         );
 

--- a/src/cache/src/Redis/Console/Doctor/Checks/BulkOperationsCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/BulkOperationsCheck.php
@@ -14,11 +14,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class BulkOperationsCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Bulk Operations (putMany/many)';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;

--- a/src/cache/src/Redis/Console/Doctor/Checks/CacheStoreCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/CacheStoreCheck.php
@@ -14,6 +14,9 @@ use Hypervel\Cache\Redis\Console\Doctor\CheckResult;
  */
 final class CacheStoreCheck implements EnvironmentCheckInterface
 {
+    /**
+     * Create a new cache store check instance.
+     */
     public function __construct(
         private readonly string $storeName,
         private readonly string $driver,
@@ -21,11 +24,17 @@ final class CacheStoreCheck implements EnvironmentCheckInterface
     ) {
     }
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Cache Store Configuration';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(): CheckResult
     {
         $result = new CheckResult;
@@ -49,6 +58,9 @@ final class CacheStoreCheck implements EnvironmentCheckInterface
         return $result;
     }
 
+    /**
+     * Get details about how to fix a failed check.
+     */
     public function getFixInstructions(): ?string
     {
         if ($this->driver !== 'redis') {

--- a/src/cache/src/Redis/Console/Doctor/Checks/CleanupVerificationCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/CleanupVerificationCheck.php
@@ -11,15 +11,21 @@ use Redis;
 /**
  * Verifies that cleanup properly removes all test data.
  *
- * This check runs AFTER cleanup to ensure no test keys remain in Redis.
+ * This check runs after cleanup to ensure no test keys remain in Redis.
  */
 final class CleanupVerificationCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Cleanup Verification';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -102,7 +108,7 @@ final class CleanupVerificationCheck implements CheckInterface
 
         return array_filter(
             $members,
-            fn ($m) => str_starts_with($m, $testPrefix)
+            fn (string $member): bool => str_starts_with($member, $testPrefix)
         );
     }
 }

--- a/src/cache/src/Redis/Console/Doctor/Checks/ConcurrencyCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/ConcurrencyCheck.php
@@ -20,16 +20,25 @@ final class ConcurrencyCheck implements CheckInterface
 {
     private ?OutputInterface $output = null;
 
+    /**
+     * Set the console output instance.
+     */
     public function setOutput(OutputInterface $output): void
     {
         $this->output = $output;
     }
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Real Concurrency (Coroutines)';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -50,6 +59,9 @@ final class ConcurrencyCheck implements CheckInterface
         return $result;
     }
 
+    /**
+     * Test atomic add operations across concurrent coroutines.
+     */
     private function testAtomicAdd(DoctorContext $context, CheckResult $result): void
     {
         $key = $context->prefixed('real-concurrent:add-' . Str::random(8));
@@ -58,38 +70,45 @@ final class ConcurrencyCheck implements CheckInterface
 
         try {
             $results = parallel([
-                fn () => $context->cache->tags([$tag])->add($key, 'process-1', 60),
-                fn () => $context->cache->tags([$tag])->add($key, 'process-2', 60),
-                fn () => $context->cache->tags([$tag])->add($key, 'process-3', 60),
-                fn () => $context->cache->tags([$tag])->add($key, 'process-4', 60),
-                fn () => $context->cache->tags([$tag])->add($key, 'process-5', 60),
+                fn (): bool => $context->cache->tags([$tag])->add($key, 'process-1', 60),
+                fn (): bool => $context->cache->tags([$tag])->add($key, 'process-2', 60),
+                fn (): bool => $context->cache->tags([$tag])->add($key, 'process-3', 60),
+                fn (): bool => $context->cache->tags([$tag])->add($key, 'process-4', 60),
+                fn (): bool => $context->cache->tags([$tag])->add($key, 'process-5', 60),
             ]);
 
-            $successCount = count(array_filter($results, fn ($r): bool => $r === true));
+            $successCount = count(array_filter($results, fn (bool $succeeded): bool => $succeeded === true));
             $result->assert(
                 $successCount === 1,
                 'Atomic add() - exactly 1 of 5 coroutines succeeded'
             );
-        } catch (Throwable $e) {
-            $this->output?->writeln("  <fg=yellow>⊘</> Atomic add() test skipped ({$e->getMessage()})");
+        } catch (Throwable $exception) {
+            $this->output?->writeln("  <fg=yellow>⊘</> Atomic add() test skipped ({$exception->getMessage()})");
         }
     }
 
+    /**
+     * Test concurrent tag flush operations.
+     */
     private function testConcurrentFlush(DoctorContext $context, CheckResult $result): void
     {
         $tag1 = $context->prefixed('concurrent-flush-a-' . Str::random(8));
         $tag2 = $context->prefixed('concurrent-flush-b-' . Str::random(8));
 
         // Create 5 items with both tags
-        for ($i = 0; $i < 5; ++$i) {
-            $context->cache->tags([$tag1, $tag2])->put($context->prefixed("flush-item-{$i}"), "value-{$i}", 60);
+        for ($itemIndex = 0; $itemIndex < 5; ++$itemIndex) {
+            $context->cache->tags([$tag1, $tag2])->put(
+                $context->prefixed("flush-item-{$itemIndex}"),
+                "value-{$itemIndex}",
+                60
+            );
         }
 
         try {
             // Flush both tags concurrently
             parallel([
-                fn () => $context->cache->tags([$tag1])->flush(),
-                fn () => $context->cache->tags([$tag2])->flush(),
+                fn (): bool => $context->cache->tags([$tag1])->flush(),
+                fn (): bool => $context->cache->tags([$tag2])->flush(),
             ]);
 
             if ($context->isAnyMode()) {
@@ -111,8 +130,8 @@ final class ConcurrencyCheck implements CheckInterface
                     'Concurrent flush - both tag ZSETs deleted (all mode)'
                 );
             }
-        } catch (Throwable $e) {
-            $this->output?->writeln("  <fg=yellow>⊘</> Concurrent flush test skipped ({$e->getMessage()})");
+        } catch (Throwable $exception) {
+            $this->output?->writeln("  <fg=yellow>⊘</> Concurrent flush test skipped ({$exception->getMessage()})");
         }
     }
 }

--- a/src/cache/src/Redis/Console/Doctor/Checks/EdgeCasesCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/EdgeCasesCheck.php
@@ -14,11 +14,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class EdgeCasesCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Edge Cases';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;

--- a/src/cache/src/Redis/Console/Doctor/Checks/EnvironmentCheckInterface.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/EnvironmentCheckInterface.php
@@ -10,7 +10,7 @@ use Hypervel\Cache\Redis\Console\Doctor\CheckResult;
  * Interface for environment/requirement checks.
  *
  * Environment checks verify system requirements (PHP extensions, Redis version, etc.)
- * and run BEFORE the full DoctorContext is created. They fail fast if requirements
+ * and run before the full DoctorContext is created. They fail fast if requirements
  * aren't met, preventing functional checks from running.
  */
 interface EnvironmentCheckInterface

--- a/src/cache/src/Redis/Console/Doctor/Checks/ExpirationCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/ExpirationCheck.php
@@ -6,6 +6,7 @@ namespace Hypervel\Cache\Redis\Console\Doctor\Checks;
 
 use Hypervel\Cache\Redis\Console\Doctor\CheckResult;
 use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
+use Hypervel\Support\Sleep;
 use Hypervel\Support\Str;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -19,16 +20,25 @@ final class ExpirationCheck implements CheckInterface
 {
     private ?OutputInterface $output = null;
 
+    /**
+     * Set the console output instance.
+     */
     public function setOutput(OutputInterface $output): void
     {
         $this->output = $output;
     }
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Expiration Tests';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -40,7 +50,7 @@ final class ExpirationCheck implements CheckInterface
         $context->cache->tags([$tag])->put($key, 'val', 1);
 
         $this->output?->writeln('  <fg=gray>Waiting 2 seconds for expiration...</>');
-        sleep(2);
+        Sleep::sleep(2);
 
         if ($context->isAnyMode()) {
             // Any mode: direct get works
@@ -61,6 +71,9 @@ final class ExpirationCheck implements CheckInterface
         return $result;
     }
 
+    /**
+     * Test expiration cleanup in any-tag mode.
+     */
     private function testAnyModeExpiration(
         DoctorContext $context,
         CheckResult $result,
@@ -77,6 +90,9 @@ final class ExpirationCheck implements CheckInterface
         );
     }
 
+    /**
+     * Test expiration cleanup in all-tags mode.
+     */
     private function testAllModeExpiration(
         DoctorContext $context,
         CheckResult $result,

--- a/src/cache/src/Redis/Console/Doctor/Checks/FlushBehaviorCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/FlushBehaviorCheck.php
@@ -15,11 +15,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class FlushBehaviorCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Flush Behavior Semantics';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -33,9 +39,12 @@ final class FlushBehaviorCheck implements CheckInterface
         return $result;
     }
 
+    /**
+     * Test flush behavior in any-tag mode.
+     */
     private function testAnyMode(DoctorContext $context, CheckResult $result): void
     {
-        // Setup items with different tag combinations
+        // Set up items with different tag combinations
         $context->cache->tags([$context->prefixed('color:red'), $context->prefixed('color:blue')])->put($context->prefixed('flush:purple'), 'purple', 60);
         $context->cache->tags([$context->prefixed('color:red'), $context->prefixed('color:yellow')])->put($context->prefixed('flush:orange'), 'orange', 60);
         $context->cache->tags([$context->prefixed('color:blue'), $context->prefixed('color:yellow')])->put($context->prefixed('flush:green'), 'green', 60);
@@ -60,13 +69,16 @@ final class FlushBehaviorCheck implements CheckInterface
         $result->assert(
             $context->cache->get($context->prefixed('flush:green')) === null
             && $context->cache->get($context->prefixed('flush:blue')) === null,
-            'Flushing multiple tags removes items with ANY of those tags'
+            'Flushing multiple tags removes items with any of those tags'
         );
     }
 
+    /**
+     * Test flush behavior in all-tags mode.
+     */
     private function testAllMode(DoctorContext $context, CheckResult $result): void
     {
-        // Setup items with different tag combinations
+        // Set up items with different tag combinations
         $redTag = $context->prefixed('color:red');
         $blueTag = $context->prefixed('color:blue');
         $yellowTag = $context->prefixed('color:yellow');
@@ -97,7 +109,7 @@ final class FlushBehaviorCheck implements CheckInterface
             'Flushing one tag removes all items tracked in that tag ZSET'
         );
 
-        // Flush multiple tags - removes items tracked in ANY of those ZSETs
+        // Flush multiple tags - removes items tracked in any of those ZSETs
         $context->cache->tags([$blueTag, $yellowTag])->flush();
 
         $greenGone = $context->cache->tags($greenTags)->get($context->prefixed('flush:green')) === null;
@@ -105,7 +117,7 @@ final class FlushBehaviorCheck implements CheckInterface
 
         $result->assert(
             $greenGone && $blueGone,
-            'Flushing multiple tags removes items tracked in ANY of those ZSETs'
+            'Flushing multiple tags removes items tracked in any of those ZSETs'
         );
     }
 }

--- a/src/cache/src/Redis/Console/Doctor/Checks/ForeverStorageCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/ForeverStorageCheck.php
@@ -15,11 +15,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class ForeverStorageCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Forever Storage (No Expiration)';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -53,12 +59,15 @@ final class ForeverStorageCheck implements CheckInterface
                 $keyTtl === -1,
                 'forever() with tags: key has no expiration'
             );
-            $this->testAllMode($context, $result, $foreverTag, $foreverKey, $namespacedKey);
+            $this->testAllMode($context, $result, $foreverTag, $namespacedKey);
         }
 
         return $result;
     }
 
+    /**
+     * Test hash-field expiration in any-tag mode.
+     */
     private function testAnyModeHashTtl(DoctorContext $context, CheckResult $result, string $tag, string $key): void
     {
         // Verify hash field also has no expiration
@@ -69,11 +78,13 @@ final class ForeverStorageCheck implements CheckInterface
         );
     }
 
+    /**
+     * Test forever storage metadata in all-tags mode.
+     */
     private function testAllMode(
         DoctorContext $context,
         CheckResult $result,
         string $tag,
-        string $key,
         string $namespacedKey,
     ): void {
         // Verify sorted set score is -1 for forever items

--- a/src/cache/src/Redis/Console/Doctor/Checks/HashFieldExpirationCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/HashFieldExpirationCheck.php
@@ -20,17 +20,26 @@ final class HashFieldExpirationCheck implements EnvironmentCheckInterface
 {
     private bool $available = false;
 
+    /**
+     * Create a new hash-field expiration check instance.
+     */
     public function __construct(
         private readonly RedisConnection $redis,
         private readonly string $taggingMode,
     ) {
     }
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Hash Field Expiration Commands';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(): CheckResult
     {
         $result = new CheckResult;
@@ -63,6 +72,9 @@ final class HashFieldExpirationCheck implements EnvironmentCheckInterface
         return $result;
     }
 
+    /**
+     * Get details about how to fix a failed check.
+     */
     public function getFixInstructions(): ?string
     {
         if ($this->taggingMode === 'all') {

--- a/src/cache/src/Redis/Console/Doctor/Checks/HashStructuresCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/HashStructuresCheck.php
@@ -14,11 +14,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class HashStructuresCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Redis Hash Structures Verification';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;

--- a/src/cache/src/Redis/Console/Doctor/Checks/IncrementDecrementCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/IncrementDecrementCheck.php
@@ -15,11 +15,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class IncrementDecrementCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Increment/Decrement Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -76,6 +82,9 @@ final class IncrementDecrementCheck implements CheckInterface
         return $result;
     }
 
+    /**
+     * Test tag expiration metadata in any-tag mode.
+     */
     private function testAnyModeHashTtl(DoctorContext $context, CheckResult $result): void
     {
         // Verify hash field has no expiration for non-TTL key
@@ -86,16 +95,19 @@ final class IncrementDecrementCheck implements CheckInterface
         );
     }
 
+    /**
+     * Test tag expiration metadata in all-tags mode.
+     */
     private function testAllMode(DoctorContext $context, CheckResult $result): void
     {
         // Verify ZSET entry exists for incremented key
         $counterTag = $context->prefixed('counters');
-        $incrKey = $context->prefixed('incr:new');
+        $incrementKey = $context->prefixed('incr:new');
 
         $tagSetKey = $context->tagHashKey($counterTag);
 
         // Compute namespaced key using central source of truth
-        $namespacedKey = $context->namespacedKey([$counterTag], $incrKey);
+        $namespacedKey = $context->namespacedKey([$counterTag], $incrementKey);
 
         // Verify ZSET entry exists
         // Note: increment on non-existent key creates with no TTL, so score should be -1

--- a/src/cache/src/Redis/Console/Doctor/Checks/LargeDatasetCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/LargeDatasetCheck.php
@@ -16,11 +16,17 @@ final class LargeDatasetCheck implements CheckInterface
 {
     private const int ITEM_COUNT = 500;
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Large Dataset Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -30,8 +36,12 @@ final class LargeDatasetCheck implements CheckInterface
         // Bulk insert
         $startTime = microtime(true);
 
-        for ($i = 0; $i < $count; ++$i) {
-            $context->cache->tags([$tag])->put($context->prefixed("large:item{$i}"), "value{$i}", 60);
+        for ($itemIndex = 0; $itemIndex < $count; ++$itemIndex) {
+            $context->cache->tags([$tag])->put(
+                $context->prefixed("large:item{$itemIndex}"),
+                "value{$itemIndex}",
+                60
+            );
         }
 
         $insertTime = microtime(true) - $startTime;

--- a/src/cache/src/Redis/Console/Doctor/Checks/MemoryLeakPreventionCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/MemoryLeakPreventionCheck.php
@@ -17,11 +17,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class MemoryLeakPreventionCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Memory Leak Prevention';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -35,6 +41,9 @@ final class MemoryLeakPreventionCheck implements CheckInterface
         return $result;
     }
 
+    /**
+     * Test leak prevention in any-tag mode.
+     */
     private function testAnyMode(DoctorContext $context, CheckResult $result): void
     {
         // Create item with short TTL
@@ -68,6 +77,9 @@ final class MemoryLeakPreventionCheck implements CheckInterface
         );
     }
 
+    /**
+     * Test leak prevention in all-tags mode.
+     */
     private function testAllMode(DoctorContext $context, CheckResult $result): void
     {
         // Create item with future TTL

--- a/src/cache/src/Redis/Console/Doctor/Checks/MultipleTagsCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/MultipleTagsCheck.php
@@ -11,16 +11,22 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  * Tests operations with multiple tags.
  *
  * Flush behavior differs between modes:
- * - Any mode: Flushing ANY tag removes the item
- * - All mode: Flushing requires ALL tags to match
+ * - Any mode: Flushing any tag removes the item
+ * - All mode: Flushing requires all tags to match
  */
 final class MultipleTagsCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Multiple Tag Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -56,7 +62,9 @@ final class MultipleTagsCheck implements CheckInterface
     }
 
     /**
-     * @param array<string> $tags
+     * Test multiple-tag behavior in any-tag mode.
+     *
+     * @param list<string> $tags
      */
     private function testAnyMode(DoctorContext $context, CheckResult $result, array $tags, string $key): void
     {
@@ -73,7 +81,7 @@ final class MultipleTagsCheck implements CheckInterface
 
         $result->assert(
             $context->cache->get($key) === null,
-            'Flushing ANY tag removes the item (any behavior)'
+            'Flushing any tag removes the item (any behavior)'
         );
 
         $result->assert(
@@ -83,7 +91,9 @@ final class MultipleTagsCheck implements CheckInterface
     }
 
     /**
-     * @param array<string> $tags
+     * Test multiple-tag behavior in all-tags mode.
+     *
+     * @param list<string> $tags
      */
     private function testAllMode(DoctorContext $context, CheckResult $result, array $tags, string $key): void
     {
@@ -116,11 +126,11 @@ final class MultipleTagsCheck implements CheckInterface
         // Same order should retrieve
         $sameOrder = $context->cache->tags([$context->prefixed('alpha'), $context->prefixed('beta')])->get($orderKey);
 
-        // Different order creates different namespace - should NOT retrieve
-        $diffOrder = $context->cache->tags([$context->prefixed('beta'), $context->prefixed('alpha')])->get($orderKey);
+        // Different order creates different namespace - should not retrieve
+        $differentOrder = $context->cache->tags([$context->prefixed('beta'), $context->prefixed('alpha')])->get($orderKey);
 
         $result->assert(
-            $sameOrder === 'ordered' && $diffOrder === null,
+            $sameOrder === 'ordered' && $differentOrder === null,
             'Tag order matters - different order creates different namespace'
         );
     }

--- a/src/cache/src/Redis/Console/Doctor/Checks/PhpRedisCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/PhpRedisCheck.php
@@ -25,11 +25,17 @@ final class PhpRedisCheck implements EnvironmentCheckInterface
     ) {
     }
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'PHPRedis Extension';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(): CheckResult
     {
         $result = new CheckResult;
@@ -45,15 +51,18 @@ final class PhpRedisCheck implements EnvironmentCheckInterface
         $result->assert(true, "PHPRedis extension is installed (v{$this->installedVersion})");
 
         $requiredVersion = $this->requiredVersion();
-        $versionOk = version_compare($this->installedVersion, $requiredVersion, '>=');
+        $versionIsSupported = version_compare($this->installedVersion, $requiredVersion, '>=');
         $result->assert(
-            $versionOk,
+            $versionIsSupported,
             'PHPRedis version >= ' . $requiredVersion
         );
 
         return $result;
     }
 
+    /**
+     * Get details about how to fix a failed check.
+     */
     public function getFixInstructions(): ?string
     {
         if (! extension_loaded('redis')) {

--- a/src/cache/src/Redis/Console/Doctor/Checks/RedisVersionCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/RedisVersionCheck.php
@@ -27,17 +27,26 @@ final class RedisVersionCheck implements EnvironmentCheckInterface
 
     private bool $connectionFailed = false;
 
+    /**
+     * Create a new Redis version check instance.
+     */
     public function __construct(
         private readonly RedisConnection $redis,
         private readonly string $taggingMode,
     ) {
     }
 
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Redis/Valkey Version';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(): CheckResult
     {
         $result = new CheckResult;
@@ -63,9 +72,9 @@ final class RedisVersionCheck implements EnvironmentCheckInterface
 
             // Version requirement only applies to any mode
             if ($this->taggingMode === 'any') {
-                $versionOk = version_compare($this->serviceVersion, $requiredVersion, '>=');
+                $versionIsSupported = version_compare($this->serviceVersion, $requiredVersion, '>=');
                 $result->assert(
-                    $versionOk,
+                    $versionIsSupported,
                     "{$this->serviceName} version >= {$requiredVersion} (required for any tagging mode)"
                 );
             } else {
@@ -74,14 +83,17 @@ final class RedisVersionCheck implements EnvironmentCheckInterface
                     "{$this->serviceName} version check skipped (all mode has no version requirement)"
                 );
             }
-        } catch (Throwable $e) {
+        } catch (Throwable $exception) {
             $this->connectionFailed = true;
-            $result->assert(false, 'Redis/Valkey server is reachable: ' . $e->getMessage());
+            $result->assert(false, 'Redis/Valkey server is reachable: ' . $exception->getMessage());
         }
 
         return $result;
     }
 
+    /**
+     * Get details about how to fix a failed check.
+     */
     public function getFixInstructions(): ?string
     {
         if ($this->connectionFailed) {

--- a/src/cache/src/Redis/Console/Doctor/Checks/SequentialOperationsCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/SequentialOperationsCheck.php
@@ -14,11 +14,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class SequentialOperationsCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Sequential Rapid Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -26,8 +32,8 @@ final class SequentialOperationsCheck implements CheckInterface
         // Rapid writes to same key
         $rapidTag = $context->prefixed('rapid');
         $rapidKey = $context->prefixed('concurrent:key');
-        for ($i = 0; $i < 10; ++$i) {
-            $context->cache->tags([$rapidTag])->put($rapidKey, "value{$i}", 60);
+        for ($writeIndex = 0; $writeIndex < 10; ++$writeIndex) {
+            $context->cache->tags([$rapidTag])->put($rapidKey, "value{$writeIndex}", 60);
         }
 
         if ($context->isAnyMode()) {
@@ -43,7 +49,7 @@ final class SequentialOperationsCheck implements CheckInterface
         // Multiple increments
         $context->cache->put($context->prefixed('concurrent:counter'), 0, 60);
 
-        for ($i = 0; $i < 50; ++$i) {
+        for ($incrementIndex = 0; $incrementIndex < 50; ++$incrementIndex) {
             $context->cache->increment($context->prefixed('concurrent:counter'));
         }
 
@@ -56,8 +62,8 @@ final class SequentialOperationsCheck implements CheckInterface
         $context->cache->forget($context->prefixed('concurrent:add'));
         $results = [];
 
-        for ($i = 0; $i < 5; ++$i) {
-            $results[] = $context->cache->add($context->prefixed('concurrent:add'), "value{$i}", 60);
+        for ($addIndex = 0; $addIndex < 5; ++$addIndex) {
+            $results[] = $context->cache->add($context->prefixed('concurrent:add'), "value{$addIndex}", 60);
         }
 
         $result->assert(

--- a/src/cache/src/Redis/Console/Doctor/Checks/SharedTagFlushCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/SharedTagFlushCheck.php
@@ -15,21 +15,27 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class SharedTagFlushCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Shared Tag Flush (Orphan Prevention)';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
 
-        $tagA = $context->prefixed('tagA-' . bin2hex(random_bytes(4)));
-        $tagB = $context->prefixed('tagB-' . bin2hex(random_bytes(4)));
+        $firstTag = $context->prefixed('tagA-' . bin2hex(random_bytes(4)));
+        $secondTag = $context->prefixed('tagB-' . bin2hex(random_bytes(4)));
         $key = $context->prefixed('shared:' . bin2hex(random_bytes(4)));
         $value = 'value-' . bin2hex(random_bytes(4));
 
-        $tags = [$tagA, $tagB];
+        $tags = [$firstTag, $secondTag];
 
         // Store item with both tags
         $context->cache->tags($tags)->put($key, $value, 60);
@@ -41,37 +47,40 @@ final class SharedTagFlushCheck implements CheckInterface
                 $context->cache->get($key) === $value,
                 'Item with shared tags is stored'
             );
-            $this->testAnyMode($context, $result, $tagA, $tagB, $key);
+            $this->testAnyMode($context, $result, $firstTag, $secondTag, $key);
         } else {
             // All mode: must use tagged get
             $result->assert(
                 $context->cache->tags($tags)->get($key) === $value,
                 'Item with shared tags is stored'
             );
-            $this->testAllMode($context, $result, $tagA, $tagB, $key, $tags);
+            $this->testAllMode($context, $result, $firstTag, $secondTag, $key, $tags);
         }
 
         return $result;
     }
 
+    /**
+     * Test shared-tag flushing in any-tag mode.
+     */
     private function testAnyMode(
         DoctorContext $context,
         CheckResult $result,
-        string $tagA,
-        string $tagB,
+        string $firstTag,
+        string $secondTag,
         string $key,
     ): void {
         // Verify in both tag hashes
-        $tagAKey = $context->tagHashKey($tagA);
-        $tagBKey = $context->tagHashKey($tagB);
+        $firstTagKey = $context->tagHashKey($firstTag);
+        $secondTagKey = $context->tagHashKey($secondTag);
 
         $result->assert(
-            $context->redis->hExists($tagAKey, $key) && $context->redis->hExists($tagBKey, $key),
+            $context->redis->hExists($firstTagKey, $key) && $context->redis->hExists($secondTagKey, $key),
             'Key exists in both tag hashes (any mode)'
         );
 
         // Flush Tag A
-        $context->cache->tags([$tagA])->flush();
+        $context->cache->tags([$firstTag])->flush();
 
         $result->assert(
             $context->cache->get($key) === null,
@@ -81,36 +90,38 @@ final class SharedTagFlushCheck implements CheckInterface
         // In lazy mode (Hypervel default), orphans remain in Tag B hash
         // They will be cleaned by the scheduled prune command
         $result->assert(
-            $context->redis->hExists($tagBKey, $key),
+            $context->redis->hExists($secondTagKey, $key),
             'Orphaned field exists in shared tag (lazy cleanup - will be cleaned by prune command)'
         );
     }
 
     /**
-     * @param array<string> $tags
+     * Test shared-tag flushing in all-tags mode.
+     *
+     * @param list<string> $tags
      */
     private function testAllMode(
         DoctorContext $context,
         CheckResult $result,
-        string $tagA,
-        string $tagB,
+        string $firstTag,
+        string $secondTag,
         string $key,
         array $tags,
     ): void {
         // Verify both tag ZSETs contain entries before flush
-        $tagASetKey = $context->tagHashKey($tagA);
-        $tagBSetKey = $context->tagHashKey($tagB);
+        $firstTagSetKey = $context->tagHashKey($firstTag);
+        $secondTagSetKey = $context->tagHashKey($secondTag);
 
-        $tagACount = $context->redis->zCard($tagASetKey);
-        $tagBCount = $context->redis->zCard($tagBSetKey);
+        $firstTagCount = $context->redis->zCard($firstTagSetKey);
+        $secondTagCount = $context->redis->zCard($secondTagSetKey);
 
         $result->assert(
-            $tagACount > 0 && $tagBCount > 0,
+            $firstTagCount > 0 && $secondTagCount > 0,
             'Key exists in both tag ZSETs before flush (all mode)'
         );
 
         // Flush Tag A
-        $context->cache->tags([$tagA])->flush();
+        $context->cache->tags([$firstTag])->flush();
 
         $result->assert(
             $context->cache->tags($tags)->get($key) === null,
@@ -119,10 +130,10 @@ final class SharedTagFlushCheck implements CheckInterface
 
         // In all mode, the cache key is deleted when any tag is flushed
         // Orphaned entries remain in Tag B's ZSET until prune is run
-        $tagBCountAfter = $context->redis->zCard($tagBSetKey);
+        $secondTagCountAfter = $context->redis->zCard($secondTagSetKey);
 
         $result->assert(
-            $tagBCountAfter > 0,
+            $secondTagCountAfter > 0,
             'Orphaned entry exists in shared tag ZSET (cleaned by prune command)'
         );
     }

--- a/src/cache/src/Redis/Console/Doctor/Checks/TaggedOperationsCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/TaggedOperationsCheck.php
@@ -17,11 +17,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class TaggedOperationsCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Tagged Cache Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -41,10 +47,10 @@ final class TaggedOperationsCheck implements CheckInterface
             $this->testAnyMode($context, $result, $tag, $key);
         } else {
             // All mode: key is namespaced with xxh128 of tags
-            // Direct get without tags will NOT find the item
+            // Direct get without tags will not find the item
             $result->assert(
                 $context->cache->get($key) === null,
-                'Tagged item NOT retrievable without tags (namespace differs)'
+                'Tagged item not retrievable without tags (namespace differs)'
             );
             $this->testAllMode($context, $result, $tag, $key);
         }
@@ -68,6 +74,9 @@ final class TaggedOperationsCheck implements CheckInterface
         return $result;
     }
 
+    /**
+     * Test tagged operations in any-tag mode.
+     */
     private function testAnyMode(DoctorContext $context, CheckResult $result, string $tag, string $key): void
     {
         // Verify hash structure exists
@@ -90,6 +99,9 @@ final class TaggedOperationsCheck implements CheckInterface
         );
     }
 
+    /**
+     * Test tagged operations in all-tags mode.
+     */
     private function testAllMode(DoctorContext $context, CheckResult $result, string $tag, string $key): void
     {
         // In all mode, get() on tagged cache works

--- a/src/cache/src/Redis/Console/Doctor/Checks/TaggedRememberCheck.php
+++ b/src/cache/src/Redis/Console/Doctor/Checks/TaggedRememberCheck.php
@@ -14,11 +14,17 @@ use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
  */
 final class TaggedRememberCheck implements CheckInterface
 {
+    /**
+     * Get the human-readable name of this check.
+     */
     public function name(): string
     {
         return 'Tagged Remember Operations';
     }
 
+    /**
+     * Run the check and return results.
+     */
     public function run(DoctorContext $context): CheckResult
     {
         $result = new CheckResult;
@@ -37,13 +43,13 @@ final class TaggedRememberCheck implements CheckInterface
         if ($context->isAnyMode()) {
             // Any mode: direct get works
             $result->assert(
-                $value === 'remembered-value' && $context->cache->get($rememberKey) === 'remembered-value', // @phpstan-ignore identical.alwaysTrue (diagnostic assertion)
+                $value === 'remembered-value' && $context->cache->get($rememberKey) === 'remembered-value',
                 'remember() with tags stores and returns value'
             );
         } else {
             // All mode: must use tagged get
             $result->assert(
-                $value === 'remembered-value' && $context->cache->tags([$tag])->get($rememberKey) === 'remembered-value', // @phpstan-ignore identical.alwaysTrue (diagnostic assertion)
+                $value === 'remembered-value' && $context->cache->tags([$tag])->get($rememberKey) === 'remembered-value',
                 'remember() with tags stores and returns value'
             );
         }
@@ -57,13 +63,13 @@ final class TaggedRememberCheck implements CheckInterface
         if ($context->isAnyMode()) {
             // Any mode: direct get works
             $result->assert(
-                $value === 'forever-value' && $context->cache->get($foreverKey) === 'forever-value', // @phpstan-ignore identical.alwaysTrue (diagnostic assertion)
+                $value === 'forever-value' && $context->cache->get($foreverKey) === 'forever-value',
                 'rememberForever() with tags stores and returns value'
             );
         } else {
             // All mode: must use tagged get
             $result->assert(
-                $value === 'forever-value' && $context->cache->tags([$tag])->get($foreverKey) === 'forever-value', // @phpstan-ignore identical.alwaysTrue (diagnostic assertion)
+                $value === 'forever-value' && $context->cache->tags([$tag])->get($foreverKey) === 'forever-value',
                 'rememberForever() with tags stores and returns value'
             );
         }

--- a/src/cache/src/Redis/Console/Doctor/DoctorContext.php
+++ b/src/cache/src/Redis/Console/Doctor/DoctorContext.php
@@ -88,7 +88,7 @@ final class DoctorContext
 
     /**
      * Check if the store is configured for 'any' tag mode.
-     * In this mode, flushing ANY matching tag removes the item.
+     * In this mode, flushing any matching tag removes the item.
      */
     public function isAnyMode(): bool
     {
@@ -97,7 +97,7 @@ final class DoctorContext
 
     /**
      * Check if the store is configured for 'all' tag mode.
-     * In this mode, items must match ALL specified tags.
+     * In this mode, items must match all specified tags.
      */
     public function isAllMode(): bool
     {
@@ -124,7 +124,7 @@ final class DoctorContext
      * Get patterns to match all tag storage structures with a given tag name prefix.
      *
      * Used for cleanup operations to delete dynamically-created test tags.
-     * Returns patterns for BOTH tag modes to ensure complete cleanup
+     * Returns patterns for both tag modes to ensure complete cleanup
      * regardless of current mode (e.g., if config changed between runs):
      * - Any mode: {cachePrefix}_any:tag:{tagNamePrefix}*
      * - All mode: {cachePrefix}_all:tag:{tagNamePrefix}*
@@ -146,7 +146,7 @@ final class DoctorContext
      * Get patterns to match all cache value keys with a given key prefix.
      *
      * Used for cleanup operations to delete test cache values.
-     * Returns patterns for BOTH tag modes to ensure complete cleanup
+     * Returns patterns for both tag modes to ensure complete cleanup
      * regardless of current mode (e.g., if config changed between runs):
      * - Untagged keys: {cachePrefix}{keyPrefix}* (same in both modes)
      * - Tagged keys in all mode: {cachePrefix}{xxh128}:{keyPrefix}* (namespaced)

--- a/src/cache/src/Redis/Console/DoctorCommand.php
+++ b/src/cache/src/Redis/Console/DoctorCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Cache\Redis\Console;
 
-use Exception;
 use Hypervel\Cache\Redis\Console\Concerns\DetectsRedisStore;
 use Hypervel\Cache\Redis\Console\Doctor\CheckResult;
 use Hypervel\Cache\Redis\Console\Doctor\Checks\AddOperationsCheck;
@@ -33,12 +32,14 @@ use Hypervel\Cache\Redis\Console\Doctor\Checks\TaggedOperationsCheck;
 use Hypervel\Cache\Redis\Console\Doctor\Checks\TaggedRememberCheck;
 use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
 use Hypervel\Cache\RedisStore;
+use Hypervel\Cache\Repository;
 use Hypervel\Console\Command;
 use Hypervel\Console\Prohibitable;
 use Hypervel\Contracts\Cache\Factory as CacheContract;
 use Hypervel\Redis\RedisConnection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
 
 #[AsCommand(name: 'cache:redis-doctor')]
 class DoctorCommand extends Command
@@ -62,6 +63,9 @@ class DoctorCommand extends Command
 
     /** @var list<string> */
     private array $failures = [];
+
+    /** @var list<string> */
+    private array $cleanupFailures = [];
 
     /**
      * Unique prefix to prevent collision with production data.
@@ -93,7 +97,7 @@ class DoctorCommand extends Command
         }
 
         // Validate that the store is using redis driver
-        /** @var \Hypervel\Cache\Repository $repository */
+        /** @var Repository $repository */
         $repository = $this->hypervel->make(CacheContract::class)->store($storeName);
         $store = $repository->getStore();
 
@@ -110,7 +114,7 @@ class DoctorCommand extends Command
         $this->info('Checking System Requirements...');
         $this->newLine();
 
-        return $store->getContext()->withConnection(function (RedisConnection $redis) use ($repository, $store, $storeName, $tagMode) {
+        return $store->getContext()->withConnection(function (RedisConnection $redis) use ($repository, $store, $storeName, $tagMode): int {
             if (! $this->runEnvironmentChecks($storeName, $store, $tagMode, $redis)) {
                 return self::FAILURE;
             }
@@ -142,7 +146,9 @@ class DoctorCommand extends Command
 
             $this->displaySummary();
 
-            return $this->testsFailed === 0 ? self::SUCCESS : self::FAILURE;
+            return $this->testsFailed === 0 && $this->cleanupFailures === []
+                ? self::SUCCESS
+                : self::FAILURE;
         });
     }
 
@@ -335,8 +341,11 @@ class DoctorCommand extends Command
                     $this->line('  Tag Mode: <fg=cyan>' . $store->getTagMode()->value . '</>');
                 }
             }
-        } catch (Exception) {
-            $this->line('  Service: <fg=red>Connection failed</>');
+        } catch (Throwable $exception) {
+            $this->line(
+                '  Service: <fg=red>Connection failed ('
+                . $exception::class . '): ' . $exception->getMessage() . '</>'
+            );
         }
 
         $this->newLine(2);
@@ -347,6 +356,9 @@ class DoctorCommand extends Command
      */
     protected function cleanup(DoctorContext $context, bool $silent = false): void
     {
+        $phase = $silent ? 'Preflight cleanup' : 'Cleanup';
+        $cleanupFailureCount = count($this->cleanupFailures);
+
         if (! $silent) {
             $this->newLine();
             $this->info('Cleaning up test data...');
@@ -362,10 +374,12 @@ class DoctorCommand extends Command
         ];
 
         foreach ($testTags as $tag) {
+            $prefixedTag = $context->prefixed($tag);
+
             try {
-                $context->cache->tags([$context->prefixed($tag)])->flush();
-            } catch (Exception) {
-                // Ignore cleanup errors
+                $context->cache->tags([$prefixedTag])->flush();
+            } catch (Throwable $exception) {
+                $this->recordCleanupFailure("{$phase}: flush tag '{$prefixedTag}'", $exception);
             }
         }
 
@@ -373,19 +387,19 @@ class DoctorCommand extends Command
         foreach ($context->getCacheValuePatterns(self::TEST_PREFIX) as $pattern) {
             try {
                 $this->flushKeysByPattern($context->store, $pattern);
-            } catch (Exception) {
-                // Ignore cleanup errors
+            } catch (Throwable $exception) {
+                $this->recordCleanupFailure("{$phase}: flush cache keys matching '{$pattern}'", $exception);
             }
         }
 
         // Delete tag storage structures for dynamically-created test tags
-        // Uses patterns for BOTH modes to ensure complete cleanup regardless of current mode
+        // Uses patterns for both modes to ensure complete cleanup regardless of current mode
         // e.g., tagA-{random}, tagB-{random} from SharedTagFlushCheck
         foreach ($context->getTagStoragePatterns(self::TEST_PREFIX) as $pattern) {
             try {
                 $this->flushKeysByPattern($context->store, $pattern);
-            } catch (Exception) {
-                // Ignore cleanup errors
+            } catch (Throwable $exception) {
+                $this->recordCleanupFailure("{$phase}: flush tag storage matching '{$pattern}'", $exception);
             }
         }
 
@@ -397,7 +411,7 @@ class DoctorCommand extends Command
                 $members = $context->redis->zRange($registryKey, 0, -1);
                 $testMembers = array_filter(
                     $members,
-                    fn ($m) => str_starts_with($m, self::TEST_PREFIX)
+                    fn (string $member): bool => str_starts_with($member, self::TEST_PREFIX)
                 );
                 if (! empty($testMembers)) {
                     $context->redis->zrem($registryKey, ...$testMembers);
@@ -406,14 +420,25 @@ class DoctorCommand extends Command
                 if ($context->redis->zCard($registryKey) === 0) {
                     $context->redis->del($registryKey);
                 }
-            } catch (Exception) {
-                // Ignore cleanup errors
+            } catch (Throwable $exception) {
+                $this->recordCleanupFailure("{$phase}: clean tag registry", $exception);
             }
         }
 
-        if (! $silent) {
+        if (! $silent && count($this->cleanupFailures) === $cleanupFailureCount) {
             $this->info('Cleanup complete.');
         }
+    }
+
+    /**
+     * Record and report a cleanup failure.
+     */
+    private function recordCleanupFailure(string $operation, Throwable $exception): void
+    {
+        $failure = $operation . ' failed (' . $exception::class . '): ' . $exception->getMessage();
+
+        $this->cleanupFailures[] = $failure;
+        $this->error($failure);
     }
 
     /**
@@ -445,6 +470,15 @@ class DoctorCommand extends Command
             }
         }
 
+        if ($this->cleanupFailures !== []) {
+            $this->newLine();
+            $this->error('Cleanup failures:');
+
+            foreach ($this->cleanupFailures as $failure) {
+                $this->error("  - {$failure}");
+            }
+        }
+
         $this->info('═══════════════════════════════════════════════════════════════');
     }
 
@@ -464,7 +498,7 @@ class DoctorCommand extends Command
     private function flushKeysByPattern(RedisStore $store, string $pattern): void
     {
         $store->getContext()->withConnection(
-            fn (RedisConnection $connection) => $connection->flushByPattern($pattern)
+            fn (RedisConnection $connection): int => $connection->flushByPattern($pattern)
         );
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Add.php
+++ b/src/cache/src/Redis/Operations/AllTag/Add.php
@@ -24,6 +24,9 @@ use function Hypervel\Support\now;
  */
 class Add
 {
+    /**
+     * Create a new add operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly Serialization $serialization,

--- a/src/cache/src/Redis/Operations/AllTag/AddEntry.php
+++ b/src/cache/src/Redis/Operations/AllTag/AddEntry.php
@@ -21,6 +21,9 @@ use function Hypervel\Support\now;
  */
 class AddEntry
 {
+    /**
+     * Create a new add-entry operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
     ) {
@@ -64,7 +67,7 @@ class AddEntry
      */
     private function executePipeline(string $key, int $score, array $tagIds, ?string $updateWhen): void
     {
-        $this->context->withConnection(function (RedisConnection $connection) use ($key, $score, $tagIds, $updateWhen) {
+        $this->context->withConnection(function (RedisConnection $connection) use ($key, $score, $tagIds, $updateWhen): void {
             $prefix = $this->context->prefix();
             $pipeline = $connection->pipeline();
 
@@ -92,7 +95,7 @@ class AddEntry
      */
     private function executeCluster(string $key, int $score, array $tagIds, ?string $updateWhen): void
     {
-        $this->context->withConnection(function (RedisConnection $connection) use ($key, $score, $tagIds, $updateWhen) {
+        $this->context->withConnection(function (RedisConnection $connection) use ($key, $score, $tagIds, $updateWhen): void {
             $prefix = $this->context->prefix();
 
             foreach ($tagIds as $tagId) {

--- a/src/cache/src/Redis/Operations/AllTag/Decrement.php
+++ b/src/cache/src/Redis/Operations/AllTag/Decrement.php
@@ -23,6 +23,9 @@ class Decrement
      */
     private const int FOREVER_SCORE = -1;
 
+    /**
+     * Create a new decrement operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
     ) {
@@ -50,7 +53,7 @@ class Decrement
      */
     private function executePipeline(string $key, int $value, array $tagIds): int|false
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): int|false {
             $prefix = $this->context->prefix();
 
             $pipeline = $connection->pipeline();
@@ -79,7 +82,7 @@ class Decrement
      */
     private function executeCluster(string $key, int $value, array $tagIds): int|false
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): int|false {
             $prefix = $this->context->prefix();
 
             // ZADD NX to each tag's sorted set (sequential - cross-slot)

--- a/src/cache/src/Redis/Operations/AllTag/Flush.php
+++ b/src/cache/src/Redis/Operations/AllTag/Flush.php
@@ -11,6 +11,9 @@ class Flush
 {
     private const int CHUNK_SIZE = 1000;
 
+    /**
+     * Create a new flush operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly GetEntries $getEntries,
@@ -40,7 +43,7 @@ class Flush
         $isCluster = $this->context->isCluster();
 
         $entries = $this->getEntries->execute($tagIds)
-            ->map(fn (string $key) => $prefix . $key);
+            ->map(fn (string $key): string => $prefix . $key);
 
         foreach ($entries->chunk(self::CHUNK_SIZE) as $chunk) {
             $keys = $chunk->all();
@@ -49,7 +52,7 @@ class Flush
                 continue;
             }
 
-            $this->context->withConnection(function (RedisConnection $connection) use ($keys, $isCluster) {
+            $this->context->withConnection(function (RedisConnection $connection) use ($keys, $isCluster): void {
                 // Cluster keys may occupy different slots and cannot share a pipeline.
                 if ($isCluster) {
                     $connection->del(...$keys);
@@ -86,9 +89,9 @@ class Flush
             return;
         }
 
-        $this->context->withConnection(function (RedisConnection $connection) use ($tagNames) {
+        $this->context->withConnection(function (RedisConnection $connection) use ($tagNames): void {
             $tagKeys = array_map(
-                fn (string $name) => $this->context->tagHashKey($name),
+                fn (string $name): string => $this->context->tagHashKey($name),
                 $tagNames
             );
 

--- a/src/cache/src/Redis/Operations/AllTag/FlushStale.php
+++ b/src/cache/src/Redis/Operations/AllTag/FlushStale.php
@@ -20,6 +20,9 @@ use function Hypervel\Support\now;
  */
 class FlushStale
 {
+    /**
+     * Create a new flush-stale operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
     ) {
@@ -57,7 +60,7 @@ class FlushStale
      */
     private function executePipeline(array $tagIds): void
     {
-        $this->context->withConnection(function (RedisConnection $connection) use ($tagIds) {
+        $this->context->withConnection(function (RedisConnection $connection) use ($tagIds): void {
             $prefix = $this->context->prefix();
             $timestamp = (string) now()->getTimestamp();
 
@@ -80,7 +83,7 @@ class FlushStale
      */
     private function executeCluster(array $tagIds): void
     {
-        $this->context->withConnection(function (RedisConnection $connection) use ($tagIds) {
+        $this->context->withConnection(function (RedisConnection $connection) use ($tagIds): void {
             $prefix = $this->context->prefix();
             $timestamp = (string) now()->getTimestamp();
 

--- a/src/cache/src/Redis/Operations/AllTag/Forever.php
+++ b/src/cache/src/Redis/Operations/AllTag/Forever.php
@@ -21,6 +21,9 @@ class Forever
 {
     private const int FOREVER_SCORE = -1;
 
+    /**
+     * Create a new forever operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly Serialization $serialization,
@@ -49,7 +52,7 @@ class Forever
      */
     private function executePipeline(string $key, mixed $value, array $tagIds): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): bool {
             $prefix = $this->context->prefix();
             $serialized = $this->serialization->serialize($connection, $value);
 
@@ -75,7 +78,7 @@ class Forever
      */
     private function executeCluster(string $key, mixed $value, array $tagIds): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): bool {
             $prefix = $this->context->prefix();
             $serialized = $this->serialization->serialize($connection, $value);
 

--- a/src/cache/src/Redis/Operations/AllTag/GetEntries.php
+++ b/src/cache/src/Redis/Operations/AllTag/GetEntries.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Cache\Redis\Operations\AllTag;
 
+use Generator;
 use Hypervel\Cache\Redis\Support\StoreContext;
 use Hypervel\Redis\PhpRedis;
 use Hypervel\Redis\RedisConnection;
@@ -11,6 +12,9 @@ use Hypervel\Support\LazyCollection;
 
 class GetEntries
 {
+    /**
+     * Create a new get-entries operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
     ) {
@@ -27,7 +31,7 @@ class GetEntries
         $context = $this->context;
         $prefix = $this->context->prefix();
 
-        return new LazyCollection(function () use ($context, $prefix, $tagIds) {
+        return new LazyCollection(function () use ($context, $prefix, $tagIds): Generator {
             foreach ($tagIds as $tagId) {
                 $cursor = PhpRedis::initialScanCursor();
                 $seen = [];

--- a/src/cache/src/Redis/Operations/AllTag/Increment.php
+++ b/src/cache/src/Redis/Operations/AllTag/Increment.php
@@ -23,6 +23,9 @@ class Increment
      */
     private const int FOREVER_SCORE = -1;
 
+    /**
+     * Create a new increment operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
     ) {
@@ -50,7 +53,7 @@ class Increment
      */
     private function executePipeline(string $key, int $value, array $tagIds): int|false
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): int|false {
             $prefix = $this->context->prefix();
 
             $pipeline = $connection->pipeline();
@@ -79,7 +82,7 @@ class Increment
      */
     private function executeCluster(string $key, int $value, array $tagIds): int|false
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): int|false {
             $prefix = $this->context->prefix();
 
             // ZADD NX to each tag's sorted set (sequential - cross-slot)

--- a/src/cache/src/Redis/Operations/AllTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AllTag/Prune.php
@@ -8,7 +8,6 @@ use Hypervel\Cache\Redis\Support\StoreContext;
 use Hypervel\Redis\Operations\SafeScan;
 use Hypervel\Redis\PhpRedis;
 use Hypervel\Redis\RedisConnection;
-use Redis;
 
 /**
  * Prune stale and orphaned entries from all tag sorted sets.
@@ -48,13 +47,13 @@ class Prune
      */
     public function execute(int $scanCount = self::DEFAULT_SCAN_COUNT): array
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($scanCount) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($scanCount): array {
             $pattern = $this->context->tagScanPattern();
             $optPrefix = $this->context->optPrefix();
             $prefix = $this->context->prefix();
             $now = time();
 
-            $stats = [
+            $statistics = [
                 'tags_scanned' => 0,
                 'stale_entries_removed' => 0,
                 'entries_checked' => 0,
@@ -66,25 +65,25 @@ class Prune
             $safeScan = new SafeScan($connection, $optPrefix);
 
             foreach ($safeScan->execute($pattern, $scanCount) as $tagKey) {
-                ++$stats['tags_scanned'];
+                ++$statistics['tags_scanned'];
 
                 // Step 1: Remove TTL-expired entries (stale by time)
                 $staleRemoved = $connection->zRemRangeByScore($tagKey, '0', (string) $now);
-                $stats['stale_entries_removed'] += is_int($staleRemoved) ? $staleRemoved : 0;
+                $statistics['stale_entries_removed'] += is_int($staleRemoved) ? $staleRemoved : 0;
 
                 // Step 2: Remove orphaned entries (cache key doesn't exist)
                 $orphanResult = $this->removeOrphanedEntries($connection, $tagKey, $prefix, $scanCount);
-                $stats['entries_checked'] += $orphanResult['checked'];
-                $stats['orphans_removed'] += $orphanResult['removed'];
+                $statistics['entries_checked'] += $orphanResult['checked'];
+                $statistics['orphans_removed'] += $orphanResult['removed'];
 
                 // Step 3: Delete if empty
                 if ($connection->zCard($tagKey) === 0) {
                     $connection->del($tagKey);
-                    ++$stats['empty_sets_deleted'];
+                    ++$statistics['empty_sets_deleted'];
                 }
             }
 
-            return $stats;
+            return $statistics;
         });
     }
 

--- a/src/cache/src/Redis/Operations/AllTag/Put.php
+++ b/src/cache/src/Redis/Operations/AllTag/Put.php
@@ -22,6 +22,9 @@ use function Hypervel\Support\now;
  */
 class Put
 {
+    /**
+     * Create a new put operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly Serialization $serialization,
@@ -53,7 +56,7 @@ class Put
      */
     private function executePipeline(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $seconds, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $seconds, $tagIds): bool {
             $prefix = $this->context->prefix();
             $score = now()->addSeconds($seconds)->getTimestamp();
             $serialized = $this->serialization->serialize($connection, $value);
@@ -83,7 +86,7 @@ class Put
      */
     private function executeCluster(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $seconds, $tagIds) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $seconds, $tagIds): bool {
             $prefix = $this->context->prefix();
             $score = now()->addSeconds($seconds)->getTimestamp();
             $serialized = $this->serialization->serialize($connection, $value);

--- a/src/cache/src/Redis/Operations/AllTag/PutMany.php
+++ b/src/cache/src/Redis/Operations/AllTag/PutMany.php
@@ -18,6 +18,9 @@ use function Hypervel\Support\now;
  */
 class PutMany
 {
+    /**
+     * Create a new put-many operation instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly Serialization $serialization,
@@ -54,12 +57,12 @@ class PutMany
      */
     private function executePipeline(array $values, int $seconds, array $tagIds, string $namespace): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($values, $seconds, $tagIds, $namespace) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($values, $seconds, $tagIds, $namespace): bool {
             $prefix = $this->context->prefix();
             $score = now()->addSeconds($seconds)->getTimestamp();
             $ttl = max(1, $seconds);
 
-            // Prepare all data upfront
+            // Prepare all data up front
             $preparedEntries = [];
             foreach ($values as $key => $value) {
                 $namespacedKey = $namespace . $key;
@@ -73,12 +76,12 @@ class PutMany
             // Batch ZADD: one command per tag with all cache keys as members
             // ZADD format: key, score1, member1, score2, member2, ...
             foreach ($tagIds as $tagId) {
-                $zaddArgs = [];
+                $zaddArguments = [];
                 foreach ($namespacedKeys as $key) {
-                    $zaddArgs[] = $score;
-                    $zaddArgs[] = $key;
+                    $zaddArguments[] = $score;
+                    $zaddArguments[] = $key;
                 }
-                $pipeline->zadd($prefix . $tagId, ...$zaddArgs);
+                $pipeline->zadd($prefix . $tagId, ...$zaddArguments);
             }
 
             // Then all SETEXs
@@ -96,17 +99,17 @@ class PutMany
      * Execute using sequential commands for Redis Cluster.
      *
      * Uses variadic ZADD to batch all cache keys into a single command per tag.
-     * This is safe in cluster mode because variadic ZADD targets ONE sorted set key,
+     * This is safe in cluster mode because variadic ZADD targets one sorted set key,
      * which resides in a single slot.
      */
     private function executeCluster(array $values, int $seconds, array $tagIds, string $namespace): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($values, $seconds, $tagIds, $namespace) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($values, $seconds, $tagIds, $namespace): bool {
             $prefix = $this->context->prefix();
             $score = now()->addSeconds($seconds)->getTimestamp();
             $ttl = max(1, $seconds);
 
-            // Prepare all data upfront
+            // Prepare all data up front
             $preparedEntries = [];
             foreach ($values as $key => $value) {
                 $namespacedKey = $namespace . $key;
@@ -116,20 +119,19 @@ class PutMany
             $namespacedKeys = array_keys($preparedEntries);
 
             // Batch ZADD: one command per tag with all cache keys as members
-            // Each tag's sorted set is in ONE slot, so variadic ZADD works in cluster
+            // Each tag's sorted set is in one slot, so variadic ZADD works in cluster
             foreach ($tagIds as $tagId) {
-                $zaddArgs = [];
+                $zaddArguments = [];
                 foreach ($namespacedKeys as $key) {
-                    $zaddArgs[] = $score;
-                    $zaddArgs[] = $key;
+                    $zaddArguments[] = $score;
+                    $zaddArguments[] = $key;
                 }
-                $connection->zadd($prefix . $tagId, ...$zaddArgs);
+                $connection->zadd($prefix . $tagId, ...$zaddArguments);
             }
 
             // Then all SETEXs
             $allSucceeded = true;
             foreach ($preparedEntries as $namespacedKey => $serialized) {
-                // @phpstan-ignore booleanNot.alwaysTrue (setex can fail in edge cases)
                 if (! $connection->setex($prefix . $namespacedKey, $ttl, $serialized)) {
                     $allSucceeded = false;
                 }

--- a/src/cache/src/Redis/Operations/AllTagOperations.php
+++ b/src/cache/src/Redis/Operations/AllTagOperations.php
@@ -47,6 +47,9 @@ class AllTagOperations
 
     private ?Prune $prune = null;
 
+    /**
+     * Create a new all-tag operations instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly Serialization $serialization,

--- a/src/cache/src/Redis/Operations/AnyTag/Forever.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Forever.php
@@ -11,7 +11,7 @@ use Hypervel\Redis\RedisConnection;
 /**
  * Store an item in the cache indefinitely with tags support.
  *
- * Stores the cache key and tag hash fields WITHOUT expiration (TTL = -1).
+ * Stores the cache key and tag hash fields without expiration (TTL = -1).
  * Items must be manually deleted or flushed via tags.
  *
  * Optimization: Uses Lua script to perform set, tag cleanup (remove from old),
@@ -52,7 +52,7 @@ class Forever
      */
     private function executeCluster(string $key, mixed $value, array $tags): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags): bool {
             $prefix = $this->context->prefix();
 
             // Get old tags to handle replacement correctly (remove from old, add to new)
@@ -84,28 +84,28 @@ class Forever
                 $connection->hdel($this->context->tagHashKey($tag), $key);
             }
 
-            // Calculate expiry for Registry (Year 9999)
+            // Calculate expiry for the registry (Year 9999)
             $expiry = StoreContext::MAX_EXPIRY;
             $registryKey = $this->context->registryKey();
 
-            // 1. Add to each tag's hash without expiration (Cross-slot, sequential)
+            // 1. Add to each tag's hash without expiration (cross-slot, sequential)
             foreach ($tags as $tag) {
                 $tag = (string) $tag;
                 $connection->hSet($this->context->tagHashKey($tag), $key, StoreContext::TAG_FIELD_VALUE);
                 // No HEXPIRE for forever items
             }
 
-            // 2. Update Registry (Same slot, single command optimization)
+            // 2. Update registry (same slot, single command optimization)
             if (! empty($tags)) {
-                $zaddArgs = [];
+                $zaddArguments = [];
 
                 foreach ($tags as $tag) {
-                    $zaddArgs[] = $expiry;
-                    $zaddArgs[] = (string) $tag;
+                    $zaddArguments[] = $expiry;
+                    $zaddArguments[] = (string) $tag;
                 }
 
-                // Update Registry: ZADD with GT (Greater Than) to only extend expiry
-                $connection->zadd($registryKey, ['GT'], ...$zaddArgs);
+                // Update registry: ZADD with GT (greater than) to only extend expiry
+                $connection->zadd($registryKey, ['GT'], ...$zaddArguments);
             }
 
             return true;
@@ -117,7 +117,7 @@ class Forever
      */
     private function executeUsingLua(string $key, mixed $value, array $tags): bool
     {
-        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags) {
+        return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags): bool {
             $prefix = $this->context->prefix();
 
             $keys = [
@@ -125,7 +125,7 @@ class Forever
                 $this->context->reverseIndexKey($key), // KEYS[2]
             ];
 
-            $args = [
+            $arguments = [
                 $this->serialization->serializeForLua($connection, $value), // ARGV[1]
                 $this->context->fullTagPrefix(),             // ARGV[2]
                 $this->context->fullRegistryKey(),           // ARGV[3]
@@ -134,7 +134,7 @@ class Forever
                 ...$tags,                                    // ARGV[6...]
             ];
 
-            $connection->evalWithShaCache($this->storeForeverWithTagsScript(), $keys, $args);
+            $connection->evalWithShaCache($this->storeForeverWithTagsScript(), $keys, $arguments);
 
             return true;
         });

--- a/src/cache/src/Redis/Operations/AnyTag/GetTagItems.php
+++ b/src/cache/src/Redis/Operations/AnyTag/GetTagItems.php
@@ -33,7 +33,7 @@ class GetTagItems
      * Execute the query.
      *
      * @param array<int, int|string> $tags Array of tag names
-     * @return Generator Yields key => value pairs
+     * @return Generator<string, mixed, void, void> Yields key => value pairs
      */
     public function execute(array $tags): Generator
     {
@@ -66,8 +66,8 @@ class GetTagItems
     /**
      * Fetch values for a list of keys.
      *
-     * @param array<int, string> $keys Array of cache keys (without prefix)
-     * @return Generator Yields key => value pairs
+     * @param list<string> $keys Array of cache keys (without prefix)
+     * @return Generator<string, mixed, void, void> Yields key => value pairs
      */
     private function fetchValues(array $keys): Generator
     {
@@ -76,10 +76,10 @@ class GetTagItems
         }
 
         $prefix = $this->context->prefix();
-        $prefixedKeys = array_map(fn ($key): string => $prefix . $key, $keys);
+        $prefixedKeys = array_map(fn (string $key): string => $prefix . $key, $keys);
 
         $results = $this->context->withConnection(
-            function (RedisConnection $connection) use ($prefixedKeys, $keys) {
+            function (RedisConnection $connection) use ($prefixedKeys, $keys): array {
                 $values = $connection->mget($prefixedKeys);
                 $items = [];
 

--- a/src/cache/src/Redis/Operations/AnyTag/PutMany.php
+++ b/src/cache/src/Redis/Operations/AnyTag/PutMany.php
@@ -232,7 +232,7 @@ class PutMany
 
                     $fields = array_fill_keys($keys, StoreContext::TAG_FIELD_VALUE);
 
-                    $pipeline->hsetex($tagHashKey, $fields, ['EX' => $ttl]); // @phpstan-ignore method.nonObject (phpredis pipeline() returns Redis)
+                    $pipeline->hsetex($tagHashKey, $fields, ['EX' => $ttl]);
                 }
 
                 // Update Registry in batch

--- a/src/cache/src/Redis/Operations/AnyTagOperations.php
+++ b/src/cache/src/Redis/Operations/AnyTagOperations.php
@@ -45,6 +45,9 @@ class AnyTagOperations
 
     private ?Prune $prune = null;
 
+    /**
+     * Create a new any-tag operations instance.
+     */
     public function __construct(
         private readonly StoreContext $context,
         private readonly Serialization $serialization,

--- a/src/cache/src/Redis/Operations/Flush.php
+++ b/src/cache/src/Redis/Operations/Flush.php
@@ -23,7 +23,7 @@ class Flush
     /**
      * Execute the flush operation.
      *
-     * Warning: This removes ALL keys from the Redis database, not just cache keys.
+     * Warning: This removes all keys from the Redis database, not just cache keys.
      */
     public function execute(): bool
     {

--- a/src/cache/src/Redis/Support/MonitoringDetector.php
+++ b/src/cache/src/Redis/Support/MonitoringDetector.php
@@ -15,6 +15,9 @@ use Hypervel\Telescope\Telescope;
  */
 class MonitoringDetector
 {
+    /**
+     * Create a new monitoring detector instance.
+     */
     public function __construct(
         private readonly Repository $config,
     ) {

--- a/src/cache/src/Redis/Support/Serialization.php
+++ b/src/cache/src/Redis/Support/Serialization.php
@@ -14,11 +14,11 @@ use Redis;
  * This class centralizes the serialization logic needed for both
  * regular Redis operations and Lua script ARGV parameters.
  *
- * IMPORTANT: All methods require a RedisConnection parameter to avoid
- * the N+1 pool checkout problem. Never add methods that call
- * withConnection() internally - if serialization methods acquire their
- * own connection, batch operations like putMany(1000) would checkout
- * 1001 connections instead of 1, causing massive performance degradation.
+ * Every method requires a RedisConnection parameter to avoid the N+1 pool
+ * checkout problem. Serialization methods must not call withConnection()
+ * internally: if they acquire their own connection, batch operations such as
+ * putMany(1000) would check out 1001 connections instead of 1, causing massive
+ * performance degradation.
  */
 class Serialization
 {
@@ -37,13 +37,13 @@ class Serialization
      * When a serializer is configured on the connection, returns the raw value
      * (phpredis will auto-serialize). Otherwise, uses PHP serialization.
      *
-     * @param RedisConnection $conn The connection to use for serialization checks
+     * @param RedisConnection $connection The connection to use for serialization checks
      * @param mixed $value The value to serialize
      * @return mixed The serialized value
      */
-    public function serialize(RedisConnection $conn, mixed $value): mixed
+    public function serialize(RedisConnection $connection, mixed $value): mixed
     {
-        if ($conn->serialized()) {
+        if ($connection->serialized()) {
             return $value;
         }
 
@@ -55,34 +55,34 @@ class Serialization
      *
      * Unlike regular serialization (which returns raw values when a serializer
      * is configured, expecting phpredis to auto-serialize), Lua scripts require
-     * pre-serialized string values in ARGV because phpredis does NOT auto-serialize
-     * Lua ARGV parameters.
+     * pre-serialized string values in ARGV because phpredis does not automatically
+     * serialize Lua ARGV parameters.
      *
      * This method handles three scenarios:
      * 1. Serializer configured (igbinary/json/php): Use pack() which calls _serialize()
      * 2. No serializer, but compression enabled: PHP serialize, then compress
      * 3. No serializer, no compression: Just PHP serialize
      *
-     * @param RedisConnection $conn The connection to use for serialization
+     * @param RedisConnection $connection The connection to use for serialization
      * @param mixed $value The value to serialize
      * @return string The serialized value suitable for Lua ARGV
      */
-    public function serializeForLua(RedisConnection $conn, mixed $value): string
+    public function serializeForLua(RedisConnection $connection, mixed $value): string
     {
         // Case 1: Serializer configured (e.g. igbinary/json)
-        // pack() calls _serialize() which handles serialization AND compression
-        if ($conn->serialized()) {
-            return $conn->pack([$value])[0];
+        // pack() calls _serialize() which handles serialization and compression
+        if ($connection->serialized()) {
+            return $connection->pack([$value])[0];
         }
 
         // No serializer - must PHP-serialize first
         $serialized = $this->phpSerialize($value);
 
         // Case 2: Check if compression is enabled (even without serializer)
-        if ($conn->getOption(Redis::OPT_COMPRESSION) !== Redis::COMPRESSION_NONE) {
+        if ($connection->getOption(Redis::OPT_COMPRESSION) !== Redis::COMPRESSION_NONE) {
             // _serialize() applies compression even with SERIALIZER_NONE
             // Cast to string in case serialize() returned a numeric value
-            return $conn->_serialize(is_numeric($serialized) ? (string) $serialized : $serialized);
+            return $connection->_serialize(is_numeric($serialized) ? (string) $serialized : $serialized);
         }
 
         // Case 3: No serializer, no compression
@@ -96,17 +96,17 @@ class Serialization
      * When a serializer is configured on the connection, returns the value as-is
      * (phpredis already unserialized it). Otherwise, uses PHP unserialization.
      *
-     * @param RedisConnection $conn The connection to use for unserialization checks
+     * @param RedisConnection $connection The connection to use for unserialization checks
      * @param mixed $value The value to unserialize
      * @return mixed The unserialized value, or null if input was null/false
      */
-    public function unserialize(RedisConnection $conn, mixed $value): mixed
+    public function unserialize(RedisConnection $connection, mixed $value): mixed
     {
         if ($value === null || $value === false) {
             return null;
         }
 
-        if ($conn->serialized()) {
+        if ($connection->serialized()) {
             return $value;
         }
 

--- a/src/cache/src/Redis/Support/StoreContext.php
+++ b/src/cache/src/Redis/Support/StoreContext.php
@@ -28,6 +28,9 @@ class StoreContext
 
     private readonly TagKeyBuilder $tagKeyBuilder;
 
+    /**
+     * Create a new store context instance.
+     */
     public function __construct(
         private readonly RedisFactory $redis,
         private readonly string $connectionName,
@@ -154,7 +157,7 @@ class StoreContext
     public function optPrefix(): string
     {
         return $this->withConnection(
-            fn (RedisConnection $connection) => (string) $connection->getOption(Redis::OPT_PREFIX)
+            fn (RedisConnection $connection): string => (string) $connection->getOption(Redis::OPT_PREFIX)
         );
     }
 

--- a/src/cache/src/Redis/Support/TagKeyBuilder.php
+++ b/src/cache/src/Redis/Support/TagKeyBuilder.php
@@ -9,12 +9,14 @@ use Hypervel\Cache\TagMode;
 /**
  * Builds Redis-internal tag storage key names.
  *
- * The key formats here are Redis implementation details that were
- * previously methods on the TagMode enum. Moved out so the enum stays
- * purely semantic.
+ * Keeping key formats here centralizes Redis implementation details while
+ * allowing the TagMode enum to remain purely semantic.
  */
 class TagKeyBuilder
 {
+    /**
+     * Create a new tag key builder instance.
+     */
     public function __construct(
         private readonly TagMode $mode,
         private readonly string $prefix,

--- a/src/collections/src/Arr.php
+++ b/src/collections/src/Arr.php
@@ -462,7 +462,7 @@ class Arr
             // Support depends on Collections, so this native depth cannot reference Support\Json; 513 reads 512 containers.
             $items instanceof Jsonable => json_decode($items->toJson(), true, 513),
             $items instanceof JsonSerializable => (array) $items->jsonSerialize(),
-            is_object($items) => (array) $items, // @phpstan-ignore function.alreadyNarrowedType
+            is_object($items) => (array) $items,
             default => throw new InvalidArgumentException('Items cannot be represented by a scalar value.'),
         };
     }

--- a/src/collections/src/Collection.php
+++ b/src/collections/src/Collection.php
@@ -1195,7 +1195,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function shift(int $count = 1): mixed
     {
-        // @phpstan-ignore smaller.alwaysFalse (defensive validation - native int type allows negative values)
         if ($count < 0) {
             throw new InvalidArgumentException('Number of shifted items may not be less than zero.');
         }
@@ -1242,11 +1241,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function sliding(int $size = 2, int $step = 1): static
     {
-        // @phpstan-ignore smaller.alwaysFalse (defensive validation - native int type allows non-positive values)
         if ($size < 1) {
             throw new InvalidArgumentException('Size value must be at least 1.');
         }
-        if ($step < 1) { // @phpstan-ignore smaller.alwaysFalse
+        if ($step < 1) {
             throw new InvalidArgumentException('Step value must be at least 1.');
         }
 

--- a/src/console/src/Application.php
+++ b/src/console/src/Application.php
@@ -55,6 +55,9 @@ class Application extends SymfonyApplication implements ConsoleApplicationContra
      */
     protected bool $commandLoaderSet = false;
 
+    /**
+     * Create a new console application instance.
+     */
     public function __construct(
         protected ApplicationContract $container,
         protected Dispatcher $dispatcher,
@@ -534,17 +537,15 @@ class Application extends SymfonyApplication implements ConsoleApplicationContra
     #[Override]
     protected function getDefaultInputDefinition(): InputDefinition
     {
-        return tap(parent::getDefaultInputDefinition(), function ($definition) {
+        return tap(parent::getDefaultInputDefinition(), function (InputDefinition $definition): void {
             $definition->addOption($this->getEnvironmentOption());
         });
     }
 
     /**
      * Get the global environment option for the definition.
-     *
-     * @return InputOption
      */
-    protected function getEnvironmentOption()
+    protected function getEnvironmentOption(): InputOption
     {
         return self::createEnvironmentOption();
     }

--- a/src/console/src/Command.php
+++ b/src/console/src/Command.php
@@ -298,8 +298,8 @@ class Command extends SymfonyCommand
         $callback = function () use ($input, $output, $commandMutex, &$exception): int {
             try {
                 $this->exitCode = $this->executeCommand($input, $output);
-            } catch (Throwable $e) {
-                $exception = $e;
+            } catch (Throwable $throwable) {
+                $exception = $throwable;
                 $this->exitCode = self::FAILURE;
             } finally {
                 try {
@@ -350,7 +350,6 @@ class Command extends SymfonyCommand
                 $this->eventDispatcher->dispatch(new BeforeHandle($this));
             }
 
-            /* @phpstan-ignore-next-line */
             $statusCode = $this->hypervel->call([$this, $method]);
             if (is_int($statusCode)) {
                 $this->exitCode = $statusCode;
@@ -419,7 +418,7 @@ class Command extends SymfonyCommand
             if (! class_exists($command)) {
                 $command = clone $this->getApplication()->find($command);
             } else {
-                $command = $this->hypervel->make($command);
+                $command = clone $this->hypervel->make($command);
             }
         } else {
             $command = clone $command;

--- a/src/console/src/Commands/ScheduleClearCacheCommand.php
+++ b/src/console/src/Commands/ScheduleClearCacheCommand.php
@@ -24,7 +24,7 @@ class ScheduleClearCacheCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle(Schedule $schedule)
+    public function handle(Schedule $schedule): void
     {
         $mutexCleared = false;
 

--- a/src/console/src/Commands/ScheduleListCommand.php
+++ b/src/console/src/Commands/ScheduleListCommand.php
@@ -54,7 +54,7 @@ class ScheduleListCommand extends Command
      *
      * @throws Exception
      */
-    public function handle()
+    public function handle(): void
     {
         $environments = Arr::wrap($this->option('environment'));
 
@@ -328,7 +328,7 @@ class ScheduleListCommand extends Command
 
             return sprintf(
                 '%s:%s',
-                str_replace($this->hypervel->basePath() . DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''), /* @phpstan-ignore-line */
+                str_replace($this->hypervel->basePath() . DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
                 $function->getStartLine()
             );
         }

--- a/src/console/src/Commands/ScheduleTestCommand.php
+++ b/src/console/src/Commands/ScheduleTestCommand.php
@@ -28,7 +28,7 @@ class ScheduleTestCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(): void
     {
         $commands = $this->hypervel->make(Schedule::class)->events();
 
@@ -45,11 +45,13 @@ class ScheduleTestCommand extends Command
         }
 
         if (empty($commandNames)) {
-            return $this->info('No scheduled commands have been defined.'); // @phpstan-ignore method.void
+            $this->components->info('No scheduled commands have been defined.');
+
+            return;
         }
 
         if (! empty($name = $this->option('name'))) {
-            $matches = array_filter($commandNames, function ($commandName) use ($name) {
+            $matches = array_filter($commandNames, function (string $commandName) use ($name): bool {
                 return trim(preg_replace('/^php artisan /', '', $commandName)) === $name;
             });
 
@@ -98,7 +100,7 @@ class ScheduleTestCommand extends Command
     {
         if (count($commandNames) !== count(array_unique($commandNames))) {
             // Some commands (likely closures) have the same name, append unique indexes to each one...
-            $uniqueCommandNames = array_map(function ($index, $value) {
+            $uniqueCommandNames = array_map(function (int $index, string $value): string {
                 return "{$value} [{$index}]";
             }, array_keys($commandNames), $commandNames);
 

--- a/src/console/src/QuestionHelper.php
+++ b/src/console/src/QuestionHelper.php
@@ -57,7 +57,7 @@ class QuestionHelper extends SymfonyQuestionHelper
 
         if ($question instanceof ChoiceQuestion) {
             foreach ($question->getChoices() as $key => $value) {
-                (new TwoColumnDetail($output))->render($value, $key); /* @phpstan-ignore-line */
+                (new TwoColumnDetail($output))->render($value, $key);
             }
         }
 

--- a/src/container/src/Container.php
+++ b/src/container/src/Container.php
@@ -83,28 +83,28 @@ class Container implements ContainerContract
      *
      * @var bool[]
      */
-    protected $resolved = [];
+    protected array $resolved = [];
 
     /**
      * The container's bindings.
      *
      * @var array[]
      */
-    protected $bindings = [];
+    protected array $bindings = [];
 
     /**
      * The container's method bindings.
      *
      * @var Closure[]
      */
-    protected $methodBindings = [];
+    protected array $methodBindings = [];
 
     /**
      * The container's shared instances.
      *
      * @var array<string, mixed>
      */
-    protected $instances = [];
+    protected array $instances = [];
 
     /**
      * Auto-singletoned instances for unbound concrete classes.
@@ -116,7 +116,7 @@ class Container implements ContainerContract
      *
      * @var object[]
      */
-    protected $autoSingletons = [];
+    protected array $autoSingletons = [];
 
     /**
      * Cacheable first resolutions currently owned by a coroutine.
@@ -143,119 +143,119 @@ class Container implements ContainerContract
      *
      * @var array<string, true>
      */
-    protected $scopedInstances = [];
+    protected array $scopedInstances = [];
 
     /**
      * The registered type aliases.
      *
      * @var string[]
      */
-    protected $aliases = [];
+    protected array $aliases = [];
 
     /**
      * The registered aliases keyed by the abstract name.
      *
      * @var array[]
      */
-    protected $abstractAliases = [];
+    protected array $abstractAliases = [];
 
     /**
      * The extension closures for services.
      *
      * @var array[]
      */
-    protected $extenders = [];
+    protected array $extenders = [];
 
     /**
      * All of the registered tags.
      *
      * @var array[]
      */
-    protected $tags = [];
+    protected array $tags = [];
 
     /**
      * The contextual binding map.
      *
      * @var array[]
      */
-    public $contextual = [];
+    public array $contextual = [];
 
     /**
      * The contextual attribute handlers.
      *
      * @var array[]
      */
-    public $contextualAttributes = [];
+    public array $contextualAttributes = [];
 
     /**
      * Whether an abstract class has already had its attributes checked for bindings.
      *
      * @var array<class-string, true>
      */
-    protected $checkedForAttributeBindings = [];
+    protected array $checkedForAttributeBindings = [];
 
     /**
      * Whether a class has already been checked for Singleton or Scoped attributes.
      *
      * @var array<class-string, null|"scoped"|"singleton">
      */
-    protected $checkedForSingletonOrScopedAttributes = [];
+    protected array $checkedForSingletonOrScopedAttributes = [];
 
     /**
      * All of the registered rebound callbacks.
      *
      * @var array[]
      */
-    protected $reboundCallbacks = [];
+    protected array $reboundCallbacks = [];
 
     /**
      * All of the global before resolving callbacks.
      *
      * @var Closure[]
      */
-    protected $globalBeforeResolvingCallbacks = [];
+    protected array $globalBeforeResolvingCallbacks = [];
 
     /**
      * All of the global resolving callbacks.
      *
      * @var Closure[]
      */
-    protected $globalResolvingCallbacks = [];
+    protected array $globalResolvingCallbacks = [];
 
     /**
      * All of the global after resolving callbacks.
      *
      * @var Closure[]
      */
-    protected $globalAfterResolvingCallbacks = [];
+    protected array $globalAfterResolvingCallbacks = [];
 
     /**
      * All of the before resolving callbacks by class type.
      *
      * @var array[]
      */
-    protected $beforeResolvingCallbacks = [];
+    protected array $beforeResolvingCallbacks = [];
 
     /**
      * All of the resolving callbacks by class type.
      *
      * @var array[]
      */
-    protected $resolvingCallbacks = [];
+    protected array $resolvingCallbacks = [];
 
     /**
      * All of the after resolving callbacks by class type.
      *
      * @var array[]
      */
-    protected $afterResolvingCallbacks = [];
+    protected array $afterResolvingCallbacks = [];
 
     /**
      * All of the after resolving attribute callbacks by class type.
      *
      * @var array<string, list<Closure>>
      */
-    protected $afterResolvingAttributeCallbacks = [];
+    protected array $afterResolvingAttributeCallbacks = [];
 
     /**
      * The callback used to determine the container's environment.

--- a/src/coordinator/src/Timer.php
+++ b/src/coordinator/src/Timer.php
@@ -34,6 +34,9 @@ class Timer
 
     private static int $round = 0;
 
+    /**
+     * Create a new timer instance.
+     */
     public function __construct(private ?LoggerInterface $logger = null)
     {
     }

--- a/src/core/src/Logger/StdoutLogger.php
+++ b/src/core/src/Logger/StdoutLogger.php
@@ -51,6 +51,9 @@ class StdoutLogger implements StdoutLoggerInterface
     /** @var array<string, true> */
     private array $logLevels;
 
+    /**
+     * Create a new stdout logger instance.
+     */
     public function __construct(private Repository $config, ?OutputInterface $output = null)
     {
         $this->output = $output ?? new ConsoleOutput;

--- a/src/database/src/ConnectionResolver.php
+++ b/src/database/src/ConnectionResolver.php
@@ -48,6 +48,9 @@ class ConnectionResolver implements ConnectionResolverInterface
      */
     protected array $nonCoroutineConnections = [];
 
+    /**
+     * Create a new connection resolver instance.
+     */
     public function __construct(
         protected Container $container
     ) {

--- a/src/database/src/Connectors/Connector.php
+++ b/src/database/src/Connectors/Connector.php
@@ -62,7 +62,7 @@ class Connector
     {
         return version_compare(PHP_VERSION, '8.4.0', '<')
             ? new PDO($dsn, $username, $password, $options)
-            : PDO::connect($dsn, $username, $password, $options); /* @phpstan-ignore staticMethod.notFound (PHP 8.4) */
+            : PDO::connect($dsn, $username, $password, $options);
     }
 
     /**

--- a/src/database/src/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/database/src/Eloquent/BroadcastableModelEventOccurred.php
@@ -57,7 +57,7 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
             : $this->channels;
 
         return (new Collection($channels))
-            ->map(fn ($channel) => $channel instanceof Model ? new PrivateChannel($channel) : $channel) /* @phpstan-ignore-line */
+            ->map(fn ($channel) => $channel instanceof Model ? new PrivateChannel($channel) : $channel)
             ->all();
     }
 

--- a/src/database/src/Eloquent/Builder.php
+++ b/src/database/src/Eloquent/Builder.php
@@ -475,7 +475,7 @@ class Builder implements BuilderContract
             return [];
         }
 
-        if (! is_array(array_first($values))) { /* @phpstan-ignore function.alreadyNarrowedType */
+        if (! is_array(array_first($values))) {
             $values = [$values];
         }
 
@@ -660,7 +660,6 @@ class Builder implements BuilderContract
         try {
             return $this->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, value($values))));
         } catch (UniqueConstraintViolationException $e) {
-            // @phpstan-ignore return.type (first() returns hydrated TModel, not stdClass)
             return $this->useWritePdo()->where($attributes)->first() ?? throw $e;
         }
     }
@@ -1379,7 +1378,7 @@ class Builder implements BuilderContract
      */
     public function hasNamedScope(string $scope): bool
     {
-        return $this->model && $this->model->hasNamedScope($scope); // @phpstan-ignore booleanAnd.leftAlwaysTrue (model can be null before setModel() is called)
+        return $this->model && $this->model->hasNamedScope($scope);
     }
 
     /**

--- a/src/database/src/Eloquent/Casts/AsCollection.php
+++ b/src/database/src/Eloquent/Casts/AsCollection.php
@@ -96,7 +96,6 @@ class AsCollection implements Castable
             $map = $map[0] . '@' . $map[1];
         }
 
-        // @phpstan-ignore argument.type (implode handles null gracefully for serialization format)
         return static::class . ':' . implode(',', [$class, $map]);
     }
 }

--- a/src/database/src/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/database/src/Eloquent/Casts/AsEncryptedCollection.php
@@ -101,7 +101,6 @@ class AsEncryptedCollection implements Castable
             $map = $map[0] . '@' . $map[1];
         }
 
-        // @phpstan-ignore argument.type (implode handles null gracefully for serialization format)
         return static::class . ':' . implode(',', [$class, $map]);
     }
 }

--- a/src/database/src/Eloquent/Collection.php
+++ b/src/database/src/Eloquent/Collection.php
@@ -247,7 +247,7 @@ class Collection extends BaseCollection implements QueueableCollection
         [$relation, $class] = array_shift($tuples);
 
         $this->filter(function ($model) use ($relation, $class) {
-            // @phpstan-ignore function.impossibleType (collection may contain nulls at runtime)
+            // The collection may contain nulls at runtime.
             return ! is_null($model)
                 && ! $model->relationLoaded($relation)
                 && $model::class === $class;
@@ -281,7 +281,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $relation = reset($relation);
         }
 
-        // @phpstan-ignore function.impossibleType (collection may contain nulls at runtime)
+        // The collection may contain nulls at runtime.
         $models->filter(fn ($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
 
         if (empty($path)) {
@@ -407,7 +407,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::map($callback);
 
-        // @phpstan-ignore instanceof.alwaysTrue (callback may transform to non-Model types)
+        // The callback may transform the items to non-model values.
         return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
@@ -427,7 +427,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::mapWithKeys($callback);
 
-        // @phpstan-ignore instanceof.alwaysTrue (callback may transform to non-Model types)
+        // The callback may transform the items to non-model values.
         return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
@@ -727,7 +727,6 @@ class Collection extends BaseCollection implements QueueableCollection
 
     /**
      * @return \Hypervel\Support\Collection<int<0, 1>, static<TKey, TModel>>
-     * @phpstan-ignore return.phpDocType (partition returns Collection of collections)
      */
     #[Override]
     public function partition(mixed $key, mixed $operator = null, mixed $value = null)

--- a/src/database/src/Eloquent/Concerns/PreventsCircularRecursion.php
+++ b/src/database/src/Eloquent/Concerns/PreventsCircularRecursion.php
@@ -87,7 +87,7 @@ trait PreventsCircularRecursion
     {
         static::getRecursionCache()->offsetSet(
             $object,
-            tap(static::getRecursiveCallStack($object), fn (&$stack) => $stack[$hash] = $value),
+            tap(static::getRecursiveCallStack($object), fn (array &$stack) => $stack[$hash] = $value),
         );
 
         return static::getRecursiveCallStack($object)[$hash];

--- a/src/database/src/Eloquent/Model.php
+++ b/src/database/src/Eloquent/Model.php
@@ -1928,7 +1928,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $builderClass = static::$resolvedBuilderClasses[static::class]
             ??= $this->resolveCustomBuilderClass();
 
-        // @phpstan-ignore function.alreadyNarrowedType (defensive: validates custom builder class at runtime)
         if ($builderClass && is_subclass_of($builderClass, Builder::class)) {
             return new $builderClass($query);
         }
@@ -2075,7 +2074,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         return $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
             ->useWritePdo()
-            ->with(is_string($with) ? func_get_args() : $with) // @phpstan-ignore method.notFound (Eloquent __call forwarding)
+            ->with(is_string($with) ? func_get_args() : $with)
             ->first();
     }
 
@@ -2858,7 +2857,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         if (version_compare(PHP_VERSION, '8.4.0', '>=')) {
             foreach ((new ReflectionClass($this))->getProperties() as $property) {
-                // @phpstan-ignore method.notFound (PHP 8.4+ only, guarded by version check)
                 if ($property->hasHooks()) {
                     unset($keys[$property->getName()]);
                 }

--- a/src/database/src/Eloquent/ModelInspector.php
+++ b/src/database/src/Eloquent/ModelInspector.php
@@ -218,7 +218,6 @@ class ModelInspector
      */
     protected function getEvents(Model $model): BaseCollection
     {
-        // @phpstan-ignore return.type (values() resets keys to int, PHPStan doesn't track this)
         return (new BaseCollection($model->dispatchesEvents()))
             ->map(fn (string $class, string $event) => [
                 'event' => $event,
@@ -342,7 +341,6 @@ class ModelInspector
      */
     protected function getCastsWithDates(Model $model): BaseCollection
     {
-        // @phpstan-ignore return.type (flip() makes column names the keys, PHPStan doesn't track this)
         return (new BaseCollection($model->getDates()))
             ->filter()
             ->flip()

--- a/src/database/src/Eloquent/Relations/HasManyThrough.php
+++ b/src/database/src/Eloquent/Relations/HasManyThrough.php
@@ -26,7 +26,6 @@ class HasManyThrough extends HasOneOrManyThrough
      */
     public function one(): HasOneThrough
     {
-        // @phpstan-ignore return.type (template types lost through closure/tap in noConstraints)
         return HasOneThrough::noConstraints(fn () => new HasOneThrough(
             tap($this->getQuery(), fn (Builder $query) => $query->getQuery()->joins = []),
             $this->farParent,

--- a/src/database/src/Eloquent/Relations/HasOneOrMany.php
+++ b/src/database/src/Eloquent/Relations/HasOneOrMany.php
@@ -251,10 +251,8 @@ abstract class HasOneOrMany extends Relation
     public function createOrFirst(array $attributes = [], Closure|array $values = []): Model
     {
         try {
-            // @phpstan-ignore return.type (generic type lost through withSavepointIfNeeded callback)
             return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, value($values))));
         } catch (UniqueConstraintViolationException $e) {
-            // @phpstan-ignore return.type (generic type lost through where()->first() chain)
             return $this->useWritePdo()->where($attributes)->first() ?? throw $e;
         }
     }

--- a/src/database/src/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/database/src/Eloquent/Relations/HasOneOrManyThrough.php
@@ -91,7 +91,6 @@ abstract class HasOneOrManyThrough extends Relation
 
         $localValue = $this->farParent[$this->localKey];
 
-        // @phpstan-ignore argument.type (Builder<*> vs Builder<TRelatedModel>)
         $this->performJoin($query);
 
         if (static::shouldAddConstraints()) {
@@ -223,7 +222,6 @@ abstract class HasOneOrManyThrough extends Relation
         try {
             return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, value($values))));
         } catch (UniqueConstraintViolationException $exception) {
-            // @phpstan-ignore return.type (generic type lost through where()->first() chain)
             return $this->useWritePdo()->where($attributes)->first() ?? throw $exception;
         }
     }
@@ -622,7 +620,6 @@ abstract class HasOneOrManyThrough extends Relation
             return $this->getRelationExistenceQueryForThroughSelfRelation($query, $parentQuery, $columns);
         }
 
-        // @phpstan-ignore argument.type (Builder<*> vs Builder<TRelatedModel>)
         $this->performJoin($query);
 
         // @phpstan-ignore return.type (fluent query methods return the Eloquent builder at runtime)

--- a/src/database/src/Eloquent/Relations/Relation.php
+++ b/src/database/src/Eloquent/Relations/Relation.php
@@ -196,7 +196,6 @@ abstract class Relation implements BuilderContract
             throw new MultipleRecordsFoundException($count);
         }
 
-        // @phpstan-ignore return.type (Collection::first() generic type lost; count check above ensures non-null)
         return $result->first();
     }
 
@@ -468,7 +467,6 @@ abstract class Relation implements BuilderContract
     protected static function buildMorphMapFromModels(?array $models = null): ?array
     {
         if (is_null($models) || ! array_is_list($models)) {
-            // @phpstan-ignore return.type (returns the keyed array unchanged)
             return $models;
         }
 

--- a/src/database/src/Pool/PooledConnection.php
+++ b/src/database/src/Pool/PooledConnection.php
@@ -57,6 +57,9 @@ class PooledConnection implements PoolConnectionInterface
 
     protected ?Dispatcher $dispatcher = null;
 
+    /**
+     * Create a new pooled connection instance.
+     */
     public function __construct(
         protected Container $container,
         protected DbPool $pool,

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -3847,11 +3847,9 @@ class Builder implements BuilderContract
     public function incrementEach(array $columns, array $extra = []): int
     {
         foreach ($columns as $column => $amount) {
-            // @phpstan-ignore function.alreadyNarrowedType (runtime validation for user input)
             if (! is_numeric($amount)) {
                 throw new InvalidArgumentException("Non-numeric value passed as increment amount for column: '{$column}'.");
             }
-            // @phpstan-ignore function.alreadyNarrowedType (runtime validation - user could pass indexed array)
             if (! is_string($column)) {
                 throw new InvalidArgumentException('Non-associative array passed to incrementEach method.');
             }

--- a/src/database/src/Query/Grammars/PostgresGrammar.php
+++ b/src/database/src/Query/Grammars/PostgresGrammar.php
@@ -640,7 +640,6 @@ class PostgresGrammar extends Grammar
             ->map(fn ($attribute) => $this->parseJsonPathArrayKeys($attribute))
             ->collapse()
             ->map(function ($attribute) use ($quote) {
-                // @phpstan-ignore notIdentical.alwaysFalse (PHPDoc type inference too narrow; runtime values can be numeric strings)
                 return filter_var($attribute, FILTER_VALIDATE_INT) !== false
                     ? $attribute
                     : $quote . $attribute . $quote;

--- a/src/database/src/Schema/MySqlSchemaState.php
+++ b/src/database/src/Schema/MySqlSchemaState.php
@@ -109,22 +109,18 @@ class MySqlSchemaState extends SchemaState
             ? ' --socket="${:HYPERVEL_LOAD_SOCKET}"'
             : ' --host="${:HYPERVEL_LOAD_HOST}" --port="${:HYPERVEL_LOAD_PORT}"';
 
-        /* @phpstan-ignore class.notFound */
         if (isset($config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA])) {
             $value .= ' --ssl-ca="${:HYPERVEL_LOAD_SSL_CA}"';
         }
 
-        /* @phpstan-ignore class.notFound */
         if (isset($config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : PDO::MYSQL_ATTR_SSL_CERT])) {
             $value .= ' --ssl-cert="${:HYPERVEL_LOAD_SSL_CERT}"';
         }
 
-        /* @phpstan-ignore class.notFound */
         if (isset($config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : PDO::MYSQL_ATTR_SSL_KEY])) {
             $value .= ' --ssl-key="${:HYPERVEL_LOAD_SSL_KEY}"';
         }
 
-        /** @phpstan-ignore class.notFound */
         $verifyCertOption = PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
 
         if (isset($config['options'][$verifyCertOption]) && $config['options'][$verifyCertOption] === false) {
@@ -153,9 +149,9 @@ class MySqlSchemaState extends SchemaState
             'HYPERVEL_LOAD_USER' => $config['username'],
             'HYPERVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'HYPERVEL_LOAD_DATABASE' => $config['database'],
-            'HYPERVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound
-            'HYPERVEL_LOAD_SSL_CERT' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : PDO::MYSQL_ATTR_SSL_CERT] ?? '', // @phpstan-ignore class.notFound
-            'HYPERVEL_LOAD_SSL_KEY' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : PDO::MYSQL_ATTR_SSL_KEY] ?? '', // @phpstan-ignore class.notFound
+            'HYPERVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA] ?? '',
+            'HYPERVEL_LOAD_SSL_CERT' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : PDO::MYSQL_ATTR_SSL_CERT] ?? '',
+            'HYPERVEL_LOAD_SSL_KEY' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : PDO::MYSQL_ATTR_SSL_KEY] ?? '',
         ]);
     }
 

--- a/src/engine/src/WebSocket/WebSocket.php
+++ b/src/engine/src/WebSocket/WebSocket.php
@@ -51,7 +51,7 @@ class WebSocket implements WebSocketInterface
         try {
             while (true) {
                 /** @var false|string|SwFrame $frame */
-                $frame = $this->connection->recv(-1); // @phpstan-ignore arguments.count (recv accepts timeout parameter)
+                $frame = $this->connection->recv(-1);
                 if ($frame === false) {
                     $this->logger?->warning(
                         sprintf(

--- a/src/fortify/src/Actions/RedirectIfTwoFactorAuthenticatable.php
+++ b/src/fortify/src/Actions/RedirectIfTwoFactorAuthenticatable.php
@@ -103,7 +103,7 @@ class RedirectIfTwoFactorAuthenticatable implements RedirectsIfTwoFactorAuthenti
             throw new RuntimeException('Fortify password authentication requires a guard with a user provider.');
         }
 
-        $provider = $guard->getProvider(); /* @phpstan-ignore method.notFound (getProvider() is on GuardHelpers, not the guard contract) */
+        $provider = $guard->getProvider();
 
         if (! $provider instanceof UserProvider) {
             throw new RuntimeException('Fortify password authentication requires a guard with a user provider.');

--- a/src/fortify/src/Http/Requests/TwoFactorLoginRequest.php
+++ b/src/fortify/src/Http/Requests/TwoFactorLoginRequest.php
@@ -169,7 +169,7 @@ class TwoFactorLoginRequest extends FormRequest
             throw new RuntimeException('Fortify two-factor login requires an Eloquent authentication guard provider.');
         }
 
-        $provider = $guard->getProvider(); /* @phpstan-ignore method.notFound (getProvider() is on GuardHelpers, not the guard contract) */
+        $provider = $guard->getProvider();
 
         if (! $provider instanceof EloquentUserProvider) {
             throw new RuntimeException('Fortify two-factor login requires an Eloquent authentication guard provider.');

--- a/src/foundation/src/Bootstrap/HandleExceptions.php
+++ b/src/foundation/src/Bootstrap/HandleExceptions.php
@@ -282,7 +282,7 @@ class HandleExceptions
         if (class_exists(ErrorHandler::class)) {
             $instance = ErrorHandler::instance();
 
-            if ((fn () => $this->enabled ?? false)->call($instance)) { // @phpstan-ignore nullCoalesce.property, if.alwaysFalse (Closure::call() rebinds $this to ErrorHandler; phpstan can't model this)
+            if ((fn () => $this->enabled ?? false)->call($instance)) { // @phpstan-ignore nullCoalesce.property (Closure::call() rebinds $this to ErrorHandler; PHPStan cannot model this)
                 $instance->disable();
                 $instance->enable($testCase);
             }

--- a/src/foundation/src/Configuration/Middleware.php
+++ b/src/foundation/src/Configuration/Middleware.php
@@ -345,7 +345,6 @@ class Middleware
     public function getMiddlewareGroups(): array
     {
         $middleware = [
-            /* @phpstan-ignore arrayValues.list */
             'web' => array_values(array_filter([
                 \Hypervel\Cookie\Middleware\EncryptCookies::class,
                 \Hypervel\Cookie\Middleware\AddQueuedCookiesToResponse::class,

--- a/src/foundation/src/Console/Kernel.php
+++ b/src/foundation/src/Console/Kernel.php
@@ -503,8 +503,8 @@ class Kernel implements KernelContract
         $this->app->instance(ApplicationContract::class, $this->artisan);
 
         if ($this->symfonyDispatcher instanceof EventDispatcher) {
-            $this->artisan->setDispatcher($this->symfonyDispatcher); /* @phpstan-ignore-line */
-            $this->artisan->setSignalsToDispatchEvent(); /* @phpstan-ignore-line */
+            $this->artisan->setDispatcher($this->symfonyDispatcher);
+            $this->artisan->setSignalsToDispatchEvent();
         }
 
         return $this->artisan;

--- a/src/foundation/src/Exceptions/Renderer/Frame.php
+++ b/src/foundation/src/Exceptions/Renderer/Frame.php
@@ -74,7 +74,7 @@ class Frame
     {
         return match (true) {
             ! isset($this->frame['file']) => '[internal function]',
-            ! is_string($this->frame['file']) => '[unknown file]', // @phpstan-ignore booleanNot.alwaysFalse (defensive, matches Laravel)
+            ! is_string($this->frame['file']) => '[unknown file]',
             default => str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $this->frame['file']),
         };
     }
@@ -119,7 +119,7 @@ class Frame
      */
     public function args(): array
     {
-        if (! isset($this->frame['args']) || ! is_array($this->frame['args']) || count($this->frame['args']) === 0) { // @phpstan-ignore booleanNot.alwaysFalse (defensive, no native type enforcement)
+        if (! isset($this->frame['args']) || ! is_array($this->frame['args']) || count($this->frame['args']) === 0) {
             return [];
         }
 

--- a/src/foundation/src/helpers.php
+++ b/src/foundation/src/helpers.php
@@ -238,7 +238,6 @@ if (! function_exists('bcrypt')) {
      */
     function bcrypt(#[\SensitiveParameter] string $value, array $options = []): string
     {
-        /* @phpstan-ignore-next-line */
         return app('hash')->driver('bcrypt')->make($value, $options);
     }
 }
@@ -301,7 +300,7 @@ if (! function_exists('cache')) {
             return $manager->get($key, $default);
         }
 
-        if (! is_array($key)) { // @phpstan-ignore function.alreadyNarrowedType (validates PHPDoc contract at runtime)
+        if (! is_array($key)) {
             throw new InvalidArgumentException(
                 'When setting a value in the cache, you must pass an array of key / value pairs.'
             );
@@ -441,7 +440,6 @@ if (! function_exists('decrypt')) {
      */
     function decrypt(string $value, bool $unserialize = true): mixed
     {
-        /* @phpstan-ignore-next-line */
         return app('encrypter')->decrypt($value, $unserialize);
     }
 }
@@ -481,7 +479,6 @@ if (! function_exists('encrypt')) {
      */
     function encrypt(#[\SensitiveParameter] mixed $value, bool $serialize = true): string
     {
-        /* @phpstan-ignore-next-line */
         return app('encrypter')->encrypt($value, $serialize);
     }
 }

--- a/src/horizon/src/AutoScaler.php
+++ b/src/horizon/src/AutoScaler.php
@@ -68,8 +68,8 @@ class AutoScaler
             });
 
             return [$queue => [
-                'size' => $queues->sum('size'), // @phpstan-ignore argument.unresolvableType
-                'time' => $queues->sum('time'), // @phpstan-ignore argument.unresolvableType
+                'size' => $queues->sum('size'),
+                'time' => $queues->sum('time'),
             ]];
         });
     }

--- a/src/horizon/src/Console/ForgetFailedCommand.php
+++ b/src/horizon/src/Console/ForgetFailedCommand.php
@@ -33,7 +33,7 @@ class ForgetFailedCommand extends Command
             do {
                 $failedJobs = collect($repository->getFailed());
 
-                $failedJobs->pluck('id')->each(function (string $failedId) use ($repository): void { // @phpstan-ignore argument.type
+                $failedJobs->pluck('id')->each(function (string $failedId) use ($repository): void {
                     $repository->deleteFailed($failedId);
 
                     if ($this->hypervel->make(FailedJobProviderInterface::class)->forget($failedId)) {

--- a/src/horizon/src/Notifications/LongWaitDetected.php
+++ b/src/horizon/src/Notifications/LongWaitDetected.php
@@ -84,12 +84,12 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
                 ->username($fromName)
                 ->text($text)
                 ->headerBlock($title)
-                ->sectionBlock(function (SectionBlock $block) use ($content): void { // @phpstan-ignore-line
+                ->sectionBlock(function (SectionBlock $block) use ($content): void {
                     $block->text($content);
                 });
         }
 
-        return (new SlackMessage) // @phpstan-ignore-line
+        return (new SlackMessage)
             ->from($fromName)
             ->to(Horizon::$slackChannel)
             ->error()

--- a/src/horizon/src/Repositories/RedisJobRepository.php
+++ b/src/horizon/src/Repositories/RedisJobRepository.php
@@ -519,7 +519,7 @@ class RedisJobRepository implements JobRepository
             $this->keys
         );
 
-        $job = is_array($attributes) && $attributes[0] !== null // @phpstan-ignore function.alreadyNarrowedType (Redis hmget can return false at runtime despite PHPDoc)
+        $job = is_array($attributes) && $attributes[0] !== null
             ? (object) array_combine($this->keys, $attributes)
             : null;
 
@@ -603,7 +603,6 @@ class RedisJobRepository implements JobRepository
      */
     public function deleteFailed(string $id): int
     {
-        /* @phpstan-ignore-next-line */
         return $this->connection()->zrem('failed_jobs', $id) !== 1
             ? 0
             : $this->connection()->del($id);

--- a/src/horizon/src/WaitTimeCalculator.php
+++ b/src/horizon/src/WaitTimeCalculator.php
@@ -62,7 +62,7 @@ class WaitTimeCalculator
 
         return $queue === null || $queue === ''
             ? $queues
-            : $queues->intersect([$queue]); // @phpstan-ignore argument.type
+            : $queues->intersect([$queue]);
     }
 
     /**

--- a/src/jwt/src/ClaimFactory.php
+++ b/src/jwt/src/ClaimFactory.php
@@ -55,7 +55,6 @@ class ClaimFactory
         ];
 
         if ($this->lockSubject && method_exists($provider, 'getModel')) {
-            /* @phpstan-ignore-next-line method.notFound */
             $claims['prv'] = $this->subjectModelHash($provider->getModel());
         }
 
@@ -128,7 +127,6 @@ class ClaimFactory
             return true;
         }
 
-        /* @phpstan-ignore-next-line method.notFound */
         $model = $provider->getModel();
 
         return isset($payload['prv'])

--- a/src/log/src/LogManager.php
+++ b/src/log/src/LogManager.php
@@ -159,7 +159,7 @@ class LogManager implements LoggerInterface
             $underlyingLogger = $logger->getLogger();
 
             if (method_exists($underlyingLogger, 'pushProcessor')) {
-                $underlyingLogger->pushProcessor($this->makeContextProcessor()); // @phpstan-ignore method.notFound
+                $underlyingLogger->pushProcessor($this->makeContextProcessor());
             }
 
             if ($cache) {

--- a/src/mail/src/Events/MessageSent.php
+++ b/src/mail/src/Events/MessageSent.php
@@ -27,7 +27,7 @@ class MessageSent
      */
     public function __serialize(): array
     {
-        $hasAttachments = (new Collection($this->message->getAttachments()))->isNotEmpty(); // @phpstan-ignore property.nonObject
+        $hasAttachments = (new Collection($this->message->getAttachments()))->isNotEmpty();
 
         return [
             'sent' => $this->sent,

--- a/src/mail/src/MailManager.php
+++ b/src/mail/src/MailManager.php
@@ -541,10 +541,8 @@ class MailManager implements FactoryContract
      */
     protected function createMailgunTransport(array $config): TransportInterface
     {
-        /* @phpstan-ignore-next-line */
         $factory = new MailgunTransportFactory(null, $this->getHttpClient($config));
 
-        /* @phpstan-ignore-next-line */
         return $factory->create(new Dsn(
             'mailgun+' . $config['scheme'],
             $config['endpoint'],
@@ -635,8 +633,6 @@ class MailManager implements FactoryContract
 
     /**
      * Get a configured Symfony HTTP client instance.
-     *
-     * @phpstan-ignore-next-line
      */
     protected function getHttpClient(array $config): ?HttpClientInterface
     {
@@ -647,7 +643,6 @@ class MailManager implements FactoryContract
             $maxHostConnections = Arr::pull($options, 'max_host_connections', 6);
             $maxPendingPushes = Arr::pull($options, 'max_pending_pushes', 50);
 
-            /* @phpstan-ignore-next-line */
             return HttpClient::create($options, $maxHostConnections, $maxPendingPushes);
         }
 

--- a/src/mail/src/Mailable.php
+++ b/src/mail/src/Mailable.php
@@ -1570,7 +1570,6 @@ class Mailable implements MailableContract, Renderable
             return;
         }
 
-        /* @phpstan-ignore-next-line */
         $attachments = $this->attachments();
 
         Collection::make(is_object($attachments) ? [$attachments] : $attachments)

--- a/src/mail/src/Transport/SesV2Transport.php
+++ b/src/mail/src/Transport/SesV2Transport.php
@@ -74,7 +74,7 @@ class SesV2Transport extends AbstractTransport implements Stringable
 
             throw new TransportException(
                 sprintf('Request to AWS SES V2 API failed. Reason: %s.', $reason),
-                is_int($e->getCode()) ? $e->getCode() : 0, // @phpstan-ignore function.alreadyNarrowedType
+                is_int($e->getCode()) ? $e->getCode() : 0,
                 $e
             );
         }

--- a/src/nested-set/src/Eloquent/AncestorsRelation.php
+++ b/src/nested-set/src/Eloquent/AncestorsRelation.php
@@ -89,7 +89,7 @@ class AncestorsRelation extends BaseRelation
             $minimumRgt = null;
 
             foreach ($group as $model) {
-                $rgt = $model->getRgt(); /* @phpstan-ignore method.notFound */
+                $rgt = $model->getRgt();
 
                 if ($rgt !== null && $minimumRgt !== null && $rgt >= $minimumRgt) {
                     continue;

--- a/src/nested-set/src/Eloquent/DescendantsRelation.php
+++ b/src/nested-set/src/Eloquent/DescendantsRelation.php
@@ -70,7 +70,7 @@ class DescendantsRelation extends BaseRelation
             $maximumRgt = null;
 
             foreach ($group as $model) {
-                $rgt = $model->getRgt(); /* @phpstan-ignore method.notFound */
+                $rgt = $model->getRgt();
 
                 if ($rgt !== null && $maximumRgt !== null && $rgt <= $maximumRgt) {
                     continue;

--- a/src/nested-set/src/Eloquent/QueryBuilder.php
+++ b/src/nested-set/src/Eloquent/QueryBuilder.php
@@ -1574,10 +1574,10 @@ class QueryBuilder extends EloquentBuilder
                 // Set the intended parent without scheduling a tree action.
                 static::assignRepairNode(
                     $model,
-                    $model->getLft(), /* @phpstan-ignore method.notFound */
-                    $model->getRgt(), /* @phpstan-ignore method.notFound */
+                    $model->getLft(),
+                    $model->getRgt(),
                     $parentId,
-                    $model->getDepth(), /* @phpstan-ignore method.notFound */
+                    $model->getDepth(),
                 );
 
                 unset($existing[$key]);
@@ -1586,11 +1586,11 @@ class QueryBuilder extends EloquentBuilder
             foreach ([
                 'children',
                 $keyName,
-                $model->getParentIdName(), /* @phpstan-ignore method.notFound */
-                $model->getLftName(), /* @phpstan-ignore method.notFound */
-                $model->getRgtName(), /* @phpstan-ignore method.notFound */
-                $model->getDepthName(), /* @phpstan-ignore method.notFound */
-                ...array_keys($model->getNestedSetScope()), /* @phpstan-ignore method.notFound */
+                $model->getParentIdName(),
+                $model->getLftName(),
+                $model->getRgtName(),
+                $model->getDepthName(),
+                ...array_keys($model->getNestedSetScope()),
             ] as $ownedAttribute) {
                 unset($itemData[$ownedAttribute]);
             }

--- a/src/nested-set/src/Eloquent/SiblingsRelation.php
+++ b/src/nested-set/src/Eloquent/SiblingsRelation.php
@@ -105,7 +105,7 @@ class SiblingsRelation extends BaseRelation
         foreach ($models as $model) {
             $scope = $this->scopeKey($model);
             $groups[$scope]['model'] ??= $model;
-            $parentId = $model->getParentId(); /* @phpstan-ignore method.notFound */
+            $parentId = $model->getParentId();
 
             if ($parentId === null) {
                 $groups[$scope]['has_root'] = true;
@@ -116,12 +116,12 @@ class SiblingsRelation extends BaseRelation
 
         foreach ($groups as $group) {
             $query->orWhere(function (QueryBuilder $query) use ($group) {
-                $group['model']->applyNestedSetScope($query); /* @phpstan-ignore method.notFound */
+                $group['model']->applyNestedSetScope($query);
 
                 $query->where(function (QueryBuilder $query) use ($group) {
                     $parents = array_values($group['parents'] ?? []);
                     $hasRoot = $group['has_root'] ?? false;
-                    $parentIdName = $group['model']->getParentIdName(); /* @phpstan-ignore method.notFound */
+                    $parentIdName = $group['model']->getParentIdName();
                     $qualifiedParentIdName = $group['model']->qualifyColumn($parentIdName);
 
                     if ($parents !== []) {

--- a/src/notifications/src/Channels/BroadcastChannel.php
+++ b/src/notifications/src/Channels/BroadcastChannel.php
@@ -49,11 +49,11 @@ class BroadcastChannel
     protected function getData(mixed $notifiable, Notification $notification): mixed
     {
         if (method_exists($notification, 'toBroadcast')) {
-            return $notification->toBroadcast($notifiable); /* @phpstan-ignore-line */
+            return $notification->toBroadcast($notifiable);
         }
 
         if (method_exists($notification, 'toArray')) {
-            return $notification->toArray($notifiable); /* @phpstan-ignore-line */
+            return $notification->toArray($notifiable);
         }
 
         throw new RuntimeException('Notification is missing toBroadcast / toArray method.');

--- a/src/notifications/src/Channels/DatabaseChannel.php
+++ b/src/notifications/src/Channels/DatabaseChannel.php
@@ -28,11 +28,11 @@ class DatabaseChannel
         return [
             'id' => $notification->id,
             'type' => method_exists($notification, 'databaseType')
-                ? $notification->databaseType($notifiable) // @phpstan-ignore-line
+                ? $notification->databaseType($notifiable)
                 : get_class($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => method_exists($notification, 'initialDatabaseReadAtValue')
-                ? $notification->initialDatabaseReadAtValue($notifiable) // @phpstan-ignore-line
+                ? $notification->initialDatabaseReadAtValue($notifiable)
                 : null,
         ];
     }
@@ -45,12 +45,11 @@ class DatabaseChannel
     protected function getData(mixed $notifiable, Notification $notification): array
     {
         if (method_exists($notification, 'toDatabase')) {
-            return is_array($data = $notification->toDatabase($notifiable)) // @phpstan-ignore-line
+            return is_array($data = $notification->toDatabase($notifiable))
                 ? $data : $data->data;
         }
 
         if (method_exists($notification, 'toArray')) {
-            /* @phpstan-ignore-next-line */
             return $notification->toArray($notifiable);
         }
 

--- a/src/notifications/src/Channels/MailChannel.php
+++ b/src/notifications/src/Channels/MailChannel.php
@@ -137,7 +137,6 @@ class MailChannel
     {
         $this->addressMessage($mailMessage, $notifiable, $notification, $message);
 
-        /* @phpstan-ignore-next-line */
         $mailMessage->subject($message->subject ?: Str::title(
             Str::snake(class_basename($notification), ' ')
         ));

--- a/src/notifications/src/Channels/SlackWebApiChannel.php
+++ b/src/notifications/src/Channels/SlackWebApiChannel.php
@@ -35,7 +35,6 @@ class SlackWebApiChannel
             throw new RuntimeException('Notification is missing `toSlack` method.');
         }
 
-        // @phpstan-ignore-next-line
         $message = $notification->toSlack($notifiable);
 
         $route = $this->determineRoute($notifiable, $notification);

--- a/src/notifications/src/Channels/SlackWebhookChannel.php
+++ b/src/notifications/src/Channels/SlackWebhookChannel.php
@@ -38,7 +38,7 @@ class SlackWebhookChannel
         }
 
         return $this->client->post($url, $this->buildJsonPayload(
-            $notification->toSlack($notifiable) // @phpstan-ignore-line
+            $notification->toSlack($notifiable)
         ));
     }
 

--- a/src/notifications/src/Events/BroadcastNotificationCreated.php
+++ b/src/notifications/src/Events/BroadcastNotificationCreated.php
@@ -78,7 +78,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     public function broadcastWith(): array
     {
         if (method_exists($this->notification, 'broadcastWith')) {
-            return $this->notification->broadcastWith(); /* @phpstan-ignore-line */
+            return $this->notification->broadcastWith();
         }
 
         return array_merge($this->data, [
@@ -93,7 +93,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     public function broadcastType(): string
     {
         return method_exists($this->notification, 'broadcastType')
-            ? $this->notification->broadcastType() /* @phpstan-ignore-line */
+            ? $this->notification->broadcastType()
             : get_class($this->notification);
     }
 
@@ -103,7 +103,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     public function broadcastAs(): string
     {
         return method_exists($this->notification, 'broadcastAs')
-            ? $this->notification->broadcastAs() /* @phpstan-ignore-line */
+            ? $this->notification->broadcastAs()
             : __CLASS__;
     }
 }

--- a/src/pagination/src/AbstractCursorPaginator.php
+++ b/src/pagination/src/AbstractCursorPaginator.php
@@ -574,8 +574,6 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function setCollection(Collection $collection): static
     {
-        // The receiver's templates are rebound by @phpstan-this-out only after this assignment.
-        /* @phpstan-ignore assign.propertyType */
         $this->items = $collection;
 
         return $this;

--- a/src/passkeys/src/Actions/VerifyPasskey.php
+++ b/src/passkeys/src/Actions/VerifyPasskey.php
@@ -169,7 +169,7 @@ class VerifyPasskey
             throw new RuntimeException('Passkey passwordless login requires an Eloquent authentication guard provider.');
         }
 
-        $provider = $guard->getProvider(); /* @phpstan-ignore method.notFound (getProvider() is on GuardHelpers, not the guard contract) */
+        $provider = $guard->getProvider();
 
         if (! $provider instanceof EloquentUserProvider) {
             throw new RuntimeException('Passkey passwordless login requires an Eloquent authentication guard provider.');

--- a/src/process/src/Pipe.php
+++ b/src/process/src/Pipe.php
@@ -54,7 +54,7 @@ class Pipe
 
         return (new Collection($this->pendingProcesses))
             ->reduce(function ($previousProcessResult, $pendingProcess, $key) use ($output) {
-                if (! $pendingProcess instanceof PendingProcess) { // @phpstan-ignore instanceof.alwaysTrue (defensive validation)
+                if (! $pendingProcess instanceof PendingProcess) {
                     throw new InvalidArgumentException('Process pipe must only contain pending processes.');
                 }
 

--- a/src/process/src/Pool.php
+++ b/src/process/src/Pool.php
@@ -53,7 +53,7 @@ class Pool
         call_user_func($this->callback, $this);
 
         foreach ($this->pendingProcesses as $pendingProcess) {
-            if (! $pendingProcess instanceof PendingProcess) { // @phpstan-ignore instanceof.alwaysTrue (defensive validation)
+            if (! $pendingProcess instanceof PendingProcess) {
                 throw new InvalidArgumentException('Process pool must only contain pending processes.');
             }
         }

--- a/src/prompts/src/Progress.php
+++ b/src/prompts/src/Progress.php
@@ -44,10 +44,10 @@ class Progress extends Prompt
     public function __construct(public string $label, public int|iterable $steps, public string $hint = '')
     {
         if ($this->steps instanceof Traversable && ! is_countable($this->steps)) {
-            $this->steps = iterator_to_array($this->steps, false); // @phpstan-ignore assign.propertyType (PHPStan cannot preserve the generic iterable property type after materialization.)
+            $this->steps = iterator_to_array($this->steps, false);
         }
 
-        $this->total = match (true) { // @phpstan-ignore assign.propertyType (PHPStan does not follow the normalized iterable through the match.)
+        $this->total = match (true) {
             is_int($this->steps) => $this->steps,
             is_countable($this->steps) => count($this->steps),
             default => throw new InvalidArgumentException('Unable to count steps.'),

--- a/src/prompts/src/Themes/Default/DataTableRenderer.php
+++ b/src/prompts/src/Themes/Default/DataTableRenderer.php
@@ -387,7 +387,7 @@ class DataTableRenderer extends Renderer implements Scrolling
             $dataLines = array_map(fn ($line, $index) => match ($index) {
                 $visualPos => preg_replace('/.$/', $this->cyan('┃'), $this->pad($line, $innerWidth)) ?? '',
                 default => preg_replace('/.$/', $this->gray('│'), $this->pad($line, $innerWidth)) ?? '',
-            }, array_values($dataLines), range(0, $numVisual - 1)); // @phpstan-ignore arrayValues.list
+            }, array_values($dataLines), range(0, $numVisual - 1));
         }
 
         return $dataLines;

--- a/src/prompts/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -61,7 +61,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
     protected function renderOptions(MultiSelectPrompt $prompt): string
     {
         return implode(PHP_EOL, $this->scrollbar(
-            array_values(array_map(function ($label, $key) use ($prompt) { // @phpstan-ignore arrayValues.list
+            array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 
                 $index = array_search($key, array_keys($prompt->options));

--- a/src/prompts/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/SearchPromptRenderer.php
@@ -109,7 +109,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
         }
 
         return implode(PHP_EOL, $this->scrollbar(
-            array_values(array_map(function ($label, $key) use ($prompt) { // @phpstan-ignore arrayValues.list
+            array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 10);
 
                 $index = array_search($key, array_keys($prompt->matches()));

--- a/src/prompts/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/SelectPromptRenderer.php
@@ -62,7 +62,7 @@ class SelectPromptRenderer extends Renderer implements Scrolling
     protected function renderOptions(SelectPrompt $prompt): string
     {
         return implode(PHP_EOL, $this->scrollbar(
-            array_values(array_map(function ($label, $key) use ($prompt) { // @phpstan-ignore arrayValues.list
+            array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 
                 $index = array_search($key, array_keys($prompt->options));

--- a/src/queue/src/DatabaseQueue.php
+++ b/src/queue/src/DatabaseQueue.php
@@ -458,9 +458,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function getLockForPopping(): bool|string
     {
-        /* @phpstan-ignore-next-line */
         $databaseEngine = $this->getDatabase()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        /* @phpstan-ignore-next-line */
         $databaseVersion = $this->getDatabase()->getConfig('version') ?? $this->getDatabase()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if (Str::of($databaseVersion)->contains('MariaDB')) {

--- a/src/queue/src/Jobs/BeanstalkdJob.php
+++ b/src/queue/src/Jobs/BeanstalkdJob.php
@@ -100,7 +100,6 @@ class BeanstalkdJob extends Job
             return $this->attempts;
         }
 
-        /* @phpstan-ignore-next-line */
         $stats = $this->getPheanstalk()->statsJob($this->job);
 
         return $this->attempts = (int) $stats->reserves;

--- a/src/queue/src/Worker.php
+++ b/src/queue/src/Worker.php
@@ -862,15 +862,11 @@ class Worker
             return;
         }
 
-        /* @phpstan-ignore-next-line */
         if (! $this->cache->get('job-exceptions:' . $uuid)) {
-            /* @phpstan-ignore-next-line */
             $this->cache->put('job-exceptions:' . $uuid, 0, CarbonImmutable::now()->addDay());
         }
 
-        /* @phpstan-ignore-next-line */
         if ($maxExceptions <= $this->cache->increment('job-exceptions:' . $uuid)) {
-            /* @phpstan-ignore-next-line */
             $this->cache->forget('job-exceptions:' . $uuid);
 
             $this->failJob($job, $e);

--- a/src/sanctum/src/Sanctum.php
+++ b/src/sanctum/src/Sanctum.php
@@ -100,7 +100,6 @@ class Sanctum
             $token->shouldReceive('can')->andReturn(true);
         } else {
             $expectation = $token->shouldReceive('can');
-            // @phpstan-ignore method.notFound (A named shouldReceive() returns an expectation, not HigherOrderMessage.)
             $expectation->andReturnUsing(function (UnitEnum|string $ability) use ($abilities): bool {
                 return in_array(enum_value($ability), $abilities, true);
             });
@@ -109,9 +108,7 @@ class Sanctum
         // @phpstan-ignore method.notFound (The documented HasApiTokens trait provides this method.)
         $user->withAccessToken($token);
 
-        // @phpstan-ignore property.notFound (Eloquent and compatible authenticatables expose this testing flag.)
         if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
-            // @phpstan-ignore property.notFound (Eloquent and compatible authenticatables expose this testing flag.)
             $user->wasRecentlyCreated = false;
         }
 

--- a/src/sentry/src/SentryServiceProvider.php
+++ b/src/sentry/src/SentryServiceProvider.php
@@ -481,7 +481,6 @@ class SentryServiceProvider extends ServiceProvider
      */
     protected function registerCoroutineContextPropagation(): void
     {
-        /* @phpstan-ignore-next-line */
         Coroutine::afterCreated(function (): void {
             $parentId = Coroutine::parentId();
             $stack = CoroutineContext::get(Hub::CONTEXT_STACK_KEY)

--- a/src/support/src/Lottery.php
+++ b/src/support/src/Lottery.php
@@ -52,7 +52,7 @@ class Lottery
             throw new RuntimeException('Float must not be greater than 1.');
         }
 
-        if ($outOf !== null && $outOf < 1) { /* @phpstan-ignore smaller.alwaysFalse, booleanAnd.alwaysFalse */
+        if ($outOf !== null && $outOf < 1) {
             throw new RuntimeException('Lottery "out of" value must be greater than or equal to 1.');
         }
 

--- a/src/support/src/Str.php
+++ b/src/support/src/Str.php
@@ -881,7 +881,7 @@ class Str
         $length = $length - $password->count();
 
         return $password->merge($options->pipe(
-            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)]) // @phpstan-ignore argument.type, return.type
+            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }
 
@@ -1015,7 +1015,7 @@ class Str
     {
         try {
             return (string) $value;
-        } catch (Throwable) { // @phpstan-ignore catch.neverThrown (__toString can throw)
+        } catch (Throwable) {
             return $fallback;
         }
     }
@@ -1245,7 +1245,6 @@ class Str
                 $hyphenatedWords = explode('-', $lowercaseWord);
 
                 $hyphenatedWords = array_map(function ($part) use ($minorWords) {
-                    // @phpstan-ignore smallerOrEqual.alwaysTrue (defensive check)
                     return (in_array($part, $minorWords) && mb_strlen($part) <= 3)
                         ? $part
                         : mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1);
@@ -1254,7 +1253,7 @@ class Str
                 $words[$i] = implode('-', $hyphenatedWords);
             } else {
                 if (in_array($lowercaseWord, $minorWords)
-                    && mb_strlen($lowercaseWord) <= 3 // @phpstan-ignore smallerOrEqual.alwaysTrue
+                    && mb_strlen($lowercaseWord) <= 3
                     && ! ($i === 0 || in_array(mb_substr($words[$i - 1], -1), $endPunctuation))) {
                     $words[$i] = $lowercaseWord;
                 } else {

--- a/src/support/src/Stringable.php
+++ b/src/support/src/Stringable.php
@@ -276,12 +276,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function split(string|int $pattern, int $limit = -1, int $flags = 0): Collection
     {
         if (filter_var($pattern, FILTER_VALIDATE_INT) !== false) {
-            return new Collection(mb_str_split($this->value, $pattern)); // @phpstan-ignore return.type
+            return new Collection(mb_str_split($this->value, $pattern));
         }
 
         $segments = preg_split($pattern, $this->value, $limit, $flags);
 
-        return ! empty($segments) ? new Collection($segments) : new Collection; // @phpstan-ignore return.type
+        return ! empty($segments) ? new Collection($segments) : new Collection;
     }
 
     /**

--- a/src/telescope/src/ExtractTags.php
+++ b/src/telescope/src/ExtractTags.php
@@ -94,8 +94,8 @@ class ExtractTags
     protected static function targetsFor(mixed $job): array
     {
         switch (true) {
-            case $job instanceof BroadcastEvent: // @phpstan-ignore-line
-                return [$job->event]; // @phpstan-ignore-line
+            case $job instanceof BroadcastEvent:
+                return [$job->event];
             case $job instanceof CallQueuedListener:
                 return [static::extractEvent($job)];
             case $job instanceof SendQueuedMailable:

--- a/src/telescope/src/Storage/DatabaseEntriesRepository.php
+++ b/src/telescope/src/Storage/DatabaseEntriesRepository.php
@@ -69,13 +69,13 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
             ->all();
 
         return new EntryResult(
-            $entry->uuid, // @phpstan-ignore-line
+            $entry->uuid,
             null,
-            $entry->batch_id, // @phpstan-ignore-line
-            $entry->type, // @phpstan-ignore-line
-            $entry->family_hash, // @phpstan-ignore-line
-            $entry->content, // @phpstan-ignore-line
-            $entry->created_at, // @phpstan-ignore-line
+            $entry->batch_id,
+            $entry->type,
+            $entry->family_hash,
+            $entry->content,
+            $entry->created_at,
             $tags
         );
     }
@@ -106,9 +106,9 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
     }
 
     /**
-     * Counts the occurences of an exception.
+     * Count the occurrences of an exception.
      */
-    protected function countExceptionOccurences(IncomingEntry $exception): int
+    protected function countExceptionOccurrences(IncomingEntry $exception): int
     {
         return $this->table('telescope_entries')
             ->where('type', EntryType::EXCEPTION)
@@ -187,7 +187,7 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
 
             $families
                 ->each(function ($family, $familyHash) use (&$occurrences, &$lastUuids): void {
-                    $occurrences[$familyHash] = $this->countExceptionOccurences($family->first());
+                    $occurrences[$familyHash] = $this->countExceptionOccurrences($family->first());
                     $lastUuids[$familyHash] = $family->last()->uuid;
                 });
 
@@ -255,7 +255,7 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
     {
         try {
             $this->table('telescope_entries_tags')->insert($tags);
-        } catch (UniqueConstraintViolationException $e) {
+        } catch (UniqueConstraintViolationException) {
             // Ignore tags that already exist...
         }
     }
@@ -309,7 +309,7 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
                         ];
                     })->toArray()
                 );
-            } catch (UniqueConstraintViolationException $e) {
+            } catch (UniqueConstraintViolationException) {
                 // Ignore tags that already exist...
             }
         }
@@ -345,7 +345,7 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
     {
         try {
             $this->setMonitorTags($this->monitoring());
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             $this->setMonitorTags([]);
         }
     }

--- a/src/telescope/src/TelescopeServiceProvider.php
+++ b/src/telescope/src/TelescopeServiceProvider.php
@@ -41,7 +41,6 @@ class TelescopeServiceProvider extends ServiceProvider
 
         Telescope::start($this->app);
         Telescope::listenForStorageOpportunities($this->app);
-        /* @phpstan-ignore-next-line */
         Coroutine::afterCreated(function () {
             $keys = [
                 Telescope::SHOULD_RECORD_CONTEXT_KEY => false,

--- a/src/telescope/src/Watchers/CommandWatcher.php
+++ b/src/telescope/src/Watchers/CommandWatcher.php
@@ -34,9 +34,9 @@ class CommandWatcher extends Watcher
 
         Telescope::recordCommand(IncomingEntry::make([
             'command' => $command->getName(),
-            'exit_code' => (fn () => $this->exitCode)->call($command), /* @phpstan-ignore-line */
-            'arguments' => (fn () => $this->input->getArguments())->call($command), /* @phpstan-ignore-line */
-            'options' => (fn () => $this->input->getOptions())->call($command), /* @phpstan-ignore-line */
+            'exit_code' => (fn () => $this->exitCode)->call($command),
+            'arguments' => (fn () => $this->input->getArguments())->call($command),
+            'options' => (fn () => $this->input->getOptions())->call($command),
         ]));
     }
 

--- a/src/telescope/src/Watchers/JobWatcher.php
+++ b/src/telescope/src/Watchers/JobWatcher.php
@@ -94,7 +94,6 @@ class JobWatcher extends Watcher
             return;
         }
 
-        /* @phpstan-ignore-next-line */
         $uuid = $event->job->payload()['telescope_uuid'] ?? null;
 
         if (! $uuid) {
@@ -116,7 +115,6 @@ class JobWatcher extends Watcher
             $update
         )->removeTags(['failed']));
 
-        /* @phpstan-ignore-next-line */
         $this->updateBatch($event->job->payload());
     }
 
@@ -130,7 +128,6 @@ class JobWatcher extends Watcher
         }
 
         try {
-            /* @phpstan-ignore-next-line */
             $uuid = $event->job->payload()['telescope_uuid'] ?? null;
         } catch (InvalidPayloadException) {
             return;
@@ -160,7 +157,6 @@ class JobWatcher extends Watcher
             $update
         )->addTags(['failed']));
 
-        /* @phpstan-ignore-next-line */
         $this->updateBatch($event->job->payload());
     }
 

--- a/src/telescope/src/Watchers/MailWatcher.php
+++ b/src/telescope/src/Watchers/MailWatcher.php
@@ -33,21 +33,20 @@ class MailWatcher extends Watcher
             return;
         }
 
-        /* @phpstan-ignore-next-line */
         $body = $event->message->getBody();
 
         Telescope::recordMail(IncomingEntry::make([
             'mailable' => $this->getMailable($event),
             'queued' => $this->getQueuedStatus($event),
-            'from' => $this->formatAddresses($event->message->getFrom()), // @phpstan-ignore-line
-            'replyTo' => $this->formatAddresses($event->message->getReplyTo()), // @phpstan-ignore-line
-            'to' => $this->formatAddresses($event->message->getTo()), // @phpstan-ignore-line
-            'cc' => $this->formatAddresses($event->message->getCc()), // @phpstan-ignore-line
-            'bcc' => $this->formatAddresses($event->message->getBcc()), // @phpstan-ignore-line
-            'subject' => $event->message->getSubject(), // @phpstan-ignore-line
-            'html' => $body instanceof AbstractPart ? ($event->message->getHtmlBody() ?? $event->message->getTextBody()) : $body, // @phpstan-ignore-line
-            'raw' => $event->message->toString(), // @phpstan-ignore-line
-        ])->tags($this->tags($event->message, $event->data))); // @phpstan-ignore-line
+            'from' => $this->formatAddresses($event->message->getFrom()),
+            'replyTo' => $this->formatAddresses($event->message->getReplyTo()),
+            'to' => $this->formatAddresses($event->message->getTo()),
+            'cc' => $this->formatAddresses($event->message->getCc()),
+            'bcc' => $this->formatAddresses($event->message->getBcc()),
+            'subject' => $event->message->getSubject(),
+            'html' => $body instanceof AbstractPart ? ($event->message->getHtmlBody() ?? $event->message->getTextBody()) : $body,
+            'raw' => $event->message->toString(),
+        ])->tags($this->tags($event->message, $event->data)));
     }
 
     /**
@@ -98,9 +97,9 @@ class MailWatcher extends Watcher
     private function tags(mixed $message, array $data): array
     {
         return array_merge(
-            array_keys($this->formatAddresses($message->getTo()) ?: []), // @phpstan-ignore-line
-            array_keys($this->formatAddresses($message->getCc()) ?: []), // @phpstan-ignore-line
-            array_keys($this->formatAddresses($message->getBcc()) ?: []), // @phpstan-ignore-line
+            array_keys($this->formatAddresses($message->getTo()) ?: []),
+            array_keys($this->formatAddresses($message->getCc()) ?: []),
+            array_keys($this->formatAddresses($message->getBcc()) ?: []),
             $data['__telescope'] ?? []
         );
     }

--- a/src/testbench/src/Bootstrap/LoadConfigurationWithWorkbench.php
+++ b/src/testbench/src/Bootstrap/LoadConfigurationWithWorkbench.php
@@ -37,7 +37,7 @@ class LoadConfigurationWithWorkbench extends LoadConfiguration
 
         $userModel = Workbench::applicationUserModel();
 
-        if (is_string($userModel) && is_a($userModel, AuthenticatableContract::class, true)) { /* @phpstan-ignore function.alreadyNarrowedType */
+        if (is_string($userModel) && is_a($userModel, AuthenticatableContract::class, true)) {
             $app->make('config')->set('auth.providers.users.model', $userModel);
         }
     }

--- a/src/testbench/src/Bootstrap/RegisterProviders.php
+++ b/src/testbench/src/Bootstrap/RegisterProviders.php
@@ -26,7 +26,6 @@ class RegisterProviders extends \Hypervel\Foundation\Bootstrap\RegisterProviders
             }
         }
 
-        /* @phpstan-ignore return.type */
         return tap(
             array_merge($providers, static::$merge, array_values($packageProviders ?? [])),
             static function (): void {

--- a/src/testbench/src/Foundation/Application.php
+++ b/src/testbench/src/Foundation/Application.php
@@ -291,7 +291,7 @@ class Application
     protected function hasConfiguredEnvironmentVariable(string $key): bool
     {
         foreach ($this->config['env'] as $environmentVariable) {
-            if (! is_string($environmentVariable)) { /* @phpstan-ignore function.alreadyNarrowedType */
+            if (! is_string($environmentVariable)) {
                 continue;
             }
 

--- a/src/testbench/src/Foundation/Bootstrap/LoadMigrationsFromArray.php
+++ b/src/testbench/src/Foundation/Bootstrap/LoadMigrationsFromArray.php
@@ -89,7 +89,7 @@ final class LoadMigrationsFromArray
         )->when(
             $this->includesDefaultMigrations($app),
             static fn (Collection $migrations): Collection => $migrations->push(default_migration_path()),
-        )->filter(static fn (mixed $migration): bool => is_string($migration)) /* @phpstan-ignore function.alreadyNarrowedType */
+        )->filter(static fn (mixed $migration): bool => is_string($migration))
             ->transform(static fn (string $migration): ?string => transform_relative_path($migration, $app->basePath()))
             ->filter(static fn (?string $migration): bool => $migration !== null)
             ->values()

--- a/src/testbench/src/Foundation/Bootstrap/SyncTestbenchCachedRoutes.php
+++ b/src/testbench/src/Foundation/Bootstrap/SyncTestbenchCachedRoutes.php
@@ -20,9 +20,8 @@ class SyncTestbenchCachedRoutes
         $router = $app->make('router');
         $routeFiles = glob($app->basePath(join_paths('routes', 'testbench-*.php'))) ?: [];
 
-        /* @phpstan-ignore argument.type */
         (new Collection($routeFiles))
-            ->each(static function ($routeFile) use ($app, $router) { // @phpstan-ignore closure.unusedUse, closure.unusedUse
+            ->each(static function ($routeFile) use ($app, $router) {
                 // Required route files inherit both application and router scope from this loader.
                 require $routeFile;
             });

--- a/src/testbench/src/Foundation/Config.php
+++ b/src/testbench/src/Foundation/Config.php
@@ -180,7 +180,7 @@ class Config extends Fluent implements ConfigContract
      */
     public function __construct(iterable $attributes = [])
     {
-        parent::__construct(array_replace($this->defaultAttributes, is_array($attributes) ? $attributes : iterator_to_array($attributes))); /* @phpstan-ignore function.alreadyNarrowedType */
+        parent::__construct(array_replace($this->defaultAttributes, is_array($attributes) ? $attributes : iterator_to_array($attributes)));
     }
 
     /**
@@ -223,7 +223,7 @@ class Config extends Fluent implements ConfigContract
                 static fn (?string $path): ?string => transform_relative_path($path, $workingPath)
             );
 
-            if (isset($config['env']) && \is_array($config['env']) && Arr::isAssoc($config['env'])) { /* @phpstan-ignore booleanAnd.rightAlwaysTrue */
+            if (isset($config['env']) && \is_array($config['env']) && Arr::isAssoc($config['env'])) {
                 $config['env'] = parse_environment_variables($config['env']);
             }
         }

--- a/src/testbench/src/PHPUnit/AttributeParser.php
+++ b/src/testbench/src/PHPUnit/AttributeParser.php
@@ -98,7 +98,7 @@ class AttributeParser
     protected static function resolveAttribute(ReflectionAttribute $attribute): array
     {
         $instance = isset(class_implements($attribute->getName())[Resolvable::class])
-            ? transform($attribute->newInstance(), static fn (Resolvable $instance) => $instance->resolve()) // @phpstan-ignore argument.unresolvableType
+            ? transform($attribute->newInstance(), static fn (Resolvable $instance) => $instance->resolve())
             : $attribute->newInstance();
 
         if ($instance === null) {

--- a/src/validation/src/ClosureValidationRule.php
+++ b/src/validation/src/ClosureValidationRule.php
@@ -52,7 +52,7 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
             return $this->pendingPotentiallyTranslatedString($attribute, $message);
         }, $this->validator);
 
-        return ! $this->failed; // @phpstan-ignore booleanNot.alwaysTrue (callback sets $this->failed)
+        return ! $this->failed;
     }
 
     /**

--- a/src/validation/src/InvokableValidationRule.php
+++ b/src/validation/src/InvokableValidationRule.php
@@ -83,7 +83,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             return $this->pendingPotentiallyTranslatedString($attribute, $message);
         });
 
-        return ! $this->failed; // @phpstan-ignore booleanNot.alwaysTrue (callback sets $this->failed)
+        return ! $this->failed;
     }
 
     /**

--- a/src/validation/src/Rules/Email.php
+++ b/src/validation/src/Rules/Email.php
@@ -80,7 +80,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             return static::default();
         }
 
-        if (! is_callable($callback) && ! $callback instanceof static) { // @phpstan-ignore instanceof.alwaysTrue, booleanAnd.alwaysFalse (callable values like closures are not instances)
+        if (! is_callable($callback) && ! $callback instanceof static) {
             throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
         }
 
@@ -183,10 +183,6 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     public function passes(string $attribute, mixed $value): bool
     {
         $this->messages = [];
-
-        if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
-            return false;
-        }
 
         $validator = Validator::make(
             $this->data,

--- a/src/validation/src/Rules/Enum.php
+++ b/src/validation/src/Rules/Enum.php
@@ -59,7 +59,6 @@ class Enum implements Rule, Stringable, ValidatorAwareRule
         }
 
         try {
-            /* @phpstan-ignore-next-line */
             $value = $this->type::tryFrom($value);
 
             return ! is_null($value) && $this->isDesirable($value);

--- a/src/validation/src/Rules/File.php
+++ b/src/validation/src/Rules/File.php
@@ -95,7 +95,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
             return static::default();
         }
 
-        if (! is_callable($callback) && ! $callback instanceof static) { // @phpstan-ignore instanceof.alwaysTrue, booleanAnd.alwaysFalse (callable values like closures are not instances)
+        if (! is_callable($callback) && ! $callback instanceof static) {
             throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
         }
 

--- a/src/validation/src/Rules/Password.php
+++ b/src/validation/src/Rules/Password.php
@@ -131,7 +131,7 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
             return static::default();
         }
 
-        if (! is_callable($callback) && ! $callback instanceof static) { // @phpstan-ignore instanceof.alwaysTrue, booleanAnd.alwaysFalse (callable values like closures are not instances)
+        if (! is_callable($callback) && ! $callback instanceof static) {
             throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
         }
 

--- a/src/validation/src/Validator.php
+++ b/src/validation/src/Validator.php
@@ -417,7 +417,6 @@ class Validator implements ValidatorContract
     {
         if (is_array($callback) && ! is_callable($callback)) {
             foreach ($callback as $rule) {
-                /* @phpstan-ignore-next-line */
                 $this->after(method_exists($rule, 'after') ? $rule->after(...) : $rule);
             }
 
@@ -872,7 +871,7 @@ class Validator implements ValidatorContract
         // used by getExtraConditions / DatabasePresenceVerifier::addConditions
         $normalizedWheres = [];
         foreach ($wheres as $where) {
-            if (is_array($where) && isset($where['column'], $where['value'])) { // @phpstan-ignore function.alreadyNarrowedType (runtime guard — native type is array, not typed array shape)
+            if (is_array($where) && isset($where['column'], $where['value'])) {
                 $normalizedWheres[$where['column']] = $where['value'];
             }
         }
@@ -2067,7 +2066,6 @@ class Validator implements ValidatorContract
     {
         [$class, $method] = Str::parseCallback($callback, 'validate');
 
-        /* @phpstan-ignore-next-line */
         return $this->container->make($class)
             ->{$method}(...array_values($parameters));
     }

--- a/src/view/src/Compilers/Compiler.php
+++ b/src/view/src/Compilers/Compiler.php
@@ -63,7 +63,6 @@ abstract class Compiler
             return $this->files->lastModified($path) >= $this->files->lastModified($compiled);
         } catch (ErrorException $exception) {
             // The compiled file might have been deleted between the initial check and lastModified() call
-            // @phpstan-ignore booleanNot.alwaysFalse
             if (! $this->files->exists($compiled)) {
                 return true;
             }

--- a/src/view/src/Compilers/ComponentTagCompiler.php
+++ b/src/view/src/Compilers/ComponentTagCompiler.php
@@ -138,9 +138,8 @@ class ComponentTagCompiler
 
     /**
      * Set a bound attribute for the current component.
-     * @param mixed $attribute
      */
-    protected function setBoundAttribute($attribute): void
+    protected function setBoundAttribute(string $attribute): void
     {
         $boundAttributes = CoroutineContext::get(self::BOUND_ATTRIBUTES_CONTEXT_KEY, []);
         $boundAttributes[$attribute] = true;
@@ -149,6 +148,8 @@ class ComponentTagCompiler
 
     /**
      * Get the bound attributes for the current component.
+     *
+     * @return array<string, true>
      */
     protected function getBoundAttributes(): array
     {
@@ -326,9 +327,9 @@ class ComponentTagCompiler
                         : $component;
 
                 if (! is_null($guess = match (true) {
-                    $viewFactory->exists($guess = $path['prefixHash'] . $delimiter . $formattedComponent) => $guess,  // @phpstan-ignore variable.undefined
-                    $viewFactory->exists($guess = $path['prefixHash'] . $delimiter . $formattedComponent . '.index') => $guess,  // @phpstan-ignore variable.undefined
-                    $viewFactory->exists($guess = $path['prefixHash'] . $delimiter . $formattedComponent . '.' . Str::afterLast($formattedComponent, '.')) => $guess,  // @phpstan-ignore variable.undefined
+                    $viewFactory->exists($guess = $path['prefixHash'] . $delimiter . $formattedComponent) => $guess,
+                    $viewFactory->exists($guess = $path['prefixHash'] . $delimiter . $formattedComponent . '.index') => $guess,
+                    $viewFactory->exists($guess = $path['prefixHash'] . $delimiter . $formattedComponent . '.' . Str::afterLast($formattedComponent, '.')) => $guess,
                     default => null,
                 })) {
                     return $guess;

--- a/tests/Cache/Redis/Console/BenchmarkCommandTest.php
+++ b/tests/Cache/Redis/Console/BenchmarkCommandTest.php
@@ -4,18 +4,24 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Cache\Redis\Console;
 
+use Error;
+use Hypervel\Cache\Redis\Console\Benchmark\BenchmarkContext;
 use Hypervel\Cache\Redis\Console\BenchmarkCommand;
 use Hypervel\Cache\Redis\Exceptions\BenchmarkMemoryException;
+use Hypervel\Cache\Redis\Support\StoreContext;
 use Hypervel\Cache\RedisStore;
 use Hypervel\Cache\Repository;
+use Hypervel\Cache\TagMode;
 use Hypervel\Console\Command;
 use Hypervel\Console\OutputStyle;
 use Hypervel\Contracts\Cache\Factory as CacheContract;
 use Hypervel\Testbench\TestCase;
 use Mockery as m;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
+use Throwable;
 
 class BenchmarkCommandTest extends TestCase
 {
@@ -96,6 +102,104 @@ class BenchmarkCommandTest extends TestCase
         $this->assertStringContainsString('redis-cli KEYS "shared:', $output->fetch());
     }
 
+    public function testSuccessfulBenchmarkCleansUpOnce(): void
+    {
+        $this->mockFullCacheStore('redis');
+        $context = $this->mockBenchmarkContext();
+        $command = $this->createFullCommand($context);
+        $output = new BufferedOutput;
+
+        $this->assertSame(Command::SUCCESS, $command->run($this->benchmarkInput(), $output));
+        $this->assertTrue($command->comparisonRan);
+    }
+
+    public function testSuccessfulBenchmarkFailsWhenCleanupThrows(): void
+    {
+        $cleanupException = new RuntimeException('cleanup failed');
+        $this->mockFullCacheStore('redis');
+        $context = $this->mockBenchmarkContext($cleanupException);
+        $command = $this->createFullCommand($context);
+        $output = new BufferedOutput;
+
+        $this->assertSame(Command::FAILURE, $command->run($this->benchmarkInput(), $output));
+        $this->assertTrue($command->comparisonRan);
+        $this->assertStringContainsString(
+            'Benchmark cleanup failed (' . $cleanupException::class . '): cleanup failed',
+            $output->fetch(),
+        );
+    }
+
+    public function testMemoryFailureStillCleansUp(): void
+    {
+        $this->mockFullCacheStore('redis');
+        $context = $this->mockBenchmarkContext();
+        $command = $this->createFullCommand(benchmarkContext: $context, comparisonException: new BenchmarkMemoryException(1, 2, 50));
+        $output = new BufferedOutput;
+
+        $this->assertSame(Command::FAILURE, $command->run($this->benchmarkInput(), $output));
+        $outputText = $output->fetch();
+        $this->assertStringContainsString('Benchmark aborted due to memory constraints.', $outputText);
+        $this->assertStringContainsString('Automatic cleanup will run next.', $outputText);
+        $this->assertStringNotContainsString('Cleanup skipped', $outputText);
+    }
+
+    public function testMemoryAndCleanupFailuresAreBothReported(): void
+    {
+        $cleanupException = new RuntimeException('cleanup after memory failure failed');
+        $this->mockFullCacheStore('redis');
+        $context = $this->mockBenchmarkContext($cleanupException);
+        $command = $this->createFullCommand(benchmarkContext: $context, comparisonException: new BenchmarkMemoryException(1, 2, 50));
+        $output = new BufferedOutput;
+
+        $this->assertSame(Command::FAILURE, $command->run($this->benchmarkInput(), $output));
+        $outputText = $output->fetch();
+        $this->assertStringContainsString('Benchmark aborted due to memory constraints.', $outputText);
+        $this->assertStringContainsString(
+            'Benchmark cleanup failed (' . $cleanupException::class . '): cleanup after memory failure failed',
+            $outputText,
+        );
+    }
+
+    public function testCleanupFailureDoesNotReplaceUnexpectedSuiteException(): void
+    {
+        $suiteException = new RuntimeException('suite failed');
+        $cleanupException = new RuntimeException('cleanup after suite failure failed');
+        $this->mockFullCacheStore('redis');
+        $context = $this->mockBenchmarkContext($cleanupException);
+        $command = $this->createFullCommand($context, $suiteException);
+        $output = new BufferedOutput;
+        $caughtException = null;
+
+        try {
+            $command->run($this->benchmarkInput(), $output);
+        } catch (Throwable $exception) {
+            $caughtException = $exception;
+        }
+
+        $this->assertSame($suiteException, $caughtException);
+        $this->assertNull($suiteException->getPrevious());
+        $this->assertStringContainsString(
+            'Benchmark cleanup failed (' . $cleanupException::class . '): cleanup after suite failure failed',
+            $output->fetch(),
+        );
+    }
+
+    public function testSystemInformationFailureIsReportedWithoutStoppingBenchmark(): void
+    {
+        $displayException = new Error('service info failed');
+        $this->mockFullCacheStore('redis', $displayException);
+        $context = $this->mockBenchmarkContext();
+        $command = $this->createFullCommand($context);
+        $output = new BufferedOutput;
+
+        $this->assertSame(Command::SUCCESS, $command->run($this->benchmarkInput(), $output));
+        $this->assertTrue($command->comparisonRan);
+        $this->assertStringContainsString(
+            'Cache Service: Connection failed (' . $displayException::class . '): service info failed',
+            $output->fetch(),
+        );
+    }
+
     private function mockCacheStore(string $name): void
     {
         $store = m::mock(RedisStore::class);
@@ -110,9 +214,98 @@ class BenchmarkCommandTest extends TestCase
         $this->app->instance(CacheContract::class, $cache);
     }
 
+    /**
+     * Mock the cache calls made by the complete benchmark command.
+     */
+    private function mockFullCacheStore(string $name, ?Throwable $displayException = null): void
+    {
+        $store = m::mock(RedisStore::class);
+
+        if ($displayException === null) {
+            $storeContext = m::mock(StoreContext::class);
+            $storeContext->shouldReceive('withConnection')
+                ->once()
+                ->andReturn(['redis_version' => '8.0.0']);
+
+            $store->shouldReceive('getContext')->once()->andReturn($storeContext);
+            $store->shouldReceive('getTagMode')->once()->andReturn(TagMode::Any);
+        } else {
+            $store->shouldNotReceive('getContext');
+            $store->shouldNotReceive('getTagMode');
+        }
+
+        $repository = m::mock(Repository::class);
+
+        if ($displayException === null) {
+            $repository->shouldReceive('getStore')->twice()->andReturn($store);
+        } else {
+            $getStoreCalls = 0;
+            $repository->shouldReceive('getStore')
+                ->twice()
+                ->andReturnUsing(function () use (&$getStoreCalls, $displayException, $store): RedisStore {
+                    ++$getStoreCalls;
+
+                    if ($getStoreCalls === 2) {
+                        throw $displayException;
+                    }
+
+                    return $store;
+                });
+        }
+
+        $repository->shouldReceive('get')->once()->with('test')->andReturnNull();
+
+        $cacheManager = m::mock(CacheContract::class);
+        $cacheManager->shouldReceive('store')->times(3)->with($name)->andReturn($repository);
+
+        $this->app->instance(CacheContract::class, $cacheManager);
+    }
+
+    /**
+     * Mock a benchmark context with controlled cleanup behavior.
+     */
+    private function mockBenchmarkContext(?Throwable $cleanupException = null): BenchmarkContext
+    {
+        $context = m::mock(BenchmarkContext::class);
+        $cleanup = $context->shouldReceive('cleanup')->once();
+
+        if ($cleanupException === null) {
+            $cleanup->andReturnNull();
+        } else {
+            $cleanup->andThrow($cleanupException);
+        }
+
+        return $context;
+    }
+
+    /**
+     * Create the input for a complete benchmark run.
+     */
+    private function benchmarkInput(): ArrayInput
+    {
+        return new ArrayInput([
+            '--scale' => 'small',
+            '--runs' => '1',
+            '--compare-tag-modes' => true,
+            '--force' => true,
+            '--store' => 'redis',
+        ]);
+    }
+
     private function createCommand(): TestableBenchmarkCommand
     {
         $command = new TestableBenchmarkCommand;
+        $command->setHypervel($this->app);
+
+        return $command;
+    }
+
+    /**
+     * Create a command that retains the complete production handle flow.
+     */
+    private function createFullCommand(BenchmarkContext $benchmarkContext, ?Throwable $comparisonException = null): FullBenchmarkCommand
+    {
+        $command = new FullBenchmarkCommand($benchmarkContext, $comparisonException);
         $command->setHypervel($this->app);
 
         return $command;
@@ -136,5 +329,40 @@ class TestableBenchmarkCommand extends BenchmarkCommand
         $this->storeName = $storeName;
 
         parent::displayMemoryError($exception);
+    }
+}
+
+class FullBenchmarkCommand extends BenchmarkCommand
+{
+    public bool $comparisonRan = false;
+
+    /**
+     * Create a benchmark command with controlled execution behavior.
+     */
+    public function __construct(
+        private readonly BenchmarkContext $benchmarkContext,
+        private readonly ?Throwable $comparisonException,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Return the controlled benchmark context.
+     */
+    protected function createContext(array $config, CacheContract $cacheManager): BenchmarkContext
+    {
+        return $this->benchmarkContext;
+    }
+
+    /**
+     * Run the controlled comparison behavior.
+     */
+    protected function runComparison(BenchmarkContext $context, int $runs): void
+    {
+        $this->comparisonRan = true;
+
+        if ($this->comparisonException !== null) {
+            throw $this->comparisonException;
+        }
     }
 }

--- a/tests/Cache/Redis/Console/DoctorCommandTest.php
+++ b/tests/Cache/Redis/Console/DoctorCommandTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Cache\Redis\Console;
 
 use Closure;
+use Error;
 use Hypervel\Cache\CacheManager;
+use Hypervel\Cache\Redis\Console\Doctor\CheckResult;
 use Hypervel\Cache\Redis\Console\Doctor\Checks\HashFieldExpirationCheck;
 use Hypervel\Cache\Redis\Console\Doctor\Checks\PhpRedisCheck;
 use Hypervel\Cache\Redis\Console\Doctor\DoctorContext;
@@ -13,8 +15,10 @@ use Hypervel\Cache\Redis\Console\DoctorCommand;
 use Hypervel\Cache\Redis\Support\StoreContext;
 use Hypervel\Cache\RedisStore;
 use Hypervel\Cache\Repository;
+use Hypervel\Cache\TaggedCache;
 use Hypervel\Cache\TagMode;
 use Hypervel\Config\Repository as ConfigRepository;
+use Hypervel\Console\OutputStyle;
 use Hypervel\Contracts\Cache\Factory as CacheContract;
 use Hypervel\Contracts\Cache\Store;
 use Hypervel\Redis\PhpRedisConnection;
@@ -26,12 +30,14 @@ use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
+use Throwable;
 
-/**
- * Tests for the cache:redis-doctor command.
- */
 class DoctorCommandTest extends TestCase
 {
+    private const int CLEANUP_TEST_TAG_COUNT = 25;
+
+    private const int CLEANUP_PATTERN_COUNT = 4;
+
     #[DataProvider('phpRedisRequirements')]
     public function testPhpRedisCheckUsesRequirementForTagMode(string $taggingMode, string $requiredVersion): void
     {
@@ -184,6 +190,163 @@ class DoctorCommandTest extends TestCase
         );
     }
 
+    public function testCleanupReportsEveryFailureAndContinuesThroughLaterOperations(): void
+    {
+        $tagException = new Error('tag cleanup failed');
+        $cachePatternException = new RuntimeException('cache pattern cleanup failed');
+        $tagPatternException = new Error('tag pattern cleanup failed');
+        $registryException = new RuntimeException('registry cleanup failed');
+        $context = $this->createCleanupContext(
+            tagException: $tagException,
+            // Cleanup flushes two cache-value patterns, then two tag-storage patterns.
+            patternExceptions: [
+                1 => $cachePatternException,
+                3 => $tagPatternException,
+            ],
+            registryException: $registryException,
+        );
+        $command = new ControlledDoctorCommand;
+        $command->setHypervel($this->app);
+        $output = new BufferedOutput;
+        $command->setOutput(new OutputStyle(new ArrayInput([]), $output));
+
+        $command->exposedCleanup($context);
+        $command->exposedCleanup($this->createCleanupContext());
+
+        $functionalResult = new CheckResult;
+        $functionalResult->assert(false, 'controlled functional failure');
+        $command->exposedDisplayCheckResult($functionalResult);
+        $command->exposedDisplaySummary();
+
+        $outputText = $output->fetch();
+        $cachePattern = $context->getCacheValuePatterns('_doctor:test:')[0];
+        $tagPattern = $context->getTagStoragePatterns('_doctor:test:')[0];
+        $this->assertStringContainsString(
+            "Cleanup: flush tag '_doctor:test:products' failed (" . $tagException::class . '): tag cleanup failed',
+            $outputText,
+        );
+        $this->assertStringContainsString(
+            "Cleanup: flush cache keys matching '{$cachePattern}' failed (" . $cachePatternException::class . '): cache pattern cleanup failed',
+            $outputText,
+        );
+        $this->assertStringContainsString(
+            "Cleanup: flush tag storage matching '{$tagPattern}' failed (" . $tagPatternException::class . '): tag pattern cleanup failed',
+            $outputText,
+        );
+        $this->assertStringContainsString(
+            'Cleanup: clean tag registry failed (' . $registryException::class . '): registry cleanup failed',
+            $outputText,
+        );
+        $this->assertSame(1, substr_count($outputText, 'Cleanup complete.'));
+        $this->assertStringContainsString('1 TEST(S) FAILED (out of 1 total)', $outputText);
+        $this->assertStringContainsString('Failed tests:', $outputText);
+        $this->assertStringContainsString('controlled functional failure', $outputText);
+        $this->assertStringContainsString('Cleanup failures:', $outputText);
+    }
+
+    public function testPreflightCleanupFailureRemainsVisibleAndFailsTheCompletedRun(): void
+    {
+        $cleanupException = new Error('preflight cleanup failed');
+        $context = $this->createCleanupContext(
+            tagException: $cleanupException,
+            cleanupInvocations: 2,
+        );
+        $this->bindDoctorContext($context);
+        $command = new ControlledDoctorCommand;
+        $command->setHypervel($this->app);
+        $output = new BufferedOutput;
+
+        $result = $command->run(new ArrayInput(['--store' => 'redis']), $output);
+
+        $outputText = $output->fetch();
+        $this->assertSame(DoctorCommand::FAILURE, $result);
+        $this->assertTrue($command->functionalChecksRan);
+        $this->assertStringContainsString(
+            "Preflight cleanup: flush tag '_doctor:test:products' failed (" . $cleanupException::class . '): preflight cleanup failed',
+            $outputText,
+        );
+        $this->assertStringContainsString('ALL TESTS PASSED (1 tests)', $outputText);
+        $this->assertStringContainsString('Cleanup failures:', $outputText);
+        $this->assertStringContainsString('Cleanup complete.', $outputText);
+    }
+
+    public function testCleanupFailureDoesNotReplaceActiveFunctionalException(): void
+    {
+        $functionalException = new RuntimeException('functional checks failed');
+        $cleanupException = new Error('final cleanup failed');
+        $context = $this->createCleanupContext(
+            tagException: $cleanupException,
+            failingTagFlush: self::CLEANUP_TEST_TAG_COUNT + 1,
+            cleanupInvocations: 2,
+        );
+        $this->bindDoctorContext($context);
+        $command = new ControlledDoctorCommand($functionalException);
+        $command->setHypervel($this->app);
+        $output = new BufferedOutput;
+        $caughtException = null;
+
+        try {
+            $command->run(new ArrayInput(['--store' => 'redis']), $output);
+        } catch (Throwable $exception) {
+            $caughtException = $exception;
+        }
+
+        $this->assertSame($functionalException, $caughtException);
+        $this->assertNull($functionalException->getPrevious());
+        $this->assertStringContainsString(
+            "Cleanup: flush tag '_doctor:test:products' failed (" . $cleanupException::class . '): final cleanup failed',
+            $output->fetch(),
+        );
+    }
+
+    public function testSystemInformationErrorIsVisibleAndDoesNotStopDiagnostics(): void
+    {
+        config()->set('cache.default', 'redis');
+        $displayException = new Error('system information failed');
+        $connection = m::mock(RedisConnection::class);
+        $storeContext = m::mock(StoreContext::class);
+        $storeContext->shouldReceive('withConnection')
+            ->once()
+            ->andReturnUsing(fn (callable $callback): mixed => $callback($connection));
+
+        $store = m::mock(RedisStore::class);
+        $store->shouldReceive('getContext')->once()->andReturn($storeContext);
+        $store->shouldReceive('getTagMode')->once()->andReturn(TagMode::Any);
+        $store->shouldReceive('getPrefix')->once()->andReturn('cache:');
+
+        $repository = m::mock(Repository::class);
+        $repository->shouldReceive('getStore')->once()->andReturn($store);
+
+        $storeCalls = 0;
+        $cacheManager = m::mock(CacheContract::class);
+        $cacheManager->shouldReceive('store')
+            ->twice()
+            ->with('redis')
+            ->andReturnUsing(function () use (&$storeCalls, $displayException, $repository): Repository {
+                ++$storeCalls;
+
+                if ($storeCalls === 1) {
+                    throw $displayException;
+                }
+
+                return $repository;
+            });
+        $this->app->instance(CacheContract::class, $cacheManager);
+
+        $command = new SystemInformationDoctorCommand;
+        $command->setHypervel($this->app);
+        $output = new BufferedOutput;
+
+        $result = $command->run(new ArrayInput(['--store' => 'redis']), $output);
+
+        $this->assertSame(DoctorCommand::SUCCESS, $result);
+        $this->assertTrue($command->functionalChecksRan);
+        $this->assertStringContainsString(
+            'Service: Connection failed (' . $displayException::class . '): system information failed',
+            $output->fetch(),
+        );
+    }
+
     public function testDoctorFailsForNonRedisStore(): void
     {
         $nonRedisStore = m::mock(Store::class);
@@ -228,7 +391,7 @@ class DoctorCommandTest extends TestCase
         // Mock Redis store
         $context = m::mock(StoreContext::class);
         $context->shouldReceive('withConnection')
-            ->andReturnUsing(function ($callback) {
+            ->andReturnUsing(function (callable $callback): mixed {
                 $connection = m::mock(PhpRedisConnection::class);
                 $connection->shouldReceive('info')->with('server')->andReturn(['redis_version' => '7.0.0']);
                 return $callback($connection);
@@ -285,7 +448,7 @@ class DoctorCommandTest extends TestCase
         // Mock Redis store
         $context = m::mock(StoreContext::class);
         $context->shouldReceive('withConnection')
-            ->andReturnUsing(function ($callback) {
+            ->andReturnUsing(function (callable $callback): mixed {
                 $connection = m::mock(PhpRedisConnection::class);
                 $connection->shouldReceive('info')->with('server')->andReturn(['redis_version' => '7.0.0']);
                 return $callback($connection);
@@ -352,7 +515,7 @@ class DoctorCommandTest extends TestCase
         $context = m::mock(StoreContext::class);
         $context->shouldReceive('withConnection')
             ->twice()
-            ->andReturnUsing(function (callable $callback) use (&$borrowedConnection, $connection) {
+            ->andReturnUsing(function (callable $callback) use (&$borrowedConnection, $connection): mixed {
                 $borrowedConnection = true;
 
                 try {
@@ -431,7 +594,7 @@ class DoctorCommandTest extends TestCase
         // Mock Redis store with 'all' mode
         $context = m::mock(StoreContext::class);
         $context->shouldReceive('withConnection')
-            ->andReturnUsing(function ($callback) {
+            ->andReturnUsing(function (callable $callback): mixed {
                 $connection = m::mock(PhpRedisConnection::class);
                 $connection->shouldReceive('info')->with('server')->andReturn(['redis_version' => '7.0.0']);
                 return $callback($connection);
@@ -521,7 +684,7 @@ class DoctorCommandTest extends TestCase
 
         $context = m::mock(StoreContext::class);
         $context->shouldReceive('withConnection')
-            ->andReturnUsing(function ($callback) {
+            ->andReturnUsing(function (callable $callback): mixed {
                 $connection = m::mock(PhpRedisConnection::class);
                 $connection->shouldReceive('info')->with('server')->andReturn(['redis_version' => '7.2.4']);
                 return $callback($connection);
@@ -553,5 +716,208 @@ class DoctorCommandTest extends TestCase
         $this->assertStringContainsString('System Information', $outputText);
         $this->assertStringContainsString('PHP Version', $outputText);
         $this->assertStringContainsString('Hypervel', $outputText);
+    }
+
+    /**
+     * Create a doctor context with controlled cleanup failures.
+     *
+     * @param array<int, Throwable> $patternExceptions
+     */
+    private function createCleanupContext(
+        ?Throwable $tagException = null,
+        int $failingTagFlush = 1,
+        array $patternExceptions = [],
+        ?Throwable $registryException = null,
+        int $cleanupInvocations = 1,
+    ): DoctorContext {
+        $taggedCache = m::mock(TaggedCache::class);
+        $tagFlushCalls = 0;
+        $taggedCache->shouldReceive('flush')
+            ->times(self::CLEANUP_TEST_TAG_COUNT * $cleanupInvocations)
+            ->andReturnUsing(function () use (&$tagFlushCalls, $failingTagFlush, $tagException): bool {
+                ++$tagFlushCalls;
+
+                if ($tagException !== null && $tagFlushCalls === $failingTagFlush) {
+                    throw $tagException;
+                }
+
+                return true;
+            });
+
+        $repository = m::mock(Repository::class);
+        $repository->shouldReceive('tags')
+            ->times(self::CLEANUP_TEST_TAG_COUNT * $cleanupInvocations)
+            ->andReturn($taggedCache);
+
+        $connection = m::mock(RedisConnection::class);
+        $patternCalls = 0;
+        $connection->shouldReceive('flushByPattern')
+            ->times(self::CLEANUP_PATTERN_COUNT * $cleanupInvocations)
+            ->andReturnUsing(function (string $pattern) use (&$patternCalls, $patternExceptions): int {
+                ++$patternCalls;
+
+                if (isset($patternExceptions[$patternCalls])) {
+                    throw $patternExceptions[$patternCalls];
+                }
+
+                return 0;
+            });
+
+        if ($registryException === null) {
+            $connection->shouldReceive('zRange')->times($cleanupInvocations)->andReturn([]);
+            $connection->shouldReceive('zCard')->times($cleanupInvocations)->andReturn(0);
+            $connection->shouldReceive('del')->times($cleanupInvocations)->andReturn(1);
+        } else {
+            $connection->shouldReceive('zRange')->once()->andThrow($registryException);
+            $connection->shouldNotReceive('zCard');
+            $connection->shouldNotReceive('del');
+        }
+
+        $storeContext = m::mock(StoreContext::class);
+        $storeContext->shouldReceive('registryKey')->andReturn('cache:_any:tag_registry');
+        $storeContext->shouldReceive('withConnection')
+            ->andReturnUsing(fn (callable $callback): mixed => $callback($connection));
+
+        $store = m::mock(RedisStore::class);
+        $store->shouldReceive('getContext')->andReturn($storeContext);
+        $store->shouldReceive('getTagMode')->andReturn(TagMode::Any);
+        $store->shouldReceive('getPrefix')->andReturn('cache:');
+
+        return new DoctorContext(
+            cache: $repository,
+            store: $store,
+            redis: $connection,
+            cachePrefix: 'cache:',
+            storeName: 'redis',
+        );
+    }
+
+    /**
+     * Bind a controlled doctor context to the command's cache lookup.
+     */
+    private function bindDoctorContext(DoctorContext $context): void
+    {
+        $context->cache->shouldReceive('getStore')->once()->andReturn($context->store);
+
+        $cacheManager = m::mock(CacheContract::class);
+        $cacheManager->shouldReceive('store')->once()->with('redis')->andReturn($context->cache);
+        $this->app->instance(CacheContract::class, $cacheManager);
+    }
+}
+
+class ControlledDoctorCommand extends DoctorCommand
+{
+    public bool $functionalChecksRan = false;
+
+    /**
+     * Create a doctor command with controlled functional behavior.
+     */
+    public function __construct(private readonly ?Throwable $functionalException = null)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Clean up through the production cleanup path.
+     */
+    public function exposedCleanup(DoctorContext $context, bool $silent = false): void
+    {
+        $this->cleanup($context, $silent);
+    }
+
+    /**
+     * Display a controlled functional result.
+     */
+    public function exposedDisplayCheckResult(CheckResult $result): void
+    {
+        $this->displayCheckResult($result);
+    }
+
+    /**
+     * Display the production summary.
+     */
+    public function exposedDisplaySummary(): void
+    {
+        $this->displaySummary();
+    }
+
+    /**
+     * Skip unrelated system information in cleanup-focused tests.
+     */
+    protected function displaySystemInformation(): void
+    {
+    }
+
+    /**
+     * Accept the controlled environment.
+     */
+    protected function runEnvironmentChecks(
+        string $storeName,
+        RedisStore $store,
+        string $taggingMode,
+        RedisConnection $redis,
+    ): bool {
+        return true;
+    }
+
+    /**
+     * Run the controlled functional result and exception.
+     */
+    protected function runFunctionalChecks(DoctorContext $context): void
+    {
+        $this->functionalChecksRan = true;
+        $result = new CheckResult;
+        $result->assert(true, 'controlled functional check');
+        $this->displayCheckResult($result);
+
+        if ($this->functionalException !== null) {
+            throw $this->functionalException;
+        }
+    }
+
+    /**
+     * Skip unrelated cleanup verification in cleanup-focused tests.
+     */
+    protected function runCleanupVerification(DoctorContext $context): void
+    {
+    }
+}
+
+class SystemInformationDoctorCommand extends DoctorCommand
+{
+    public bool $functionalChecksRan = false;
+
+    /**
+     * Accept the controlled environment.
+     */
+    protected function runEnvironmentChecks(
+        string $storeName,
+        RedisStore $store,
+        string $taggingMode,
+        RedisConnection $redis,
+    ): bool {
+        return true;
+    }
+
+    /**
+     * Record that functional diagnostics continued.
+     */
+    protected function runFunctionalChecks(DoctorContext $context): void
+    {
+        $this->functionalChecksRan = true;
+    }
+
+    /**
+     * Skip unrelated cleanup in the system-information test.
+     */
+    protected function cleanup(DoctorContext $context, bool $silent = false): void
+    {
+    }
+
+    /**
+     * Skip unrelated cleanup verification in the system-information test.
+     */
+    protected function runCleanupVerification(DoctorContext $context): void
+    {
     }
 }

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Database;
 
 use Hypervel\Database\Capsule\Manager as DB;
+use Hypervel\Database\ConnectionInterface;
 use Hypervel\Database\Eloquent\Model as Eloquent;
+use Hypervel\Database\Schema\Blueprint;
+use Hypervel\Database\Schema\Builder;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Tests\TestCase;
 use RuntimeException;
@@ -30,23 +33,23 @@ class DatabaseEloquentTimestampsTest extends TestCase
     }
 
     /**
-     * Setup the database schema.
+     * Set up the database schema.
      */
-    public function createSchema()
+    public function createSchema(): void
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', function (Blueprint $table): void {
             $table->increments('id');
             $table->string('email')->unique();
             $table->timestamps();
         });
 
-        $this->schema()->create('users_created_at', function ($table) {
+        $this->schema()->create('users_created_at', function (Blueprint $table): void {
             $table->increments('id');
             $table->string('email')->unique();
             $table->string('created_at');
         });
 
-        $this->schema()->create('users_updated_at', function ($table) {
+        $this->schema()->create('users_updated_at', function (Blueprint $table): void {
             $table->increments('id');
             $table->string('email')->unique();
             $table->string('updated_at');
@@ -65,10 +68,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * Tests...
-     */
-    public function testUserWithCreatedAtAndUpdatedAt()
+    public function testUserWithCreatedAtAndUpdatedAt(): void
     {
         CarbonImmutable::setTestNow($now = CarbonImmutable::now());
 
@@ -76,11 +76,11 @@ class DatabaseEloquentTimestampsTest extends TestCase
             'email' => 'test@test.com',
         ]);
 
-        $this->assertEquals($now->toDateTimeString(), $user->created_at->toDateTimeString());
-        $this->assertEquals($now->toDateTimeString(), $user->updated_at->toDateTimeString());
+        $this->assertSame($now->toDateTimeString(), $user->created_at->toDateTimeString());
+        $this->assertSame($now->toDateTimeString(), $user->updated_at->toDateTimeString());
     }
 
-    public function testUserWithCreatedAt()
+    public function testUserWithCreatedAt(): void
     {
         CarbonImmutable::setTestNow($now = CarbonImmutable::now());
 
@@ -88,10 +88,10 @@ class DatabaseEloquentTimestampsTest extends TestCase
             'email' => 'test@test.com',
         ]);
 
-        $this->assertEquals($now->toDateTimeString(), $user->created_at->toDateTimeString());
+        $this->assertSame($now->toDateTimeString(), $user->created_at->toDateTimeString());
     }
 
-    public function testUserWithUpdatedAt()
+    public function testUserWithUpdatedAt(): void
     {
         CarbonImmutable::setTestNow($now = CarbonImmutable::now());
 
@@ -99,10 +99,10 @@ class DatabaseEloquentTimestampsTest extends TestCase
             'email' => 'test@test.com',
         ]);
 
-        $this->assertEquals($now->toDateTimeString(), $user->updated_at->toDateTimeString());
+        $this->assertSame($now->toDateTimeString(), $user->updated_at->toDateTimeString());
     }
 
-    public function testWithoutTimestamp()
+    public function testWithoutTimestamp(): void
     {
         CarbonImmutable::setTestNow($now = CarbonImmutable::now()->setYear(1995)->startOfYear());
         $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
@@ -110,10 +110,10 @@ class DatabaseEloquentTimestampsTest extends TestCase
 
         $this->assertTrue($user->usesTimestamps());
 
-        $user->withoutTimestamps(function () use ($user) {
+        $user->withoutTimestamps(function () use ($user): void {
             $this->assertFalse($user->usesTimestamps());
 
-            $user->withoutTimestamps(function () use ($user) {
+            $user->withoutTimestamps(function () use ($user): void {
                 $this->assertFalse($user->usesTimestamps());
             });
 
@@ -128,7 +128,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertSame('bar@example.com', $user->email);
     }
 
-    public function testWithoutTimestampWhenAlreadyIgnoringTimestamps()
+    public function testWithoutTimestampWhenAlreadyIgnoringTimestamps(): void
     {
         CarbonImmutable::setTestNow($now = CarbonImmutable::now()->setYear(1995)->startOfYear());
         $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
@@ -138,7 +138,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
 
         $this->assertFalse($user->usesTimestamps());
 
-        $user->withoutTimestamps(function () use ($user) {
+        $user->withoutTimestamps(function () use ($user): void {
             $this->assertFalse($user->usesTimestamps());
             $user->update([
                 'email' => 'bar@example.com',
@@ -150,7 +150,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertSame('bar@example.com', $user->email);
     }
 
-    public function testWithoutTimestampRestoresWhenClosureThrowsException()
+    public function testWithoutTimestampRestoresWhenClosureThrowsException(): void
     {
         $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
 
@@ -174,7 +174,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertTrue($user->timestamps);
     }
 
-    public function testWithoutTimestampsRespectsClasses()
+    public function testWithoutTimestampsRespectsClasses(): void
     {
         $a = new UserWithCreatedAndUpdated;
         $b = new UserWithCreatedAndUpdated;
@@ -186,7 +186,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        Eloquent::withoutTimestamps(function () use ($a, $b, $z) {
+        Eloquent::withoutTimestamps(function () use ($a, $b, $z): void {
             $this->assertFalse($a->usesTimestamps());
             $this->assertFalse($b->usesTimestamps());
             $this->assertFalse($z->usesTimestamps());
@@ -200,7 +200,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        UserWithCreatedAndUpdated::withoutTimestamps(function () use ($a, $b, $z) {
+        UserWithCreatedAndUpdated::withoutTimestamps(function () use ($a, $b, $z): void {
             $this->assertFalse($a->usesTimestamps());
             $this->assertFalse($b->usesTimestamps());
             $this->assertTrue($z->usesTimestamps());
@@ -214,7 +214,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        UserWithUpdated::withoutTimestamps(function () use ($a, $b, $z) {
+        UserWithUpdated::withoutTimestamps(function () use ($a, $b, $z): void {
             $this->assertTrue($a->usesTimestamps());
             $this->assertTrue($b->usesTimestamps());
             $this->assertFalse($z->usesTimestamps());
@@ -228,7 +228,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        Eloquent::withoutTimestampsOn([], function () use ($a, $b, $z) {
+        Eloquent::withoutTimestampsOn([], function () use ($a, $b, $z): void {
             $this->assertTrue($a->usesTimestamps());
             $this->assertTrue($b->usesTimestamps());
             $this->assertTrue($z->usesTimestamps());
@@ -242,7 +242,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        Eloquent::withoutTimestampsOn([UserWithCreatedAndUpdated::class], function () use ($a, $b, $z) {
+        Eloquent::withoutTimestampsOn([UserWithCreatedAndUpdated::class], function () use ($a, $b, $z): void {
             $this->assertFalse($a->usesTimestamps());
             $this->assertFalse($b->usesTimestamps());
             $this->assertTrue($z->usesTimestamps());
@@ -256,7 +256,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        Eloquent::withoutTimestampsOn([UserWithUpdated::class], function () use ($a, $b, $z) {
+        Eloquent::withoutTimestampsOn([UserWithUpdated::class], function () use ($a, $b, $z): void {
             $this->assertTrue($a->usesTimestamps());
             $this->assertTrue($b->usesTimestamps());
             $this->assertFalse($z->usesTimestamps());
@@ -270,7 +270,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
         $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
 
-        Eloquent::withoutTimestampsOn([UserWithCreatedAndUpdated::class, UserWithUpdated::class], function () use ($a, $b, $z) {
+        Eloquent::withoutTimestampsOn([UserWithCreatedAndUpdated::class, UserWithUpdated::class], function () use ($a, $b, $z): void {
             $this->assertFalse($a->usesTimestamps());
             $this->assertFalse($b->usesTimestamps());
             $this->assertFalse($z->usesTimestamps());
@@ -287,28 +287,22 @@ class DatabaseEloquentTimestampsTest extends TestCase
 
     /**
      * Get a database connection instance.
-     *
-     * @return \Illuminate\Database\Connection
      */
-    protected function connection()
+    protected function connection(): ConnectionInterface
     {
         return Eloquent::getConnectionResolver()->connection();
     }
 
     /**
      * Get a schema builder instance.
-     *
-     * @return \Illuminate\Database\Schema\Builder
      */
-    protected function schema()
+    protected function schema(): Builder
     {
         return $this->connection()->getSchemaBuilder();
     }
 }
 
-/**
- * Eloquent Models...
- */
+// Eloquent models.
 class UserWithCreatedAndUpdated extends Eloquent
 {
     protected ?string $table = 'users';

--- a/tests/Integration/Console/CallCommandsTest.php
+++ b/tests/Integration/Console/CallCommandsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\Console\CallCommandsTest;
 
 use Hypervel\Console\Command;
+use Hypervel\Contracts\Console\Kernel;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Support\Facades\Artisan;
 use Hypervel\Testbench\TestCase;
@@ -14,33 +15,47 @@ class CallCommandsTest extends TestCase
 {
     protected function defineEnvironment(ApplicationContract $app): void
     {
-        Artisan::command('test:caller-by-name', function () {
+        Artisan::command('test:caller-by-name', function (): void {
             $this->call('test:callee');
         });
 
-        Artisan::command('test:caller-by-class', function () {
+        Artisan::command('test:caller-by-class', function (): void {
             $this->call(CalleeCommand::class);
         });
 
-        Artisan::command('test:caller-by-instance', function () {
+        Artisan::command('test:caller-by-class-twice', function (): void {
+            $this->call(CalleeCommand::class);
+            $this->call(CalleeCommand::class);
+        });
+
+        Artisan::command('test:caller-by-instance', function (): void {
             $this->call($this->getHypervel()->make(CalleeCommand::class));
         });
 
-        $app->make(\Hypervel\Contracts\Console\Kernel::class)
+        $app->make(Kernel::class)
             ->registerCommand($app->make(CalleeCommand::class));
     }
 
-    public function testItCanCallCommandByName()
+    public function testItCanCallCommandByName(): void
     {
         $this->artisan('test:caller-by-name')->assertSuccessful();
     }
 
-    public function testItCanCallCommandByClass()
+    public function testItCanCallCommandByClass(): void
     {
         $this->artisan('test:caller-by-class')->assertSuccessful();
     }
 
-    public function testItCanCallCommandByInstance()
+    public function testClassCommandCallsUseFreshInstances(): void
+    {
+        $this->assertSame(Command::SUCCESS, Artisan::call('test:caller-by-class-twice'));
+
+        $output = Artisan::output();
+        $this->assertSame(2, substr_count($output, 'child run count: 1'));
+        $this->assertStringNotContainsString('child run count: 2', $output);
+    }
+
+    public function testItCanCallCommandByInstance(): void
     {
         $this->artisan('test:caller-by-instance')->assertSuccessful();
     }
@@ -53,8 +68,13 @@ class CalleeCommand extends Command
 
     protected string $description = 'A test callee command';
 
+    private int $runs = 0;
+
     public function handle(): int
     {
+        ++$this->runs;
+        $this->line("child run count: {$this->runs}");
+
         return self::SUCCESS;
     }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
@@ -26,14 +26,14 @@ class ScheduleTestCommandTest extends TestCase
         Artisan::registerCommand(new BarCommandStub);
     }
 
-    public function testRunNoDefinedCommands()
+    public function testRunNoDefinedCommands(): void
     {
         $this->artisan(ScheduleTestCommand::class)
             ->assertSuccessful()
             ->expectsOutputToContain('No scheduled commands have been defined.');
     }
 
-    public function testRunNoMatchingCommand()
+    public function testRunNoMatchingCommand(): void
     {
         $this->schedule->command(BarCommandStub::class);
 
@@ -42,7 +42,7 @@ class ScheduleTestCommandTest extends TestCase
             ->expectsOutputToContain('No matching scheduled command found.');
     }
 
-    public function testRunUsingNameOption()
+    public function testRunUsingNameOption(): void
     {
         $this->schedule->command(BarCommandStub::class)->name('bar-command');
         $this->schedule->job(BarJobStub::class);
@@ -79,7 +79,7 @@ class ScheduleTestCommandTest extends TestCase
         $this->assertTrue($callbackRan);
     }
 
-    public function testRunUsingChoices()
+    public function testRunUsingChoices(): void
     {
         $this->schedule->command(BarCommandStub::class)->name('bar-command');
         $this->schedule->job(BarJobStub::class);
@@ -103,14 +103,14 @@ class BarCommandStub extends Command
 
     protected string $description = 'This is the description of the command.';
 
-    public function handle()
+    public function handle(): void
     {
     }
 }
 
 class BarJobStub
 {
-    public function __invoke()
+    public function __invoke(): void
     {
     }
 }

--- a/tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
+++ b/tests/Integration/Database/MariaDb/DatabaseMariaDbConnectionTest.php
@@ -26,7 +26,7 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
     protected function afterRefreshingDatabase(): void
     {
         if (! Schema::hasTable(self::TABLE)) {
-            Schema::create(self::TABLE, function (Blueprint $table) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
                 $table->json(self::JSON_COL)->nullable();
                 $table->float(self::FLOAT_COL)->nullable();
             });
@@ -39,7 +39,7 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
     }
 
     #[DataProvider('floatComparisonsDataProvider')]
-    public function testJsonFloatComparison($value, $operator, $shouldMatch)
+    public function testJsonFloatComparison(float $value, string $operator, bool $shouldMatch): void
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => '{"rank":' . self::FLOAT_VAL . '}']);
 
@@ -50,7 +50,12 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
         );
     }
 
-    public static function floatComparisonsDataProvider()
+    /**
+     * Provide JSON float comparisons.
+     *
+     * @return list<array{0: float, 1: string, 2: bool}>
+     */
+    public static function floatComparisonsDataProvider(): array
     {
         return [
             [0.2, '=', true],
@@ -65,15 +70,15 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
         ];
     }
 
-    public function testFloatValueStoredCorrectly()
+    public function testFloatValueStoredCorrectly(): void
     {
         DB::table(self::TABLE)->insert([self::FLOAT_COL => self::FLOAT_VAL]);
 
-        $this->assertEquals(self::FLOAT_VAL, DB::table(self::TABLE)->value(self::FLOAT_COL));
+        $this->assertSame(self::FLOAT_VAL, DB::table(self::TABLE)->value(self::FLOAT_COL));
     }
 
     #[DataProvider('jsonWhereNullDataProvider')]
-    public function testJsonWhereNull($expected, $key, array $value = ['value' => 123])
+    public function testJsonWhereNull(bool $expected, string $key, array $value = ['value' => 123]): void
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
 
@@ -81,14 +86,19 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
     }
 
     #[DataProvider('jsonWhereNullDataProvider')]
-    public function testJsonWhereNotNull($expected, $key, array $value = ['value' => 123])
+    public function testJsonWhereNotNull(bool $expected, string $key, array $value = ['value' => 123]): void
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
 
         $this->assertSame(! $expected, DB::table(self::TABLE)->whereNotNull(self::JSON_COL . '->' . $key)->exists());
     }
 
-    public static function jsonWhereNullDataProvider()
+    /**
+     * Provide JSON null comparisons.
+     *
+     * @return array<string, array{0: bool, 1: string, 2?: array<array-key, mixed>}>
+     */
+    public static function jsonWhereNullDataProvider(): array
     {
         return [
             'key not exists' => [true, 'invalid'],
@@ -110,7 +120,7 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
         ];
     }
 
-    public function testJsonPathUpdate()
+    public function testJsonPathUpdate(): void
     {
         DB::table(self::TABLE)->insert([
             [self::JSON_COL => '{"foo":["bar"]}'],
@@ -123,7 +133,7 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
     }
 
     #[DataProvider('jsonContainsKeyDataProvider')]
-    public function testWhereJsonContainsKey($count, $column)
+    public function testWhereJsonContainsKey(int $count, string $column): void
     {
         DB::table(self::TABLE)->insert([
             ['json_col' => '{"foo":{"bar":["baz"]}}'],
@@ -136,7 +146,12 @@ class DatabaseMariaDbConnectionTest extends MariaDbTestCase
         $this->assertSame($count, DB::table(self::TABLE)->whereJsonContainsKey($column)->count());
     }
 
-    public static function jsonContainsKeyDataProvider()
+    /**
+     * Provide JSON paths and their expected match counts.
+     *
+     * @return array<string, array{0: int, 1: string}>
+     */
+    public static function jsonContainsKeyDataProvider(): array
     {
         return [
             'string key' => [4, 'json_col->foo'],

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -27,7 +27,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
     protected function afterRefreshingDatabase(): void
     {
         if (! Schema::hasTable(self::TABLE)) {
-            Schema::create(self::TABLE, function (Blueprint $table) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
                 $table->json(self::JSON_COL)->nullable();
                 $table->float(self::FLOAT_COL)->nullable();
             });
@@ -40,7 +40,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
     }
 
     #[DataProvider('floatComparisonsDataProvider')]
-    public function testJsonFloatComparison($value, $operator, $shouldMatch)
+    public function testJsonFloatComparison(float $value, string $operator, bool $shouldMatch): void
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => '{"rank":' . self::FLOAT_VAL . '}']);
 
@@ -51,7 +51,12 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         );
     }
 
-    public static function floatComparisonsDataProvider()
+    /**
+     * Provide JSON float comparisons.
+     *
+     * @return list<array{0: float, 1: string, 2: bool}>
+     */
+    public static function floatComparisonsDataProvider(): array
     {
         return [
             [0.2, '=', true],
@@ -66,15 +71,15 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         ];
     }
 
-    public function testFloatValueStoredCorrectly()
+    public function testFloatValueStoredCorrectly(): void
     {
         DB::table(self::TABLE)->insert([self::FLOAT_COL => self::FLOAT_VAL]);
 
-        $this->assertEquals(self::FLOAT_VAL, DB::table(self::TABLE)->value(self::FLOAT_COL));
+        $this->assertSame(self::FLOAT_VAL, DB::table(self::TABLE)->value(self::FLOAT_COL));
     }
 
     #[DataProvider('jsonWhereNullDataProvider')]
-    public function testJsonWhereNull($expected, $key, array $value = ['value' => 123])
+    public function testJsonWhereNull(bool $expected, string $key, array $value = ['value' => 123]): void
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
 
@@ -82,14 +87,19 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
     }
 
     #[DataProvider('jsonWhereNullDataProvider')]
-    public function testJsonWhereNotNull($expected, $key, array $value = ['value' => 123])
+    public function testJsonWhereNotNull(bool $expected, string $key, array $value = ['value' => 123]): void
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
 
         $this->assertSame(! $expected, DB::table(self::TABLE)->whereNotNull(self::JSON_COL . '->' . $key)->exists());
     }
 
-    public static function jsonWhereNullDataProvider()
+    /**
+     * Provide JSON null comparisons.
+     *
+     * @return array<string, array{0: bool, 1: string, 2?: array<array-key, mixed>}>
+     */
+    public static function jsonWhereNullDataProvider(): array
     {
         return [
             'key not exists' => [true, 'invalid'],
@@ -111,7 +121,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         ];
     }
 
-    public function testJsonPathUpdate()
+    public function testJsonPathUpdate(): void
     {
         DB::table(self::TABLE)->insert([
             [self::JSON_COL => '{"foo":["bar"]}'],
@@ -124,7 +134,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
     }
 
     #[DataProvider('jsonContainsKeyDataProvider')]
-    public function testWhereJsonContainsKey($count, $column)
+    public function testWhereJsonContainsKey(int $count, string $column): void
     {
         DB::table(self::TABLE)->insert([
             ['json_col' => '{"foo":{"bar":["baz"]}}'],
@@ -137,7 +147,12 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         $this->assertSame($count, DB::table(self::TABLE)->whereJsonContainsKey($column)->count());
     }
 
-    public static function jsonContainsKeyDataProvider()
+    /**
+     * Provide JSON paths and their expected match counts.
+     *
+     * @return array<string, array{0: int, 1: string}>
+     */
+    public static function jsonContainsKeyDataProvider(): array
     {
         return [
             'string key' => [4, 'json_col->foo'],
@@ -151,24 +166,24 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         ];
     }
 
-    public function testLastInsertIdIsPreserved()
+    public function testLastInsertIdIsPreserved(): void
     {
         if (! Schema::hasTable('auto_id_table')) {
-            Schema::create('auto_id_table', function (Blueprint $table) {
+            Schema::create('auto_id_table', function (Blueprint $table): void {
                 $table->id();
             });
         }
 
         try {
-            static $callbackExecuted = false;
-            DB::listen(function (QueryExecuted $event) use (&$callbackExecuted) {
+            $callbackExecuted = false;
+            DB::listen(function (QueryExecuted $event) use (&$callbackExecuted): void {
                 DB::getPdo()->query('SELECT 1');
                 $callbackExecuted = true;
             });
 
             $id = DB::table('auto_id_table')->insertGetId([]);
             $this->assertTrue($callbackExecuted, 'The query listener was not executed.');
-            $this->assertEquals(1, $id);
+            $this->assertSame(1, $id);
         } finally {
             Schema::drop('auto_id_table');
         }

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Validation;
 
-use Hypervel\Support\Arr;
 use Hypervel\Testbench\TestCase;
 use Hypervel\Translation\ArrayLoader;
 use Hypervel\Translation\Translator;
@@ -24,7 +23,7 @@ class ValidationEmailRuleTest extends TestCase
     {
         parent::setUp();
 
-        $this->app->singleton('translator', function () {
+        $this->app->singleton('translator', function (): Translator {
             $translator = new Translator(
                 new ArrayLoader,
                 'en'
@@ -38,7 +37,7 @@ class ValidationEmailRuleTest extends TestCase
         });
     }
 
-    public function testBasic()
+    public function testBasic(): void
     {
         $this->fails(
             Email::default(),
@@ -55,13 +54,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             12345,
-            [Email::class]
+            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email(),
             12345,
-            [Email::class]
+            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
         );
 
         $this->passes(
@@ -84,63 +83,93 @@ class ValidationEmailRuleTest extends TestCase
             ['taylor@laravel.com'],
         );
 
-        $this->passes(Email::default(), null);
+        $this->fails(
+            Email::default(),
+            null,
+            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+        );
 
-        $this->passes(Rule::email(), null);
+        $this->fails(
+            Rule::email(),
+            null,
+            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+        );
+
+        $validator = new Validator(
+            resolve('translator'),
+            [self::ATTRIBUTE => null],
+            [self::ATTRIBUTE => ['nullable', Rule::email()]]
+        );
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame([], $validator->messages()->toArray());
     }
 
     /**
-     * @param mixed $rule
-     * @param array|string $values
-     * @param array $expectedMessages
-     * @param null|string $customValidationMessage
+     * Assert that values fail the email rule.
+     *
+     * @param null|int|list<string>|string $values
+     * @param list<string> $expectedMessages
      */
-    protected function fails($rule, $values, $expectedMessages, $customValidationMessage = null)
-    {
+    protected function fails(
+        Email $rule,
+        array|int|string|null $values,
+        array $expectedMessages,
+        ?string $customValidationMessage = null
+    ): void {
         $this->assertValidationRules($rule, $values, false, $expectedMessages, $customValidationMessage);
     }
 
     /**
-     * @param mixed $rule
-     * @param array|string $values
-     * @param bool $expectToPass
-     * @param array $expectedMessages
-     * @param null|string $customValidationMessage
+     * Assert an email rule's result and messages.
+     *
+     * @param null|int|list<string>|string $values
+     * @param list<string> $expectedMessages
      */
-    protected function assertValidationRules($rule, $values, $expectToPass, $expectedMessages = [], $customValidationMessage = null)
-    {
-        $values = Arr::wrap($values);
+    protected function assertValidationRules(
+        Email $rule,
+        array|int|string|null $values,
+        bool $expectToPass,
+        array $expectedMessages = [],
+        ?string $customValidationMessage = null
+    ): void {
+        $values = is_array($values) ? $values : [$values];
 
         $translator = resolve('translator');
 
         foreach ($values as $value) {
-            $v = new Validator(
+            $validator = new Validator(
                 $translator,
                 [self::ATTRIBUTE => $value],
-                [self::ATTRIBUTE => is_object($rule) ? clone $rule : $rule],
+                [self::ATTRIBUTE => clone $rule],
                 $customValidationMessage ? [self::ATTRIBUTE . '.email' => $customValidationMessage] : []
             );
 
-            $this->assertSame($expectToPass, $v->passes(), 'Expected email input ' . $value . ' to ' . ($expectToPass ? 'pass' : 'fail') . '.');
+            $this->assertSame(
+                $expectToPass,
+                $validator->passes(),
+                'Expected email input ' . var_export($value, true) . ' to ' . ($expectToPass ? 'pass' : 'fail') . '.'
+            );
 
             $this->assertSame(
                 $expectToPass ? [] : [self::ATTRIBUTE => $expectedMessages],
-                $v->messages()->toArray(),
-                'Expected different message for email input ' . $value,
+                $validator->messages()->toArray(),
+                'Expected different message for email input ' . var_export($value, true),
             );
         }
     }
 
     /**
-     * @param mixed $rule
-     * @param array|string $values
+     * Assert that values pass the email rule.
+     *
+     * @param null|int|list<string>|string $values
      */
-    protected function passes($rule, $values)
+    protected function passes(Email $rule, array|int|string|null $values): void
     {
         $this->assertValidationRules($rule, $values, true);
     }
 
-    public function testRfcCompliantStrict()
+    public function testRfcCompliantStrict(): void
     {
         $emailThatFailsBothNonStrictButFailsInStrict = 'username@sub..example.com';
         $emailThatPassesNonStrictButFailsInStrict = '"has space"@example.com';
@@ -181,8 +210,37 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    public function testStrict(): void
+    {
+        $emailThatFailsInStrict = 'username@sub..example.com';
+        $emailThatPassesNonStrictButFailsInStrict = '"has space"@example.com';
+        $emailThatPassesInStrict = 'plainaddress@example.com';
+
+        $this->fails(
+            (new Email)->strict(),
+            $emailThatPassesNonStrictButFailsInStrict,
+            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+        );
+
+        $this->fails(
+            Rule::email()->strict(),
+            $emailThatFailsInStrict,
+            ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
+        );
+
+        $this->passes(
+            (new Email)->strict(),
+            $emailThatPassesInStrict
+        );
+
+        $this->passes(
+            Rule::email()->strict(),
+            $emailThatPassesInStrict
+        );
+    }
+
     #[RequiresPhpExtension('intl')]
-    public function testValidateMxRecord()
+    public function testValidateMxRecord(): void
     {
         $this->fails(
             (new Email)->validateMxRecord(),
@@ -208,7 +266,7 @@ class ValidationEmailRuleTest extends TestCase
     }
 
     #[RequiresPhpExtension('Intl')]
-    public function testPreventSpoofing()
+    public function testPreventSpoofing(): void
     {
         $this->fails(
             (new Email)->preventSpoofing(),
@@ -256,7 +314,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testWithNativeValidation()
+    public function testWithNativeValidation(): void
     {
         $this->fails(
             (new Email)->withNativeValidation(),
@@ -281,7 +339,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testWithNativeValidationAllowUnicode()
+    public function testWithNativeValidationAllowUnicode(): void
     {
         $this->fails(
             (new Email)->withNativeValidation(allowUnicode: true),
@@ -316,7 +374,7 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testRfcCompliantNonStrict()
+    public function testRfcCompliantNonStrict(): void
     {
         $this->fails(
             (new Email)->rfcCompliant(),
@@ -374,7 +432,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['a@[IPv6:2001:db8::1]'])] // Domain-literal with normal IPv6
     #[TestWith(['user@[IPv6:::]'])] // invalid shorthand IPv6
     #[TestWith(['"ab\(c"@example.com'])]
-    public function testEmailsThatPassOnRfcCompliantButFailOnStrict($email)
+    public function testEmailsThatPassOnRfcCompliantButFailOnStrict(string $email): void
     {
         $this->passes(
             Rule::email()->rfcCompliant(),
@@ -403,7 +461,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['a@b.c'])]
     #[TestWith(['user@xn--bcher-kva.example'])]
     #[TestWith(['user@bücher.example'])]
-    public function testEmailsThatPassOnBothRfcCompliantAndStrict($email)
+    public function testEmailsThatPassOnBothRfcCompliantAndStrict(string $email): void
     {
         $this->passes(
             Rule::email()->rfcCompliant(),
@@ -433,7 +491,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['"unescaped"quote@example.com'])]
     #[TestWith(['https://example.com'])]
     #[TestWith(['with\escape@example.com'])]
-    public function testEmailsThatFailOnBothRfcCompliantAndStrict($email)
+    public function testEmailsThatFailOnBothRfcCompliantAndStrict(string $email): void
     {
         $this->fails(
             Rule::email()->rfcCompliant(),
@@ -463,7 +521,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['a@b.c'])] // Minimal email
     #[TestWith(['user@xn--bcher-kva.example'])] // Punycode domain (bücher)
     #[TestWith(['user@bücher.example'])] // Unicode domain
-    public function testEmailsThatPassOnBothRfcCompliantAndRfcCompliantStrict($email)
+    public function testEmailsThatPassOnBothRfcCompliantAndRfcCompliantStrict(string $email): void
     {
         $this->passes(
             Rule::email()->rfcCompliant(),
@@ -478,7 +536,7 @@ class ValidationEmailRuleTest extends TestCase
 
     #[TestWith(['déjà@example.com'])]
     #[TestWith(['测试@example.com'])]
-    public function testEmailsThatFailWithNativeValidationAsciiPassUnicode($email)
+    public function testEmailsThatFailWithNativeValidationAsciiPassUnicode(string $email): void
     {
         $this->fails(
             Rule::email()->withNativeValidation(),
@@ -499,7 +557,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['пример@пример.рф'])] // Cyrillic domain
     #[TestWith(['例子@例子.公司'])] // Chinese domain
     #[TestWith(['name@123.123.123.123'])] // Numeric domain
-    public function testEmailsThatFailOnBothWithNativeValidationAsciiAndUnicode($email)
+    public function testEmailsThatFailOnBothWithNativeValidationAsciiAndUnicode(string $email): void
     {
         $this->fails(
             Rule::email()->withNativeValidation(),
@@ -519,7 +577,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['joe_smith@example.org'])]
     #[TestWith(['user@[IPv6:2001:db8:1ff::a0b:dbd0]'])]
     #[TestWith(['test@xn--bcher-kva.com'])] // Punycode for bücher.com
-    public function testEmailsThatPassBothWithNativeValidationAsciiAndUnicode($email)
+    public function testEmailsThatPassBothWithNativeValidationAsciiAndUnicode(string $email): void
     {
         $this->passes(
             Rule::email()->withNativeValidation(),
@@ -543,7 +601,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['пример@пример.рф'])] // Cyrillic local and domain
     #[TestWith(['例子@例子.公司'])] // Chinese local and domain
     #[TestWith(['name@123.123.123.123'])] // Numeric domain
-    public function testEmailsThatFailWithNativeValidationAsciiPassRfcCompliant($email)
+    public function testEmailsThatFailWithNativeValidationAsciiPassRfcCompliant(string $email): void
     {
         $this->fails(
             Rule::email()->withNativeValidation(),
@@ -578,7 +636,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['user@[IPv6:::1]'])] // IPv6 domain with unusual short form
     #[TestWith(['a@[IPv6:2001:db8::1]'])] // IPv6 domain normal form
     #[TestWith(['user@[IPv6:2001:db8:1ff::a0b:dbd0]'])] // Fully expanded IPv6
-    public function testEmailsThatPassWithNativeValidationAndRfcCompliant($email)
+    public function testEmailsThatPassWithNativeValidationAndRfcCompliant(string $email): void
     {
         $this->passes(
             Rule::email()->withNativeValidation(),
@@ -600,7 +658,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith([' space@domain.com'])] // Leading space in local part
     #[TestWith(['user@domain:port.com'])] // Colon in domain (mimics a port)
     #[TestWith(['username@domain-with-hyphen-.com'])] // Trailing hyphen in domain
-    public function testEmailsThatFailWithNativeValidationAndRfcCompliant($email)
+    public function testEmailsThatFailWithNativeValidationAndRfcCompliant(string $email): void
     {
         $this->fails(
             Rule::email()->withNativeValidation(),
@@ -623,7 +681,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['user@[IPv6:2001:db8::1]'])] // Domain-literal with normal IPv6
     #[TestWith(['user@[IPv6:2001:db8:1ff::a0b:dbd0]'])] // Domain-literal with full IPv6 address
     #[TestWith(['"ab\(c"@example.com'])] // Quoted local part with escaped character
-    public function testEmailsThatPassNativeValidationFailRfcCompliantStrict($email)
+    public function testEmailsThatPassNativeValidationFailRfcCompliantStrict(string $email): void
     {
         $this->passes(
             Rule::email()->withNativeValidation(),
@@ -640,7 +698,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['пример@пример.рф'])] // Unicode domain in Cyrillic script
     #[TestWith(['例子@例子.公司'])] // Unicode domain in Chinese script
     #[TestWith(['name@123.123.123.123'])] // IP address in domain part
-    public function testEmailsThatFailNativeValidationPassRfcCompliantStrict($email)
+    public function testEmailsThatFailNativeValidationPassRfcCompliantStrict(string $email): void
     {
         $this->fails(
             Rule::email()->withNativeValidation(),
@@ -657,7 +715,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['user@example.com'])] // Simple, valid email
     #[TestWith(['joe.smith+dev@example.co.uk'])] // Plus-tagged email with subdomain TLD
     #[TestWith(['user!#$%&\'*+/=?^_`{|}~@example.com'])] // Unusual valid characters in local part
-    public function testEmailsThatPassBothNativeValidationAndRfcCompliantStrict($email)
+    public function testEmailsThatPassBothNativeValidationAndRfcCompliantStrict(string $email): void
     {
         $this->passes(
             Rule::email()->withNativeValidation(),
@@ -682,7 +740,7 @@ class ValidationEmailRuleTest extends TestCase
     #[TestWith(['some((double))comment@example.com'])] // Nested comment in local part
     #[TestWith(['"test\\\"quote"@example.com'])] // Escaped quote in quoted local part
     #[TestWith(['" leading.space"@example.com'])] // Leading space in quoted local part
-    public function testEmailsThatFailBothNativeValidationAndRfcCompliantStrict($email)
+    public function testEmailsThatFailBothNativeValidationAndRfcCompliantStrict(string $email): void
     {
         $this->fails(
             Rule::email()->withNativeValidation(),
@@ -698,7 +756,7 @@ class ValidationEmailRuleTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
-    public function testCombiningRules()
+    public function testCombiningRules(): void
     {
         $this->passes(
             (new Email)->rfcCompliant(strict: true)->preventSpoofing(),
@@ -769,9 +827,9 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
-    public function testMacro()
+    public function testMacro(): void
     {
-        Email::macro('laravelEmployee', function () {
+        Email::macro('laravelEmployee', function (): Email {
             return static::default()->rules('ends_with:@laravel.com');
         });
 
@@ -799,7 +857,7 @@ class ValidationEmailRuleTest extends TestCase
     }
 
     #[RequiresPhpExtension('Intl')]
-    public function testItCanSetDefaultUsing()
+    public function testItCanSetDefaultUsing(): void
     {
         $this->assertInstanceOf(Email::class, Email::default());
 
@@ -810,7 +868,7 @@ class ValidationEmailRuleTest extends TestCase
             $spoofingEmail
         );
 
-        Email::defaults(function () {
+        Email::defaults(function (): Email {
             return (new Email)->preventSpoofing();
         });
 
@@ -820,7 +878,7 @@ class ValidationEmailRuleTest extends TestCase
             ['The ' . self::ATTRIBUTE_REPLACED . ' must be a valid email address.']
         );
 
-        Email::defaults(function () {
+        Email::defaults(function (): Email {
             return Rule::email()->rfcCompliant();
         });
 
@@ -829,7 +887,7 @@ class ValidationEmailRuleTest extends TestCase
             $spoofingEmail
         );
 
-        Email::defaults(function () {
+        Email::defaults(function (): Email {
             return Rule::email()->preventSpoofing();
         });
 
@@ -841,9 +899,9 @@ class ValidationEmailRuleTest extends TestCase
     }
 
     #[RequiresPhpExtension('Intl')]
-    public function testValidationMessages()
+    public function testValidationMessages(): void
     {
-        Email::defaults(function () {
+        Email::defaults(function (): Email {
             return Rule::email()->preventSpoofing();
         });
 


### PR DESCRIPTION
## Why

A framework audit found several real correctness issues alongside incomplete typing and stale PHPStan suppressions. The most important failures were in cleanup paths: benchmark and doctor commands could hide failures, report success after incomplete cleanup, or replace the exception that caused the original failure.

Hypervel command resolution also had a worker-lifetime issue. Nested calls using a command class string executed the auto-singletoned container prototype directly, allowing mutable command state to survive into later calls.

## What changed

### Redis benchmark and doctor commands

- Run benchmark cleanup for successful suites, memory failures, and unexpected throwables.
- Report cleanup failures without replacing an active suite exception.
- Return failure when a successful benchmark cannot clean up its data.
- Keep doctor cleanup best-effort across tags, patterns, and registry entries while recording every thrown failure.
- Keep functional assertion results separate from cleanup health and fail the doctor command when either is unhealthy.
- Include throwable details when optional Redis system information cannot be read.
- Complete Redis doctor and cache-operation callback types, method documentation, names, and comments without changing Redis batching or round trips.

### Console command lifetime

- Clone container-resolved class-string commands before nested execution.
- Preserve the existing application and console context assignment on the clone.
- Complete void return types across the schedule command family.
- Align the empty schedule test output with the existing console component rendering.

### Validation and Telescope

- Let the nested email validator reject non-string values so callers receive the translated email validation message instead of the rule class name.
- Exercise null values directly and retain nullable behavior at the validator boundary.
- Correct the protected Telescope exception occurrence method spelling and update its internal caller without retaining a misspelled compatibility shim.
- Remove unused exception bindings while preserving bindings whose error codes are inspected.

### Types and source cleanup

- Add native array types to the container registries whose initialization and mutation paths are array-only.
- Add directly proven parameter, callback, property, and return types across the audited framework paths and database tests.
- Complete missing constructor and method documentation in the touched families.
- Replace a raw source delay with the fakeable Sleep API.
- Remove stale imports, dead parameters, analyzer-only comments, and misleading emphasis.
- Remove all stale inline PHPStan suppressions found by unmatched-ignore reporting and five stale global patterns. Suppressions that still cover real dynamic framework behavior remain in place.

## Compatibility and performance

Laravel public APIs remain intact. The Telescope spelling correction is an intentional correction to a Hypervel protected method, and no alias is retained for the misspelling.

The changes do not add application hot-path network calls, retries, registries, or new state machinery. Nested class-string command execution adds one shallow clone, matching the per-execution isolation already used by other command resolution paths.

## Verification

- Full formatter, PHPStan, parallel test, Testbench, and dogfood checks through composer fix.
- Focused Redis benchmark and doctor regressions covering success, cleanup failure, memory failure, and competing exceptions.
- Focused console tests for nested command state and schedule commands.
- Focused validation, Telescope storage, container, view compiler, and database tests.
- Full PHPStan audit with unmatched-ignore reporting enabled, followed by the standard configuration.
- Final formatting, source analysis, and diff checks.