### PR TITLE
Fix DatabaseTruncation in Testbench

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -30,6 +30,7 @@
 
 ## Testing
 
+- Make parallel database isolation URL-aware. A persistent connection configured only with `url` currently skips worker-database rewriting, so ParaTest workers share one database. Normalize the connection before deciding whether it can be managed, keep in-memory SQLite process-local, and either rewrite supported persistent URLs per worker or fail with a clear error when automatic isolation is impossible.
 - Port current Laravel's complete `tests/Support/SupportTestingEventFakeTest.php`, preserving Hypervel-specific EventFake coverage and coroutine-safe test behavior.
 - Complete Testing assertion coverage: port the remaining current Laravel `TestResponseTest` cases through the incremental upstream-update workflow, and add focused coverage for `TestView`'s public assertion and string surface where Laravel has no equivalent suite.
 - Add the repository-required `: void` return type to the remaining untyped HTTP test methods: 176 in `tests/Http/HttpClientTest.php`, 30 in `tests/Http/HttpRequestTrustedStateTest.php`, and 4 in `tests/Http/HttpRequestTrustedStateCoroutineTest.php`. Verify each file after the mechanical conversion.

--- a/src/database/src/SQLiteDatabase.php
+++ b/src/database/src/SQLiteDatabase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hypervel\Database;
 
