### PR TITLE
Add strict coroutine child termination waits

### DIFF
--- a/src/coroutine/src/Exceptions/ChildTerminationTimeoutException.php
+++ b/src/coroutine/src/Exceptions/ChildTerminationTimeoutException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Coroutine\Exceptions;
 
-class ChildUnwindTimeoutException extends WaitTimeoutException
+class ChildTerminationTimeoutException extends WaitTimeoutException
 {
 }

--- a/src/coroutine/src/Exceptions/ChildUnwindTimeoutException.php
+++ b/src/coroutine/src/Exceptions/ChildUnwindTimeoutException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Coroutine\Exceptions;
+
+class ChildUnwindTimeoutException extends WaitTimeoutException
+{
+}

--- a/src/coroutine/src/Waiter.php
+++ b/src/coroutine/src/Waiter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Coroutine;
 
 use Closure;
+use Hypervel\Coroutine\Exceptions\ChildUnwindTimeoutException;
 use Hypervel\Coroutine\Exceptions\ExceptionThrower;
 use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
 use Hypervel\Engine\Channel;
@@ -38,11 +39,17 @@ class Waiter
      * @param array<string>|bool $copyContext When set, parent coroutine context is copied to the child.
      *                                        false = fresh context (default), true or empty array = copy all keys, non-empty array = copy listed keys only.
      *                                        Object values are shared by reference unless they implement Hypervel\Context\ReplicableContext.
+     * @param bool $waitForChildTermination Wait without a limit when a cancelled child exceeds the cleanup allowance
      * @return TReturn
      * @throws WaitTimeoutException When the wait times out
+     * @throws ChildUnwindTimeoutException When a cancelled child outlives the cleanup allowance in strict mode
      */
