### PR TITLE
Add first-party PHPStan support for Eloquent forwarding and scopes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,9 @@
 # should be fixed at the source, or suppressed inline for genuine static analysis
 # limitations.
 
+includes:
+  - src/database/extension.neon
+
 parameters:
   tmpDir: .cache/phpstan
   level: 5
@@ -83,11 +86,6 @@ parameters:
     - identifier: method.childReturnType
       path: src/database/*
     - identifier: method.childParameterType
-      path: src/database/*
-
-    # Relation @mixin forwarding - Relation methods returning $this forward to Builder methods
-    # PHPStan sees Builder return type but the actual return is $this (the Relation)
-    - message: '#should return \$this\(Hypervel\\Database\\Eloquent\\Relations\\.+\) but returns Hypervel\\Database\\(Query|Eloquent)\\Builder#'
       path: src/database/*
 
     # BelongsToMany pivot intersection type - PHPDoc uses object{pivot: ...}&TRelatedModel

--- a/phpstan.types.neon.dist
+++ b/phpstan.types.neon.dist
@@ -1,3 +1,6 @@
+includes:
+    - src/database/extension.neon
+
 parameters:
     level: max
     tmpDir: .cache/phpstan-types

--- a/src/database/composer.json
+++ b/src/database/composer.json
@@ -62,7 +62,8 @@
         "hypervel/support": "^0.4"
     },
     "require-dev": {
-        "fakerphp/faker": "^1.24"
+        "fakerphp/faker": "^1.24",
+        "phpstan/phpstan": "^2.0"
     },
     "suggest": {
         "fakerphp/faker": "Required to use Eloquent model factories (^1.24)."
@@ -74,6 +75,11 @@
         "hypervel": {
             "providers": [
                 "Hypervel\\Database\\DatabaseServiceProvider"
+            ]
+        },
+        "phpstan": {
+            "includes": [
+                "extension.neon"
             ]
         },
         "branch-alias": {

--- a/src/database/extension.neon
+++ b/src/database/extension.neon
@@ -1,5 +1,15 @@
 services:
     -
+        class: Hypervel\Database\PHPStan\ModelScopeMethodResolver
+    -
         class: Hypervel\Database\PHPStan\ForwardedFluentMethodExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: Hypervel\Database\PHPStan\ForwardedModelMethodExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension
+    -
+        class: Hypervel\Database\PHPStan\NamedScopeMethodExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension

--- a/src/database/extension.neon
+++ b/src/database/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: Hypervel\Database\PHPStan\ForwardedFluentMethodExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/src/database/src/Eloquent/Builder.php
+++ b/src/database/src/Eloquent/Builder.php
@@ -934,6 +934,13 @@ class Builder implements BuilderContract
 
     /**
      * Invoke the "after query" modification callbacks.
+     *
+     * A callback that replaces the collection type owns the resulting type change.
+     *
+     * @template TCollection of BaseCollection
+     *
+     * @param TCollection $result
+     * @return TCollection
      */
     public function applyAfterQueryCallbacks(BaseCollection $result): BaseCollection
     {

--- a/src/database/src/Eloquent/Model.php
+++ b/src/database/src/Eloquent/Model.php
@@ -298,6 +298,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static array $scopeMethodAttributes = [];
 
     /**
+     * Cache of whether methods are callable legacy local scopes.
+     *
+     * @var array<string, bool>
+     */
+    protected static array $legacyScopeMethods = [];
+
+    /**
      * Cache of soft deletable models.
      *
      * @var array<class-string<self>, bool>
@@ -547,7 +554,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         static::$classDeclaredAttributes = [];
         static::$classPropertyDeclarers = [];
         static::$guardConfigurations = [];
-        static::$scopeMethodAttributes = [];
+        self::flushScopeCaches();
 
         static::$globalScopes = [];
     }
@@ -1975,7 +1982,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function hasNamedScope(string $scope): bool
     {
-        return method_exists($this, 'scope' . ucfirst($scope))
+        return static::isLegacyScopeMethod($scope)
             || static::isScopeMethodWithAttribute($scope);
     }
 
@@ -2014,6 +2021,33 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         return static::$scopeMethodAttributes[$key] = ! $reflection->isPrivate()
             && $reflection->getAttributes(LocalScope::class) !== [];
+    }
+
+    /**
+     * Determine if the given method is a callable legacy local scope.
+     */
+    protected static function isLegacyScopeMethod(string $scope): bool
+    {
+        $key = static::class . "\0" . strtolower($scope);
+
+        if (array_key_exists($key, static::$legacyScopeMethods)) {
+            return static::$legacyScopeMethods[$key];
+        }
+
+        $method = 'scope' . ucfirst($scope);
+
+        // Query-derived dynamic scope names can be arbitrary. Do not retain misses
+        // for nonexistent methods in a long-running worker.
+        if (! method_exists(static::class, $method)) {
+            return false;
+        }
+
+        $reflection = new ReflectionMethod(static::class, $method);
+        $declaredName = $reflection->getName();
+
+        return static::$legacyScopeMethods[$key] = strlen($declaredName) > 5
+            && ! $reflection->isPrivate()
+            && ! ctype_lower($declaredName[5]);
     }
 
     /**
@@ -2653,6 +2687,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Flush local scope caches.
+     */
+    private static function flushScopeCaches(): void
+    {
+        static::$scopeMethodAttributes = [];
+        static::$legacyScopeMethods = [];
+    }
+
+    /**
      * Flush all static state.
      */
     public static function flushState(): void
@@ -2668,7 +2711,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         static::$classDeclaredAttributes = [];
         static::$classPropertyDeclarers = [];
         static::$guardConfigurations = [];
-        static::$scopeMethodAttributes = [];
+        self::flushScopeCaches();
         static::$modelsShouldPreventLazyLoading = false;
         static::$modelsShouldAutomaticallyEagerLoadRelationships = false;
         static::$lazyLoadingViolationCallback = null;

--- a/src/database/src/Eloquent/Relations/BelongsToMany.php
+++ b/src/database/src/Eloquent/Relations/BelongsToMany.php
@@ -852,6 +852,11 @@ class BelongsToMany extends Relation
             : $this->related->newCollection();
     }
 
+    /**
+     * Execute the query as a "select" statement.
+     *
+     * @return \Hypervel\Database\Eloquent\Collection<int, object{pivot: TPivotModel}&TRelatedModel>
+     */
     public function get(array $columns = ['*']): BaseCollection
     {
         // First we'll add the proper select columns onto the query so it is run with

--- a/src/database/src/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/database/src/Eloquent/Relations/HasOneOrManyThrough.php
@@ -417,6 +417,11 @@ abstract class HasOneOrManyThrough extends Relation
         return $callback();
     }
 