+use InvalidArgumentException;
+
 class SQLiteDatabase
 {
     /**
@@ -40,5 +42,23 @@ class SQLiteDatabase
         parse_str($query ?? '', $parameters);
 
         return ($parameters['mode'] ?? null) === 'memory';
+    }
+
+    /**
+     * Determine if a connection configuration resolves to an in-memory SQLite database.
+     *
+     * Discrete configurations pass through normalization unchanged. Malformed URLs
+     * intentionally fail with the database configuration parser's exception.
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function isInMemoryConfiguration(array $configuration): bool
+    {
+        $configuration = (new ConfigurationUrlParser)->parseConfiguration($configuration);
+        $database = $configuration['database'] ?? null;
+
+        return ($configuration['driver'] ?? null) === 'sqlite'
+            && is_string($database)
+            && static::isInMemory($database);
     }
 }

--- a/src/foundation/src/Testing/Concerns/InteractsWithParallelDatabase.php
+++ b/src/foundation/src/Testing/Concerns/InteractsWithParallelDatabase.php
@@ -78,7 +78,8 @@ trait InteractsWithParallelDatabase
      * Ensure the per-worker database exists, creating it if needed.
      *
      * Called from database testing traits (RefreshDatabase, DatabaseMigrations,
-     * DatabaseTransactions) after the app is booted and connections are available.
+     * DatabaseTruncation, DatabaseTransactions) after the app is booted and
+     * connections are available.
      * The config has already been rewritten by configureParallelDatabaseName().
      *
      * No-op when not running in parallel or when using in-memory SQLite.

--- a/src/foundation/src/Testing/DatabaseTruncation.php
+++ b/src/foundation/src/Testing/DatabaseTruncation.php
@@ -5,14 +5,21 @@ declare(strict_types=1);
 namespace Hypervel\Foundation\Testing;
 
 use Hypervel\Contracts\Console\Kernel;
+use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Database\ConnectionInterface;
+use Hypervel\Database\SQLiteDatabase;
+use Hypervel\Foundation\Testing\Concerns\InteractsWithParallelDatabase;
 use Hypervel\Foundation\Testing\Traits\CanConfigureMigrationCommands;
 use Hypervel\Support\Arr;
 use Hypervel\Support\Collection;
 
+/**
+ * This concern is mutually exclusive with RefreshDatabase and DatabaseMigrations.
+ */
 trait DatabaseTruncation
 {
     use CanConfigureMigrationCommands;
+    use InteractsWithParallelDatabase;
 
     /**
      * The cached names of the database tables for each connection.
@@ -24,6 +31,9 @@ trait DatabaseTruncation
      */
     protected function truncateDatabaseTables(): void
     {
+        $this->ensureParallelDatabaseExists();
+        $this->restoreInMemoryDatabases();
+
         $this->beforeTruncatingDatabase();
 
         // Migrate and seed the database on first run...
@@ -31,6 +41,8 @@ trait DatabaseTruncation
             $this->artisan('migrate:fresh', $this->migrateFreshUsing());
 
             $this->app->make(Kernel::class)->setArtisan(null);
+
+            $this->cacheInMemoryDatabases();
 
             RefreshDatabaseState::$migrated = true;
 
@@ -49,6 +61,76 @@ trait DatabaseTruncation
         }
 
         $this->afterTruncatingDatabase();
+    }
+
+    /**
+     * Restore the in-memory databases between tests.
+     */
+    protected function restoreInMemoryDatabases(): void
+    {
+        if (RefreshDatabaseState::$inMemoryConnections === []) {
+            return;
+        }
+
+        $database = $this->app->make('db');
+        $defaultConnection = $this->app->make('config')->string('database.default');
+
+        foreach ($this->connectionsToTruncate() as $name) {
+            $connectionName = $name ?? $defaultConnection;
+
+            if (isset(RefreshDatabaseState::$inMemoryConnections[$connectionName])) {
+                // The PDO outlives its original application; the dispatcher must not.
+                $database->connection($name)
+                    ->setPdo(RefreshDatabaseState::$inMemoryConnections[$connectionName])
+                    ->setEventDispatcher($this->app->make(Dispatcher::class));
+            }
+        }
+    }
+
+    /**
+     * Cache the in-memory databases after migration.
+     */
+    protected function cacheInMemoryDatabases(): void
+    {
+        $database = $this->app->make('db');
+        $config = $this->app->make('config');
+        $defaultConnection = $config->string('database.default');
+
+        foreach ($this->connectionsToTruncate() as $name) {
+            if ($this->usingInMemoryDatabaseForTruncation($name)) {
+                $connectionName = $name ?? $defaultConnection;
+
+                RefreshDatabaseState::$inMemoryConnections[$connectionName]
+                    = $database->connection($name)->getPdo();
+            }
+        }
+    }
+
+    /**
+     * Determine if any connection being truncated uses an in-memory database.
+     */
+    protected function usingInMemoryDatabasesForTruncation(): bool
+    {
+        foreach ($this->connectionsToTruncate() as $name) {
+            if ($this->usingInMemoryDatabaseForTruncation($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the given connection uses an in-memory database.
+     */
+    protected function usingInMemoryDatabaseForTruncation(?string $name): bool
+    {
+        $config = $this->app->make('config');
+        $name ??= $config->string('database.default');
+        $configuration = $config->get("database.connections.{$name}");
+
+        return is_array($configuration)
+            && SQLiteDatabase::isInMemoryConfiguration($configuration);
     }
 
     /**

--- a/src/foundation/src/Testing/RefreshDatabase.php
+++ b/src/foundation/src/Testing/RefreshDatabase.php
@@ -93,11 +93,10 @@ trait RefreshDatabase
     {
         $config = $this->app->make('config');
         $name ??= $this->getRefreshConnection();
+        $configuration = $config->get("database.connections.{$name}");
 
-        // All supported SQLite memory URI forms need the same refresh lifecycle.
-        return SQLiteDatabase::isInMemory(
-            $config->string("database.connections.{$name}.database")
-        );
+        return is_array($configuration)
+            && SQLiteDatabase::isInMemoryConfiguration($configuration);
     }
 
     /**

--- a/src/testbench/src/Concerns/HandlesDatabases.php
+++ b/src/testbench/src/Concerns/HandlesDatabases.php
@@ -77,14 +77,10 @@ trait HandlesDatabases
 
         $connection ??= $config->get('database.default');
 
-        /** @var null|array{driver: string, database: string} $database */
-        $database = $config->get("database.connections.{$connection}");
+        $configuration = $config->get("database.connections.{$connection}");
 
-        if ($database === null || $database['driver'] !== 'sqlite') {
-            return false;
-        }
-
-        return SQLiteDatabase::isInMemory($database['database']);
+        return is_array($configuration)
+            && SQLiteDatabase::isInMemoryConfiguration($configuration);
     }
 
     /**

--- a/src/testbench/src/Concerns/InteractsWithMigrations.php
+++ b/src/testbench/src/Concerns/InteractsWithMigrations.php
@@ -9,6 +9,7 @@ use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Database\Migrations\Migrator;
 use Hypervel\Foundation\Console\Kernel as FoundationConsoleKernel;
 use Hypervel\Foundation\Testing\DatabaseMigrations;
+use Hypervel\Foundation\Testing\DatabaseTruncation;
 use Hypervel\Foundation\Testing\RefreshDatabaseState;
 use Hypervel\Support\Arr;
 use Hypervel\Testbench\Attributes\ResetRefreshDatabaseState;
@@ -31,7 +32,7 @@ trait InteractsWithMigrations
 
     protected function setUpInteractsWithMigrations(): void
     {
-        if ($this->usesSqliteInMemoryDatabaseConnection()) {
+        if ($this->usesInMemoryDatabaseForMigrationState()) {
             $this->afterApplicationCreated(static function (): void {
                 static::usesTestingFeature(new ResetRefreshDatabaseState);
             });
@@ -41,6 +42,9 @@ trait InteractsWithMigrations
     protected function tearDownInteractsWithMigrations(): void
     {
         $hasInMemoryConnections = ! empty(RefreshDatabaseState::$inMemoryConnections);
+        $preservesInMemoryDatabase = static::usesTestingConcern(DatabaseTruncation::class)
+            && ! static::usesTestingConcern(DatabaseMigrations::class)
+            && ! static::usesRefreshDatabaseTestingConcern();
         $processors = $this->cachedTestMigratorProcessors;
         $this->cachedTestMigratorProcessors = [];
         $failure = null;
@@ -48,7 +52,11 @@ trait InteractsWithMigrations
         try {
             if (
                 (count($processors) > 0 && static::usesRefreshDatabaseTestingConcern())
-                || ($hasInMemoryConnections && $this->usesSqliteInMemoryDatabaseConnection())
+                || (
+                    ! $preservesInMemoryDatabase
+                    && $hasInMemoryConnections
+                    && $this->usesInMemoryDatabaseForMigrationState()
+                )
             ) {
                 ResetRefreshDatabaseState::run();
             }
@@ -79,9 +87,37 @@ trait InteractsWithMigrations
         /** @var ApplicationContract $app */
         $app = $this->app;
 
+        if (
+            (is_string($paths) || Arr::isList($paths))
+            && $this->shouldRegisterMigrationPaths()
+        ) {
+            /** @var list<string>|string $paths */
+            load_migration_paths($app, $paths);
+
+            return;
+        }
+
+        /** @var array<string, mixed>|string $paths */
+        $this->runMigrationProcessor($app, $this->resolvePackageMigrationsOptions($paths));
+    }
+
+    /**
+     * Determine whether migration paths should be registered for an upcoming migration.
+     */
+    protected function shouldRegisterMigrationPaths(): bool
+    {
         $migrateRefresh = property_exists($this, 'migrateRefresh')
             && (bool) $this->migrateRefresh;
-        $refreshesDatabase = static::usesTestingConcern(DatabaseMigrations::class)
+
+        // List and string paths target the default connection; named options use a processor.
+        return static::usesTestingConcern(DatabaseMigrations::class)
+            || (
+                static::usesTestingConcern(DatabaseTruncation::class)
+                && (
+                    RefreshDatabaseState::$migrated === false
+                    || $this->usesSqliteInMemoryDatabaseConnection()
+                )
+            )
             || (
                 static::usesRefreshDatabaseTestingConcern()
                 && (
@@ -92,19 +128,6 @@ trait InteractsWithMigrations
                     )
                 )
             );
-
-        if (
-            (is_string($paths) || Arr::isList($paths))
-            && $refreshesDatabase
-        ) {
-            /** @var list<string>|string $paths */
-            load_migration_paths($app, $paths);
-
-            return;
-        }
-
-        /** @var array<string, mixed>|string $paths */
-        $this->runMigrationProcessor($app, $this->resolvePackageMigrationsOptions($paths));
     }
 
     /**
@@ -199,6 +222,19 @@ trait InteractsWithMigrations
         array_unshift($this->cachedTestMigratorProcessors, $migrator);
 
         $this->resetApplicationArtisanCommands($app);
+    }
+
+    /**
+     * Determine whether the active database concern retains in-memory state.
+     */
+    protected function usesInMemoryDatabaseForMigrationState(): bool
+    {
+        if (static::usesTestingConcern(DatabaseTruncation::class)) {
+            // Every cached truncation PDO needs the same class-boundary state owner.
+            return $this->usingInMemoryDatabasesForTruncation(); /* @phpstan-ignore method.notFound */
+        }
+
+        return $this->usesSqliteInMemoryDatabaseConnection();
     }
 
     protected function resetApplicationArtisanCommands(ApplicationContract $app): void

--- a/src/testbench/src/Concerns/WithHypervelMigrations.php
+++ b/src/testbench/src/Concerns/WithHypervelMigrations.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Testbench\Concerns;
 
-use Hypervel\Foundation\Testing\DatabaseMigrations;
-use Hypervel\Foundation\Testing\RefreshDatabaseState;
-
 use function Hypervel\Testbench\after_resolving;
 use function Hypervel\Testbench\default_migration_path;
 
@@ -25,21 +22,7 @@ trait WithHypervelMigrations
             return;
         }
 
-        $migrateRefresh = property_exists($this, 'migrateRefresh')
-            && (bool) $this->migrateRefresh;
-        $refreshesDatabase = static::usesTestingConcern(DatabaseMigrations::class)
-            || (
-                static::usesRefreshDatabaseTestingConcern()
-                && (
-                    $migrateRefresh
-                    || (
-                        RefreshDatabaseState::$migrated === false
-                        && RefreshDatabaseState::$lazilyRefreshed === false
-                    )
-                )
-            );
-
-        if ($refreshesDatabase) {
+        if ($this->shouldRegisterMigrationPaths()) {
             after_resolving($this->app, 'migrator', static function ($migrator, $app): void {
                 $migrator->path(default_migration_path());
             });

--- a/src/testbench/src/TestCase.php
+++ b/src/testbench/src/TestCase.php
@@ -10,8 +10,12 @@ use Hypervel\Coordinator\CoordinatorManager;
 use Hypervel\Filesystem\Filesystem;
 use Hypervel\Foundation\Testing\DatabaseMigrations;
 use Hypervel\Foundation\Testing\DatabaseTransactions;
+use Hypervel\Foundation\Testing\DatabaseTruncation;
 use Hypervel\Foundation\Testing\RefreshDatabase;
 use Hypervel\Foundation\Testing\TestCase as BaseTestCase;
+use Hypervel\Testbench\Attributes\ResetRefreshDatabaseState;
+use Hypervel\Testbench\Attributes\WithMigration;
+use ReflectionMethod;
 use RuntimeException;
 use Swoole\Timer;
 use Throwable;
@@ -24,6 +28,7 @@ use Throwable;
  *
  * @method void refreshDatabase()
  * @method void runDatabaseMigrations()
+ * @method void truncateDatabaseTables()
  * @method void beginDatabaseTransaction()
  * @method void disableMiddlewareForAllTests()
  * @method void disableEventsForAllTests()
@@ -133,6 +138,9 @@ class TestCase extends BaseTestCase implements Contracts\TestCase
      */
     protected function setUpDatabaseTraits(array $uses): void
     {
+        // Reset before database attributes register paths against retained schema state.
+        $this->prepareDatabaseTruncationForMethod($uses);
+
         $this->setUpDatabaseRequirements(function () use ($uses): void {
             if (isset($uses[RefreshDatabase::class])) {
                 $this->refreshDatabase();
@@ -141,11 +149,38 @@ class TestCase extends BaseTestCase implements Contracts\TestCase
             if (isset($uses[DatabaseMigrations::class])) {
                 $this->runDatabaseMigrations();
             }
+
+            if (isset($uses[DatabaseTruncation::class])) {
+                $this->truncateDatabaseTables();
+            }
         });
 
         if (isset($uses[DatabaseTransactions::class])) {
             $this->beginDatabaseTransaction();
         }
+    }
+
+    /**
+     * Isolate method-specific migration sets from the retained truncation schema.
+     */
+    protected function prepareDatabaseTruncationForMethod(array $uses): void
+    {
+        if (! isset($uses[DatabaseTruncation::class])) {
+            return;
+        }
+
+        $method = $this->resolvePhpUnitTestMethodName();
+
+        if ($method === null
+            || (new ReflectionMethod(static::class, $method))->getAttributes(WithMigration::class) === []) {
+            return;
+        }
+
+        ResetRefreshDatabaseState::run();
+
+        $this->beforeApplicationDestroyed(static function (): void {
+            ResetRefreshDatabaseState::run();
+        });
     }
 
     /**

--- a/tests/Database/SQLiteDatabaseTest.php
+++ b/tests/Database/SQLiteDatabaseTest.php
@@ -61,4 +61,28 @@ class SQLiteDatabaseTest extends TestCase
             'mixed-case mode value is not memory' => ['file:database?mode=MEMORY', false],
         ];
     }
+
+    #[DataProvider('configurationProvider')]
+    public function testItClassifiesInMemoryConnectionConfigurations(array $configuration, bool $expected): void
+    {
+        $this->assertSame($expected, SQLiteDatabase::isInMemoryConfiguration($configuration));
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, bool}>
+     */
+    public static function configurationProvider(): array
+    {
+        return [
+            'discrete SQLite memory' => [['driver' => 'sqlite', 'database' => ':memory:'], true],
+            'SQLite memory URL' => [['url' => 'sqlite:///:memory:'], true],
+            'URL overrides discrete values' => [[
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'url' => 'mysql://root:secret@database/app',
+            ], false],
+            'non-SQLite memory name' => [['driver' => 'mysql', 'database' => ':memory:'], false],
+            'incomplete configuration' => [['driver' => 'sqlite'], false],
+        ];
+    }
 }

--- a/tests/Foundation/Testing/DatabaseTruncationTest.php
+++ b/tests/Foundation/Testing/DatabaseTruncationTest.php
@@ -8,12 +8,15 @@ use Hypervel\Config\Repository;
 use Hypervel\Container\Container;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Database\Connection;
+use Hypervel\Database\DatabaseManager;
 use Hypervel\Database\Query\Builder as QueryBuilder;
 use Hypervel\Database\Schema\Builder;
 use Hypervel\Database\Schema\PostgresBuilder;
 use Hypervel\Foundation\Testing\DatabaseTruncation;
+use Hypervel\Foundation\Testing\RefreshDatabaseState;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
+use PDO;
 
 class DatabaseTruncationTest extends TestCase
 {
@@ -24,6 +27,8 @@ class DatabaseTruncationTest extends TestCase
     private ?array $tablesToTruncate = null;
 
     private ?array $exceptTables = null;
+
+    private array $connectionsToTruncate = [null];
 
     protected function setUp(): void
     {
@@ -44,8 +49,10 @@ class DatabaseTruncationTest extends TestCase
     {
         $this->app = null;
         static::$allTables = [];
+        RefreshDatabaseState::$inMemoryConnections = [];
         $this->tablesToTruncate = null;
         $this->exceptTables = null;
+        $this->connectionsToTruncate = [null];
 
         parent::tearDown();
     }
@@ -179,6 +186,73 @@ class DatabaseTruncationTest extends TestCase
         $this->truncateTablesForConnection($connection, 'test');
 
         $this->assertEquals(['public.foo', 'public.bar', 'my_schema.foo', 'my_schema.baz'], $truncatedTables);
+    }
+
+    public function testRestoreSkipsDatabaseResolutionWhenNoInMemoryConnectionIsCached(): void
+    {
+        $this->restoreInMemoryDatabases();
+
+        $this->assertFalse($this->app->resolved('db'));
+    }
+
+    public function testCachesAndRestoresConfiguredInMemoryConnections(): void
+    {
+        $defaultPdo = m::mock(PDO::class);
+        $namedPdo = m::mock(PDO::class);
+        $sourceDefault = m::mock(Connection::class);
+        $sourceNamed = m::mock(Connection::class);
+        $sourceDefault->shouldReceive('getPdo')->once()->andReturn($defaultPdo);
+        $sourceNamed->shouldReceive('getPdo')->once()->andReturn($namedPdo);
+
+        $sourceDatabase = m::mock(DatabaseManager::class);
+        $sourceDatabase->shouldReceive('connection')->once()->with(null)->andReturn($sourceDefault);
+        $sourceDatabase->shouldReceive('connection')->once()->with('named')->andReturn($sourceNamed);
+        $sourceDatabase->shouldNotReceive('connection')->with('file');
+
+        $this->app->instance('config', new Repository([
+            'database' => [
+                'default' => 'default',
+                'connections' => [
+                    'default' => ['driver' => 'sqlite', 'database' => ':memory:'],
+                    'named' => ['driver' => 'sqlite', 'database' => 'file::memory:?cache=shared'],
+                    'file' => ['driver' => 'sqlite', 'database' => '/tmp/database.sqlite'],
+                ],
+            ],
+        ]));
+        $this->app->instance('db', $sourceDatabase);
+        $this->connectionsToTruncate = [null, 'named', 'file'];
+
+        $this->cacheInMemoryDatabases();
+
+        $dispatcher = m::mock(Dispatcher::class);
+        $restoredDefault = m::mock(Connection::class);
+        $restoredNamed = m::mock(Connection::class);
+        $restoredDefault->shouldReceive('setPdo')->once()->with($defaultPdo)->andReturnSelf();
+        $restoredDefault->shouldReceive('setEventDispatcher')->once()->with($dispatcher)->andReturnSelf();
+        $restoredNamed->shouldReceive('setPdo')->once()->with($namedPdo)->andReturnSelf();
+        $restoredNamed->shouldReceive('setEventDispatcher')->once()->with($dispatcher)->andReturnSelf();
+
+        $restoredDatabase = m::mock(DatabaseManager::class);
+        $restoredDatabase->shouldReceive('connection')->once()->with(null)->andReturn($restoredDefault);
+        $restoredDatabase->shouldReceive('connection')->once()->with('named')->andReturn($restoredNamed);
+        $restoredDatabase->shouldNotReceive('connection')->with('file');
+
+        $this->app->instance('db', $restoredDatabase);
+        $this->app->instance(Dispatcher::class, $dispatcher);
+
+        $this->restoreInMemoryDatabases();
+
+        $this->connectionsToTruncate = ['named', 'file'];
+
+        $this->assertTrue($this->usingInMemoryDatabasesForTruncation());
+
+        $this->connectionsToTruncate = ['missing'];
+
+        $this->assertFalse($this->usingInMemoryDatabasesForTruncation());
+        $this->assertSame([
+            'default' => $defaultPdo,
+            'named' => $namedPdo,
+        ], RefreshDatabaseState::$inMemoryConnections);
     }
 
     private function arrangeConnection(

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -224,7 +224,7 @@ class RefreshDatabaseTest extends TestCase
         }
     }
 
-    public function testBeginDatabaseTransactionWorkSetsMigratedAndCachesPdoTogether()
+    public function testBeginDatabaseTransactionWorkSetsMigratedAndCachesPdoTogether(): void
     {
         // Regression test for the RefreshDatabase + RunTestsInCoroutine +
         // mid-setUp skip bug. The invariant the fix establishes is that

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -254,7 +254,7 @@ class RefreshDatabaseTest extends TestCase
             'database' => [
                 'default' => 'default',
                 'connections' => [
-                    'default' => ['database' => ':memory:'],
+                    'default' => ['driver' => 'sqlite', 'database' => ':memory:'],
                 ],
             ],
         ]));
@@ -291,7 +291,7 @@ class RefreshDatabaseTest extends TestCase
             'database' => [
                 'default' => 'default',
                 'connections' => [
-                    'default' => ['database' => ':memory:'],
+                    'default' => ['driver' => 'sqlite', 'database' => ':memory:'],
                 ],
             ],
         ]));