-    public function wait(Closure $closure, ?float $timeout = null, bool|array $copyContext = false): mixed
-    {
+    public function wait(
+        Closure $closure,
+        ?float $timeout = null,
+        bool|array $copyContext = false,
+        bool $waitForChildTermination = false,
+    ): mixed {
         if ($timeout === null) {
             $timeout = $this->popTimeout;
         }
@@ -71,6 +78,19 @@ class Waiter
             // then give the child a bounded interval to unwind and run deferred cleanup.
             EngineCoroutine::cancelById($childCoroutineId, throwException: true);
             Coroutine::join([$childCoroutineId], $this->pushTimeout);
+
+            // A false join may mean either timeout or a missing coroutine, so only
+            // existence proves that the child survived the cleanup allowance.
+            if ($waitForChildTermination && Coroutine::exists($childCoroutineId)) {
+                Coroutine::join([$childCoroutineId]);
+
+                // The wait already timed out, so discard any result produced during the extended unwind.
+                throw new ChildUnwindTimeoutException(sprintf(
+                    'Channel wait failed, reason: Timed out for %s s and child coroutine did not terminate within %s s',
+                    $timeout,
+                    $this->pushTimeout,
+                ));
+            }
 
             throw new WaitTimeoutException(sprintf('Channel wait failed, reason: Timed out for %s s', $timeout));
         }

--- a/src/coroutine/src/Waiter.php
+++ b/src/coroutine/src/Waiter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Coroutine;
 
 use Closure;
-use Hypervel\Coroutine\Exceptions\ChildUnwindTimeoutException;
+use Hypervel\Coroutine\Exceptions\ChildTerminationTimeoutException;
 use Hypervel\Coroutine\Exceptions\ExceptionThrower;
 use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
 use Hypervel\Engine\Channel;
@@ -42,7 +42,7 @@ class Waiter
      * @param bool $waitForChildTermination Wait without a limit when a cancelled child exceeds the cleanup allowance
      * @return TReturn
      * @throws WaitTimeoutException When the wait times out
-     * @throws ChildUnwindTimeoutException When a cancelled child outlives the cleanup allowance in strict mode
+     * @throws ChildTerminationTimeoutException When a cancelled child outlives the cleanup allowance in strict mode
      */
     public function wait(
         Closure $closure,
@@ -85,7 +85,7 @@ class Waiter
                 Coroutine::join([$childCoroutineId]);
 
                 // The wait already timed out, so discard any result produced during the extended unwind.
-                throw new ChildUnwindTimeoutException(sprintf(
+                throw new ChildTerminationTimeoutException(sprintf(
                     'Channel wait failed, reason: Timed out for %s s and child coroutine did not terminate within %s s',
                     $timeout,
                     $this->pushTimeout,

--- a/src/coroutine/src/functions.php
+++ b/src/coroutine/src/functions.php
@@ -6,7 +6,7 @@ namespace Hypervel\Coroutine;
 
 use Closure;
 use Hypervel\Container\Container;
-use Hypervel\Coroutine\Exceptions\ChildUnwindTimeoutException;
+use Hypervel\Coroutine\Exceptions\ChildTerminationTimeoutException;
 use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
 use RuntimeException;
 use Swoole\Runtime;
@@ -37,7 +37,7 @@ function parallel(array $callables, int $concurrent = 0, bool|array $copyContext
  * @param bool $waitForChildTermination Wait without a limit when a cancelled child exceeds the cleanup allowance
  * @return TReturn
  * @throws WaitTimeoutException When the wait times out
- * @throws ChildUnwindTimeoutException When a cancelled child outlives the cleanup allowance in strict mode
+ * @throws ChildTerminationTimeoutException When a cancelled child outlives the cleanup allowance in strict mode
  */
 function wait(
     Closure $closure,

--- a/src/coroutine/src/functions.php
+++ b/src/coroutine/src/functions.php
@@ -6,6 +6,8 @@ namespace Hypervel\Coroutine;
 
 use Closure;
 use Hypervel\Container\Container;
+use Hypervel\Coroutine\Exceptions\ChildUnwindTimeoutException;
+use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
 use RuntimeException;
 use Swoole\Runtime;
 
@@ -32,13 +34,20 @@ function parallel(array $callables, int $concurrent = 0, bool|array $copyContext
  * @param array<string>|bool $copyContext When set, parent coroutine context is copied to the child.
  *                                        false = fresh context (default), true or empty array = copy all keys, non-empty array = copy listed keys only.
  *                                        Object values are shared by reference unless they implement Hypervel\Context\ReplicableContext.
+ * @param bool $waitForChildTermination Wait without a limit when a cancelled child exceeds the cleanup allowance
  * @return TReturn
+ * @throws WaitTimeoutException When the wait times out
+ * @throws ChildUnwindTimeoutException When a cancelled child outlives the cleanup allowance in strict mode
  */
-function wait(Closure $closure, ?float $timeout = null, bool|array $copyContext = false): mixed
-{
+function wait(
+    Closure $closure,
+    ?float $timeout = null,
+    bool|array $copyContext = false,
+    bool $waitForChildTermination = false,
+): mixed {
     return Container::getInstance()
         ->make(Waiter::class)
-        ->wait($closure, $timeout, $copyContext);
+        ->wait($closure, $timeout, $copyContext, $waitForChildTermination);
 }
 
 /**

--- a/src/docs/coroutines.md
+++ b/src/docs/coroutines.md
@@ -467,7 +467,7 @@ $result = wait(function () {
 }, timeout: 2.0, waitForChildTermination: true);
 ```
 
-The requested timeout still cancels the child. If the child stops within the cleanup period, `wait` throws `WaitTimeoutException` as usual. If the child remains active after that period, `wait` continues waiting until it exits and then throws `ChildUnwindTimeoutException`. This exception extends `WaitTimeoutException`, so an existing catch for `WaitTimeoutException` handles both cases.
+The requested timeout still cancels the child. If the child stops within the cleanup period, `wait` throws `WaitTimeoutException` as usual. If the child remains active after that period, `wait` continues waiting until it exits and then throws `ChildTerminationTimeoutException`. This exception extends `WaitTimeoutException`, so an existing catch for `WaitTimeoutException` handles both cases.
 
 > [!WARNING]
 > Waiting for child termination has no secondary timeout. A child that catches cancellation and does not finish can keep the waiting coroutine blocked indefinitely.

--- a/src/docs/coroutines.md
+++ b/src/docs/coroutines.md
@@ -459,6 +459,19 @@ If the timeout is reached, Hypervel cancels the child by throwing `Swoole\Corout
 
 Code that catches the cancellation and keeps running may remain active after this 10-second cleanup period.
 
+If the waiting code must not continue while the child remains active, pass `waitForChildTermination: true`:
+
+```php
+$result = wait(function () {
+    // ...
+}, timeout: 2.0, waitForChildTermination: true);
+```
+
+The requested timeout still cancels the child. If the child stops within the cleanup period, `wait` throws `WaitTimeoutException` as usual. If the child remains active after that period, `wait` continues waiting until it exits and then throws `ChildUnwindTimeoutException`. This exception extends `WaitTimeoutException`, so an existing catch for `WaitTimeoutException` handles both cases.
+
+> [!WARNING]
+> Waiting for child termination has no secondary timeout. A child that catches cancellation and does not finish can keep the waiting coroutine blocked indefinitely.
+
 You may also use the `Waiter` class directly:
 
 ```php
@@ -470,6 +483,8 @@ $result = $waiter->wait(function () {
     return 'done';
 });
 ```
+
+The `Waiter::wait` method accepts the same `waitForChildTermination` argument as the helper.
 
 <a name="wait-groups"></a>
 ### Wait Groups

--- a/tests/Coroutine/WaiterTest.php
+++ b/tests/Coroutine/WaiterTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Coroutine;
 use Hypervel\Container\Container;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Coroutine\Coroutine;
+use Hypervel\Coroutine\Exceptions\ChildUnwindTimeoutException;
 use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
 use Hypervel\Coroutine\Waiter;
 use Hypervel\Engine\Channel;
@@ -17,6 +18,7 @@ use Hypervel\Tests\TestCase;
 use ReflectionProperty;
 use RuntimeException;
 use Swoole\Coroutine\CanceledException;
+use Throwable;
 
 use function Hypervel\Coroutine\wait;
 
@@ -280,6 +282,27 @@ class WaiterTest extends TestCase
         $this->assertFalse(Coroutine::exists($childCoroutineId));
     }
 
+    public function testStrictTimeoutThrowsTheBaseExceptionWhenTheChildStopsWithinTheCleanupBudget(): void
+    {
+        $childCoroutineId = null;
+        $waiter = new class extends Waiter {
+            protected float $pushTimeout = 0.05;
+        };
+
+        try {
+            $waiter->wait(function () use (&$childCoroutineId): void {
+                $childCoroutineId = Coroutine::id();
+                Coroutine::sleep(0.05);
+            }, 0.001, waitForChildTermination: true);
+            $this->fail('The waiter should time out.');
+        } catch (WaitTimeoutException $exception) {
+        }
+
+        $this->assertSame(WaitTimeoutException::class, $exception::class);
+        $this->assertIsInt($childCoroutineId);
+        $this->assertFalse(Coroutine::exists($childCoroutineId));
+    }
+
     public function testTimeoutReturnsWhenTheChildOutlivesTheCleanupBudget(): void
     {
         $childCoroutineId = null;
@@ -320,6 +343,62 @@ class WaiterTest extends TestCase
         }
 
         $this->assertTrue($childCompleted);
+        $this->assertFalse(Coroutine::exists($childCoroutineId));
+    }
+
+    public function testStrictTimeoutWaitsForChildTerminationAfterTheCleanupBudget(): void
+    {
+        $childCoroutineId = null;
+        $trailingWorkStarted = new Channel(1);
+        $releaseTrailingWork = new Channel(1);
+        $outcome = new Channel(1);
+        $waiter = new class extends Waiter {
+            protected float $pushTimeout = 0.001;
+        };
+
+        Container::getInstance()->instance(Waiter::class, $waiter);
+
+        $waitingCoroutineId = Coroutine::create(function () use (
+            &$childCoroutineId,
+            $outcome,
+            $releaseTrailingWork,
+            $trailingWorkStarted,
+        ): void {
+            try {
+                wait(function () use (&$childCoroutineId, $releaseTrailingWork, $trailingWorkStarted): void {
+                    $childCoroutineId = Coroutine::id();
+
+                    try {
+                        Coroutine::sleep(0.05);
+                    } catch (CanceledException) {
+                        $trailingWorkStarted->push(true);
+                        $releaseTrailingWork->pop();
+                    }
+                }, timeout: 0.002, waitForChildTermination: true);
+
+                $outcome->push('returned');
+            } catch (Throwable $exception) {
+                $outcome->push($exception);
+            }
+        });
+
+        try {
+            $this->assertTrue($trailingWorkStarted->pop(0.01));
+            $this->assertIsInt($childCoroutineId);
+            $this->assertTrue(Coroutine::exists($childCoroutineId));
+            $this->assertFalse($outcome->pop(0.05));
+        } finally {
+            $releaseTrailingWork->push(true);
+            Coroutine::join([$waitingCoroutineId]);
+        }
+
+        $exception = $outcome->pop(0.01);
+
+        $this->assertInstanceOf(ChildUnwindTimeoutException::class, $exception);
+        $this->assertSame(
+            'Channel wait failed, reason: Timed out for 0.002 s and child coroutine did not terminate within 0.001 s',
+            $exception->getMessage(),
+        );
         $this->assertFalse(Coroutine::exists($childCoroutineId));
     }
 }

--- a/tests/Coroutine/WaiterTest.php
+++ b/tests/Coroutine/WaiterTest.php
@@ -7,7 +7,7 @@ namespace Hypervel\Tests\Coroutine;
 use Hypervel\Container\Container;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Coroutine\Coroutine;
-use Hypervel\Coroutine\Exceptions\ChildUnwindTimeoutException;
+use Hypervel\Coroutine\Exceptions\ChildTerminationTimeoutException;
 use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
 use Hypervel\Coroutine\Waiter;
 use Hypervel\Engine\Channel;
@@ -394,7 +394,7 @@ class WaiterTest extends TestCase
 
         $exception = $outcome->pop(0.01);
 
-        $this->assertInstanceOf(ChildUnwindTimeoutException::class, $exception);
+        $this->assertInstanceOf(ChildTerminationTimeoutException::class, $exception);
         $this->assertSame(
             'Channel wait failed, reason: Timed out for 0.002 s and child coroutine did not terminate within 0.001 s',
             $exception->getMessage(),


### PR DESCRIPTION
## Summary

This PR adds an opt-in termination guarantee to the coroutine `wait` API.

- Add `waitForChildTermination` to the `wait` helper and `Waiter::wait`.
- Preserve the existing bounded timeout behavior by default.
- Add `ChildTerminationTimeoutException` for children that survive the cleanup allowance in strict mode.
- Cover the timeout and cleanup boundaries with real coroutine tests.
- Document the API and its indefinite-wait tradeoff.

## Motivation

A timed-out `Waiter` cancels its child and gives it a bounded period to unwind. A child may catch the cancellation and continue running after that period. Returning control at that point is the right general-purpose behavior, but some callers must not continue while the child remains active.

Making every wait unbounded would turn ordinary queue, scheduler, and testing calls into potential permanent stalls. The stronger guarantee therefore belongs on the individual wait operation.

## Implementation

The new argument is trailing and defaults to `false`:

```php
$result = wait(
    fn () => performWork(),
    timeout: 2.0,
    waitForChildTermination: true,
);
```

The timeout path still cancels the child and performs the existing bounded join first. In strict mode, `Waiter` then checks whether the child still exists. This check is required because a false Swoole join result can mean either that the cleanup period expired or that the coroutine was already gone.

If the child survived, `Waiter` joins it without a second deadline. Once the child exits, the caller receives `ChildTerminationTimeoutException`. The new exception extends `WaitTimeoutException`, so callers may continue handling all wait timeouts together or distinguish this condition when needed.

The option is per call rather than constructor state. `Waiter` may be a worker-lifetime auto-singleton, while the required termination guarantee varies by operation.

## Behavior

- Default calls retain the bounded cleanup behavior.
- Strict calls whose child exits within the cleanup allowance receive the normal `WaitTimeoutException`.
- Strict calls whose child survives the allowance remain blocked until it exits, then receive `ChildTerminationTimeoutException`.
- Results produced after the cleanup allowance are discarded because the original wait has already timed out.
- Strict mode has no secondary timeout. A child that catches cancellation and never exits can keep its caller blocked indefinitely.

The strict branch is reached only after a timeout. Existing successful waits and default timeout callers do not perform an additional coroutine lookup or join.

## Tests

The coroutine tests cover:

- existing default-mode deferred cleanup;
- strict cleanup that completes within the bounded allowance;
- a cancellation-catching child that remains alive beyond the allowance;
- the caller remaining blocked until that child is released;
- the dedicated exception type and diagnostic timeout values;
- public helper argument forwarding.

The full formatter, static analysis, parallel test, Testbench, and dogfood checks pass.

## Documentation

The coroutine documentation explains both entry points, the exception relationship, and the indefinite-blocking consequence of opting into strict termination.