+    /**
+     * Execute the query as a "select" statement.
+     *
+     * @return \Hypervel\Database\Eloquent\Collection<int, TRelatedModel>
+     */
     public function get(array $columns = ['*']): BaseCollection
     {
         $builder = $this->prepareQueryBuilder($columns);

--- a/src/database/src/Eloquent/Relations/Relation.php
+++ b/src/database/src/Eloquent/Relations/Relation.php
@@ -202,7 +202,7 @@ abstract class Relation implements BuilderContract
     /**
      * Execute the query as a "select" statement.
      *
-     * @return \Hypervel\Support\Collection<int, TRelatedModel>
+     * @return \Hypervel\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function get(array $columns = ['*']): BaseCollection
     {

--- a/src/database/src/PHPStan/ForwardedFluentMethodExtension.php
+++ b/src/database/src/PHPStan/ForwardedFluentMethodExtension.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use Hypervel\Database\Eloquent\Builder as EloquentBuilder;
+use Hypervel\Database\Eloquent\Relations\Relation;
+use Hypervel\Database\Query\Builder as QueryBuilder;
+use LogicException;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\Type;
+
+/**
+ * Preserve the receiving Eloquent builder or relation through fluent forwarding.
+ */
+class ForwardedFluentMethodExtension implements MethodsClassReflectionExtension
+{
+    /** @var list<string> */
+    private const array RELATION_NON_DECORATED_METHODS = [
+        'applyscopes',
+        'clone',
+    ];
+
+    /** @var list<string> */
+    private const array RELATION_DOCUMENTED_FLUENT_METHODS = [
+        'wherecan',
+        'withcan',
+    ];
+
+    /** @var list<string> */
+    private readonly array $passthru;
+
+    /** @var array<string, false|MethodReflection> */
+    private array $methods = [];
+
+    private readonly OutOfClassScope $scope;
+
+    /**
+     * Create a forwarded fluent method extension.
+     */
+    public function __construct(private readonly ReflectionProvider $reflectionProvider)
+    {
+        /** @var list<string> $passthru */
+        $passthru = $this->reflectionProvider
+            ->getClass(EloquentBuilder::class)
+            ->getNativeReflection()
+            ->getDefaultProperties()['passthru'];
+
+        $this->passthru = $passthru;
+        $this->scope = new OutOfClassScope;
+    }
+
+    /**
+     * Determine whether the class exposes the forwarded fluent method.
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return $this->resolveMethod($classReflection, $methodName) !== null;
+    }
+
+    /**
+     * Return the forwarded fluent method.
+     */
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->resolveMethod($classReflection, $methodName)
+            ?? throw new LogicException(sprintf(
+                'Forwarded fluent method [%s::%s] was not resolved.',
+                $classReflection->getName(),
+                $methodName,
+            ));
+    }
+
+    /**
+     * Resolve and cache a forwarded fluent method.
+     */
+    private function resolveMethod(ClassReflection $classReflection, string $methodName): ?MethodReflection
+    {
+        $isEloquentHost = $this->isClassOrSubclassOf($classReflection, EloquentBuilder::class);
+        $isRelationHost = ! $isEloquentHost
+            && $this->isClassOrSubclassOf($classReflection, Relation::class);
+
+        if (! $isEloquentHost && ! $isRelationHost) {
+            return null;
+        }
+
+        $cacheKey = $classReflection->getCacheKey() . ':' . strtolower($methodName);
+
+        if (array_key_exists($cacheKey, $this->methods)) {
+            $cachedMethod = $this->methods[$cacheKey];
+
+            return $cachedMethod === false ? null : $cachedMethod;
+        }
+
+        $method = null;
+
+        if (! $this->hasNativeOrDocumentedMethod($classReflection, $methodName)) {
+            if ($isEloquentHost) {
+                $method = $this->resolveEloquentBuilderMethod($classReflection, $methodName);
+            } else {
+                $method = $this->resolveRelationMethod($classReflection, $methodName);
+            }
+        }
+
+        $this->methods[$cacheKey] = $method ?? false;
+
+        return $method;
+    }
+
+    /**
+     * Resolve a fluent method forwarded by an Eloquent builder.
+     */
+    private function resolveEloquentBuilderMethod(
+        ClassReflection $classReflection,
+        string $methodName,
+    ): ?MethodReflection {
+        if (in_array(strtolower($methodName), $this->passthru, strict: true)) {
+            return null;
+        }
+
+        $queryBuilder = $this->reflectionProvider->getClass(QueryBuilder::class);
+
+        if (! $queryBuilder->hasNativeMethod($methodName)) {
+            return null;
+        }
+
+        if (! $this->returnsStatic($queryBuilder->getNativeMethod($methodName))) {
+            return null;
+        }
+
+        $modelType = $this->templateType($classReflection, EloquentBuilder::class, 'TModel');
+        $method = $this->queryBuilderType($modelType)->getMethod($methodName, $this->scope);
+
+        return new ForwardedFluentMethodReflection($classReflection, $method);
+    }
+
+    /**
+     * Resolve a fluent method forwarded by a relation.
+     */
+    private function resolveRelationMethod(ClassReflection $classReflection, string $methodName): ?MethodReflection
+    {
+        $normalizedMethodName = strtolower($methodName);
+        $relatedType = $this->templateType($classReflection, Relation::class, 'TRelatedModel');
+        $eloquentBuilder = $this->reflectionProvider->getClass(EloquentBuilder::class);
+
+        if ($eloquentBuilder->hasNativeMethod($methodName)) {
+            if (in_array($normalizedMethodName, self::RELATION_NON_DECORATED_METHODS, strict: true)
+                || ! $this->returnsStatic($eloquentBuilder->getNativeMethod($methodName))) {
+                return null;
+            }
+
+            $method = $this->eloquentBuilderType($relatedType)->getMethod($methodName, $this->scope);
+
+            return new ForwardedFluentMethodReflection($classReflection, $method);
+        }
+
+        $queryBuilder = $this->reflectionProvider->getClass(QueryBuilder::class);
+
+        if ($queryBuilder->hasNativeMethod($methodName)) {
+            if (in_array(strtolower($methodName), $this->passthru, strict: true)
+                || ! $this->returnsStatic($queryBuilder->getNativeMethod($methodName))) {
+                return null;
+            }
+
+            $method = $this->queryBuilderType($relatedType)->getMethod($methodName, $this->scope);
+
+            return new ForwardedFluentMethodReflection($classReflection, $method);
+        }
+
+        if (! in_array($normalizedMethodName, self::RELATION_DOCUMENTED_FLUENT_METHODS, strict: true)) {
+            return null;
+        }
+
+        $method = $this->eloquentBuilderType($relatedType)->getMethod($methodName, $this->scope);
+
+        return new ForwardedFluentMethodReflection($classReflection, $method);
+    }
+
+    /**
+     * Determine whether a class owns a native or documented method.
+     */
+    private function hasNativeOrDocumentedMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if ($classReflection->hasNativeMethod($methodName)) {
+            return true;
+        }
+
+        foreach (array_keys($classReflection->getMethodTags()) as $documentedMethod) {
+            if (strcasecmp($documentedMethod, $methodName) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the class is or extends the target class.
+     *
+     * @param class-string $targetClass
+     */
+    private function isClassOrSubclassOf(ClassReflection $classReflection, string $targetClass): bool
+    {
+        return $classReflection->getName() === $targetClass
+            || $classReflection->isSubclassOfClass($this->reflectionProvider->getClass($targetClass));
+    }
+
+    /**
+     * Return an active template type from a class ancestor.
+     *
+     * @param class-string $ancestorClass
+     */
+    private function templateType(
+        ClassReflection $classReflection,
+        string $ancestorClass,
+        string $templateName,
+    ): Type {
+        $type = $classReflection
+            ->getAncestorWithClassName($ancestorClass)
+            ?->getActiveTemplateTypeMap()
+            ->getType($templateName);
+
+        return $type ?? throw new LogicException(sprintf(
+            'Template type [%s] is not available for [%s].',
+            $templateName,
+            $classReflection->getName(),
+        ));
+    }
+
+    /**
+     * Create a generic Eloquent builder type.
+     */
+    private function eloquentBuilderType(Type $modelType): GenericObjectType
+    {
+        return new GenericObjectType(EloquentBuilder::class, [$modelType]);
+    }
+
+    /**
+     * Create a generic query builder type.
+     */
+    private function queryBuilderType(Type $modelType): GenericObjectType
+    {
+        return new GenericObjectType(QueryBuilder::class, [new IntegerType, $modelType]);
+    }
+
+    /**
+     * Determine whether every method variant returns static.
+     */
+    private function returnsStatic(MethodReflection $method): bool
+    {
+        foreach ($method->getVariants() as $variant) {
+            if (! $variant->getReturnType() instanceof StaticType) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/database/src/PHPStan/ForwardedFluentMethodReflection.php
+++ b/src/database/src/PHPStan/ForwardedFluentMethodReflection.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedParametersAcceptor;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ThisType;
+use PHPStan\Type\Type;
+
+/**
+ * Describe a forwarded fluent method whose runtime result is the receiving object.
+ */
+class ForwardedFluentMethodReflection implements MethodReflection
+{
+    /**
+     * Create a forwarded fluent method reflection.
+     */
+    public function __construct(
+        private readonly ClassReflection $declaringClass,
+        private readonly MethodReflection $forwardedMethod,
+    ) {
+    }
+
+    /**
+     * Return the method name.
+     */
+    public function getName(): string
+    {
+        return $this->forwardedMethod->getName();
+    }
+
+    /**
+     * Return the declaring class.
+     */
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->declaringClass;
+    }
+
+    /**
+     * Determine whether the method is static.
+     */
+    public function isStatic(): bool
+    {
+        return $this->forwardedMethod->isStatic();
+    }
+
+    /**
+     * Determine whether the method is private.
+     */
+    public function isPrivate(): bool
+    {
+        return $this->forwardedMethod->isPrivate();
+    }
+
+    /**
+     * Determine whether the method is public.
+     */
+    public function isPublic(): bool
+    {
+        return $this->forwardedMethod->isPublic();
+    }
+
+    /**
+     * Return the method docblock.
+     */
+    public function getDocComment(): ?string
+    {
+        return $this->forwardedMethod->getDocComment();
+    }
+
+    /**
+     * Return the method prototype.
+     */
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /**
+     * Return the callable variants with the receiving object as their result.
+     *
+     * @return list<ParametersAcceptor>
+     */
+    public function getVariants(): array
+    {
+        return array_map(
+            fn (ParametersAcceptor $variant): FunctionVariant => new FunctionVariant(
+                $variant->getTemplateTypeMap(),
+                $variant->getResolvedTemplateTypeMap(),
+                $variant->getParameters(),
+                $variant->isVariadic(),
+                new ThisType($this->declaringClass),
+                $variant instanceof ExtendedParametersAcceptor ? $variant->getCallSiteVarianceMap() : null,
+            ),
+            $this->forwardedMethod->getVariants(),
+        );
+    }
+
+    /**
+     * Determine whether the method is deprecated.
+     */
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->forwardedMethod->isDeprecated();
+    }
+
+    /**
+     * Return the deprecation description.
+     */
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->forwardedMethod->getDeprecatedDescription();
+    }
+
+    /**
+     * Determine whether the method is final.
+     */
+    public function isFinal(): TrinaryLogic
+    {
+        return $this->forwardedMethod->isFinal();
+    }
+
+    /**
+     * Determine whether the method is internal.
+     */
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->forwardedMethod->isInternal();
+    }
+
+    /**
+     * Return the declared throw type.
+     */
+    public function getThrowType(): ?Type
+    {
+        return $this->forwardedMethod->getThrowType();
+    }
+
+    /**
+     * Determine whether the method has side effects.
+     */
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return $this->forwardedMethod->hasSideEffects();
+    }
+}