@@ -309,10 +309,12 @@ class RefreshDatabaseTest extends TestCase
                 'default' => 'file',
                 'connections' => [
                     'file' => [
+                        'driver' => 'sqlite',
                         'database' => ParallelTesting::tempDir('RefreshDatabaseTest')
                             . '/database.sqlite',
                     ],
-                    'memory' => ['database' => 'file::memory:?cache=shared'],
+                    'memory' => ['driver' => 'sqlite', 'database' => 'file::memory:?cache=shared'],
+                    'url_memory' => ['url' => 'sqlite:///:memory:'],
                 ],
             ],
         ]));
@@ -320,6 +322,7 @@ class RefreshDatabaseTest extends TestCase
         $this->assertFalse($this->usingInMemoryDatabase());
         $this->assertFalse($this->usingInMemoryDatabase('file'));
         $this->assertTrue($this->usingInMemoryDatabase('memory'));
+        $this->assertTrue($this->usingInMemoryDatabase('url_memory'));
 
         $this->connectionsToTransact = ['file', 'memory'];
 
@@ -362,10 +365,11 @@ class RefreshDatabaseTest extends TestCase
                 'default' => 'file',
                 'connections' => [
                     'file' => [
+                        'driver' => 'sqlite',
                         'database' => ParallelTesting::tempDir('RefreshDatabaseTest')
                             . '/database.sqlite',
                     ],
-                    'memory' => ['database' => 'file::memory:?cache=shared'],
+                    'memory' => ['driver' => 'sqlite', 'database' => 'file::memory:?cache=shared'],
                 ],
             ],
         ]));

--- a/tests/Testbench/Databases/DatabaseTruncationExistingDatabaseTest.php
+++ b/tests/Testbench/Databases/DatabaseTruncationExistingDatabaseTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testbench\Databases;
+
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Foundation\Testing\DatabaseTruncation;
+use Hypervel\Foundation\Testing\RefreshDatabaseState;
+use Hypervel\Support\Facades\ParallelTesting;
+use Hypervel\Support\Facades\Schema;
+use Hypervel\Testbench\Attributes\ResetRefreshDatabaseState;
+use Hypervel\Testbench\TestCase;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+
+use function Hypervel\Testbench\workbench_path;
+
+#[ResetRefreshDatabaseState]
+class DatabaseTruncationExistingDatabaseTest extends TestCase
+{
+    use DatabaseTruncation;
+
+    private static string $databaseDirectory;
+
+    #[Override]
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        self::$databaseDirectory = ParallelTesting::tempDir('database-truncation-existing');
+
+        $files = new Filesystem;
+        $files->ensureDirectoryExists(self::$databaseDirectory);
+        $files->put(self::$databaseDirectory . '/database.sqlite', '');
+
+        $app->make('config')->set(
+            'database.connections.testing.database',
+            self::$databaseDirectory . '/database.sqlite',
+        );
+    }
+
+    #[Override]
+    protected function defineDatabaseMigrations(): void
+    {
+        RefreshDatabaseState::$migrated = true;
+
+        $this->loadMigrationsFrom(workbench_path('database/migrations'));
+    }
+
+    #[Test]
+    public function itRunsNewMigrationPathsWhenThePersistentDatabaseWasAlreadyMigrated(): void
+    {
+        $this->assertCount(1, $this->cachedTestMigratorProcessors);
+        $this->assertTrue(Schema::hasTable('testbench_users'));
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        try {
+            parent::tearDown();
+
+            $this->assertTrue(RefreshDatabaseState::$migrated);
+        } finally {
+            (new Filesystem)->deleteDirectory(self::$databaseDirectory);
+        }
+    }
+}