--- a/src/database/src/PHPStan/ForwardedModelMethodExtension.php
+++ b/src/database/src/PHPStan/ForwardedModelMethodExtension.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use Hypervel\Database\Eloquent\Model;
+use LogicException;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Type;
+
+/**
+ * Describe Eloquent builder methods forwarded through models.
+ */
+class ForwardedModelMethodExtension implements MethodsClassReflectionExtension
+{
+    /** @var array<string, false|MethodReflection> */
+    private array $methods = [];
+
+    private readonly OutOfClassScope $scope;
+
+    /**
+     * Create a forwarded model method extension.
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ModelScopeMethodResolver $scopeMethods,
+    ) {
+        $this->scope = new OutOfClassScope;
+    }
+
+    /**
+     * Determine whether the model exposes the forwarded builder method.
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return $this->resolveMethod($classReflection, $methodName) !== null;
+    }
+
+    /**
+     * Return the forwarded builder method.
+     */
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->resolveMethod($classReflection, $methodName)
+            ?? throw new LogicException(sprintf(
+                'Forwarded model method [%s::%s] was not resolved.',
+                $classReflection->getName(),
+                $methodName,
+            ));
+    }
+
+    /**
+     * Resolve and cache a builder method forwarded through a model.
+     */
+    private function resolveMethod(ClassReflection $classReflection, string $methodName): ?MethodReflection
+    {
+        if (! $this->isModel($classReflection)) {
+            return null;
+        }
+
+        $cacheKey = $classReflection->getCacheKey() . ':' . strtolower($methodName);
+
+        if (array_key_exists($cacheKey, $this->methods)) {
+            $cachedMethod = $this->methods[$cacheKey];
+
+            return $cachedMethod === false ? null : $cachedMethod;
+        }
+
+        $method = null;
+
+        if (! $this->hasNativeOrDocumentedMethod($classReflection, $methodName)) {
+            $builderType = $this->activeBuilderType($classReflection);
+            $scopeMethod = $this->scopeMethods->resolve($classReflection, $methodName);
+
+            if (($scopeMethod === null || $this->hasNativeMethod($builderType, $methodName))
+                && $builderType->hasMethod($methodName)->yes()) {
+                $method = new ForwardedModelMethodReflection(
+                    $classReflection,
+                    $builderType->getMethod($methodName, $this->scope),
+                );
+            }
+        }
+
+        $this->methods[$cacheKey] = $method ?? false;
+
+        return $method;
+    }
+
+    /**
+     * Return the active query builder type for a model.
+     *
+     * Preserve the raw static type so PHPStan can rebind it to the called-on model.
+     */
+    private function activeBuilderType(ClassReflection $classReflection): Type
+    {
+        $variants = $classReflection->getMethod('query', $this->scope)->getVariants();
+
+        return $variants[0]->getReturnType();
+    }
+
+    /**
+     * Determine whether an active builder owns a native method.
+     */
+    private function hasNativeMethod(Type $builderType, string $methodName): bool
+    {
+        foreach ($builderType->getObjectClassReflections() as $builderClass) {
+            if ($builderClass->hasNativeMethod($methodName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether a class owns a native or documented method.
+     */
+    private function hasNativeOrDocumentedMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if ($classReflection->hasNativeMethod($methodName)) {
+            return true;
+        }
+
+        foreach (array_keys($classReflection->getMethodTags()) as $documentedMethod) {
+            if (strcasecmp($documentedMethod, $methodName) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the class is an Eloquent model.
+     */
+    private function isModel(ClassReflection $classReflection): bool
+    {
+        return $classReflection->getName() === Model::class
+            || $classReflection->isSubclassOfClass($this->reflectionProvider->getClass(Model::class));
+    }
+}

--- a/src/database/src/PHPStan/ForwardedModelMethodReflection.php
+++ b/src/database/src/PHPStan/ForwardedModelMethodReflection.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+/**
+ * Describe a builder method forwarded through an Eloquent model.
+ */
+class ForwardedModelMethodReflection implements MethodReflection
+{
+    /**
+     * Create a forwarded model method reflection.
+     */
+    public function __construct(
+        private readonly ClassReflection $declaringClass,
+        private readonly MethodReflection $forwardedMethod,
+    ) {
+    }
+
+    /**
+     * Return the method name.
+     */
+    public function getName(): string
+    {
+        return $this->forwardedMethod->getName();
+    }
+
+    /**
+     * Return the declaring class.
+     */
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->declaringClass;
+    }
+
+    /**
+     * Determine whether the method is static.
+     */
+    public function isStatic(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the method is private.
+     */
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the method is public.
+     */
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Return the method docblock.
+     */
+    public function getDocComment(): ?string
+    {
+        return $this->forwardedMethod->getDocComment();
+    }
+
+    /**
+     * Return the method prototype.
+     */
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /**
+     * Return the forwarded builder method variants.
+     *
+     * @return list<ParametersAcceptor>
+     */
+    public function getVariants(): array
+    {
+        return $this->forwardedMethod->getVariants();
+    }
+
+    /**
+     * Determine whether the method is deprecated.
+     */
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->forwardedMethod->isDeprecated();
+    }
+
+    /**
+     * Return the deprecation description.
+     */
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->forwardedMethod->getDeprecatedDescription();
+    }
+
+    /**
+     * Determine whether the method is final.
+     */
+    public function isFinal(): TrinaryLogic
+    {
+        return $this->forwardedMethod->isFinal();
+    }
+
+    /**
+     * Determine whether the method is internal.
+     */
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->forwardedMethod->isInternal();
+    }
+
+    /**
+     * Return the declared throw type.
+     */
+    public function getThrowType(): ?Type
+    {
+        return $this->forwardedMethod->getThrowType();
+    }
+
+    /**
+     * Determine whether the method has side effects.
+     */
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return $this->forwardedMethod->hasSideEffects();
+    }
+}

--- a/src/database/src/PHPStan/ModelScopeMethodResolver.php
+++ b/src/database/src/PHPStan/ModelScopeMethodResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use Hypervel\Database\Eloquent\Attributes\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+
+/**
+ * Resolve model methods exposed as named Eloquent scopes.
+ */
+class ModelScopeMethodResolver
+{
+    /** @var array<string, array<string, MethodReflection>> */
+    private array $methods = [];
+
+    /**
+     * Resolve a model scope by its exposed name.
+     */
+    public function resolve(ClassReflection $modelClass, string $scope): ?MethodReflection
+    {
+        return $this->methods($modelClass)[strtolower($scope)] ?? null;
+    }
+
+    /**
+     * Return the named scopes exposed by a model.
+     *
+     * @return array<string, MethodReflection>
+     */
+    private function methods(ClassReflection $modelClass): array
+    {
+        $cacheKey = $modelClass->getCacheKey();
+
+        if (isset($this->methods[$cacheKey])) {
+            return $this->methods[$cacheKey];
+        }
+
+        $legacyScopes = [];
+        $attributedScopes = [];
+
+        foreach ($modelClass->getNativeReflection()->getMethods() as $method) {
+            if ($method->isPrivate()) {
+                continue;
+            }
+
+            $methodName = $method->getName();
+
+            if (strncasecmp($methodName, 'scope', 5) === 0
+                && strlen($methodName) > 5
+                && ! ctype_lower($methodName[5])) {
+                $legacyScopes[strtolower(substr($methodName, 5))] = $modelClass->getNativeMethod($methodName);
+            }
+
+            if ($method->getAttributes(Scope::class) !== []) {
+                $attributedScopes[strtolower($methodName)] = $modelClass->getNativeMethod($methodName);
+            }
+        }
+
+        return $this->methods[$cacheKey] = array_replace($legacyScopes, $attributedScopes);
+    }
+}

--- a/src/database/src/PHPStan/ModelScopeParameterReflection.php
+++ b/src/database/src/PHPStan/ModelScopeParameterReflection.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\Type;
+
+/**
+ * Preserve model-relative parameter types on an exposed scope method.
+ */
+class ModelScopeParameterReflection implements ParameterReflection
+{
+    /**
+     * Create a model scope parameter reflection.
+     */
+    public function __construct(
+        private readonly ParameterReflection $parameter,
+        private readonly ClassReflection $modelClass,
+    ) {
+    }
+
+    /**
+     * Return the parameter name.
+     */
+    public function getName(): string
+    {
+        return $this->parameter->getName();
+    }
+
+    /**
+     * Determine whether the parameter is optional.
+     */
+    public function isOptional(): bool
+    {
+        return $this->parameter->isOptional();
+    }
+
+    /**
+     * Return the parameter type.
+     */
+    public function getType(): Type
+    {
+        return ModelScopeTypeResolver::bindToModel($this->parameter->getType(), $this->modelClass);
+    }
+
+    /**
+     * Return the parameter reference mode.
+     */
+    public function passedByReference(): PassedByReference
+    {
+        return $this->parameter->passedByReference();
+    }
+
+    /**
+     * Determine whether the parameter is variadic.
+     */
+    public function isVariadic(): bool
+    {
+        return $this->parameter->isVariadic();
+    }
+
+    /**
+     * Return the default value type.
+     */
+    public function getDefaultValue(): ?Type
+    {
+        $defaultValue = $this->parameter->getDefaultValue();
+
+        return $defaultValue === null
+            ? null
+            : ModelScopeTypeResolver::bindToModel($defaultValue, $this->modelClass);
+    }
+}

--- a/src/database/src/PHPStan/ModelScopeTypeResolver.php
+++ b/src/database/src/PHPStan/ModelScopeTypeResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
+
+/**
+ * Bind model-relative types resolved for an Eloquent receiver.
+ */
+class ModelScopeTypeResolver
+{
+    /**
+     * Bind late-static types to the concrete model receiving the scope.
+     *
+     * PHPStan binds inherited method types to their declaring class until they are explicitly rebased.
+     */
+    public static function bindToModel(Type $type, ClassReflection $modelClass): Type
+    {
+        return TypeTraverser::map(
+            $type,
+            static fn (Type $nestedType, callable $traverse): Type => $nestedType instanceof StaticType
+                ? $nestedType->changeBaseClass($modelClass)->getStaticObjectType()
+                : $traverse($nestedType),
+        );
+    }
+}

--- a/src/database/src/PHPStan/NamedScopeMethodExtension.php
+++ b/src/database/src/PHPStan/NamedScopeMethodExtension.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use Hypervel\Database\Eloquent\Builder;
+use Hypervel\Database\Eloquent\Model;
+use Hypervel\Database\Eloquent\Relations\Relation;
+use LogicException;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ThisType;
+use PHPStan\Type\Type;
+
+/**
+ * Describe model scopes exposed through models, builders, and relations.
+ */
+class NamedScopeMethodExtension implements MethodsClassReflectionExtension
+{
+    /** @var array<string, false|MethodReflection> */
+    private array $methods = [];
+
+    private readonly OutOfClassScope $scope;
+
+    /**
+     * Create a named scope method extension.
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ModelScopeMethodResolver $scopeMethods,
+    ) {
+        $this->scope = new OutOfClassScope;
+    }
+
+    /**
+     * Determine whether the receiver exposes the named scope.
+     */
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return $this->resolveMethod($classReflection, $methodName) !== null;
+    }
+
+    /**
+     * Return the named scope method.
+     */
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->resolveMethod($classReflection, $methodName)
+            ?? throw new LogicException(sprintf(
+                'Named scope method [%s::%s] was not resolved.',
+                $classReflection->getName(),
+                $methodName,
+            ));
+    }
+
+    /**
+     * Resolve and cache a named scope for an Eloquent receiver.
+     */
+    private function resolveMethod(ClassReflection $classReflection, string $methodName): ?MethodReflection
+    {
+        $isModelHost = $this->isClassOrSubclassOf($classReflection, Model::class);
+        $isBuilderHost = ! $isModelHost
+            && $this->isClassOrSubclassOf($classReflection, Builder::class);
+        $isRelationHost = ! $isModelHost && ! $isBuilderHost
+            && $this->isClassOrSubclassOf($classReflection, Relation::class);
+
+        if (! $isModelHost && ! $isBuilderHost && ! $isRelationHost) {
+            return null;
+        }
+
+        $cacheKey = $classReflection->getCacheKey() . ':' . strtolower($methodName);
+
+        if (array_key_exists($cacheKey, $this->methods)) {
+            $cachedMethod = $this->methods[$cacheKey];
+
+            return $cachedMethod === false ? null : $cachedMethod;
+        }
+
+        $host = $this->host($classReflection, $isModelHost, $isBuilderHost);
+
+        if ($host === null) {
+            return null;
+        }
+
+        [$modelClass, $receiverType, $queryType, $static] = $host;
+        $scopeMethod = $this->scopeMethods->resolve($modelClass, $methodName);
+        $method = null;
+
+        if ($scopeMethod !== null && ! $this->nativeMethodTakesPrecedence(
+            $classReflection,
+            $methodName,
+            $queryType,
+            $static,
+        )) {
+            $method = new NamedScopeMethodReflection(
+                $classReflection,
+                $modelClass,
+                $scopeMethod,
+                $methodName,
+                $receiverType,
+                $queryType,
+                $static,
+            );
+        }
+
+        $this->methods[$cacheKey] = $method ?? false;
+
+        return $method;
+    }
+
+    /**
+     * Resolve the model, receiver and query types, and static mode for an Eloquent host.
+     *
+     * @return null|array{ClassReflection, Type, Type, bool}
+     */
+    private function host(
+        ClassReflection $classReflection,
+        bool $isModelHost,
+        bool $isBuilderHost,
+    ): ?array {
+        if ($isModelHost) {
+            $queryType = $this->activeBuilderType($classReflection);
+
+            return [
+                $classReflection,
+                $queryType,
+                $queryType,
+                true,
+            ];
+        }
+
+        $templateName = $isBuilderHost ? 'TModel' : 'TRelatedModel';
+
+        $modelType = $this->templateType(
+            $classReflection,
+            $isBuilderHost ? Builder::class : Relation::class,
+            $templateName,
+        );
+        $modelClasses = $modelType->getObjectClassReflections();
+
+        if (count($modelClasses) !== 1) {
+            return null;
+        }
+
+        $receiverType = new ThisType($classReflection);
+
+        return [
+            $modelClasses[0],
+            $receiverType,
+            $isBuilderHost ? $receiverType : $this->activeBuilderType($modelClasses[0]),
+            false,
+        ];
+    }
+
+    /**
+     * Determine whether a native method wins over dynamic scope dispatch.
+     */
+    private function nativeMethodTakesPrecedence(
+        ClassReflection $classReflection,
+        string $methodName,
+        Type $queryType,
+        bool $static,
+    ): bool {
+        if ($classReflection->hasNativeMethod($methodName)
+            && (! $static || $classReflection->getNativeMethod($methodName)->isPublic())) {
+            return true;
+        }
+
+        // Model and relation hosts also yield to methods owned by their active builder.
+        foreach ($queryType->getObjectClassReflections() as $builderClass) {
+            if ($builderClass->hasNativeMethod($methodName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return the active query builder type for a model.
+     *
+     * Bind static here because scope returns are compared before PHPStan can rebind the synthesized receiver.
+     */
+    private function activeBuilderType(ClassReflection $modelClass): Type
+    {
+        $variants = $modelClass->getMethod('query', $this->scope)->getVariants();
+
+        return ModelScopeTypeResolver::bindToModel($variants[0]->getReturnType(), $modelClass);
+    }
+
+    /**
+     * Return an active template type from a class ancestor.
+     *
+     * @param class-string $ancestorClass
+     */
+    private function templateType(
+        ClassReflection $classReflection,
+        string $ancestorClass,
+        string $templateName,
+    ): Type {
+        $type = $classReflection
+            ->getAncestorWithClassName($ancestorClass)
+            ?->getActiveTemplateTypeMap()
+            ->getType($templateName);
+
+        return $type ?? throw new LogicException(sprintf(
+            'Template type [%s] is not available for [%s].',
+            $templateName,
+            $classReflection->getName(),
+        ));
+    }
+
+    /**
+     * Determine whether a class is or extends the target class.
+     *
+     * @param class-string $targetClass
+     */
+    private function isClassOrSubclassOf(ClassReflection $classReflection, string $targetClass): bool
+    {
+        return $classReflection->getName() === $targetClass
+            || $classReflection->isSubclassOfClass($this->reflectionProvider->getClass($targetClass));
+    }
+}

--- a/src/database/src/PHPStan/NamedScopeMethodReflection.php
+++ b/src/database/src/PHPStan/NamedScopeMethodReflection.php
@@ -12,8 +12,10 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 
 /**
  * Describe a model scope as invoked through an Eloquent receiver.
@@ -173,21 +175,37 @@ class NamedScopeMethodReflection implements MethodReflection
     private function returnType(Type $returnType): Type
     {
         $returnType = ModelScopeTypeResolver::bindToModel($returnType, $this->modelClass);
-        $nonNullReturnType = TypeCombinator::removeNull($returnType);
 
-        if ($nonNullReturnType->isVoid()->yes()
-            || $returnType->isNull()->yes()
-            || $nonNullReturnType->isSuperTypeOf($this->queryType)->yes()) {
+        if ($returnType->isVoid()->yes()) {
             return $this->receiverType;
         }
 
-        if (TypeCombinator::containsNull($returnType)) {
-            return TypeCombinator::union(
-                $nonNullReturnType,
-                $this->receiverType,
-            );
+        // A scalar/object union has no class names as a whole, so classify each member separately.
+        $declaredTypes = $returnType instanceof UnionType ? $returnType->getTypes() : [$returnType];
+
+        return TypeCombinator::union(...array_map(
+            fn (Type $declaredType): Type => $this->isReceiverResult($declaredType)
+                ? $this->receiverType
+                : $declaredType,
+            $declaredTypes,
+        ));
+    }
+
+    /**
+     * Determine whether a declared scope result maps to the fluent receiver.
+     */
+    private function isReceiverResult(Type $declaredType): bool
+    {
+        if ($declaredType->isNull()->yes()) {
+            return true;
         }
 
-        return $returnType;
+        if ($declaredType instanceof MixedType) {
+            // PHPStan cannot inspect the body here; conventional untyped Laravel scopes are fluent.
+            return ! $declaredType->isExplicitMixed();
+        }
+
+        return $declaredType->getObjectClassNames() !== []
+            && $declaredType->isSuperTypeOf($this->queryType)->yes();
     }
 }

--- a/src/database/src/PHPStan/NamedScopeMethodReflection.php
+++ b/src/database/src/PHPStan/NamedScopeMethodReflection.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Database\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedParametersAcceptor;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Describe a model scope as invoked through an Eloquent receiver.
+ *
+ * Relation scopes run on the relation's query but return the relation when the
+ * result is that query, matching ForwardsCalls::forwardDecoratedCallTo().
+ */
+class NamedScopeMethodReflection implements MethodReflection
+{
+    /**
+     * Create a named scope method reflection.
+     */
+    public function __construct(
+        private readonly ClassReflection $declaringClass,
+        private readonly ClassReflection $modelClass,
+        private readonly MethodReflection $scopeMethod,
+        private readonly string $methodName,
+        private readonly Type $receiverType,
+        private readonly Type $queryType,
+        private readonly bool $static,
+    ) {
+    }
+
+    /**
+     * Return the exposed scope name.
+     */
+    public function getName(): string
+    {
+        return $this->methodName;
+    }
+
+    /**
+     * Return the declaring class.
+     */
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->declaringClass;
+    }
+
+    /**
+     * Determine whether the exposed scope is static.
+     */
+    public function isStatic(): bool
+    {
+        return $this->static;
+    }
+
+    /**
+     * Determine whether the exposed scope is private.
+     */
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the exposed scope is public.
+     */
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Return no docblock for the synthesized signature.
+     */
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Return the method prototype.
+     */
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /**
+     * Return scope variants without the engine-supplied builder parameter.
+     *
+     * @return list<ParametersAcceptor>
+     */
+    public function getVariants(): array
+    {
+        return array_map(
+            fn (ParametersAcceptor $variant): FunctionVariant => new FunctionVariant(
+                $variant->getTemplateTypeMap(),
+                $variant->getResolvedTemplateTypeMap(),
+                array_map(
+                    fn (ParameterReflection $parameter): ModelScopeParameterReflection => new ModelScopeParameterReflection(
+                        $parameter,
+                        $this->modelClass,
+                    ),
+                    array_slice($variant->getParameters(), 1),
+                ),
+                $variant->isVariadic(),
+                $this->returnType($variant->getReturnType()),
+                $variant instanceof ExtendedParametersAcceptor ? $variant->getCallSiteVarianceMap() : null,
+            ),
+            $this->scopeMethod->getVariants(),
+        );
+    }
+
+    /**
+     * Determine whether the method is deprecated.
+     */
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->scopeMethod->isDeprecated();
+    }
+
+    /**
+     * Return the deprecation description.
+     */
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->scopeMethod->getDeprecatedDescription();
+    }
+
+    /**
+     * Determine whether the method is final.
+     */
+    public function isFinal(): TrinaryLogic
+    {
+        return $this->scopeMethod->isFinal();
+    }
+
+    /**
+     * Determine whether the method is internal.
+     */
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->scopeMethod->isInternal();
+    }
+
+    /**
+     * Return the declared throw type.
+     */
+    public function getThrowType(): ?Type
+    {
+        return $this->scopeMethod->getThrowType();
+    }
+
+    /**
+     * Determine whether the method has side effects.
+     */
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return $this->scopeMethod->hasSideEffects();
+    }
+
+    /**
+     * Resolve the result produced by Builder::callScope().
+     */
+    private function returnType(Type $returnType): Type
+    {
+        $returnType = ModelScopeTypeResolver::bindToModel($returnType, $this->modelClass);
+        $nonNullReturnType = TypeCombinator::removeNull($returnType);
+
+        if ($nonNullReturnType->isVoid()->yes()
+            || $returnType->isNull()->yes()
+            || $nonNullReturnType->isSuperTypeOf($this->queryType)->yes()) {
+            return $this->receiverType;
+        }
+
+        if (TypeCombinator::containsNull($returnType)) {
+            return TypeCombinator::union(
+                $nonNullReturnType,
+                $this->receiverType,
+            );
+        }
+
+        return $returnType;
+    }
+}

--- a/src/docs/database.md
+++ b/src/docs/database.md
@@ -294,6 +294,8 @@ includes:
     - vendor/hypervel/database/extension.neon
 ```
 
+A scope that declares no return type, or declares `void`, `null`, or the query builder, stays chainable. Declaring a broader type such as `mixed` or `object` tells the analyzer the scope may return something else, so that type is preserved. When a scope declares a union containing the query builder, such as `Builder|int`, the builder becomes the chainable receiver and the remaining types are kept.
+
 <a name="running-queries"></a>
 ## Running SQL Queries
 

--- a/src/docs/database.md
+++ b/src/docs/database.md
@@ -6,6 +6,7 @@
     - [Read and Write Connections](#read-and-write-connections)
     - [Connection Pooling](#connection-pooling)
     - [Configuring Database Session State](#configuring-database-session-state)
+    - [Static Analysis](#static-analysis)
 - [Running SQL Queries](#running-queries)
     - [Using Multiple Database Connections](#using-multiple-database-connections)
     - [Listening for Query Events](#listening-for-query-events)
@@ -276,6 +277,22 @@ The `getPdo` and `getReadPdo` methods configure the PDO before returning it. The
 
 > [!WARNING]
 > If a setting must persist across queries and your application connects through a database proxy or connection pooler, use a mode that keeps the same database session. For example, PgBouncer must use session pooling. Transaction and statement pooling may send consecutive queries to different database sessions, so the setting may be missing from the next query. Hypervel cannot detect the pooler's mode for you. Direct database connections are not affected.
+
+<a name="static-analysis"></a>
+### Static Analysis
+
+The Hypervel database package includes a PHPStan extension that understands fluent methods forwarded by Eloquent builders and relationships. If your application uses `phpstan/extension-installer`, the extension is loaded automatically:
+
+```shell
+composer require --dev phpstan/extension-installer
+```
+
+Without the extension installer, add the package extension to your `phpstan.neon` file:
+
+```neon
+includes:
+    - vendor/hypervel/database/extension.neon
+```
 
 <a name="running-queries"></a>
 ## Running SQL Queries

--- a/src/docs/database.md
+++ b/src/docs/database.md
@@ -281,7 +281,7 @@ The `getPdo` and `getReadPdo` methods configure the PDO before returning it. The
 <a name="static-analysis"></a>
 ### Static Analysis
 
-The Hypervel database package includes a PHPStan extension that understands fluent methods forwarded by Eloquent builders and relationships. If your application uses `phpstan/extension-installer`, the extension is loaded automatically:
+The Hypervel database package includes a PHPStan extension that understands named scopes and query methods forwarded through Eloquent models, builders, and relationships. If your application uses `phpstan/extension-installer`, the extension is loaded automatically:
 
 ```shell
 composer require --dev phpstan/extension-installer