--- a/tests/Testbench/Databases/DatabaseTruncationWithMethodMigrationTest.php
+++ b/tests/Testbench/Databases/DatabaseTruncationWithMethodMigrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testbench\Databases;
+
+use Hypervel\Foundation\Testing\DatabaseTruncation;
+use Hypervel\Foundation\Testing\RefreshDatabaseState;
+use Hypervel\Support\Facades\Schema;
+use Hypervel\Testbench\Attributes\WithMigration;
+use Hypervel\Testbench\TestCase;
+use Override;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
+
+use function Hypervel\Testbench\workbench_path;
+
+class DatabaseTruncationWithMethodMigrationTest extends TestCase
+{
+    use DatabaseTruncation;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        RefreshDatabaseState::$migrated = true;
+    }
+
+    #[Override]
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(workbench_path('database/migrations'));
+    }
+
+    #[Test]
+    #[WithMigration('notifications')]
+    public function itIsolatesMethodSpecificMigrationSets(): void
+    {
+        $this->assertTrue(Schema::hasTable('notifications'));
+    }
+
+    #[Test]
+    #[Depends('itIsolatesMethodSpecificMigrationSets')]
+    public function itRestoresTheClassSchemaAfterAMethodSpecificMigrationSet(): void
+    {
+        $this->assertTrue(Schema::hasTable('testbench_users'));
+        $this->assertFalse(Schema::hasTable('notifications'));
+    }
+}

--- a/tests/Testbench/Databases/MigrateWithHypervelMigrationsUsingDatabaseTruncationTest.php
+++ b/tests/Testbench/Databases/MigrateWithHypervelMigrationsUsingDatabaseTruncationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Testbench\Databases;
+
+use Hypervel\Foundation\Testing\DatabaseTruncation;
+use Hypervel\Foundation\Testing\RefreshDatabaseState;
+use Hypervel\Support\Facades\DB;
+use Hypervel\Support\Facades\Schema;
+use Hypervel\Testbench\Attributes\ResetRefreshDatabaseState;
+use Hypervel\Testbench\Attributes\WithConfig;
+use Hypervel\Testbench\Concerns\WithHypervelMigrations;
+use Hypervel\Testbench\TestCase;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+use function Hypervel\Testbench\workbench_path;
+
+#[WithConfig('database.default', 'testing')]
+class MigrateWithHypervelMigrationsUsingDatabaseTruncationTest extends TestCase
+{
+    use DatabaseTruncation;
+    use WithHypervelMigrations;
+
+    private bool $truncated = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        ResetRefreshDatabaseState::run();
+
+        parent::setUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::assertFalse(RefreshDatabaseState::$migrated);
+        self::assertSame([], RefreshDatabaseState::$inMemoryConnections);
+    }
+
+    #[Override]
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(workbench_path('database/migrations'));
+    }
+
+    protected function afterTruncatingDatabase(): void
+    {
+        $this->truncated = true;
+    }
+
+    #[Test]
+    #[DataProvider('applicationLifecycles')]
+    public function itMigratesOnceAndThenTruncatesAcrossApplicationLifecycles(int $lifecycle): void
+    {
+        $this->assertSame([], $this->cachedTestMigratorProcessors);
+        $this->assertTrue(RefreshDatabaseState::$migrated);
+        $this->assertSame($lifecycle === 2, $this->truncated);
+        $this->assertTrue(Schema::hasTable('users'));
+        $this->assertTrue(Schema::hasTable('testbench_users'));
+        $this->assertSame(0, DB::connection()->transactionLevel());
+        $this->assertSame(
+            0,
+            DB::table('testbench_users')->where('email', 'truncation@example.com')->count(),
+        );
+
+        DB::table('testbench_users')->insert([
+            'email' => 'truncation@example.com',
+            'password' => (string) $lifecycle,
+        ]);
+    }
+
+    public static function applicationLifecycles(): array
+    {
+        // The second case exercises database state retained by the first lifecycle.
+        return [
+            'first application' => [1],
+            'second application' => [2],
+        ];
+    }
+}