--- a/src/permission/src/Traits/HasPermissions.php
+++ b/src/permission/src/Traits/HasPermissions.php
@@ -491,7 +491,9 @@ trait HasPermissions
     /**
      * Scope the model query to certain permissions only.
      *
+     * @param Builder<static> $query
      * @param array|Collection|int|Permission|string|UnitEnum $permissions
+     * @return Builder<static>
      */
     public function scopePermission(Builder $query, $permissions, bool $without = false): Builder
     {
@@ -588,7 +590,9 @@ trait HasPermissions
      * Scope the model query to only those without certain permissions,
      * whether indirectly by role or by direct permission.
      *
+     * @param Builder<static> $query
      * @param array|Collection|int|Permission|string|UnitEnum $permissions
+     * @return Builder<static>
      */
     public function scopeWithoutPermission(Builder $query, $permissions): Builder
     {

--- a/src/permission/src/Traits/HasRoles.php
+++ b/src/permission/src/Traits/HasRoles.php
@@ -169,7 +169,9 @@ trait HasRoles
     /**
      * Scope the model query to certain roles only.
      *
+     * @param Builder<static> $query
      * @param array|Collection|int|Role|string|UnitEnum $roles
+     * @return Builder<static>
      */
     public function scopeRole(Builder $query, $roles, ?string $guard = null, bool $without = false): Builder
     {
@@ -215,7 +217,9 @@ trait HasRoles
     /**
      * Scope the model query to only those without certain roles.
      *
+     * @param Builder<static> $query
      * @param array|Collection|int|Role|string|UnitEnum $roles
+     * @return Builder<static>
      */
     public function scopeWithoutRole(Builder $query, $roles, ?string $guard = null): Builder
     {
@@ -261,7 +265,9 @@ trait HasRoles
     /**
      * Scope the model query to certain teams only.
      *
+     * @param Builder<static> $query
      * @param array|Collection|int|Model|string $teams
+     * @return Builder<static>
      */
     public function scopeTeam(Builder $query, $teams, bool $without = false): Builder
     {
@@ -300,7 +306,9 @@ trait HasRoles
     /**
      * Scope the model query to those without certain teams.
      *
+     * @param Builder<static> $query
      * @param array|Collection|int|Model|string $teams
+     * @return Builder<static>
      */
     public function scopeWithoutTeam(Builder $query, $teams): Builder
     {

--- a/src/telescope/src/IncomingEntry.php
+++ b/src/telescope/src/IncomingEntry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Telescope;
 
-use DateTimeInterface;
+use Carbon\CarbonInterface;
 use Hypervel\Container\Container;
 use Hypervel\Contracts\Auth\Authenticatable;
 use Hypervel\Support\Str;
@@ -50,7 +50,7 @@ class IncomingEntry
     /**
      * The DateTime that indicates when the entry was recorded.
      */
-    public DateTimeInterface $recordedAt;
+    public CarbonInterface $recordedAt;
 
     /**
      * Create a new incoming entry instance.
@@ -287,7 +287,7 @@ class IncomingEntry
             'family_hash' => $this->familyHash,
             'type' => $this->type,
             'content' => $this->content,
-            'created_at' => $this->recordedAt->toDateTimeString(), // @phpstan-ignore-line
+            'created_at' => $this->recordedAt->toDateTimeString(),
         ];
     }
 }

--- a/src/telescope/src/Storage/DatabaseEntriesRepository.php
+++ b/src/telescope/src/Storage/DatabaseEntriesRepository.php
@@ -61,12 +61,15 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
      */
     public function find(mixed $id): EntryResult
     {
-        $entry = EntryModel::on($this->connection)->whereUuid($id)->firstOrFail(); // @phpstan-ignore method.notFound
+        $entry = EntryModel::on($this->connection)->where('uuid', $id)->firstOrFail();
 
         $tags = $this->table('telescope_entries_tags')
             ->where('entry_uuid', $id)
             ->pluck('tag')
             ->all();
+
+        /** @var array<array-key, mixed> $content */
+        $content = $entry->content;
 
         return new EntryResult(
             $entry->uuid,
@@ -74,7 +77,7 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
             $entry->batch_id,
             $entry->type,
             $entry->family_hash,
-            $entry->content,
+            $content,
             $entry->created_at,
             $tags
         );
@@ -86,19 +89,22 @@ class DatabaseEntriesRepository implements EntriesRepository, ClearableRepositor
     public function get(?string $type, EntryQueryOptions $options): Collection
     {
         return EntryModel::on($this->connection)
-            ->withTelescopeOptions($type, $options) // @phpstan-ignore method.notFound (scope method registered at runtime)
+            ->withTelescopeOptions($type, $options)
             ->take($options->limit)
             ->orderByDesc('sequence')
             ->get()->reject(function ($entry) {
                 return ! is_array($entry->content);
             })->map(function ($entry) {
+                /** @var array<array-key, mixed> $content */
+                $content = $entry->content;
+
                 return new EntryResult(
                     $entry->uuid,
                     $entry->sequence,
                     $entry->batch_id,
                     $entry->type,
                     $entry->family_hash,
-                    $entry->content,
+                    $content,
                     $entry->created_at,
                     []
                 );

--- a/src/telescope/src/Storage/EntryModel.php
+++ b/src/telescope/src/Storage/EntryModel.php
@@ -4,12 +4,24 @@ declare(strict_types=1);
 
 namespace Hypervel\Telescope\Storage;
 
+use Carbon\CarbonInterface;
 use Hypervel\Database\Eloquent\Builder;
 use Hypervel\Database\Eloquent\Factories\HasFactory;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Support\Collection;
 use Hypervel\Telescope\Database\Factories\EntryModelFactory;
 
+/**
+ * Telescope supplies created_at for every entry even though its migration permits null.
+ *
+ * @property string $uuid
+ * @property int|string $sequence
+ * @property string $batch_id
+ * @property string $type
+ * @property null|string $family_hash
+ * @property mixed $content
+ * @property CarbonInterface $created_at
+ */
 class EntryModel extends Model
 {
     use HasFactory;
@@ -48,6 +60,9 @@ class EntryModel extends Model
 
     /**
      * Scope the query for the given query options.
+     *
+     * @param Builder<static> $query
+     * @return Builder<static>
      */
     public function scopeWithTelescopeOptions(Builder $query, ?string $type, EntryQueryOptions $options): Builder
     {

--- a/tests/Database/DatabaseEloquentAttributedScopeCacheTest.php
+++ b/tests/Database/DatabaseEloquentAttributedScopeCacheTest.php
@@ -61,20 +61,55 @@ class DatabaseEloquentAttributedScopeCacheTest extends TestCase
         $this->assertSame(0, AttributedScopeCacheModel::cachedScopeMethodCount());
     }
 
+    public function testLegacyScopesRespectVisibilityAndShareCaseInsensitiveCacheEntries(): void
+    {
+        $model = new AttributedScopeCacheModel;
+
+        $this->assertTrue($model->hasNamedScope('visible'));
+        $this->assertTrue($model->hasNamedScope('VISIBLE'));
+        $this->assertFalse($model->hasNamedScope('hidden'));
+        $this->assertSame(2, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
+    }
+
+    public function testInheritedLegacyScopesRespectVisibility(): void
+    {
+        $model = new SecondAttributedScopeCacheModel;
+
+        $this->assertTrue($model->hasNamedScope('visible'));
+        $this->assertFalse($model->hasNamedScope('hidden'));
+    }
+
+    public function testScopePrefixedMethodsAreNotTreatedAsLegacyScopes(): void
+    {
+        $model = new AttributedScopeCacheModel;
+
+        $this->assertFalse($model->hasNamedScope('d'));
+        $this->assertSame(1, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
+
+        $this->assertFalse($model->hasNamedScope('d'));
+        $this->assertSame(1, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
+    }
+
     public function testModelStaticStateResetsClearTheCache(): void
     {
         $model = new AttributedScopeCacheModel;
         $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScope('visible'));
         $this->assertSame(1, AttributedScopeCacheModel::cachedScopeMethodCount());
+        $this->assertSame(1, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
 
         Model::clearBootedModels();
         $this->assertSame(0, AttributedScopeCacheModel::cachedScopeMethodCount());
+        $this->assertSame(0, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
 
         $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScope('visible'));
         $this->assertSame(1, AttributedScopeCacheModel::cachedScopeMethodCount());
+        $this->assertSame(1, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
 
         Model::flushState();
         $this->assertSame(0, AttributedScopeCacheModel::cachedScopeMethodCount());
+        $this->assertSame(0, AttributedScopeCacheModel::cachedLegacyScopeMethodCount());
     }
 }
 
@@ -89,6 +124,19 @@ class AttributedScopeCacheModel extends Model
     {
     }
 
+    public static function scoped(array $attributes): string
+    {
+        return 'scoped';
+    }
+
+    protected function scopeVisible(): void
+    {
+    }
+
+    private function scopeHidden(): void
+    {
+    }
+
     #[Scope]
     private function privateScope(Builder $builder): void
     {
@@ -97,6 +145,11 @@ class AttributedScopeCacheModel extends Model
     public static function cachedScopeMethodCount(): int
     {
         return count(static::$scopeMethodAttributes);
+    }
+
+    public static function cachedLegacyScopeMethodCount(): int
+    {
+        return count(static::$legacyScopeMethods);
     }
 
     public static function seedScopeMethodCache(string $method, bool $isScope): void

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database\DatabaseEloquentLocalScopesTest;
 
+use BadMethodCallException;
 use Hypervel\Database\Capsule\Manager as DB;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Testbench\TestCase;
@@ -57,6 +58,20 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertEquals([true, 'foo'], $query->getBindings());
     }
 
+    public function testPrivateLegacyScopeIsNotDispatched(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        (new ScopedModel)->newQuery()->hidden();
+    }
+
+    public function testScopePrefixedMethodIsNotDispatched(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        (new ScopedModel)->newQuery()->d();
+    }
+
     public function testLocalScopeNestingDoesntDoubleFirstWhereClauseNegation()
     {
         $model = new ScopedModel;
@@ -96,5 +111,14 @@ class ScopedModel extends Model
     public function scopeType($query, $type)
     {
         $query->where('type', $type);
+    }
+
+    public static function scoped(array $attributes): string
+    {
+        return 'scoped';
+    }
+
+    private function scopeHidden($query): void
+    {
     }
 }

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -6,6 +6,7 @@ namespace Hypervel\Tests\Database\DatabaseEloquentLocalScopesTest;
 
 use BadMethodCallException;
 use Hypervel\Database\Capsule\Manager as DB;
+use Hypervel\Database\Eloquent\Builder;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Testbench\TestCase;
 
@@ -118,7 +119,7 @@ class ScopedModel extends Model
         return 'scoped';
     }
 
-    private function scopeHidden($query): void
+    private function scopeHidden(Builder $query): void
     {
     }
 }

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -30,6 +30,11 @@ function test(
     assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->withCan([Ability::Edit, 'delete'], $user));
     assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->useWritePdo());
     assertType('Hypervel\Types\Builder\User|null', $query->orderBy('id')->first());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->whereIn('id', [1])->with('relation'));
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->orderBy('id')->with('relation'));
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->limit(1)->with('relation'));
+    assertType('Hypervel\Database\Query\Builder<int, Hypervel\Types\Builder\User>', $query->dump());
+    assertType('Hypervel\Database\Query\Builder<int, Hypervel\Types\Builder\User>', $query->dumpRawSql());
     assertType('stdClass|null', $query->toBase()->first());
     assertType('stdClass|null', $query->getQuery()->first());
     assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->with('relation'));
@@ -190,6 +195,7 @@ function test(
     });
 
     assertType('Hypervel\Types\Builder\CommonBuilder<Hypervel\Types\Builder\Post>', Post::query());
+    assertType('Hypervel\Types\Builder\CommonBuilder<Hypervel\Types\Builder\Post>', Post::query()->whereIn('id', [1])->with('comments'));
     assertType('Hypervel\Types\Builder\CommonBuilder<Hypervel\Types\Builder\Post>', Post::query()->whereCan('edit'));
     assertType('Hypervel\Types\Builder\CommonBuilder<Hypervel\Types\Builder\Post>', Post::on());
     assertType('Hypervel\Types\Builder\CommonBuilder<Hypervel\Types\Builder\Post>', Post::onWriteConnection());

--- a/types/Database/Eloquent/ModelForwarding.php
+++ b/types/Database/Eloquent/ModelForwarding.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Types\ModelForwarding;
+
+use Hypervel\Database\Eloquent\Builder;
+use Hypervel\Database\Eloquent\HasBuilder;
+use Hypervel\Database\Eloquent\Model;
+
+use function PHPStan\Testing\assertType;
+
+function test(User $user, Post $post): void
+{
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\ModelForwarding\User>', User::where('active', true));
+    assertType('Hypervel\Types\ModelForwarding\User|null', User::first());
+    assertType('int<0, max>', User::count());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\ModelForwarding\User>', $user->where('active', true));
+
+    assertType('Hypervel\Types\ModelForwarding\PostBuilder<Hypervel\Types\ModelForwarding\Post>', Post::where('active', true));
+    assertType('Hypervel\Types\ModelForwarding\PostBuilder<Hypervel\Types\ModelForwarding\Post>', Post::published());
+    assertType('Hypervel\Types\ModelForwarding\Post|null', Post::first());
+    assertType('Hypervel\Types\ModelForwarding\PostBuilder<Hypervel\Types\ModelForwarding\Post>', $post->published());
+
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\ModelForwarding\Admin>', Admin::where('active', true));
+    assertType('Hypervel\Types\ModelForwarding\Admin|null', Admin::first());
+    assertType('Hypervel\Types\ModelForwarding\PostBuilder<Hypervel\Types\ModelForwarding\EditorPost>', EditorPost::where('active', true));
+}
+
+class User extends Model
+{
+}
+
+class Admin extends User
+{
+}
+
+class Post extends Model
+{
+    /** @use HasBuilder<PostBuilder<static>> */
+    use HasBuilder;
+
+    protected static string $builder = PostBuilder::class;
+}
+
+class EditorPost extends Post
+{
+}
+
+/**
+ * @template TModel of Model
+ *
+ * @extends Builder<TModel>
+ */
+class PostBuilder extends Builder
+{
+    public function published(): static
+    {
+        return $this->whereNotNull('published_at');
+    }
+}

--- a/types/Database/Eloquent/NamedScopes.php
+++ b/types/Database/Eloquent/NamedScopes.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Types\NamedScopes;
+
+use Hypervel\Contracts\Database\Eloquent\Builder as BuilderContract;
+use Hypervel\Database\Eloquent\Attributes\Scope;
+use Hypervel\Database\Eloquent\Builder;
+use Hypervel\Database\Eloquent\Collection;
+use Hypervel\Database\Eloquent\HasBuilder;
+use Hypervel\Database\Eloquent\Model;
+use Hypervel\Database\Eloquent\Relations\HasMany;
+use Hypervel\Database\Query\Builder as QueryBuilder;
+use Hypervel\Notifications\DatabaseNotification;
+use LogicException;
+
+use function PHPStan\Testing\assertType;
+
+function test(User $user, Post $post, DatabaseNotification $notification): void
+{
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::published());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', $post->published(false));
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->published());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->published());
+
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::ofType());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->ofType('article', 'tutorial'));
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->ofType());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::inherited());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::recent());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->annotatedBuilder());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->annotatedBuilder());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->customBuilder());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->nullableBuilder());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::archived());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->archived());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->archived());
+
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\NamedScopes\Article>', Article::archived());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\NamedScopes\Article>', Article::query()->archived());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Article, Hypervel\Types\NamedScopes\User>', $user->articles()->archived());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\NamedScopes\Article>', Article::archived()->get());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\NamedScopes\Article>', Article::annotatedBuilder());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\NamedScopes\Article>', Article::query()->annotatedBuilder());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Article, Hypervel\Types\NamedScopes\User>', $user->articles()->annotatedBuilder());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::inheritedBuilder());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->inheritedBuilder());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\NamedScopes\Post>', Post::inheritedCollection());
+    assertType('Hypervel\Types\NamedScopes\Post', Post::inheritedModel(new Post));
+
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\NamedScopes\Post>', Post::query()->asCollection());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\NamedScopes\Post>', $user->posts()->asCollection());
+    assertType('Hypervel\Types\NamedScopes\Post', Post::query()->asModel());
+    assertType('Hypervel\Types\NamedScopes\Post', $user->posts()->asModel());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->withSameModel(new Post));
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->withSameModel(new Post));
+    assertType('Hypervel\Database\Query\Builder', Post::query()->baseQuery());
+    assertType('Hypervel\Database\Query\Builder', $user->posts()->baseQuery());
+
+    assertType('int', Post::ranking());
+    assertType('int', Post::query()->ranking());
+    assertType('int', $user->posts()->ranking());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>|int', Post::optionalRanking());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>|int', $user->posts()->optionalRanking());
+
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::where('active', true));
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->where('active', true));
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->where('active', true));
+
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Notifications\DatabaseNotification>', DatabaseNotification::query()->read());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Notifications\DatabaseNotification>', DatabaseNotification::query()->unread()->get());
+    assertType('bool', $notification->read());
+
+    assertType('never', $user->posts()->unavailable());
+}
+
+class User extends Model
+{
+    /** @return HasMany<Post, $this> */
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    /** @return HasMany<Article, $this> */
+    public function articles(): HasMany
+    {
+        return $this->hasMany(Article::class);
+    }
+}
+
+class BaseArticle extends Model
+{
+    protected function scopeArchived(BuilderContract $query): void
+    {
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    #[Scope]
+    protected function annotatedBuilder(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+
+class Article extends BaseArticle
+{
+}
+
+class BasePost extends Model
+{
+    #[Scope]
+    protected function inherited(BuilderContract $query): void
+    {
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    #[Scope]
+    protected function inheritedBuilder(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    /** @return Collection<int, static> */
+    #[Scope]
+    protected function inheritedCollection(BuilderContract $query): Collection
+    {
+        return new Collection;
+    }
+
+    /**
+     * @param static $other
+     * @return static
+     */
+    #[Scope]
+    protected function inheritedModel(BuilderContract $query, Model $other): Model
+    {
+        return $other;
+    }
+}
+
+class Post extends BasePost
+{
+    use HasArchivedScope;
+
+    /** @use HasBuilder<PostBuilder<static>> */
+    use HasBuilder;
+
+    protected static string $builder = PostBuilder::class;
+
+    #[Scope]
+    protected function published(BuilderContract $query, bool $active = true): void
+    {
+    }
+
+    protected function scopeOfType(BuilderContract $query, string $type = 'news', string ...$additionalTypes): void
+    {
+    }
+
+    #[Scope]
+    protected static function recent(BuilderContract $query): null
+    {
+        return null;
+    }
+
+    #[Scope]
+    protected function ranking(BuilderContract $query): int
+    {
+        return 1;
+    }
+
+    #[Scope]
+    protected function optionalRanking(BuilderContract $query): ?int
+    {
+        return null;
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    #[Scope]
+    protected function annotatedBuilder(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    /**
+     * @param PostBuilder<static> $query
+     * @return PostBuilder<static>
+     */
+    #[Scope]
+    protected function customBuilder(PostBuilder $query): PostBuilder
+    {
+        return $query;
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return null|Builder<static>
+     */
+    #[Scope]
+    protected function nullableBuilder(Builder $query): ?Builder
+    {
+        return null;
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Collection<int, static>
+     */
+    #[Scope]
+    protected function asCollection(Builder $query): Collection
+    {
+        return $query->getModel()->newCollection();
+    }
+
+    /** @return $this */
+    #[Scope]
+    protected function asModel(BuilderContract $query): Model
+    {
+        return $this;
+    }
+
+    /** @param static $other */
+    #[Scope]
+    protected function withSameModel(BuilderContract $query, Model $other): void
+    {
+    }
+
+    /** @param Builder<static> $query */
+    #[Scope]
+    protected function baseQuery(Builder $query): QueryBuilder
+    {
+        return $query->toBase();
+    }
+
+    #[Scope]
+    protected function unavailable(BuilderContract $query): never
+    {
+        throw new LogicException;
+    }
+
+    protected function scopeWhere(BuilderContract $query): void
+    {
+    }
+
+    public function verifyNativeScopeSignature(BuilderContract $query): void
+    {
+        $this->published($query);
+    }
+}
+
+/**
+ * @template TModel of Model
+ *
+ * @extends Builder<TModel>
+ */
+class PostBuilder extends Builder
+{
+}
+
+trait HasArchivedScope
+{
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    protected function scopeArchived(Builder $query): Builder
+    {
+        return $query;
+    }
+}

--- a/types/Database/Eloquent/NamedScopes.php
+++ b/types/Database/Eloquent/NamedScopes.php
@@ -64,6 +64,16 @@ function test(User $user, Post $post, DatabaseNotification $notification): void
     assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>|int', Post::optionalRanking());
     assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>|int', $user->posts()->optionalRanking());
 
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::untypedReturn());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->untypedReturn());
+    assertType('mixed', Post::mixedScope());
+    assertType('mixed', Post::docblockMixed());
+    assertType('object', Post::objectScope());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>|int', Post::builderOrInt());
+    assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>|int', Post::query()->builderOrInt());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>|int', $user->posts()->builderOrInt());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\NamedScopes\Post>|Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::builderOrCollection());
+
     assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::where('active', true));
     assertType('Hypervel\Types\NamedScopes\PostBuilder<Hypervel\Types\NamedScopes\Post>', Post::query()->where('active', true));
     assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\NamedScopes\Post, Hypervel\Types\NamedScopes\User>', $user->posts()->where('active', true));
@@ -180,6 +190,51 @@ class Post extends BasePost
     protected function optionalRanking(BuilderContract $query): ?int
     {
         return null;
+    }
+
+    /** @phpstan-ignore missingType.return */
+    #[Scope]
+    protected function untypedReturn(BuilderContract $query)
+    {
+    }
+
+    #[Scope]
+    protected function mixedScope(BuilderContract $query): mixed
+    {
+        return null;
+    }
+
+    /** @return mixed */
+    #[Scope]
+    protected function docblockMixed(BuilderContract $query)
+    {
+        return null;
+    }
+
+    #[Scope]
+    protected function objectScope(BuilderContract $query): object
+    {
+        return $this;
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>|int
+     */
+    #[Scope]
+    protected function builderOrInt(Builder $query): Builder|int
+    {
+        return 1;
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>|Collection<int, static>
+     */
+    #[Scope]
+    protected function builderOrCollection(Builder $query): Builder|Collection
+    {
+        return $query;
     }
 
     /**

--- a/types/Database/Eloquent/Relations.php
+++ b/types/Database/Eloquent/Relations.php
@@ -25,7 +25,7 @@ function test(User $user, Post $post, Comment $comment, ChildUser $child): void
 {
     assertType('Hypervel\Database\Eloquent\Relations\HasOne<Hypervel\Types\Relations\Address, Hypervel\Types\Relations\User>', $user->address());
     assertType('Hypervel\Types\Relations\Address|null', $user->address()->getResults());
-    assertType('Hypervel\Support\Collection<int, Hypervel\Types\Relations\Address>', $user->address()->get());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Address>', $user->address()->get());
     assertType('Hypervel\Types\Relations\Address', $user->address()->make());
     assertType('Hypervel\Types\Relations\Address', $user->address()->create());
     assertType('Hypervel\Database\Eloquent\Relations\HasOne<Hypervel\Types\Relations\Address, Hypervel\Types\Relations\ChildUser>', $child->address());
@@ -38,6 +38,13 @@ function test(User $user, Post $post, Comment $comment, ChildUser $child): void
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Post>', $user->posts()->getResults());
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Post>', $user->posts()->fetchUsing(PDO::FETCH_ASSOC)->get());
     assertType('Hypervel\Types\Relations\Post|null', $user->posts()->useWritePdo()->first());
+    assertType('Hypervel\Database\Query\Builder<int, Hypervel\Types\Relations\Post>', $user->posts()->dump());
+    assertType('Hypervel\Database\Query\Builder<int, Hypervel\Types\Relations\Post>', $user->posts()->dumpRawSql());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Relations\Post>', $user->posts()->clone());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Relations\Post>', $user->posts()->applyScopes());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\Relations\Post, Hypervel\Types\Relations\User>', $user->posts()->whereIn('id', [1]));
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Post>', $user->posts()->whereIn('id', [1])->get());
+    assertType('Hypervel\Database\Eloquent\Relations\HasMany<Hypervel\Types\Relations\Post, Hypervel\Types\Relations\User>', $user->posts()->whereCan('edit'));
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Post>', $user->posts()->makeMany([]));
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Post>', $user->posts()->createMany([]));
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Post>', $user->posts()->createManyQuietly([]));
@@ -49,6 +56,8 @@ function test(User $user, Post $post, Comment $comment, ChildUser $child): void
 
     assertType("Hypervel\\Database\\Eloquent\\Relations\\BelongsToMany<Hypervel\\Types\\Relations\\Role, Hypervel\\Types\\Relations\\User, Hypervel\\Database\\Eloquent\\Relations\\Pivot, 'pivot'>", $user->roles());
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Role&object{pivot: Hypervel\Database\Eloquent\Relations\Pivot}>', $user->roles()->getResults());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Role&object{pivot: Hypervel\Database\Eloquent\Relations\Pivot}>', $user->roles()->get());
+    assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Role&object{pivot: Hypervel\Database\Eloquent\Relations\Pivot}>', $user->roles()->whereIn('id', [1])->get());
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Role&object{pivot: Hypervel\Database\Eloquent\Relations\Pivot}>', $user->roles()->find([1]));
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Role&object{pivot: Hypervel\Database\Eloquent\Relations\Pivot}>', $user->roles()->findMany([1, 2, 3]));
     assertType('Hypervel\Database\Eloquent\Collection<int, Hypervel\Types\Relations\Role&object{pivot: Hypervel\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOrNew([1]));


### PR DESCRIPTION
## Summary

This PR adds first-party PHPStan support for the dynamic Eloquent query API exposed through models, builders, and relations.

Eloquent forwards calls across several runtime boundaries. PHPStan previously saw only the declared receiver type, so valid forwarded methods and named scopes lost their concrete model and custom-builder types. One relation-return mismatch was hidden by a broad global ignore, while downstream packages needed local annotations or suppressions for other paths.

The new extensions model those boundaries directly instead of hiding their results.

## Implementation

- Register the database analysis extension through Composer package metadata so applications using the PHPStan extension installer receive it automatically.
- Describe fluent query methods forwarded through Eloquent builders and relations, including decorated relation returns.
- Describe query methods forwarded statically and through model instances while preserving the active builder and concrete model type.
- Expose attributed and legacy named scopes through models, builders, and relations.
- Remove the engine-supplied builder parameter from exposed scope signatures and preserve user parameters, defaults, return types, nullable returns, and inherited static types.
- Keep native model, builder, and documented methods authoritative when their names overlap dynamic forwarding or scopes.
- Cache reflected analysis results by PHPStan class identity for the lifetime of one analysis process.
- Replace the broad relation-forwarding ignore with precise analysis.
- Tighten Permission and Telescope types that the improved analysis can now verify, and remove obsolete local suppressions.
- Document the Eloquent analysis support in the database documentation.

The runtime model scope lookup now mirrors the analysis rule. It accepts callable legacy scopes, rejects private methods and ordinary methods whose names merely begin with scope, and caches results only for declared methods. Arbitrary missing query names are not retained in worker memory.

## Compatibility and runtime behavior

The PHPStan classes are analysis-only and add no application runtime work. They use PHPStan public reflection extension interfaces rather than application container services or runtime hooks.

The model cache is bounded by declared model methods. A declared legacy scope is reflected once and reused for later lookups, which removes repeated reflection work in long-lived workers. Existing attributed scopes, legacy scopes, custom builders, inherited models, and relation forwarding keep their public behavior.

## Validation

- Full Components source analysis
- Max-level committed type fixtures
- Full parallel Components test suite
- Testbench package contract suite
- Downstream package analysis, including Workflow

The type fixtures cover plain and custom builders, inherited models, model and relation receivers, scalar and model results, native-method precedence, nullable scope results, and receiver-preserving fluent calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PHPStan support for Eloquent models, builders, relations, and named scopes.
  * Added automatic static analysis for forwarded query methods and custom model scopes.
  * Improved type inference for fluent query chains, collections, relationships, and custom builders.

* **Bug Fixes**
  * Improved legacy scope detection, visibility handling, inheritance, and cache behavior.
  * Corrected timestamp and relationship collection type declarations.

* **Documentation**
  * Added database static analysis setup and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->