--- a/tests/Testbench/DefaultConfigurationTest.php
+++ b/tests/Testbench/DefaultConfigurationTest.php
@@ -86,9 +86,13 @@ class DefaultConfigurationTest extends TestCase
             'driver' => 'sqlite',
             'database' => 'file:database?mode=memory&mode=rwc',
         ]);
+        $config->set('database.connections.url_memory', [
+            'url' => 'sqlite:///:memory:',
+        ]);
 
         $this->assertTrue($this->usesSqliteInMemoryDatabaseConnection('uri_memory'));
         $this->assertFalse($this->usesSqliteInMemoryDatabaseConnection('uri_file'));
+        $this->assertTrue($this->usesSqliteInMemoryDatabaseConnection('url_memory'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

This change makes `DatabaseTruncation` work through Hypervel Testbench with the same public behavior it already has through the Foundation test case.

It also fixes the database lifecycle exposed by that integration:

- preserve in-memory SQLite databases across Testbench application recreation;
- classify URL-based SQLite connections through the same normalized configuration path as the connection factory;
- load migration paths at the correct point for initial, retained in-memory, and persistent database lifecycles;
- isolate method-level `WithMigration` schemas from the retained class schema.

## Problem

Testbench overrides the Foundation database-concern setup order so it can process requirements and attributes before migrations run. That override invoked `RefreshDatabase`, `DatabaseMigrations`, and `DatabaseTransactions`, but omitted the existing `DatabaseTruncation` concern. Tests could declare the trait without receiving its migration or truncation lifecycle.

Adding the missing invocation exposed two Testbench-specific constraints. Each test method recreates the application, which also creates a new in-memory SQLite PDO, and Testbench can register migrations after the application has booted. Without retaining the PDO and choosing the correct migration path owner, later tests either lose the migrated schema or run package migrations against a connection that is about to be replaced.

The existing SQLite memory checks also inspected raw configuration keys. Supported URL-only configurations were therefore missed, and a URL that overrides discrete driver values could be classified using the wrong driver.

## Implementation

`SQLiteDatabase::isInMemoryConfiguration()` now normalizes connection configuration with the database URL parser before checking the driver and database value. `RefreshDatabase`, Testbench, and `DatabaseTruncation` share this classifier. Missing connection records retain their existing failure path, while malformed URLs fail through the configuration parser.

`DatabaseTruncation` now participates in parallel database setup and retains every configured in-memory SQLite PDO after the initial migration. Later application instances restore those PDOs before truncation hooks run and replace the old application event dispatcher with the current one. Persistent databases keep the existing direct truncation path and avoid resolving database services when no PDO is cached.

Testbench now invokes `DatabaseTruncation` after database requirements and migration attributes are applied. Default migration paths are registered for the initial migration and retained in-memory lifecycle. Persistent databases that were already migrated continue through the rollback-capable migration processor. Method-level `WithMigration` attributes reset retained state before and after the method so their temporary schema cannot leak into sibling tests.

The todo list records a related parallel-testing gap for persistent connections configured only through a URL. That needs URL-aware worker database rewriting or a clear unsupported-configuration failure; this change does not add a narrow workaround.

## Compatibility and performance

This does not change existing public method signatures or the purpose of any testing concern. It restores the existing `DatabaseTruncation` contract for Testbench users.

The added work is limited to test setup. Normal discrete connection configuration takes the parser's no-URL path, persistent database runs take the empty PDO-cache fast path, and production application runtime is unaffected.

## Testing

- SQLite configuration classification, including URL precedence and URL-only in-memory connections
- Foundation refresh and truncation state handling
- Testbench initial and subsequent application lifecycles
- persistent already-migrated SQLite databases
- method-specific migration isolation and class-schema restoration
- the full formatting, static-analysis, parallel-test, and Testbench checks through `composer fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of SQLite in-memory databases, including URL-based configurations.
  - Preserved configured in-memory connections during database truncation and test lifecycles.
  - Improved migration handling when combining database truncation with persistent or in-memory databases.
  - Ensured method-specific migrations are isolated and class schemas are restored correctly.

- **Documentation**
  - Clarified database availability during parallel test setup.
  - Documented compatibility expectations for database testing approaches.

- **Tests**
  - Added coverage for SQLite detection, truncation, migration isolation, and repeated application lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->