### PR TITLE
Improve Prompts correctness and streaming performance

### DIFF
--- a/docs/plans/2026-08-26-1754-components-prompts-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-26-1754-components-prompts-audit-remediation-plan-codex.md
@@ -109,19 +109,27 @@ private function transformFallbackAnswer(Prompt $prompt, mixed $answer): mixed
     return $prompt->transform === null ? $answer : ($prompt->transform)($answer);
 }
 
-private function validateFallbackPrompt(Prompt $prompt, mixed $value): mixed
+private function validateFallbackPrompt(Prompt $prompt, mixed $value): ?string
 {
     $intrinsicError = $prompt->validateIntrinsic($value);
 
-    return is_string($intrinsicError) && $intrinsicError !== ''
-        ? $intrinsicError
-        : (is_callable($prompt->validate)
-            ? ($prompt->validate)($value)
-            : $this->validatePrompt($value, $prompt->validate));
+    if (is_string($intrinsicError) && $intrinsicError !== '') {
+        return $intrinsicError;
+    }
+
+    $error = is_callable($prompt->validate)
+        ? ($prompt->validate)($value)
+        : $this->validatePrompt($value, $prompt->validate);
+
+    if (! is_string($error) && $error !== null) {
+        throw new RuntimeException('The validator must return a string or null.');
+    }
+
+    return $error;
 }
 ```
 
-Apply both helpers uniformly to all thirteen framework fallback registrations. The base intrinsic hook is free for other prompt types and avoids special-case drift when a second prompt gains intrinsic validation. Keep the helper return type `mixed`: `promptUntilValid()` rejects only a nonempty string, while an existing user validation closure may return any value. Narrowing the helper to `?string` would change the protected Laravel fallback seam. Do not route fallback validation through `Prompt::validateUsing()`; `promptUntilValid()` already reaches `validatePrompt()` and doing both would validate twice.
+Apply both helpers uniformly to all thirteen framework fallback registrations. The base intrinsic hook is free for other prompt types and avoids special-case drift when a second prompt gains intrinsic validation. The private validation adapter enforces the same `string|null` result contract and exception message as interactive Prompt validation. Keep the protected Laravel-compatible `promptUntilValid()` signature and its mixed callback contract unchanged; do not route fallback validation through `Prompt::validateUsing()`, because `promptUntilValid()` already reaches `validatePrompt()` and doing both would validate twice.
 
 Change the required check to `$required !== false` and mirror `Prompt::isInvalidWhenRequired()`'s empty set: `''`, `[]`, `false`, and `null`. Use a custom required message only when the configured string is nonempty, matching interactive behavior; `required: ''` reports `Required.`, while `required: '0'` reports `0`. Keep a concise comment linking the two manually synchronized rules. `SelectPrompt` remains unaffected because its framework fallback passes `false` for required.
 
@@ -135,6 +143,7 @@ Tests must prove:
 - interactive framework array rules receive the transformed candidate rather than the raw value returned by the Prompt;
 - all framework fallbacks use intrinsic-before-caller validation without double-running the framework validator;
 - closure and array rules retain their existing dispatch;
+- callable fallback validators returning `false`, `true`, an integer, or an array throw the same contract exception as interactive validation;
 - `required: ''` and `required: '0'` still mean required, and `null` is rejected through the protected fallback seam;
 - zero defaults survive all five affected fallback readers;
 - second use of an input Prompt fails immediately even when the first use returned early or threw, while repeatable display components retain their override behavior.
@@ -377,6 +386,7 @@ Files:
 - `src/prompts/src/Task.php`
 - `src/prompts/composer.json`
 - `tests/Prompts/{Spinner,SpinnerNonCoroutine,Task,CoroutineCreateFailure}Test.php`
+- `tests/Prompts/CoroutineSafetyTest.php`
 
 The animation owner contains exactly:
 
@@ -393,6 +403,10 @@ Spinner and coroutine Task must stop/join before final erase, final render, or t
 Declare `hypervel/engine` directly in the Prompts split package because source imports `Channel`; do not rely on `hypervel/coroutine`'s transitive dependency. The root monorepo already directly requires `hypervel/engine`, so its dependency list needs no change.
 
 Tests suspend an in-flight render and prove settlement waits for it, cover immediate and normal completion, callback failure, animation-render failure, coroutine-creation failure, cursor restoration, absence of late frames, and unchanged non-coroutine Spinner behavior. Also cover an animation render dying before settlement: the stop push must not block, and a `false` join result must not obscure the captured render failure or become a new failure by itself.
+
+Fixture-only animation release waits use a checked five-second deadlock bound, not a production timing expectation. A missing release throws from the fixture so `PromptAnimation::stop()` can join and preserve the primary operation failure instead of letting Swoole unwind a parked test coroutine as a false pass. Production settlement remains unbounded because no render may outlive it.
+
+Rewrite `CoroutineSafetyTest` child execution through keyed `parallel()` calls so child exceptions are captured and all PHPUnit assertions remain in the parent. Keep one capacity-one, `true`-only ordering barrier in each of the five two-coroutine isolation tests: callback A must read only after callback B has written, or process-global leakage can pass undetected. Wait through one private helper with the same checked five-second deadlock bound. The bound is required because `Parallel::wait()` itself waits indefinitely for every callback; `parallel()` alone cannot recover a callback parked on an unbounded barrier. Remove result channels and raw `go()` orchestration. The child-to-parent and Task sublabel tests return observations directly from `parallel()`, while the additive fallback test remains behaviorally unchanged. Add `: void` to every currently untyped test method in the edited file.
 
 ### 6. Keep process signals out of coroutine Progress
 
@@ -520,7 +534,7 @@ Files:
 Documentation rules:
 
 - Use Laravel prose in `src/docs/prompts.md`.
-- Keep behavioral documentation proportional: Number is an integer prompt, valid defaults may be integers, transforms precede validation, custom fallback implementations can call `validateIntrinsic()`, and Task partial output retains its public semantics. Update the custom fallback example's truthy default/required checks so the documentation does not retain the same `"0"` bug fixed in source. Guard custom validation with `is_callable()` before invocation and continue to caller validation when `validateIntrinsic()` returns either `null` or `''`, matching source semantics.
+- Keep behavioral documentation proportional: Number is an integer prompt, valid defaults may be integers, transforms precede validation, custom fallback implementations can call `validateIntrinsic()`, and Task partial output retains its public semantics. Update the custom fallback example's truthy default/required checks so the documentation does not retain the same `"0"` bug fixed in source. Guard custom validation with `is_callable()` before invocation, continue to caller validation when `validateIntrinsic()` returns either `null` or `''`, and reject non-string/non-null validator results with the same exception as interactive validation.
 - Do not document binary framing, caches, channels, benchmark internals, or bug history in user docs.
 - Add only the three deliberate incompatible protected-API differences to README `Differences From Laravel`: Logger's `prefix()` is absent because binary framing requires subclasses to override `write()` rather than emit text prefixes; NumberPrompt's `wrapValidation()` is replaced by `validateIntrinsic()` because validation is centralized in the base pipeline; and DataTableRenderer's fused `computeColumnWidths()` is replaced by prompt-owned `naturalColumnMetrics()` plus renderer-owned `fitColumnWidths()` because those values have different invalidation keys. `validateIntrinsic()` is otherwise an additive extension hook and belongs in the canonical user documentation. Current upstream has no matching test for the removed Logger or Number method; do not invent `REMOVED:` test comments.
 - Do not add these fixes to `src/docs/porting-from-laravel.md`; they do not change normal application/package porting decisions.

--- a/docs/plans/2026-08-26-1754-components-prompts-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-26-1754-components-prompts-audit-remediation-plan-codex.md
@@ -1,0 +1,553 @@
+# Prompts Audit Remediation Plan
+
+## Objective
+
+Resolve framework-audit findings 135–145 and the related current upstream Prompts fixes in one coherent change. The result must keep Laravel's public API and extension ergonomics except for documented protected methods whose old contracts cannot coexist with the corrected transport and validation architecture.
+
+The package should read as one design:
+
+- strict integer input with one validation pipeline in interactive, non-interactive, and framework-fallback modes;
+- bounded, linear Task streaming with unambiguous transport and deterministic animation settlement;
+- prompt-local DataTable layout work that is correct for styled, ragged, and narrow content;
+- no speculative registries, invalidation APIs, protocol negotiation, compatibility shims, production instrumentation, or worker-lifetime caches.
+
+This is framework bug-fix, performance, and architectural-remediation work. Backward compatibility with earlier Hypervel releases is not a constraint. Current Laravel APIs remain the default contract.
+
+## References and verified current behavior
+
+- Audit master list: `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`, findings 135–145.
+- Hypervel package: `src/prompts`; framework fallback: `src/console/src/Concerns/ConfiguresPrompts.php`.
+- Current local upstreams: `examples/laravel/prompts` and `examples/laravel/framework/src/Illuminate/Console/Concerns/ConfiguresPrompts.php`.
+- `docs/todo.md` has no Prompts item. Do not add an unrelated ledger for pre-existing test methods without `: void`; type every new or touched test method.
+- Current upstream Prompts has two source fixes absent from Hypervel since the port point:
+  - recursively strip nested Symfony inline style tags;
+  - truncate Grid items before computing cell widths.
+- The package otherwise has the same source-file count and recognizable Laravel structure. Hypervel's coroutine-scoped overrides, terminal handling, process settlement, and ANSI-aware rendering are justified adaptations, not candidates for wholesale rollback.
+
+Measured costs that constrain the design:
+
+- Task partial output is superlinear because every chunk resends and rewraps the entire accumulated prefix. Local probes showed the growth accelerating sharply as chunk counts doubled.
+- DataTable currently rescans and sorts every cell on every frame. A 10,000-row table costs roughly 10 ms per render before ANSI stripping.
+- ANSI/markup stripping across 30,000 cells costs roughly 9–10 ms versus roughly 1 ms for bare width measurement. Correct visible-width measurement and one-scan caching must land together; adding stripping alone would regress every keystroke.
+
+## Non-negotiable invariants
+
+1. Public and protected Laravel APIs stay compatible unless this plan records a concrete reason they cannot. Retain a protected extension seam whenever its contract remains satisfiable under the new design. Remove such a seam only when its contract cannot be honored and an override would silently stop running; every such removal requires the README difference and source `REMOVED:` note.
+2. Prompt transforms run once for each successful submitted/default/fallback candidate. The value returned is the exact value validated.
+3. Intrinsic prompt rules run before caller rules and use the transformed candidate in every execution mode.
+4. Task IPC preserves payload bytes and message boundaries under partial/coalesced reads. Parent-to-child traffic is framed; the renderer acknowledgement remains the intentionally raw one-byte reverse signal.
+5. Task transport, partial layout, and retained memory scale linearly and remain bounded by visible output plus an unfinished token/escape sequence.
+6. No animation frame may be written after final settlement starts. An animation render failure must not disappear in a child coroutine.
+7. DataTable scans search-invariant source cells once per prompt instance. Terminal resizes refit in O(column count).
+8. No process-global or static cache is added. New mutable objects are operation-local and are not container-resolved services.
+
+## Finding disposition
+
+| Finding | Final remedy |
+|---|---|
+| 135 | Strict signed-decimal integer parsing; overflow-safe bounds/arrows; remove Number's public-validator swap; unify transformed validation and fallback behavior. |
+| 136 | Recompute the cursor from the complete arrow-mutated typed value. |
+| 137 | Bound Number renderer width/padding and preserve a cancelled value of `"0"` in all six affected renderers. |
+| 138 | Replace newline/id/regex IPC with fixed binary frames and an incremental decoder. |
+| 139 | Send partial deltas and use one bounded incremental layout path in process and coroutine/static Tasks. |
+| 140 | Share one Channel-backed animation owner between Spinner and coroutine Task; stop and join before settlement. |
+| 141 | Never replace process signal handlers from Progress inside a coroutine. |
+| 142 | Restore the state that preceded a transient non-revertible error. |
+| 143 | Add Ctrl-P/Ctrl-N navigation to MultiSearch. |
+| 144 | Cache natural DataTable metrics per one-shot prompt; fix styled widths, ragged data, long headers, and terminal fitting. |
+| 145 | Fix erase counts, Number helper transform placement, static/context cleanup, ANSI/Unicode scrollbar replacement, and upper-bound wording. |
+
+## Implementation plan
+
+### 1. Unify Prompt lifecycle, transforms, and intrinsic validation
+
+Files:
+
+- `src/prompts/src/Prompt.php`
+- `src/prompts/src/Concerns/Interactivity.php`
+- `src/console/src/Concerns/ConfiguresPrompts.php`
+- `tests/Prompts/PromptLifecycleTest.php`
+- `tests/Console/ConfiguresPromptsTest.php`
+
+Add a public extension hook to `Prompt`:
+
+```php
+/**
+ * Validate rules intrinsic to the prompt type.
+ */
+public function validateIntrinsic(mixed $value): ?string
+{
+    return null;
+}
+```
+
+This is deliberately public, not `@internal`: `Prompt` is an extensible abstract base, and a user-defined prompt with its own grammar should override the same hook used by first-party prompts. It prevents subclasses from reimplementing the required → intrinsic → caller-rule order.
+
+Refactor the private validation pipeline to:
+
+1. receive one already-transformed candidate;
+2. run required validation;
+3. run `validateIntrinsic()`;
+4. run the caller closure or configured framework validator;
+5. preserve the existing string-or-null validator-result contract.
+
+The existing no-external-rules short circuit moves below required and intrinsic validation and applies only when intrinsic validation returned no error, immediately before caller/global validation. A prompt with neither `$validate` nor `validateUsing` must still run and honor `validateIntrinsic()`. Pin this with standalone Number tests that configure neither validation source and still enforce integer grammar, overflow, min, and max.
+
+Invoke the configured global validation closure as `($prompt, $value)`, where `$value` is that same transformed candidate. Update Console's installed closure to validate the second argument instead of re-reading `$prompt->value()`. Existing user-defined zero/one-argument PHP closures continue to accept the additional argument because PHP ignores surplus arguments to user-defined closures; do not add a `func_num_args()` compatibility shim. Framework array rules now observe transforms without temporary Prompt state or a second transform call. Document the callback shape in the `validateUsing()` docblock.
+
+Capture the transformed candidate in `submit()` only after it passes validation, and return that stored value from the run loop only when `state === 'submit'`. The cancel path retains its current `transformedValue()` return because test fakes deliberately make `Terminal::exit()` a no-op and therefore reach the run-loop return after Ctrl-C. This avoids an uninitialized submitted value without transforming a successful candidate twice. Live revalidation after an error may transform once for each changed candidate, but no individual candidate is transformed twice.
+
+`Interactivity::default()` must transform once, validate that value, and return it. It must still throw `NonInteractiveValidationException` on failure.
+
+Enforce the actual one-shot input-prompt lifecycle with a dedicated private boolean checked and set at method entry in base `Prompt::prompt()`, before fallback, interactivity, and terminal setup can return or throw. Do not infer prior use from mutable prompt state. A second call on the same input-prompt instance throws `RuntimeException` with a direct message, including when the first call failed part-way through. Do not add reset/reuse machinery. Display elements fully override `prompt()`, while Task, Spinner, and Progress already reject it; the guard therefore covers only the real stale-state case.
+
+Keep `ConfiguresPrompts::promptUntilValid($prompt, $required, $validate)` at its exact Laravel-compatible three-parameter protected signature. Add two private helpers:
+
+```php
+private function transformFallbackAnswer(Prompt $prompt, mixed $answer): mixed
+{
+    return $prompt->transform === null ? $answer : ($prompt->transform)($answer);
+}
+
+private function validateFallbackPrompt(Prompt $prompt, mixed $value): mixed
+{
+    return $prompt->validateIntrinsic($value)
+        ?? (is_callable($prompt->validate)
+            ? ($prompt->validate)($value)
+            : $this->validatePrompt($value, $prompt->validate));
+}
+```
+
+Apply both helpers uniformly to all thirteen framework fallback registrations. The base intrinsic hook is free for other prompt types and avoids special-case drift when a second prompt gains intrinsic validation. Keep the helper return type `mixed`: `promptUntilValid()` rejects only a nonempty string, while an existing user validation closure may return any value. Narrowing the helper to `?string` would change the protected Laravel fallback seam. Do not route fallback validation through `Prompt::validateUsing()`; `promptUntilValid()` already reaches `validatePrompt()` and doing both would validate twice.
+
+Change the required check to `$required !== false` and mirror `Prompt::isInvalidWhenRequired()`'s empty set: `''`, `[]`, `false`, and `null`. Use a custom required message only when the configured string is nonempty, matching interactive behavior; `required: ''` reports `Required.`, while `required: '0'` reports `0`. Keep a concise comment linking the two manually synchronized rules. `SelectPrompt` remains unaffected because its framework fallback passes `false` for required.
+
+Replace five `$prompt->default ?: null` expressions with an explicit empty-string decision so text, textarea, suggest, autocomplete, and number preserve the valid default `"0"`/`0`.
+
+Tests must prove:
+
+- a transform with a call counter runs once per submitted/default/fallback candidate;
+- interactive, non-interactive, and framework fallback return the transformed value they validate;
+- Ctrl-C under the fake terminal retains the existing cancel result path and never reads an uninitialized submitted candidate;
+- interactive framework array rules receive the transformed candidate rather than the raw value returned by the Prompt;
+- all framework fallbacks use intrinsic-before-caller validation without double-running the framework validator;
+- closure and array rules retain their existing dispatch;
+- `required: ''` and `required: '0'` still mean required, and `null` is rejected through the protected fallback seam;
+- zero defaults survive all five affected fallback readers;
+- second use of an input Prompt fails immediately even when the first use returned early or threw, while repeatable display components retain their override behavior.
+
+### 2. Make Number a strict integer prompt
+
+Files:
+
+- `src/prompts/src/NumberPrompt.php`
+- `src/prompts/src/helpers.php`
+- `src/prompts/src/Themes/Default/NumberPromptRenderer.php`
+- `src/prompts/src/Themes/Default/TextPromptRenderer.php`
+- `src/prompts/src/Themes/Default/SuggestPromptRenderer.php`
+- `src/prompts/src/Themes/Default/AutoCompletePromptRenderer.php`
+- `src/prompts/src/Themes/Default/SearchPromptRenderer.php`
+- `src/prompts/src/Themes/Default/MultiSearchPromptRenderer.php`
+- `src/console/src/Concerns/ConfiguresPrompts.php`
+- `tests/Prompts/NumberPromptTest.php`
+- `tests/Prompts/TextPromptTest.php`
+- `tests/Prompts/SuggestPromptTest.php`
+- `tests/Prompts/AutoCompletePromptTest.php`
+- `tests/Prompts/SearchPromptTest.php`
+- `tests/Prompts/MultiSearchPromptTest.php`
+- `tests/Console/ConfiguresPromptsTest.php`
+
+Add `NumberPrompt::parseInteger(string $value): ?int` as a public static method and the one shared parser used by Prompts and Console. Static access lets the framework fallback parse raw input without constructing a second prompt and makes the grammar directly testable. It accepts only:
+
+```text
+[+-]?[0-9]+
+```
+
+It accepts leading zeroes and both signs, returns PHP integer boundaries exactly, and returns null for whitespace, decimal/exponent notation, other characters, and overflow. Implement overflow checks with normalized decimal-string comparison against `PHP_INT_MAX` and the absolute `PHP_INT_MIN`; never parse through float or rely on a coercing cast.
+
+Normalize by removing the sign and leading zeroes, compare digit count and then lexical order against `(string) PHP_INT_MAX` or `ltrim((string) PHP_INT_MIN, '-')`, and cast only after the comparison proves representability. Do not call `abs(PHP_INT_MIN)`, which itself produces a float.
+
+`NumberPrompt::value()` returns:
+
+- `''` for empty input;
+- the parsed `int` for a representable integer;
+- the original typed string for invalid or unrepresentable input.
+
+Rendering and cursor editing always use `typedValue`, never the normalized `value()`, so a user still sees `+007` and the cursor does not jump.
+
+Override `validateIntrinsic()`:
+
+- `''` and `null`: no intrinsic error; required owns emptiness;
+- `int`: check bounds only;
+- a representable grammar-valid integer string returned by a transform: parse it and check bounds;
+- a syntactically valid but unrepresentable integer string: report the applicable lower/upper bound according to its normalized sign;
+- any other value, including floats, booleans, other strings, arrays, and objects: `Must be an integer`;
+- lower bound: `Must be at least {min}`;
+- upper bound: `Must be at most {max}`.
+
+Keep the existing no-period message style; change only the words required for accuracy and the integer contract.
+
+Remove the protected Laravel `wrapValidation(mixed $validate): callable` method. Its wrapper contract conflicts with the single base pipeline because retaining it would either run intrinsic validation twice or restore Number's temporary public-validator swap. `validateIntrinsic()` is the direct replacement extension point. Record the deliberate protected-API divergence in the package README and leave a concise `REMOVED:` note at the method's natural source position; upstream has no matching method-level test to annotate.
+
+The fallback reader uses the same parser before applying the transform, so valid entries become integers and invalid entries remain available for the shared intrinsic hook. The transformed candidate is authoritative, matching existing transform-before-validation semantics and permitting an intentional normalizing transform.
+
+Constructor and helper changes:
+
+- widen `$default` from `string` to `int|string` in both Number entry points;
+- cast the default to its internal typed string before tracking it;
+- append `?Closure $transform = null` after every existing helper parameter;
+- reject `min > max` with `InvalidArgumentException`;
+- keep nonpositive/null step normalization at one, matching current Laravel behavior.
+
+Arrow behavior:
+
+- empty up starts at configured min, or 1 when unbounded, then clamps into `[min, max]`;
+- empty down starts at configured max, or 0 when unbounded, then clamps;
+- a representable current value uses overflow-safe saturating arithmetic, then preserves Laravel's directional result clamp: increase clamps only to `max`, while decrease clamps only to `min`. Do not pre-clamp the current value; an out-of-range value should continue stepping toward the range rather than jumping through it, while an arrow farther out still snaps to the applicable bound;
+- invalid current text is not coerced;
+- after every mutation, set `cursorPosition = mb_strlen(typedValue)`.
+
+Number renderer width must cap its effective minimum width against the terminal body width before building arrows, then use `max(0, $padding)`. Do not add a second truncation pass.
+
+`NumberPromptRenderer::getArrows()` must read `value()` once and use the bounds branch only when that value is an `int`. Empty input keeps both arrows active; every other raw string rejected by the strict parser, including PHP-numeric fractions or exponents, dims both arrows without a coercing cast.
+
+In all six affected cancel renderers, distinguish `''` from `"0"` explicitly rather than using truthiness.
+
+Tests must cover signs, leading zeroes, both integer boundaries, positive/negative overflow, fractions, exponents, whitespace, non-ASCII digits, min/max inclusivity, `min > max`, transform order, array/closure rules, zero/int defaults, step normalization, saturating arrows, bounded seed selection, cursor placement, integer-only bound dimming, both arrows dimmed for rejected PHP-numeric strings, raw typed rendering, narrow terminals, and cancelled `"0"` in all six renderers.
+
+### 3. Replace Task's text protocol with compact binary frames
+
+Files:
+
+- new internal frame codec under `src/prompts/src/Support/`
+- `src/prompts/src/Support/Logger.php`
+- `src/prompts/src/Support/InProcessLogger.php`
+- `src/prompts/src/Task.php`
+- new `tests/Prompts/TaskFrameTest.php`
+- `tests/Prompts/LoggerTest.php`
+- `tests/Prompts/TaskTest.php`
+- `tests/Prompts/TaskProcessTest.php`
+
+Use one fixed frame for every parent-to-renderer message:
+
+```text
++------------+----------------------+-------------------+
+| type: u8   | payload length: u32  | payload bytes     |
+| 1 byte     | 4-byte big endian    | exact length      |
++------------+----------------------+-------------------+
+```
+
+Define compact numeric types for line, success, warning, error, label, sublabel, reset, partial delta, and partial commit. Reset carries one byte for success/failure. Do not retain identifier-prefixed text, newline delimiters, regex dispatch, base64, version negotiation, or a guessed frame-size cap.
+
+Implement the codec as one `Support\TaskFrame` class. The internal frame codec owns:
+
+- frame encoding and fail-fast rejection of an unmapped protected Logger type name before any transport write;
+- an append-only receive buffer plus consumed cursor;
+- extraction of fragmented or coalesced complete frames;
+- compaction only after a meaningful consumed prefix;
+- rejection of unknown types;
+- failure on EOF with an incomplete header/payload.
+
+The four-byte length creates a protocol-defined `0xffffffff` payload maximum. The encoder fails before packing a larger PHP string; do not add a smaller policy cap.
+
+The producer and consumer are one package/deployment unit, so malformed lengths are implementation defects. Do not invent a policy limit; EOF provides the finite failure boundary.
+
+`Logger::write()` encodes one frame and uses `Utils::writeAll()`. Preserve its transport-failure behavior and Laravel-compatible constructor. Remove `prefix()`: text prefixes cannot produce valid binary frames and retaining an unused formatter would be dead, misleading extension surface.
+
+Record that protected-method divergence in `src/prompts/README.md` under `Differences From Laravel`. At the former method's natural source-order position, retain the concise `REMOVED:` note required by the porting rules: binary framing replaces text prefixes, so subclasses extend `write()` instead. Preserve Logger's public API, protected `write()`, and identifier property/constructor argument. Also retain Task's Laravel-compatible public `$identifier` property even though binary frames make both identifiers operationally unread; removing either extension surface is unrelated to the protocol fix.
+
+The renderer acknowledgement remains a raw `\x06` byte written child-to-parent after successful final cleanup. Document this intentional reverse-channel asymmetry beside `RENDERER_ACKNOWLEDGEMENT`; do not turn it into a normal frame.
+
+Retain `Task::createSocketPair()` and `Task::forkProcess()` as small protected OS seams. Add concise WHY docblocks explaining that subclasses/tests use them to exercise socket/fork/reaping failures without an injected process abstraction.
+
+Retain protected `Task::receiveMessages($socket): void` under its exact Laravel name and signature as the renderer's decode entry point. Rework its body around `TaskFrame`; do not absorb the protected extension seam into the codec.
+
+Rewrite raw protocol tests rather than preserving text-wire assertions. Cover exact representative bytes, every type with multiline/blank/NUL payloads, split header/payload, multiple frames in one read, decoder rejection of an unknown byte, encoder rejection of an unmapped protected type string before writing, incomplete EOF, reset settlement, write failure, ACK/ECHILD behavior, and process/in-process parity.
+
+`Task::resetOperationState()` must reset/recreate the frame decoder and incremental output state so supported repeated `Task::run()` calls cannot inherit a partial frame, escape sequence, or log token from an earlier operation.
+
+### 4. Make partial Task layout incremental and bounded
+
+Files:
+
+- new `src/prompts/src/Concerns/TracksTaskOutput.php`;
+- `src/prompts/src/Task.php`
+- `src/prompts/src/Support/Logger.php`
+- `src/prompts/src/Support/InProcessLogger.php`
+- `src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php` only where shared parsing support is genuinely needed;
+- `tests/Prompts/LoggerTest.php`
+- `tests/Prompts/TaskTest.php`
+- `tests/Prompts/AnsiWordwrapTest.php`
+- `tests/Prompts/ParseAnsiTextTest.php`
+
+`Logger::partial()` sends only the new chunk. It must not append to or transmit `streamBuffer`. `commitPartial()` sends an empty commit frame.
+
+Keep Logger's protected `write(string $message, ?string $type = null)` signature. Its exact existing type vocabulary remains `null` for an ordinary line plus `success`, `warning`, `error`, `label`, `sublabel`, `partial`, and `commitpartial`; do not rename those protected-seam values while assigning compact frame bytes. The internal settlement frame maps to `reset`. An unmapped string passed by a subclass, such as `debug`, throws `InvalidArgumentException` during encoding before transport-failure capture or any write. This intentionally replaces today's accidental fall-through into a plain identifier-prefixed line; it does not expand the supported protected vocabulary or require a README difference. Subclasses do not need to understand numeric protocol identifiers.
+
+Remove the socket-null early return from `Logger::partial()` when partials become delta-only, so `InProcessLogger` can forward the chunk through its sole `write()` override. Keep the null-socket guard in base `Logger::write()` so a directly constructed socketless Logger retains its existing no-op behavior.
+
+Both IPC and in-process execution call one public `@internal` `Task::applyMessage(?string $type, string $payload)` boundary. The boundary accepts the IPC superset, including the reset type and its one-byte settlement payload. `InProcessLogger` emits only Logger's ordinary message subset because in-process settlement calls `finishRendering()` directly; do not add a dead in-process reset branch for symmetry. The public visibility is the smallest honest cross-class seam for the in-process Logger, while `@internal` keeps it outside the supported user API. Keep `InProcessLogger` because `Task::run()` publicly supplies a Laravel Logger; reduce it to overriding only `write()` and forwarding the same typed message. Delete the six Hypervel-only public Task mutation bridges and their duplicate Logger overrides.
+
+Put the cohesive partial/log layout state in a private package concern composed only by Task. Its docblock must identify it as Task-owned, and the concern must declare its own incremental parsing/layout state properties while Task remains responsible for lifecycle calls such as reset and commit. Compose `InteractsWithStrings` directly in the concern so its ANSI/string dependency is explicit. This keeps the already-large Task lifecycle readable without inverting `Support` onto theme code or creating callbacks between layout objects.
+
+Retain Task's protected `?int $partialStartIndex = null` under its exact name, type, default, and meaning as the suffix boundary where the current partial region begins. Declare it with the concern's incremental state and adjust it when ring-buffer trimming discards earlier logs. The same boundary supports incremental commit/reset and the retained full-replacement seam without duplicating state.
+
+Retain protected `Task::addLogLines(string $line): void` under its exact Laravel name and signature, with its wrapping/ring-buffer internals delegated to the concern. Also retain protected `Task::replacePartialLines(string $text): void`: reset only the current incremental partial state, then consume the supplied full text as one fresh partial input. The optimized Logger/IPC path never calls this full-prefix compatibility seam, so preserving it adds no hot-path accumulation or repeated processing.
+
+The incremental partial layout retains only:
+
+- visible wrapped log lines up to Task's existing limit;
+- the unfinished logical line/current word needed for wrapping;
+- an incomplete multibyte or escape-sequence suffix;
+- active SGR state and OSC 8 hyperlink state.
+
+Completed discarded prefixes are never retained or reprocessed. Long unbroken words are split at terminal width so the unfinished token is bounded. Commit makes current partial output permanent and resets incremental state; stable status/reset also clear the partial state.
+
+Mirror `mbWordwrap()`'s word model instead of maintaining a separator queue: each space completes the current word, consecutive spaces therefore complete empty words, and the one implicit join column is dropped only when the next word wraps. Retain the real join token only for its SGR/link attributes; a long-word cut uses the same one-column candidate with no emitted join token. Track whether the current line is unset because an empty-but-set line has distinct leading-space behavior. Coalesce each complete UTF-8 word fragment that fits as one token and fall back to grapheme tokens only when the fragment needs cutting.
+
+Scan the receive buffer with one local byte cursor and retain the unconsumed suffix once per drain; never slice the remaining buffer after every escape. Hold a trailing carriage return for the next chunk so split CRLF is recognized, while a confirmed lone carriage return remains ordinary content. Complete SGR and valid OSC 8 update formatting state, other complete terminal controls are discarded, and a final incomplete CSI/OSC is emitted literally and counts toward width.
+
+Move the bounded effective-SGR updater and OSC 8 resolver into `InteractsWithStrings`, shared by `parseAnsiText()` and Task's incremental parser. The SGR map tracks fixed terminal attributes, including indexed/RGB underline color through codes 58/59; arbitrary codes remain in one bounded fallback slot. This fixes cumulative and selective-reset styling for Task, Stream, and Callout without a general terminal parser or user-derived map keys. Always run complete Task log lines through the corrected `ansiWordwrap()` so fitting and wrapped lines use the same control-sequence rules and canonical effective style.
+
+One reset method clears every concern-owned parser/partial field while retaining rendered logs. All operation reset, ordinary-line replacement, stable settlement, and partial commit paths use it, so committed partial lines cannot be replayed by a later partial.
+
+Preserve current terminal semantics:
+
+- split committed logical log lines on CRLF and LF;
+- preserve blank committed lines in both execution modes: `line('')` adds one empty entry and `line("a\n\nb")` adds `['a', '', 'b']`;
+- do not split a lone carriage return, which command-line tools use for in-place redraw;
+- continue removing cursor-reset/erase sequences from ordinary output;
+- preserve styles and hyperlinks across chunk boundaries and close/reopen them correctly across displayed lines;
+- handle chunks split within UTF-8, CSI, and OSC 8 sequences;
+- handle CRLF split across chunks and preserve a final incomplete CSI/OSC literally;
+- avoid redundant reset accumulation;
+- preserve the fast path when a pending plain-text line has no escape sequence and fits the width.
+
+Use an effective wrap width of at least one column. A zero log limit discards completed/visible log output and still must not retain an unbounded partial token.
+
+Tests must demonstrate that output and retained memory grow linearly for many small chunks, with final parity for process and in-process modes, including empty payloads and interior blank lines. Retain direct coverage of the three protected Laravel Task methods and the protected partial-region boundary: complete-line append, full partial replacement, framed receive/decode, and `partialStartIndex` movement/reset. Pin both socketless base-Logger no-op behavior and in-process partial forwarding through the shared `partial()` method. Rewrite the negative-limit state seed and sub-label assertions that call deleted Hypervel-only public bridges to go through `InProcessLogger`; do not preserve test-only bridge calls. Timing assertions do not belong in CI; add or document a reproducible local benchmark comparing the branch base and final implementation for 1k/2k/4k chunks.
+
+Also pin consecutive partials across commit, exact-width and repeated-space wrapping, escape-heavy linear scanning, complete non-formatting control removal, final-incomplete escape preservation, split CRLF, cumulative/sequential SGR, selective resets, and SGR 58/59. Put shared ANSI state regressions in `ParseAnsiTextTest` and `AnsiWordwrapTest` so Stream and Callout are covered at their owning boundary; Task tests cover the incremental and complete-line paths.
+
+### 5. Join animation ownership before settlement
+
+Files:
+
+- new `src/prompts/src/Support/PromptAnimation.php`
+- `src/prompts/src/Spinner.php`
+- `src/prompts/src/Task.php`
+- `src/prompts/composer.json`
+- `tests/Prompts/{Spinner,SpinnerNonCoroutine,Task,CoroutineCreateFailure}Test.php`
+
+The animation owner contains exactly:
+
+- a capacity-one `Hypervel\Engine\Channel` used as an interruptible stop signal;
+- the animation coroutine id;
+- the first render failure captured inside that coroutine.
+
+The animation loop calls `pop($interval)` on the channel: `false` is the frame timeout and `true` is the stop signal. Settlement pushes `true` once, joins the exact coroutine with `Coroutine::join([$id])`, then surfaces a captured render failure. Do not close the channel, because a closed channel and a timeout both return `false` and require a second state query. Do not treat `join()` returning `false` as a general failure; it also means no supplied coroutine remained active. Do not use Swoole cancellation, polling sleeps, a WaitGroup, or a general animation framework.
+
+Spinner and coroutine Task render frame zero synchronously before starting the wait-before-render animation owner. Each timeout must therefore increment the frame index before rendering, producing frame one after one interval and matching Laravel's visible cadence without its duplicate frame-zero render. The standalone Task process loop has no synchronous pre-render and remains render, increment, then sleep; the loop shapes require different increment positions to produce the same visible cadence.
+
+Spinner and coroutine Task must stop/join before final erase, final render, or terminal restoration. Callback failure remains primary when both callback and cleanup fail, matching current settlement conventions. Immediate completion must not wait a full animation interval.
+
+Declare `hypervel/engine` directly in the Prompts split package because source imports `Channel`; do not rely on `hypervel/coroutine`'s transitive dependency. The root monorepo already directly requires `hypervel/engine`, so its dependency list needs no change.
+
+Tests suspend an in-flight render and prove settlement waits for it, cover immediate and normal completion, callback failure, animation-render failure, coroutine-creation failure, cursor restoration, absence of late frames, and unchanged non-coroutine Spinner behavior. Also cover an animation render dying before settlement: the stop push must not block, and a `false` join result must not obscure the captured render failure or become a new failure by itself.
+
+### 6. Keep process signals out of coroutine Progress
+
+Files:
+
+- `src/prompts/src/Progress.php`
+- `tests/Prompts/ProgressSignalTest.php`
+- `tests/Prompts/ProgressTest.php`
+
+Only capture/replace `SIGINT` and `pcntl_async_signals` when PCNTL exists and the Progress operation is not inside a coroutine. Inside a coroutine, leave process-global signal ownership untouched. Preserve standalone cancellation rendering, process exit, exact handler/async-mode restoration, manual start/finish, map success/failure, and destructor cleanup.
+
+Tests compare both handler identity and async mode before/during/after coroutine Progress, then retain standalone signal replacement/restoration coverage. No signal emulation or process-wide lock is needed.
+
+### 7. Restore transient prompt state and keyboard parity
+
+Files:
+
+- `src/prompts/src/Prompt.php`
+- `src/prompts/src/MultiSearchPrompt.php`
+- `tests/Prompts/PromptLifecycleTest.php`
+- `tests/Prompts/DataTablePromptTest.php`
+- `tests/Prompts/MultiSearchPromptTest.php`
+
+Add one nullable transient return-state field to Prompt. When Ctrl-U cannot revert, record the current state before showing the error. On the next key, restore that recorded state and clear it. Ordinary validation errors continue restoring to `active`; do not create a generic state-machine abstraction.
+
+This keeps DataTable search active after the message and lets the next key update its search query. Test browse, search, and ordinary validation recovery.
+
+Add `Key::CTRL_P` and `Key::CTRL_N` to MultiSearch's existing previous/next arms. They must preserve the match cache and boundary behavior exactly like arrow keys.
+
+### 8. Cache and correct DataTable natural layout
+
+Files:
+
+- `src/prompts/src/DataTablePrompt.php`
+- `src/prompts/src/Themes/Default/DataTableRenderer.php`
+- `tests/Prompts/DataTablePromptTest.php`
+
+Store search-invariant natural column metrics in a protected property on the one-shot DataTablePrompt instance. Expose one no-argument public `@internal` `naturalColumnMetrics()` method that computes and memoizes a `{column count, natural widths}` record from the prompt's headers and rows. The natural metrics derive only from prompt data; terminal-width fitting remains renderer-owned. This avoids a closure-injected memoization contract, exposes no cache mutation API, and makes the data scan directly testable. Compute the metrics lazily on first render from headers and all source rows. Do not add run resets, a WeakMap/static cache, row hashes, public invalidation, production counters, or mutation tracking.
+
+Compute the row column maximum only when rows exist, using zero otherwise, before taking the maximum with the header count. A completely empty table returns zero columns and empty natural widths; the renderer retains its existing terminal-dependent single-column search-affordance fallback rather than calling `max([])` or caching a terminal width.
+
+The natural scan must:
+
+- set column count to `max(count(headers), rows === [] ? 0 : max(array_map(count(...), rows)))` by element count;
+- treat header and row integer keys as irrelevant positional metadata during measurement and rendering, preserving the original row value returned on selection;
+- normalize an array-valued header cell with the same space-joined representation used when rendering it; do not invent multiline-header semantics;
+- measure the maximum visible width of each row-cell line and normalized header after stripping ANSI and Symfony inline markup;
+- recognize both CRLF and LF when measuring and rendering multiline row cells, without treating a lone carriage return as an additional row;
+- gather and sort nonblank row widths once;
+- implement the documented P90 outlier rule consistently;
+- return natural metrics independent of terminal width.
+
+Each render then fits those metrics to current terminal width in O(columns):
+
+- reserve the existing padding, separators, scrollbar area, and outer frame;
+- give each column at least one display column;
+- do not treat headers as unshrinkable floors;
+- distribute rounding remainder deterministically;
+- guarantee `array_sum(widths) + overhead <= maxWidth` whenever the terminal can physically contain the one-column minima.
+
+Remove protected `DataTableRenderer::computeColumnWidths(headers, rows, numCols, maxWidth)`. Its Laravel contract fuses natural metrics, whose cache lifetime is the immutable prompt data, with fitted widths, whose key is the live terminal width and may change on every render. Retaining it outside the hot path would silently ignore existing overrides; keeping it live would require scratch-state or argument-comparison machinery that restores row-scale work. Leave a concise `REMOVED:` note at its natural source position naming the two live replacement seams: override `DataTablePrompt::naturalColumnMetrics()` for source sizing and protected `DataTableRenderer::fitColumnWidths()` for terminal fitting. Record this deliberate protected-API difference in the package README.
+
+Rendering continues to truncate/pad actual content to fitted widths. Tests cover ragged and sparse-keyed headers/rows, array-valued header cells, LF/CRLF multiline row cells, ANSI/Symfony style width, long headers on an 80-column terminal, empty tables, terminal resize without a second source scan, one scan across search keystrokes, and the exact fit invariant.
+
+### 9. Replace the last visible grapheme safely
+
+Files:
+
+- `src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php`
+- `src/prompts/src/Themes/Default/Concerns/DrawsScrollbars.php`
+- `src/prompts/src/Themes/Default/DataTableRenderer.php`
+- new `tests/Prompts/InteractsWithStringsTest.php`
+- `tests/Prompts/DataTablePromptTest.php`
+
+Add one protected helper to `InteractsWithStrings` that replaces the last visible grapheme while preserving trailing escape sequences and display width. `DrawsScrollbars` explicitly uses `InteractsWithStrings` instead of relying on consumers also using `DrawsBoxes`.
+
+Contract:
+
+- empty input or input whose stripped visible width is zero is returned unchanged before matching, so a line containing only terminal escapes or style tags cannot expose one of their bytes as a grapheme;
+- split the suffix with one escape-aware pattern shaped as `/(\X)((?:(?:CSI)|(?:OSC)|(?:STYLE_CLOSE))*)$/u`; use the same complete CSI and OSC grammars as `Utils::stripEscapeSequences()`, and let `STYLE_CLOSE` cover every closing token that the same helper treats as zero-width (`</info>`, `</comment>`, `</question>`, `</error>`, and `</>`). Capture the last visible grapheme separately from the entire trailing zero-width suffix and re-emit that suffix after the replacement;
+- invalid UTF-8 is unchanged; require the escape-aware `preg_match(...)` result to be exactly `1` so both a non-match and `false` from `PREG_BAD_UTF8_ERROR` return the original line;
+- replace the whole final grapheme, including combining marks and ZWJ emoji;
+- preserve trailing SGR resets and OSC 8 closes after the replacement;
+- preserve the line's `mb_strwidth`-measured width: if the removed grapheme measures wider than the replacement, insert that measured difference as padding before the scrollbar glyph. This intentionally uses the same width accounting as existing `pad()` and `longest()`; solving package-wide terminal-width inaccuracies for combining/ZWJ graphemes would require unrelated width machinery.
+
+Use PCRE's Unicode grapheme cluster (`\X`) support plus `mb_strwidth`; do not add an `ext-intl` dependency for `grapheme_*` functions.
+
+Use the helper in both the generic scrollbar trait and DataTable's multiline-aware manual scrollbar. Remove both byte-oriented `preg_replace('/.$/')` paths. Explicitly test an exact-width styled line such as `ESC[2mabcdefghijESC[22m`: replace `j`, preserve the complete trailing reset after the scrollbar glyph, and never treat the reset's final `m` as visible content. Cover the same suffix preservation for an OSC 8 close and Symfony named/inline closing tags. Escape-only and style-tag-only inputs remain byte-for-byte unchanged. Do not build a general styled-string object.
+
+### 10. Apply the remaining focused correctness fixes and upstream updates
+
+Files:
+
+- `src/prompts/src/Concerns/Erase.php`
+- `src/prompts/src/Prompt.php`
+- `src/prompts/src/Support/Utils.php`
+- `src/prompts/src/Themes/Default/GridRenderer.php`
+- new `tests/Prompts/EraseTest.php`
+- `tests/Prompts/PromptLifecycleTest.php`
+- `tests/Prompts/UtilsTest.php`
+- `tests/Prompts/GridTest.php`
+
+Changes:
+
+1. `eraseLines($count)` returns immediately for nonpositive counts. For each positive line, erase and move up one line only when another line remains, producing exact behavior for 1 and N.
+2. Make Prompt's static output and terminal declarations nullable and initialized to null. `flushState()` forgets the output and validation coroutine-context keys and resets both static fields to null; accessors retain lazy `??=` construction. Do not flush unrelated coroutine context.
+3. Port current Laravel nested inline-style stripping into centralized `Utils::stripEscapeSequences()` so nested matching tags are removed until stable.
+4. Port current Laravel Grid truncation before width/cell computation, using `max(1, maxWidth - 5)` and measuring the truncated values used for layout.
+
+Tests cover escape output for erase counts -1/0/1/3, context-key removal without whole-context loss, lazy output/terminal re-creation, nested styles, ordinary text containing angle brackets, long Grid items, narrow widths, and unchanged balanced layout.
+
+## Documentation and package metadata
+
+Files:
+
+- `src/prompts/README.md`
+- `src/docs/prompts.md`
+- `src/prompts/composer.json`
+
+Documentation rules:
+
+- Use Laravel prose in `src/docs/prompts.md`.
+- Keep behavioral documentation proportional: Number is an integer prompt, valid defaults may be integers, transforms precede validation, custom fallback implementations can call `validateIntrinsic()`, and Task partial output retains its public semantics. Update the custom fallback example's truthy default/required checks so the documentation does not retain the same `"0"` bug fixed in source. Guard custom validation with `is_callable()` before invocation so documented array rules do not fatal, and show `validateIntrinsic()` ahead of that caller validation.
+- Do not document binary framing, caches, channels, benchmark internals, or bug history in user docs.
+- Add only the three deliberate incompatible protected-API differences to README `Differences From Laravel`: Logger's `prefix()` is absent because binary framing requires subclasses to override `write()` rather than emit text prefixes; NumberPrompt's `wrapValidation()` is replaced by `validateIntrinsic()` because validation is centralized in the base pipeline; and DataTableRenderer's fused `computeColumnWidths()` is replaced by prompt-owned `naturalColumnMetrics()` plus renderer-owned `fitColumnWidths()` because those values have different invalidation keys. `validateIntrinsic()` is otherwise an additive extension hook and belongs in the canonical user documentation. Current upstream has no matching test for the removed Logger or Number method; do not invent `REMOVED:` test comments.
+- Do not add these fixes to `src/docs/porting-from-laravel.md`; they do not change normal application/package porting decisions.
+- Do not modify `docs/todo.md`.
+
+## Expected file ownership and cleanup
+
+- Delete no Laravel public methods. Remove only the explicitly justified protected `Logger::prefix()`, `NumberPrompt::wrapValidation()`, and `DataTableRenderer::computeColumnWidths()` methods, with README and source dispositions for all three.
+- Remove `Logger::$streamBuffer` after delta-only partials make it dead.
+- Remove the six Hypervel-only public Task mutation bridges after all in-process callers use `applyMessage()`.
+- Keep `InProcessLogger`, but reduce it to the one necessary `write()` adapter.
+- Retain protected `Task::receiveMessages()`, `Task::addLogLines()`, and `Task::replacePartialLines()` under their Laravel names and signatures; rework their internals around frames and incremental state.
+- Retain protected `Task::$partialStartIndex` under its exact name/type/default as the incremental partial-region boundary.
+- Remove protected `Task::$buffer`: its incomplete-newline meaning cannot survive binary framing, and `TaskFrame` owns its distinct receive buffer. Remove the newline protocol regex/constants and other line-framing state made dead by frames.
+- Protected storage internals do not receive README `Differences From Laravel` entries; unlike a silently bypassed method override, removing the obsolete line buffer does not change a supported extension behavior.
+- Do not leave comments describing replaced designs, compatibility branches, or rejected alternatives.
+
+## Verification sequence
+
+During implementation, edit one file at a time and run each changed test file immediately. Recommended coherent order:
+
+1. Prompt/Number validation and Console fallback tests.
+2. Frame codec and Logger tests.
+3. Task incremental layout and process-settlement tests.
+4. Animation owner, Spinner, and coroutine Task tests.
+5. Progress signal tests.
+6. DataTable/state/keyboard/string-layout tests.
+7. Utils/Grid/erase/static-cleanup tests.
+8. Package docs and metadata assertions.
+
+Then run the affected package/fallback set together:
+
+```bash
+./vendor/bin/phpunit --no-progress tests/Prompts tests/Console/ConfiguresPromptsTest.php
+```
+
+At the implementation checkpoint, run exactly one:
+
+```bash
+composer fix
+```
+
+After any review fixes, rerun only the relevant targeted tests unless the changes justify another full checkpoint.
+
+Before code review, inspect the complete diff against `0.4` and trace:
+
+- every Prompt execution mode and transform/validation caller;
+- every Logger message producer and Task consumer;
+- callback, animation, renderer, transport, signal, terminal, and coroutine failure precedence;
+- ANSI/OSC 8 state across chunk/layout boundaries;
+- DataTable widths against every rendering consumer;
+- worker-lifetime/static/context state and cleanup;
+- Laravel public/protected signatures and named arguments;
+- dead fields, methods, tests, comments, and documentation.
+
+Run before/after Task partial and DataTable render benchmarks outside CI and record representative environment-qualified results in the PR description. Do not add timing thresholds or production instrumentation.
+
+## Rejected machinery
+
+Do not add any of the following unless implementation exposes a new, concrete requirement and the plan is amended after review:
+
+- pipe/version negotiation or base64 Task transport;
+- arbitrary frame/output caps beyond Task's existing visible limit;
+- a generic event bus or production counters;
+- Task whole-prefix buffering;
+- Swoole coroutine cancellation for animation settlement;
+- both Channel and WaitGroup ownership;
+- DataTable static/WeakMap/hash caches or public invalidation;
+- Prompt reset/reuse support;
+- a general terminal styled-string framework;
+- a package-wide mechanical `: void` rewrite or Prompts TODO ledger;
+- FormBuilder expansion.
+
+These exclusions keep the final architecture proportional: necessary state is explicit and operation-local, hot repeated work is removed, and supported Laravel-shaped extension surfaces remain understandable from source.

--- a/docs/plans/2026-08-26-1754-components-prompts-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-26-1754-components-prompts-audit-remediation-plan-codex.md
@@ -35,8 +35,8 @@ Measured costs that constrain the design:
 1. Public and protected Laravel APIs stay compatible unless this plan records a concrete reason they cannot. Retain a protected extension seam whenever its contract remains satisfiable under the new design. Remove such a seam only when its contract cannot be honored and an override would silently stop running; every such removal requires the README difference and source `REMOVED:` note.
 2. Prompt transforms run once for each successful submitted/default/fallback candidate. The value returned is the exact value validated.
 3. Intrinsic prompt rules run before caller rules and use the transformed candidate in every execution mode.
-4. Task IPC preserves payload bytes and message boundaries under partial/coalesced reads. Parent-to-child traffic is framed; the renderer acknowledgement remains the intentionally raw one-byte reverse signal.
-5. Task transport, partial layout, and retained memory scale linearly and remain bounded by visible output plus an unfinished token/escape sequence.
+4. Task IPC preserves payload bytes and message boundaries under partial/coalesced reads. Parent-to-child traffic is framed; the renderer acknowledgement remains the intentionally raw one-byte reverse signal. Complete and incremental output paths expose the same visible text for the same terminal controls.
+5. Task transport, partial layout, and retained memory scale linearly. Plain-text carry is limited to one structural UTF-8 suffix, and any input unit that normal parsing cannot break has one fixed 4096-byte ceiling.
 6. No animation frame may be written after final settlement starts. An animation render failure must not disappear in a child coroutine.
 7. DataTable scans search-invariant source cells once per prompt instance. Terminal resizes refit in O(column count).
 8. No process-global or static cache is added. New mutable objects are operation-local and are not container-resolved services.
@@ -91,7 +91,7 @@ Refactor the private validation pipeline to:
 4. run the caller closure or configured framework validator;
 5. preserve the existing string-or-null validator-result contract.
 
-The existing no-external-rules short circuit moves below required and intrinsic validation and applies only when intrinsic validation returned no error, immediately before caller/global validation. A prompt with neither `$validate` nor `validateUsing` must still run and honor `validateIntrinsic()`. Pin this with standalone Number tests that configure neither validation source and still enforce integer grammar, overflow, min, and max.
+The existing no-external-rules short circuit moves below required and intrinsic validation and applies only when intrinsic validation returned a nonempty error, immediately before caller/global validation. Both `null` and `''` mean that intrinsic validation passed; only a nonempty string blocks caller/global validation. A prompt with neither `$validate` nor `validateUsing` must still run and honor `validateIntrinsic()`. Pin this with standalone Number tests that configure neither validation source and still enforce integer grammar, overflow, min, and max, plus a custom prompt whose empty intrinsic result still reaches a rejecting configured validator.
 
 Invoke the configured global validation closure as `($prompt, $value)`, where `$value` is that same transformed candidate. Update Console's installed closure to validate the second argument instead of re-reading `$prompt->value()`. Existing user-defined zero/one-argument PHP closures continue to accept the additional argument because PHP ignores surplus arguments to user-defined closures; do not add a `func_num_args()` compatibility shim. Framework array rules now observe transforms without temporary Prompt state or a second transform call. Document the callback shape in the `validateUsing()` docblock.
 
@@ -111,8 +111,11 @@ private function transformFallbackAnswer(Prompt $prompt, mixed $answer): mixed
 
 private function validateFallbackPrompt(Prompt $prompt, mixed $value): mixed
 {
-    return $prompt->validateIntrinsic($value)
-        ?? (is_callable($prompt->validate)
+    $intrinsicError = $prompt->validateIntrinsic($value);
+
+    return is_string($intrinsicError) && $intrinsicError !== ''
+        ? $intrinsicError
+        : (is_callable($prompt->validate)
             ? ($prompt->validate)($value)
             : $this->validatePrompt($value, $prompt->validate));
 }
@@ -275,10 +278,16 @@ Files:
 - `src/prompts/src/Support/Logger.php`
 - `src/prompts/src/Support/InProcessLogger.php`
 - `src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php` only where shared parsing support is genuinely needed;
+- `src/prompts/src/Support/Utils.php`
 - `tests/Prompts/LoggerTest.php`
 - `tests/Prompts/TaskTest.php`
+- `src/prompts/src/Themes/Default/CalloutRenderer.php`
+- `src/prompts/src/Themes/Default/Concerns/DrawsBoxes.php`
 - `tests/Prompts/AnsiWordwrapTest.php`
+- `tests/Prompts/CalloutTest.php`
+- `tests/Prompts/MultiByteWordWrapTest.php`
 - `tests/Prompts/ParseAnsiTextTest.php`
+- `tests/Prompts/UtilsTest.php`
 
 `Logger::partial()` sends only the new chunk. It must not append to or transmit `streamBuffer`. `commitPartial()` sends an empty commit frame.
 
@@ -294,20 +303,50 @@ Retain Task's protected `?int $partialStartIndex = null` under its exact name, t
 
 Retain protected `Task::addLogLines(string $line): void` under its exact Laravel name and signature, with its wrapping/ring-buffer internals delegated to the concern. Also retain protected `Task::replacePartialLines(string $text): void`: reset only the current incremental partial state, then consume the supplied full text as one fresh partial input. The optimized Logger/IPC path never calls this full-prefix compatibility seam, so preserving it adds no hot-path accumulation or repeated processing.
 
+Complete messages stay on the faster `ansiWordwrap()` path rather than passing through the incremental parser, which costs roughly two to four times as much for whole payloads. Normalize CRLF to LF once, then wrap the entire message in one call so SGR and OSC 8 state can span logical lines. While aligning parsed source characters with wrapped visible lines, `ansiWordwrap()` skips source LF bytes as separators removed by `mbWordwrap()`; never skip a lone carriage return. This shared fix also covers multiline Stream and Callout output without adding a cross-line state carrier or another parser.
+
+Task Logger styling supports ANSI terminal controls, including SGR and OSC 8, rather than Symfony style markup. Complete-versus-incremental parity applies to plain text and those supported controls; do not add a second cross-chunk markup parser for an input Laravel does not define as part of the Task Logger contract.
+
 The incremental partial layout retains only:
 
 - visible wrapped log lines up to Task's existing limit;
 - the unfinished logical line/current word needed for wrapping;
-- an incomplete multibyte or escape-sequence suffix;
+- at most the three-byte suffix that can be the start of a split UTF-8 codepoint;
+- an unfinished terminal-control buffer no larger than 4096 bytes, plus its small parser mode;
+- an indivisible grapheme fragment no larger than the same fixed ceiling;
 - active SGR state and OSC 8 hyperlink state.
 
 Completed discarded prefixes are never retained or reprocessed. Long unbroken words are split at terminal width so the unfinished token is bounded. Commit makes current partial output permanent and resets incremental state; stable status/reset also clear the partial state.
 
 Mirror `mbWordwrap()`'s word model instead of maintaining a separator queue: each space completes the current word, consecutive spaces therefore complete empty words, and the one implicit join column is dropped only when the next word wraps. Retain the real join token only for its SGR/link attributes; a long-word cut uses the same one-column candidate with no emitted join token. Track whether the current line is unset because an empty-but-set line has distinct leading-space behavior. Coalesce each complete UTF-8 word fragment that fits as one token and fall back to grapheme tokens only when the fragment needs cutting.
 
-Scan the receive buffer with one local byte cursor and retain the unconsumed suffix once per drain; never slice the remaining buffer after every escape. Hold a trailing carriage return for the next chunk so split CRLF is recognized, while a confirmed lone carriage return remains ordinary content. Complete SGR and valid OSC 8 update formatting state, other complete terminal controls are discarded, and a final incomplete CSI/OSC is emitted literally and counts toward width.
+Correct the shared `mbWordwrap()` boundary because Textarea calls it directly with long-word cutting enabled. Normalize the effective width to at least one before the short-line check. In the cut loop, skip every word whose `mb_strwidth()` already fits. Split over-width words through one internal `Utils` grapheme helper shared with Task's incremental path. The helper uses PCRE Unicode graphemes (`\X`), falls back to the current byte-preserving `mb_str_split()` behavior for malformed UTF-8, and losslessly splits any single grapheme beyond the shared 4096-byte unbreakable-input ceiling at UTF-8 codepoint boundaries. Both paths ask the same PCRE boundary check whether adjacent fragments remain one grapheme; keep them atomic across width or chunk boundaries only while their combined bytes remain within the ceiling. This preserves combining, modifier, flag, keycap, Hangul, Indic, and ZWJ clusters without a Unicode property registry, preview delay, or complete/incremental exception, while pathological Zalgo output remains bounded.
 
-Move the bounded effective-SGR updater and OSC 8 resolver into `InteractsWithStrings`, shared by `parseAnsiText()` and Task's incremental parser. The SGR map tracks fixed terminal attributes, including indexed/RGB underline color through codes 58/59; arbitrary codes remain in one bounded fallback slot. This fixes cumulative and selective-reset styling for Task, Stream, and Callout without a general terminal parser or user-derived map keys. Always run complete Task log lines through the corrected `ansiWordwrap()` so fitting and wrapped lines use the same control-sequence rules and canonical effective style.
+When an allowed grapheme itself is wider than the target, never append the still-empty preceding fragment. Accept the first word onto an unset line even when that indivisible word exceeds the width, rather than emitting a leading blank. When a later word wraps from an empty-but-set line, do not store that zero-character overflow line; the pending implicit join is dropped by wrapping. Apply the same narrow suppression in both incremental emitters: reset an empty wrapped line instead of storing it during word completion, and omit the same empty line from the unfinished-word preview. Preserve nonempty whitespace-only lines, the intentional empty preview from `partial('')`, and explicit LF/CRLF blank lines. Remove the `\p{Cf}` width-two shortcut and measure every word with `mb_strwidth()`, matching the incremental path. This deliberately uses one consistent and conservative width model: PHP measures many ZWJ emoji wider than terminals display them. Do not add separator-carry state, a terminal cell-width engine, width cache, or second wrapping algorithm to optimize display-only mismatches.
+
+Clamp Callout's `minWidth` to `max(1, min($this->minWidth, terminal columns - 6))` before resolving any content, so plain text and all three list renderers wrap against the same live terminal width. Keep the corresponding `max(1, ...)` safeguard in `DrawsBoxes::box()` because that trait also serves renderers that do not pre-resolve content. Two direct clamps at distinct lifecycle boundaries are clearer than a width-lifecycle helper.
+
+Scan each chunk once with one local byte cursor; never rescan a growing unfinished control from its introducer. Hold a trailing carriage return for the next chunk so split CRLF is recognized, while a confirmed lone carriage return remains ordinary content. On invalid non-final UTF-8 input, inspect only the final three bytes structurally: retain exactly a suffix that starts with a valid two-, three-, or four-byte lead, contains only the available continuation bytes, and is shorter than the required sequence. Consume every preceding byte even when it contains invalid UTF-8. Stray continuations, invalid leads, and complete invalid sequences must make forward progress.
+
+Starting a partial region represents its first logical line even when the first chunk is empty. Consuming LF or CRLF finishes the current line and immediately starts the next logical line, including a trailing empty line. A commit without any preceding partial remains a no-op because no region exists. This keeps `partial('')`, trailing/repeated newlines, and protected `replacePartialLines('')` aligned with complete-output and upstream behavior without special cases.
+
+Implement one operation-local terminal-control scanner. The shared 4096-byte unbreakable-input constant also bounds its retained control prefix; after the ceiling the scanner discards retained bytes while continuing only its small mode state. Match the specialized introducers before the generic grammar because `[`, `]`, `P`, `X`, `^`, and `_` are themselves valid generic final bytes:
+
+- CSI is `ESC [` followed by parameter bytes `0x30–0x3f`, then intermediate bytes `0x20–0x2f`, then one final byte `0x40–0x7e`;
+- OSC is `ESC ]` and ends at BEL or ST;
+- DCS, SOS, PM, and APC begin with `ESC P`, `ESC X`, `ESC ^`, and `ESC _` and end at ST. A BEL is invalid in these string controls and recovers by discarding through the BEL;
+- every other ESC sequence is `ESC`, zero or more intermediate bytes `0x20–0x2f`, and one final byte `0x30–0x7e`;
+- do not recognize 8-bit C1 introducers because their byte values are ambiguous with UTF-8 continuation bytes.
+
+The scanner uses one mode field covering generic ESC, CSI parameter/intermediate phases, OSC, and the other string controls; one pending-ESC bit distinguishes ST from a malformed bare ESC. It retains a control only while it remains within the fixed ceiling. Beyond that ceiling it drops the retained bytes but continues the same small state until completion or local abort, so memory remains bounded without rendering control payload as text. Complete SGR and valid OSC 8 update formatting state; every other complete control is discarded.
+
+Recognize specialized CSI/OSC/string introducers only while the retained control is exactly `ESC`. After one or more generic intermediate bytes, every byte in the final range completes that generic control, including `[`, `]`, `P`, `X`, `^`, and `_`; do not add another parser mode for a phase already represented by the retained prefix.
+
+Malformed controls abort locally instead of swallowing later output. A byte invalid for the current CSI or generic-ESC phase ends and discards that prefix, then is reprocessed normally. Inside OSC or another string control, `ESC \\` terminates through ST; a bare ESC followed by anything else aborts the string and reprocesses that ESC as a new control. This reprocessing always starts at a later byte than the discarded introducer and must guarantee forward progress for repeated ESC input. At end of input, discard any unfinished control rather than re-emitting raw terminal bytes.
+
+Keep the bounded effective-SGR updater in `InteractsWithStrings`, shared by `parseAnsiText()` and Task's incremental parser. The SGR map tracks fixed terminal attributes, including indexed/RGB underline color through codes 58/59; arbitrary codes remain in one bounded fallback slot. Treat a colon-form parameter such as `4:3` or `38:2:...` as one complete raw parameter: use its leading integer only to choose the fixed attribute slot, preserve the full token, and do not consume later semicolon parameters. This fixes cumulative, colon-form, and selective-reset styling for Task, Stream, and Callout without a general terminal parser or user-derived map keys.
+
+Keep `parseAnsiText()`, Task's scanner, and `Utils::stripEscapeSequences()` aligned on visible bytes. Complete parsing removes generic ESC controls, character-set designators, DCS/SOS/PM/APC with their payloads, malformed locally aborted prefixes, and final incomplete controls. `parseAnsiText()` retains state only for SGR and valid OSC 8. `Utils` owns one capture-free OSC 8 grammar, composes it into the typed formatting fragment shared with the scrollbar helper, and resolves link state through one internal static method. Validate with the grammar first, then split the already-validated body at its first separator to preserve semicolons in the URI; do not add redundant fallback handling for a missing separator. Do not add a public parser, formatter registry, styled-string object, or payload interpretation. Always run complete Task log lines through the corrected `ansiWordwrap()` so fitting and wrapped lines use the same control rules and canonical effective style.
 
 One reset method clears every concern-owned parser/partial field while retaining rendered logs. All operation reset, ordinary-line replacement, stable settlement, and partial commit paths use it, so committed partial lines cannot be replayed by a later partial.
 
@@ -318,8 +357,8 @@ Preserve current terminal semantics:
 - do not split a lone carriage return, which command-line tools use for in-place redraw;
 - continue removing cursor-reset/erase sequences from ordinary output;
 - preserve styles and hyperlinks across chunk boundaries and close/reopen them correctly across displayed lines;
-- handle chunks split within UTF-8, CSI, and OSC 8 sequences;
-- handle CRLF split across chunks and preserve a final incomplete CSI/OSC literally;
+- handle chunks split within UTF-8, CSI, OSC 8, generic ESC, and string-control sequences;
+- handle CRLF split across chunks and discard a final incomplete control;
 - avoid redundant reset accumulation;
 - preserve the fast path when a pending plain-text line has no escape sequence and fits the width.
 
@@ -327,7 +366,7 @@ Use an effective wrap width of at least one column. A zero log limit discards co
 
 Tests must demonstrate that output and retained memory grow linearly for many small chunks, with final parity for process and in-process modes, including empty payloads and interior blank lines. Retain direct coverage of the three protected Laravel Task methods and the protected partial-region boundary: complete-line append, full partial replacement, framed receive/decode, and `partialStartIndex` movement/reset. Pin both socketless base-Logger no-op behavior and in-process partial forwarding through the shared `partial()` method. Rewrite the negative-limit state seed and sub-label assertions that call deleted Hypervel-only public bridges to go through `InProcessLogger`; do not preserve test-only bridge calls. Timing assertions do not belong in CI; add or document a reproducible local benchmark comparing the branch base and final implementation for 1k/2k/4k chunks.
 
-Also pin consecutive partials across commit, exact-width and repeated-space wrapping, escape-heavy linear scanning, complete non-formatting control removal, final-incomplete escape preservation, split CRLF, cumulative/sequential SGR, selective resets, and SGR 58/59. Put shared ANSI state regressions in `ParseAnsiTextTest` and `AnsiWordwrapTest` so Stream and Callout are covered at their owning boundary; Task tests cover the incremental and complete-line paths.
+Also pin consecutive partials across commit, exact-width and repeated-space wrapping, escape-heavy linear scanning, complete non-formatting control removal, final-incomplete control discard, split CRLF, cumulative/sequential SGR, selective resets, SGR 58/59, and colon-form SGR such as `4:3` and `38:2:...;1`. Add unconditional complete-versus-incremental parity for empty output, trailing/repeated blank lines, formatting spanning a newline, formatting beginning after a newline, and wrapped content whose formatting begins after a newline, across every possible chunk split; separately prove a bare partial commit is a no-op. Add parity cases for every split of short valid controls; malformed CSI/OSC followed by visible output; repeated ESC forward progress; generic controls with one and two intermediates followed by each specialized-introducer byte as their final; `ESC ( B` character-set designation; DCS/APC payload removal; controls exceeding the 4096-byte ceiling; bound/reset behavior with a zero log limit; and complete-line, partial, and stripped-width agreement. Put multiline `ansiWordwrap()` regressions and shared ANSI state regressions in `AnsiWordwrapTest`, `ParseAnsiTextTest`, and `UtilsTest` so Stream and Callout are covered at their owning boundary; Task tests cover the incremental and complete-line paths. In `MultiByteWordWrapTest`, cover combining, modifier, flag, keycap, Hangul, Indic, and ZWJ graphemes; every split of representative clusters; an oversized grapheme split losslessly at the shared ceiling; a wide grapheme narrower than the target in both cut modes; the absence of leading, empty, and ZWJ-only overflow rows; malformed UTF-8 fallback; zero/negative width normalization; and unchanged nonempty whitespace-only lines. Extend the every-split complete-versus-incremental Task harness with the same grapheme set, an oversized combining cluster, double-space over-width words, and a leading separator before an over-width word; keep parity unconditional and explicit blank logical lines byte-for-byte intact. Assert that complete and incremental retained entries stay within `limit × ceiling`, including repeated complete lines and streamed/single-chunk oversized clusters. At every chunk boundary assert that wrap overflow never creates a zero-character row; assert preview/commit equality only after the final chunk because a pending separator may legitimately appear in an intermediate preview and then be dropped when the next word wraps. In `CalloutTest`, cover narrow plain, bulleted, numbered, and key-value content and prove the rendered frame remains within the terminal.
 
 ### 5. Join animation ownership before settlement
 
@@ -372,9 +411,11 @@ Tests compare both handler identity and async mode before/during/after coroutine
 Files:
 
 - `src/prompts/src/Prompt.php`
+- `src/prompts/src/SearchPrompt.php`
 - `src/prompts/src/MultiSearchPrompt.php`
 - `tests/Prompts/PromptLifecycleTest.php`
 - `tests/Prompts/DataTablePromptTest.php`
+- `tests/Prompts/SearchPromptTest.php`
 - `tests/Prompts/MultiSearchPromptTest.php`
 
 Add one nullable transient return-state field to Prompt. When Ctrl-U cannot revert, record the current state before showing the error. On the next key, restore that recorded state and clear it. Ordinary validation errors continue restoring to `active`; do not create a generic state-machine abstraction.
@@ -382,6 +423,8 @@ Add one nullable transient return-state field to Prompt. When Ctrl-U cannot reve
 This keeps DataTable search active after the message and lets the next key update its search query. Test browse, search, and ordinary validation recovery.
 
 Add `Key::CTRL_P` and `Key::CTRL_N` to MultiSearch's existing previous/next arms. They must preserve the match cache and boundary behavior exactly like arrow keys.
+
+Do not let navigation depend on a renderer populating the nullable match cache. In every up/down/tab/shift-tab/Ctrl-P/Ctrl-N arm in Search and MultiSearch, call the memoized `matches()` accessor before counting. The default renderer has already populated it on the normal path, so this remains O(1); a custom theme registered through `Prompt::addTheme()` that does not render options now receives the same navigation semantics without rerunning its options callback. Test both prompts with a minimal custom renderer that never reads matches.
 
 ### 8. Cache and correct DataTable natural layout
 
@@ -428,12 +471,13 @@ Files:
 - new `tests/Prompts/InteractsWithStringsTest.php`
 - `tests/Prompts/DataTablePromptTest.php`
 
-Add one protected helper to `InteractsWithStrings` that replaces the last visible grapheme while preserving trailing escape sequences and display width. `DrawsScrollbars` explicitly uses `InteractsWithStrings` instead of relying on consumers also using `DrawsBoxes`.
+Add one protected helper to `InteractsWithStrings` that replaces the last visible grapheme while preserving trailing formatting and display width. `DrawsScrollbars` explicitly uses `InteractsWithStrings` instead of relying on consumers also using `DrawsBoxes`. Its inputs are raw option labels rather than `parseAnsiText()` output, so it must sanitize terminal controls itself.
 
 Contract:
 
 - empty input or input whose stripped visible width is zero is returned unchanged before matching, so a line containing only terminal escapes or style tags cannot expose one of their bytes as a grapheme;
-- split the suffix with one escape-aware pattern shaped as `/(\X)((?:(?:CSI)|(?:OSC)|(?:STYLE_CLOSE))*)$/u`; use the same complete CSI and OSC grammars as `Utils::stripEscapeSequences()`, and let `STYLE_CLOSE` cover every closing token that the same helper treats as zero-width (`</info>`, `</comment>`, `</question>`, `</error>`, and `</>`). Capture the last visible grapheme separately from the entire trailing zero-width suffix and re-emit that suffix after the replacement;
+- first discard incomplete, malformed, and complete non-formatting terminal controls with the shared `Utils` grammar, preserving only formatting that can affect the visible line;
+- split the suffix with one escape-aware pattern shaped as `/(?<grapheme>\X)(?<suffix>(?:(?:SGR)|(?:OSC_8)|(?:STYLE_CLOSE))*)$/u`; deliberately narrow the alternatives to CSI ending in `m` and a complete OSC 8 command with its required parameter/URI separator, rather than depending on prior sanitization to make broader CSI/OSC alternatives safe. Let `STYLE_CLOSE` cover every closing token that the same helper treats as zero-width (`</info>`, `</comment>`, `</question>`, `</error>`, and `</>`). Capture the last visible grapheme separately from the entire trailing zero-width suffix and re-emit that suffix after the replacement;
 - invalid UTF-8 is unchanged; require the escape-aware `preg_match(...)` result to be exactly `1` so both a non-match and `false` from `PREG_BAD_UTF8_ERROR` return the original line;
 - replace the whole final grapheme, including combining marks and ZWJ emoji;
 - preserve trailing SGR resets and OSC 8 closes after the replacement;
@@ -441,7 +485,7 @@ Contract:
 
 Use PCRE's Unicode grapheme cluster (`\X`) support plus `mb_strwidth`; do not add an `ext-intl` dependency for `grapheme_*` functions.
 
-Use the helper in both the generic scrollbar trait and DataTable's multiline-aware manual scrollbar. Remove both byte-oriented `preg_replace('/.$/')` paths. Explicitly test an exact-width styled line such as `ESC[2mabcdefghijESC[22m`: replace `j`, preserve the complete trailing reset after the scrollbar glyph, and never treat the reset's final `m` as visible content. Cover the same suffix preservation for an OSC 8 close and Symfony named/inline closing tags. Escape-only and style-tag-only inputs remain byte-for-byte unchanged. Do not build a general styled-string object.
+Use the helper in both the generic scrollbar trait and DataTable's multiline-aware manual scrollbar. Remove both byte-oriented `preg_replace('/.$/')` paths. Explicitly test an exact-width styled line such as `ESC[2mabcdefghijESC[22m`: replace `j`, preserve the complete trailing reset after the scrollbar glyph, and never treat the reset's final `m` as visible content. Cover the same suffix preservation for an OSC 8 close and Symfony named/inline closing tags. Add raw-label cases for incomplete CSI/OSC, a complete malformed OSC 8 command, malformed OSC followed by SGR and visible text, generic ESC, character-set designation, DCS/APC payloads, and unchanged display width after sanitization. Escape-only and style-tag-only inputs remain byte-for-byte unchanged. Pin that the capture-free formatting fragment can be embedded twice in one regex and still match. Do not build a general styled-string object.
 
 ### 10. Apply the remaining focused correctness fixes and upstream updates
 
@@ -460,10 +504,10 @@ Changes:
 
 1. `eraseLines($count)` returns immediately for nonpositive counts. For each positive line, erase and move up one line only when another line remains, producing exact behavior for 1 and N.
 2. Make Prompt's static output and terminal declarations nullable and initialized to null. `flushState()` forgets the output and validation coroutine-context keys and resets both static fields to null; accessors retain lazy `??=` construction. Do not flush unrelated coroutine context.
-3. Port current Laravel nested inline-style stripping into centralized `Utils::stripEscapeSequences()` so nested matching tags are removed until stable.
-4. Port current Laravel Grid truncation before width/cell computation, using `max(1, maxWidth - 5)` and measuring the truncated values used for layout.
+3. Strip each valid Symfony style tag independently in centralized `Utils::stripEscapeSequences()`, rather than requiring matched pairs. One pass therefore handles nested and unclosed tags and more completely matches the intent of Laravel's repeated matched-pair removal without retaining its loop. Recognize the built-in named styles case-sensitively and the inline `fg`, `bg`, `options`, and `href` keys case-insensitively, including hex and bright color values, semicolon-separated attributes, and escaped angle brackets. Do not consume an escaped opening bracket. Leave unknown/custom tags literal because the formatter registry is unavailable at this low-level hot path. Pin these distinctions with a curated agreement table against Symfony's undecorated `OutputFormatter`; do not instantiate a formatter on the measurement hot path or add randomized CI fuzzing.
+4. Port current Laravel Grid truncation before width/cell computation, using `max(1, maxWidth - 5)` and measuring the truncated values used for layout. Type the two touched callbacks as `fn (string $item): string` and `fn (string $item): int` under Hypervel's full-typing rule.
 
-Tests cover escape output for erase counts -1/0/1/3, context-key removal without whole-context loss, lazy output/terminal re-creation, nested styles, ordinary text containing angle brackets, long Grid items, narrow widths, and unchanged balanced layout.
+Tests cover escape output for erase counts -1/0/1/3, context-key removal without whole-context loss, lazy output/terminal re-creation, nested and inline Symfony styles (`#rrggbb`, bright colors, combined attributes, and href), escaped angle brackets, unknown/custom tags, long Grid items, narrow widths, and unchanged balanced layout.
 
 ## Documentation and package metadata
 
@@ -476,7 +520,7 @@ Files:
 Documentation rules:
 
 - Use Laravel prose in `src/docs/prompts.md`.
-- Keep behavioral documentation proportional: Number is an integer prompt, valid defaults may be integers, transforms precede validation, custom fallback implementations can call `validateIntrinsic()`, and Task partial output retains its public semantics. Update the custom fallback example's truthy default/required checks so the documentation does not retain the same `"0"` bug fixed in source. Guard custom validation with `is_callable()` before invocation so documented array rules do not fatal, and show `validateIntrinsic()` ahead of that caller validation.
+- Keep behavioral documentation proportional: Number is an integer prompt, valid defaults may be integers, transforms precede validation, custom fallback implementations can call `validateIntrinsic()`, and Task partial output retains its public semantics. Update the custom fallback example's truthy default/required checks so the documentation does not retain the same `"0"` bug fixed in source. Guard custom validation with `is_callable()` before invocation and continue to caller validation when `validateIntrinsic()` returns either `null` or `''`, matching source semantics.
 - Do not document binary framing, caches, channels, benchmark internals, or bug history in user docs.
 - Add only the three deliberate incompatible protected-API differences to README `Differences From Laravel`: Logger's `prefix()` is absent because binary framing requires subclasses to override `write()` rather than emit text prefixes; NumberPrompt's `wrapValidation()` is replaced by `validateIntrinsic()` because validation is centralized in the base pipeline; and DataTableRenderer's fused `computeColumnWidths()` is replaced by prompt-owned `naturalColumnMetrics()` plus renderer-owned `fitColumnWidths()` because those values have different invalidation keys. `validateIntrinsic()` is otherwise an additive extension hook and belongs in the canonical user documentation. Current upstream has no matching test for the removed Logger or Number method; do not invent `REMOVED:` test comments.
 - Do not add these fixes to `src/docs/porting-from-laravel.md`; they do not change normal application/package porting decisions.
@@ -539,7 +583,7 @@ Run before/after Task partial and DataTable render benchmarks outside CI and rec
 Do not add any of the following unless implementation exposes a new, concrete requirement and the plan is amended after review:
 
 - pipe/version negotiation or base64 Task transport;
-- arbitrary frame/output caps beyond Task's existing visible limit;
+- arbitrary frame/output caps beyond Task's existing visible limit and the one fixed incomplete-control safety ceiling;
 - a generic event bus or production counters;
 - Task whole-prefix buffering;
 - Swoole coroutine cancellation for animation settlement;

--- a/src/console/src/Concerns/ConfiguresPrompts.php
+++ b/src/console/src/Concerns/ConfiguresPrompts.php
@@ -21,6 +21,7 @@ use Hypervel\Prompts\SuggestPrompt;
 use Hypervel\Prompts\TextareaPrompt;
 use Hypervel\Prompts\TextPrompt;
 use Hypervel\Support\Collection;
+use RuntimeException;
 use stdClass;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -219,15 +220,23 @@ trait ConfiguresPrompts
     /**
      * Validate a fallback answer.
      */
-    private function validateFallbackPrompt(Prompt $prompt, mixed $value): mixed
+    private function validateFallbackPrompt(Prompt $prompt, mixed $value): ?string
     {
         $intrinsicError = $prompt->validateIntrinsic($value);
 
-        return is_string($intrinsicError) && $intrinsicError !== ''
-            ? $intrinsicError
-            : (is_callable($prompt->validate)
-                ? ($prompt->validate)($value)
-                : $this->validatePrompt($value, $prompt->validate));
+        if (is_string($intrinsicError) && $intrinsicError !== '') {
+            return $intrinsicError;
+        }
+
+        $error = is_callable($prompt->validate)
+            ? ($prompt->validate)($value)
+            : $this->validatePrompt($value, $prompt->validate);
+
+        if (! is_string($error) && $error !== null) {
+            throw new RuntimeException('The validator must return a string or null.');
+        }
+
+        return $error;
     }
 
     /**

--- a/src/console/src/Concerns/ConfiguresPrompts.php
+++ b/src/console/src/Concerns/ConfiguresPrompts.php
@@ -221,8 +221,11 @@ trait ConfiguresPrompts
      */
     private function validateFallbackPrompt(Prompt $prompt, mixed $value): mixed
     {
-        return $prompt->validateIntrinsic($value)
-            ?? (is_callable($prompt->validate)
+        $intrinsicError = $prompt->validateIntrinsic($value);
+
+        return is_string($intrinsicError) && $intrinsicError !== ''
+            ? $intrinsicError
+            : (is_callable($prompt->validate)
                 ? ($prompt->validate)($value)
                 : $this->validatePrompt($value, $prompt->validate));
     }

--- a/src/console/src/Concerns/ConfiguresPrompts.php
+++ b/src/console/src/Concerns/ConfiguresPrompts.php
@@ -35,104 +35,136 @@ trait ConfiguresPrompts
 
         Prompt::interactive(($input->isInteractive() && defined('STDIN') && stream_isatty(STDIN)) || $this->hypervel->runningUnitTests());
 
-        Prompt::validateUsing(fn (Prompt $prompt) => $this->validatePrompt($prompt->value(), $prompt->validate));
+        Prompt::validateUsing(fn (Prompt $prompt, mixed $value) => $this->validatePrompt($value, $prompt->validate));
 
         if (windows_os() || $this->hypervel->runningUnitTests()) {
             Prompt::fallbackWhen(true);
         }
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->components->ask($prompt->label, $prompt->default === '' ? null : $prompt->default) ?? '',
+            ),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         TextareaPrompt::fallbackUsing(fn (TextareaPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->ask($prompt->label, $prompt->default ?: null, multiline: true) ?? '',
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->components->ask($prompt->label, $prompt->default === '' ? null : $prompt->default, multiline: true) ?? '',
+            ),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         NumberPrompt::fallbackUsing(fn (NumberPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->numberFallback($prompt),
+            fn () => $this->transformFallbackAnswer($prompt, $this->numberFallback($prompt)),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         PasswordPrompt::fallbackUsing(fn (PasswordPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->secret($prompt->label) ?? '',
+            fn () => $this->transformFallbackAnswer($prompt, $this->components->secret($prompt->label) ?? ''),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         PausePrompt::fallbackUsing(fn (PausePrompt $prompt) => $this->promptUntilValid(
-            function () use ($prompt) {
+            function () use ($prompt): mixed {
                 $this->components->ask($prompt->message);
 
-                return $prompt->value();
+                return $this->transformFallbackAnswer($prompt, $prompt->value());
             },
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         ConfirmPrompt::fallbackUsing(fn (ConfirmPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->confirm($prompt->label, $prompt->default),
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->components->confirm($prompt->label, $prompt->default),
+            ),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         SelectPrompt::fallbackUsing(fn (SelectPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->selectFallback($prompt->label, $prompt->options, $prompt->default),
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->selectFallback($prompt->label, $prompt->options, $prompt->default),
+            ),
             false,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         MultiSelectPrompt::fallbackUsing(fn (MultiSelectPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->multiselectFallback($prompt->label, $prompt->options, $prompt->default, $prompt->required),
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->multiselectFallback($prompt->label, $prompt->options, $prompt->default, $prompt->required),
+            ),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         DataTablePrompt::fallbackUsing(fn (DataTablePrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->datatableFallback($prompt),
+            fn () => $this->transformFallbackAnswer($prompt, $this->datatableFallback($prompt)),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         SuggestPrompt::fallbackUsing(fn (SuggestPrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->askWithCompletion($prompt->label, $this->completionOptions($prompt->options), $prompt->default ?: null) ?? '',
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->components->askWithCompletion(
+                    $prompt->label,
+                    $this->completionOptions($prompt->options),
+                    $prompt->default === '' ? null : $prompt->default,
+                ) ?? '',
+            ),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
-            fn () => $this->components->askWithCompletion($prompt->label, $this->completionOptions($prompt->options), $prompt->default ?: null) ?? '',
+            fn () => $this->transformFallbackAnswer(
+                $prompt,
+                $this->components->askWithCompletion(
+                    $prompt->label,
+                    $this->completionOptions($prompt->options),
+                    $prompt->default === '' ? null : $prompt->default,
+                ) ?? '',
+            ),
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         SearchPrompt::fallbackUsing(fn (SearchPrompt $prompt) => $this->promptUntilValid(
-            function () use ($prompt) {
+            function () use ($prompt): mixed {
                 $query = $this->components->ask($prompt->label);
 
                 $options = ($prompt->options)($query);
 
-                return $this->selectFallback($prompt->label, $options);
+                return $this->transformFallbackAnswer($prompt, $this->selectFallback($prompt->label, $options));
             },
             false,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
 
         MultiSearchPrompt::fallbackUsing(fn (MultiSearchPrompt $prompt) => $this->promptUntilValid(
-            function () use ($prompt) {
+            function () use ($prompt): mixed {
                 $query = $this->components->ask($prompt->label);
 
                 $options = ($prompt->options)($query);
 
-                return $this->multiselectFallback($prompt->label, $options, required: $prompt->required);
+                return $this->transformFallbackAnswer(
+                    $prompt,
+                    $this->multiselectFallback($prompt->label, $options, required: $prompt->required),
+                );
             },
             $prompt->required,
-            $prompt->validate
+            fn (mixed $value) => $this->validateFallbackPrompt($prompt, $value),
         ));
     }
 
@@ -151,8 +183,9 @@ trait ConfiguresPrompts
         while (true) {
             $result = $prompt();
 
-            if ($required && ($result === '' || $result === [] || $result === false)) {
-                $this->components->error(is_string($required) ? $required : 'Required.');
+            // Keep this empty set synchronized with Prompt::isInvalidWhenRequired().
+            if ($required !== false && ($result === '' || $result === [] || $result === false || $result === null)) {
+                $this->components->error(is_string($required) && strlen($required) > 0 ? $required : 'Required.');
 
                 if ($this->hypervel->runningUnitTests()) {
                     throw new PromptValidationException;
@@ -173,6 +206,25 @@ trait ConfiguresPrompts
 
             return $result;
         }
+    }
+
+    /**
+     * Transform a fallback answer.
+     */
+    private function transformFallbackAnswer(Prompt $prompt, mixed $answer): mixed
+    {
+        return $prompt->transform === null ? $answer : ($prompt->transform)($answer);
+    }
+
+    /**
+     * Validate a fallback answer.
+     */
+    private function validateFallbackPrompt(Prompt $prompt, mixed $value): mixed
+    {
+        return $prompt->validateIntrinsic($value)
+            ?? (is_callable($prompt->validate)
+                ? ($prompt->validate)($value)
+                : $this->validatePrompt($value, $prompt->validate));
     }
 
     /**
@@ -252,9 +304,12 @@ trait ConfiguresPrompts
      */
     private function numberFallback(NumberPrompt $prompt): int|string
     {
-        $answer = $this->components->ask($prompt->label, $prompt->default ?: null) ?? '';
+        $answer = $this->components->ask(
+            $prompt->label,
+            $prompt->default === '' ? null : $prompt->default,
+        ) ?? '';
 
-        return is_numeric($answer) ? (int) $answer : (string) $answer;
+        return NumberPrompt::parseInteger((string) $answer) ?? (string) $answer;
     }
 
     /**

--- a/src/docs/prompts.md
+++ b/src/docs/prompts.md
@@ -199,7 +199,7 @@ $story = textarea(
 <a name="number"></a>
 ### Number
 
-The `number` function will prompt the user with the given question, accept their numeric input, and then return it. The `number` function allows the user to use the up and down arrow keys to manipulate the number:
+The `number` function will prompt the user with the given question, accept a signed integer, and then return it. By default, valid input is returned as an integer. The `number` function allows the user to use the up and down arrow keys to manipulate the number:
 
 ```php
 use function Hypervel\Prompts\number;
@@ -1055,6 +1055,8 @@ $name = text(
 );
 ```
 
+The transformed value is passed to required, intrinsic, and additional validation before being returned.
+
 <a name="forms"></a>
 ## Forms
 
@@ -1674,23 +1676,34 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 TextPrompt::fallbackUsing(function (TextPrompt $prompt) use ($input, $output) {
-    $question = (new Question($prompt->label, $prompt->default ?: null))
+    $question = (new Question(
+        $prompt->label,
+        $prompt->default === '' ? null : $prompt->default,
+    ))
         ->setValidator(function ($answer) use ($prompt) {
-            if ($prompt->required && $answer === null) {
+            $value = $prompt->transform === null
+                ? ($answer ?? '')
+                : ($prompt->transform)($answer ?? '');
+
+            if ($prompt->required !== false && in_array($value, ['', [], false, null], true)) {
                 throw new \RuntimeException(
-                    is_string($prompt->required) ? $prompt->required : 'Required.'
+                    is_string($prompt->required) && $prompt->required !== ''
+                        ? $prompt->required
+                        : 'Required.'
                 );
             }
 
-            if ($prompt->validate) {
-                $error = ($prompt->validate)($answer ?? '');
+            $error = $prompt->validateIntrinsic($value);
 
-                if ($error) {
-                    throw new \RuntimeException($error);
-                }
+            if ($error === null && is_callable($prompt->validate)) {
+                $error = ($prompt->validate)($value);
             }
 
-            return $answer;
+            if (is_string($error) && $error !== '') {
+                throw new \RuntimeException($error);
+            }
+
+            return $value;
         });
 
     return (new SymfonyStyle($input, $output))
@@ -1699,6 +1712,8 @@ TextPrompt::fallbackUsing(function (TextPrompt $prompt) use ($input, $output) {
 ```
 
 Fallbacks must be configured individually for each prompt class. The closure will receive an instance of the prompt class and must return an appropriate type for the prompt.
+
+Custom prompt classes may override the `validateIntrinsic` method to enforce rules that belong to the prompt type itself. Custom fallback implementations should call this method before invoking any validation callback supplied by the caller, as shown above.
 
 <a name="testing"></a>
 ## Testing

--- a/src/docs/prompts.md
+++ b/src/docs/prompts.md
@@ -1699,6 +1699,10 @@ TextPrompt::fallbackUsing(function (TextPrompt $prompt) use ($input, $output) {
                 $error = ($prompt->validate)($value);
             }
 
+            if (! is_string($error) && $error !== null) {
+                throw new \RuntimeException('The validator must return a string or null.');
+            }
+
             if (is_string($error) && $error !== '') {
                 throw new \RuntimeException($error);
             }

--- a/src/docs/prompts.md
+++ b/src/docs/prompts.md
@@ -1695,7 +1695,7 @@ TextPrompt::fallbackUsing(function (TextPrompt $prompt) use ($input, $output) {
 
             $error = $prompt->validateIntrinsic($value);
 
-            if ($error === null && is_callable($prompt->validate)) {
+            if (($error === null || $error === '') && is_callable($prompt->validate)) {
                 $error = ($prompt->validate)($value);
             }
 

--- a/src/prompts/README.md
+++ b/src/prompts/README.md
@@ -9,5 +9,8 @@ Documentation: https://hypervel.org/docs/prompts
 
 - Option lists, multi-select defaults, table headers and rows, and grid items may be `Hypervel\Support\Collection` instances.
 - Spinners animate only inside a Swoole coroutine; outside one they render statically.
+- `Logger::prefix()` is not available because Task output uses binary frames. Override `write()` to customize transport writes.
+- `NumberPrompt::wrapValidation()` is replaced by `validateIntrinsic()` so every execution mode uses the same validation pipeline.
+- `DataTableRenderer::computeColumnWidths()` is split into `DataTablePrompt::naturalColumnMetrics()` and `DataTableRenderer::fitColumnWidths()` because source sizing and terminal fitting have different lifetimes.
 
 Ported from: https://github.com/laravel/prompts

--- a/src/prompts/composer.json
+++ b/src/prompts/composer.json
@@ -39,7 +39,8 @@
         "symfony/process": "^8.1",
         "hypervel/collections": "^0.4",
         "hypervel/context": "^0.4",
-        "hypervel/coroutine": "^0.4"
+        "hypervel/coroutine": "^0.4",
+        "hypervel/engine": "^0.4"
     },
     "require-dev": {
         "mockery/mockery": "1.6.x-dev"

--- a/src/prompts/src/Concerns/Erase.php
+++ b/src/prompts/src/Concerns/Erase.php
@@ -11,18 +11,16 @@ trait Erase
      */
     public function eraseLines(int $count): void
     {
-        if (! static::output()->isDecorated()) {
+        if ($count <= 0 || ! static::output()->isDecorated()) {
             return;
         }
 
         $clear = '';
         for ($i = 0; $i < $count; ++$i) {
-            $clear .= "\e[2K" . ($i < $count - 1 ? "\e[{$count}A" : '');
+            $clear .= "\e[2K" . ($i < $count - 1 ? "\e[1A" : '');
         }
 
-        if ($count) {
-            $clear .= "\e[G";
-        }
+        $clear .= "\e[G";
 
         static::writeDirectly($clear);
     }

--- a/src/prompts/src/Concerns/Interactivity.php
+++ b/src/prompts/src/Concerns/Interactivity.php
@@ -64,7 +64,7 @@ trait Interactivity
      */
     protected function default(): mixed
     {
-        $default = $this->value();
+        $default = $this->transformedValue();
 
         $this->validate($default);
 

--- a/src/prompts/src/Concerns/TracksTaskOutput.php
+++ b/src/prompts/src/Concerns/TracksTaskOutput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Prompts\Concerns;
 
+use Hypervel\Prompts\Support\Utils;
 use Hypervel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
 
 /**
@@ -12,6 +13,16 @@ use Hypervel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
 trait TracksTaskOutput
 {
     use InteractsWithStrings;
+
+    private const string CONTROL_MODE_ESCAPE = 'escape';
+
+    private const string CONTROL_MODE_CSI_PARAMETERS = 'csi-parameters';
+
+    private const string CONTROL_MODE_CSI_INTERMEDIATES = 'csi-intermediates';
+
+    private const string CONTROL_MODE_OSC = 'osc';
+
+    private const string CONTROL_MODE_STRING = 'string';
 
     /**
      * The log index where the current partial started, or null if not streaming.
@@ -45,6 +56,10 @@ trait TracksTaskOutput
 
     private int $partialWordWidth = 0;
 
+    private int $partialWordBytes = 0;
+
+    private string $partialTrailingGrapheme = '';
+
     /**
      * The real separator awaiting the next word, or null for a long-word cut.
      *
@@ -53,6 +68,14 @@ trait TracksTaskOutput
     private ?array $partialJoinToken = null;
 
     private string $partialInputBuffer = '';
+
+    private ?string $partialControlMode = null;
+
+    private string $partialControlBuffer = '';
+
+    private int $partialControlBytes = 0;
+
+    private bool $partialControlEscapePending = false;
 
     /**
      * Canonical active SGR sequences keyed by terminal attribute.
@@ -71,12 +94,11 @@ trait TracksTaskOutput
     protected function addLogLines(string $line): void
     {
         $this->resetTaskOutputTracking();
-        $width = $this->taskOutputWidth();
-        $logicalLines = preg_split('/\r\n|\n/', $line);
-
-        foreach ($logicalLines as $logicalLine) {
-            array_push($this->logs, ...$this->ansiWordwrap($logicalLine, $width, cutLongWords: true));
-        }
+        array_push($this->logs, ...$this->ansiWordwrap(
+            str_replace("\r\n", "\n", $line),
+            $this->taskOutputWidth(),
+            cutLongWords: true,
+        ));
 
         $this->trimTaskLogs();
     }
@@ -101,6 +123,7 @@ trait TracksTaskOutput
     {
         if ($this->partialStartIndex === null) {
             $this->partialStartIndex = count($this->logs);
+            $this->partialHasUnfinishedLine = true;
         }
 
         $this->partialInputBuffer .= $chunk;
@@ -139,8 +162,11 @@ trait TracksTaskOutput
         $this->partialLineUnset = true;
         $this->partialWordTokens = [];
         $this->partialWordWidth = 0;
+        $this->partialWordBytes = 0;
+        $this->partialTrailingGrapheme = '';
         $this->partialJoinToken = null;
         $this->partialInputBuffer = '';
+        $this->resetPartialControl();
         $this->partialSgr = [];
         $this->partialLink = '';
         $this->partialHasUnfinishedLine = false;
@@ -156,20 +182,17 @@ trait TracksTaskOutput
         $cursor = 0;
 
         while ($cursor < $bufferLength) {
+            if ($this->partialControlMode !== null) {
+                if ($this->consumePartialControlByte($buffer[$cursor])) {
+                    ++$cursor;
+                }
+
+                continue;
+            }
+
             if ($buffer[$cursor] === "\e") {
-                $escape = $this->readPartialEscape($buffer, $cursor, $final);
-
-                if ($escape === null) {
-                    break;
-                }
-
-                if ($escape['complete']) {
-                    $this->applyPartialEscape($escape['sequence']);
-                } else {
-                    $this->consumePartialText($escape['sequence']);
-                }
-
-                $cursor += $escape['length'];
+                $this->startPartialControl();
+                ++$cursor;
 
                 continue;
             }
@@ -199,93 +222,192 @@ trait TracksTaskOutput
         }
 
         $this->partialInputBuffer = substr($buffer, $cursor);
+
+        if ($final) {
+            $this->resetPartialControl();
+        }
     }
 
     /**
-     * Read one terminal escape sequence without mutating the input buffer.
-     *
-     * @return null|array{sequence: string, length: int, complete: bool}
+     * Start one terminal control at an ESC byte.
      */
-    private function readPartialEscape(string $buffer, int $offset, bool $final): ?array
+    private function startPartialControl(): void
     {
-        $length = strlen($buffer);
-        $remainingLength = $length - $offset;
+        $this->partialControlMode = self::CONTROL_MODE_ESCAPE;
+        $this->partialControlBuffer = "\e";
+        $this->partialControlBytes = 1;
+        $this->partialControlEscapePending = false;
+    }
 
-        if ($remainingLength === 1) {
-            if (! $final) {
-                return null;
-            }
+    /**
+     * Consume one byte of the active terminal control.
+     *
+     * Return false when the byte must be reprocessed after a local abort.
+     */
+    private function consumePartialControlByte(string $byte): bool
+    {
+        $ordinal = ord($byte);
 
-            return ['sequence' => "\e", 'length' => 1, 'complete' => false];
-        }
+        if ($this->partialControlMode === self::CONTROL_MODE_ESCAPE) {
+            if ($this->partialControlBuffer === "\e") {
+                if ($byte === '[') {
+                    $this->appendPartialControlByte($byte);
+                    $this->partialControlMode = self::CONTROL_MODE_CSI_PARAMETERS;
 
-        if ($buffer[$offset + 1] === '[') {
-            $position = $offset + 2;
-
-            while ($position < $length && ord($buffer[$position]) >= 0x30 && ord($buffer[$position]) <= 0x3F) {
-                ++$position;
-            }
-
-            while ($position < $length && ord($buffer[$position]) >= 0x20 && ord($buffer[$position]) <= 0x2F) {
-                ++$position;
-            }
-
-            if ($position >= $length || ord($buffer[$position]) < 0x40 || ord($buffer[$position]) > 0x7E) {
-                if (! $final) {
-                    return null;
+                    return true;
                 }
 
-                return [
-                    'sequence' => substr($buffer, $offset),
-                    'length' => $remainingLength,
-                    'complete' => false,
-                ];
-            }
+                if ($byte === ']') {
+                    $this->appendPartialControlByte($byte);
+                    $this->partialControlMode = self::CONTROL_MODE_OSC;
 
-            $escapeLength = $position - $offset + 1;
-
-            return [
-                'sequence' => substr($buffer, $offset, $escapeLength),
-                'length' => $escapeLength,
-                'complete' => true,
-            ];
-        }
-
-        if ($buffer[$offset + 1] === ']') {
-            $bell = strpos($buffer, "\x07", $offset + 2);
-            $stringTerminator = strpos($buffer, "\e\\", $offset + 2);
-            $end = match (true) {
-                $bell === false => $stringTerminator === false ? null : $stringTerminator + 2,
-                $stringTerminator === false => $bell + 1,
-                default => min($bell + 1, $stringTerminator + 2),
-            };
-
-            if ($end === null) {
-                if (! $final) {
-                    return null;
+                    return true;
                 }
 
-                return [
-                    'sequence' => substr($buffer, $offset),
-                    'length' => $remainingLength,
-                    'complete' => false,
-                ];
+                if (in_array($byte, ['P', 'X', '^', '_'], true)) {
+                    $this->appendPartialControlByte($byte);
+                    $this->partialControlMode = self::CONTROL_MODE_STRING;
+
+                    return true;
+                }
             }
 
-            $escapeLength = $end - $offset;
+            if ($ordinal >= 0x20 && $ordinal <= 0x2F) {
+                $this->appendPartialControlByte($byte);
 
-            return [
-                'sequence' => substr($buffer, $offset, $escapeLength),
-                'length' => $escapeLength,
-                'complete' => true,
-            ];
+                return true;
+            }
+
+            if ($ordinal >= 0x30 && $ordinal <= 0x7E) {
+                $this->appendPartialControlByte($byte);
+                $this->completePartialControl();
+
+                return true;
+            }
+
+            $this->resetPartialControl();
+
+            return false;
         }
 
-        return [
-            'sequence' => substr($buffer, $offset, 2),
-            'length' => 2,
-            'complete' => true,
-        ];
+        if ($this->partialControlMode === self::CONTROL_MODE_CSI_PARAMETERS) {
+            if ($ordinal >= 0x30 && $ordinal <= 0x3F) {
+                $this->appendPartialControlByte($byte);
+
+                return true;
+            }
+
+            if ($ordinal >= 0x20 && $ordinal <= 0x2F) {
+                $this->appendPartialControlByte($byte);
+                $this->partialControlMode = self::CONTROL_MODE_CSI_INTERMEDIATES;
+
+                return true;
+            }
+
+            if ($ordinal >= 0x40 && $ordinal <= 0x7E) {
+                $this->appendPartialControlByte($byte);
+                $this->completePartialControl();
+
+                return true;
+            }
+
+            $this->resetPartialControl();
+
+            return false;
+        }
+
+        if ($this->partialControlMode === self::CONTROL_MODE_CSI_INTERMEDIATES) {
+            if ($ordinal >= 0x20 && $ordinal <= 0x2F) {
+                $this->appendPartialControlByte($byte);
+
+                return true;
+            }
+
+            if ($ordinal >= 0x40 && $ordinal <= 0x7E) {
+                $this->appendPartialControlByte($byte);
+                $this->completePartialControl();
+
+                return true;
+            }
+
+            $this->resetPartialControl();
+
+            return false;
+        }
+
+        if ($this->partialControlEscapePending) {
+            if ($byte === '\\') {
+                $this->appendPartialControlByte($byte);
+                $this->completePartialControl();
+
+                return true;
+            }
+
+            // The pending ESC starts a new control when it is not an ST terminator.
+            $this->resetPartialControl();
+            $this->startPartialControl();
+
+            return false;
+        }
+
+        if ($byte === "\x07") {
+            $this->appendPartialControlByte($byte);
+            $this->completePartialControl();
+
+            return true;
+        }
+
+        $this->appendPartialControlByte($byte);
+
+        if ($byte === "\e") {
+            $this->partialControlEscapePending = true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Append a byte while retaining no more than the fixed control ceiling.
+     */
+    private function appendPartialControlByte(string $byte): void
+    {
+        ++$this->partialControlBytes;
+
+        if ($this->partialControlBuffer === '') {
+            return;
+        }
+
+        if ($this->partialControlBytes > Utils::MAX_UNBREAKABLE_BYTES) {
+            $this->partialControlBuffer = '';
+
+            return;
+        }
+
+        $this->partialControlBuffer .= $byte;
+    }
+
+    /**
+     * Apply and clear one complete terminal control.
+     */
+    private function completePartialControl(): void
+    {
+        $sequence = $this->partialControlBuffer;
+        $this->resetPartialControl();
+
+        if ($sequence !== '') {
+            $this->applyPartialEscape($sequence);
+        }
+    }
+
+    /**
+     * Reset the active terminal-control parser.
+     */
+    private function resetPartialControl(): void
+    {
+        $this->partialControlMode = null;
+        $this->partialControlBuffer = '';
+        $this->partialControlBytes = 0;
+        $this->partialControlEscapePending = false;
     }
 
     /**
@@ -298,15 +420,29 @@ trait TracksTaskOutput
         }
 
         if (! $final) {
-            for ($suffixLength = 1; $suffixLength <= min(3, strlen($text)); ++$suffixLength) {
-                $prefix = substr($text, 0, -$suffixLength);
+            $length = strlen($text);
 
-                if ($prefix !== '' && mb_check_encoding($prefix, 'UTF-8')) {
-                    return strlen($prefix);
+            for ($suffixLength = min(3, $length); $suffixLength >= 1; --$suffixLength) {
+                $leadPosition = $length - $suffixLength;
+                $requiredLength = match (true) {
+                    ord($text[$leadPosition]) >= 0xC2 && ord($text[$leadPosition]) <= 0xDF => 2,
+                    ord($text[$leadPosition]) >= 0xE0 && ord($text[$leadPosition]) <= 0xEF => 3,
+                    ord($text[$leadPosition]) >= 0xF0 && ord($text[$leadPosition]) <= 0xF4 => 4,
+                    default => null,
+                };
+
+                if ($requiredLength === null || $suffixLength >= $requiredLength) {
+                    continue;
                 }
-            }
 
-            return 0;
+                for ($position = $leadPosition + 1; $position < $length; ++$position) {
+                    if (ord($text[$position]) < 0x80 || ord($text[$position]) > 0xBF) {
+                        continue 2;
+                    }
+                }
+
+                return $leadPosition;
+            }
         }
 
         return strlen($text);
@@ -331,6 +467,7 @@ trait TracksTaskOutput
                 $this->partialHasUnfinishedLine = true;
             } else {
                 $this->finishPartialLogicalLine();
+                $this->partialHasUnfinishedLine = true;
             }
 
             $offset = $separatorOffset + strlen($separator);
@@ -352,7 +489,7 @@ trait TracksTaskOutput
             return;
         }
 
-        $link = $this->resolveOsc8Link($escape);
+        $link = Utils::resolveOsc8Link($escape);
 
         if ($link !== null) {
             $this->partialLink = $link;
@@ -366,21 +503,44 @@ trait TracksTaskOutput
     {
         $token = $this->partialToken($text);
 
-        if ($this->partialWordWidth + $token['width'] <= $this->taskOutputWidth()) {
+        if ($this->partialWordWidth + $token['width'] <= $this->taskOutputWidth()
+            && $this->partialWordBytes + strlen($text) <= Utils::MAX_UNBREAKABLE_BYTES) {
             $this->appendPartialWordToken($token);
 
             return;
         }
 
-        if (preg_match_all('/\X/u', $text, $matches) === false) {
-            $matches = [str_split($text)];
-        }
+        $graphemes = Utils::graphemes($this->partialTrailingGrapheme . $text);
+        $consumedBytes = strlen($this->partialTrailingGrapheme);
 
-        foreach ($matches[0] as $character) {
+        foreach ($graphemes as $character) {
+            if ($consumedBytes >= strlen($character)) {
+                $consumedBytes -= strlen($character);
+
+                continue;
+            }
+
+            if ($consumedBytes > 0) {
+                $character = substr($character, $consumedBytes);
+                $consumedBytes = 0;
+            }
+
             $token = $this->partialToken($character);
+            $exceedsWidth = $this->partialWordWidth + $token['width'] > $this->taskOutputWidth();
+            $continuedGraphemeBytes = null;
+
+            if ($this->partialWordTokens !== [] && ($exceedsWidth
+                || $this->partialWordBytes + strlen($character) > Utils::MAX_UNBREAKABLE_BYTES)) {
+                $continuedGraphemeBytes = Utils::continuedGraphemeBytes(
+                    $this->partialTrailingGrapheme,
+                    $character,
+                );
+            }
 
             if ($this->partialWordTokens !== []
-                && $this->partialWordWidth + $token['width'] > $this->taskOutputWidth()) {
+                && (($exceedsWidth && $continuedGraphemeBytes === null)
+                    || ($continuedGraphemeBytes !== null
+                        && $continuedGraphemeBytes > Utils::MAX_UNBREAKABLE_BYTES))) {
                 $this->completePartialWord();
             }
 
@@ -407,6 +567,11 @@ trait TracksTaskOutput
         }
 
         $this->partialWordWidth += $token['width'];
+        $this->partialWordBytes += strlen($token['text']);
+        $grapheme = $this->partialTrailingGrapheme . $token['text'];
+        $this->partialTrailingGrapheme = preg_match('/\X\z/u', $grapheme, $matches) === 1
+            ? $matches[0]
+            : '';
         $this->partialHasUnfinishedLine = true;
     }
 
@@ -428,7 +593,12 @@ trait TracksTaskOutput
         $wrapped = ! $this->partialLineUnset && $candidateWidth > $this->taskOutputWidth();
 
         if ($wrapped) {
-            $this->storePartialLine();
+            if ($this->partialLineTokens === []) {
+                $this->resetPartialLine();
+            } else {
+                $this->storePartialLine();
+            }
+
             $this->partialLineTokens = $this->partialWordTokens;
             $this->partialLineWidth = $this->partialWordWidth;
         } else {
@@ -443,6 +613,8 @@ trait TracksTaskOutput
         $this->partialLineUnset = false;
         $this->partialWordTokens = [];
         $this->partialWordWidth = 0;
+        $this->partialWordBytes = 0;
+        $this->partialTrailingGrapheme = '';
         $this->partialJoinToken = null;
         $this->partialHasUnfinishedLine = true;
 
@@ -545,7 +717,9 @@ trait TracksTaskOutput
             return [$this->renderPartialTokens($tokens)];
         }
 
-        $lines = [$this->renderPartialTokens($this->partialLineTokens)];
+        $lines = $this->partialLineTokens === []
+            ? []
+            : [$this->renderPartialTokens($this->partialLineTokens)];
 
         if ($this->partialWordTokens !== []) {
             $lines[] = $this->renderPartialTokens($this->partialWordTokens);

--- a/src/prompts/src/Concerns/TracksTaskOutput.php
+++ b/src/prompts/src/Concerns/TracksTaskOutput.php
@@ -1,0 +1,630 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Prompts\Concerns;
+
+use Hypervel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
+
+/**
+ * Track bounded incremental output owned by a Task operation.
+ */
+trait TracksTaskOutput
+{
+    use InteractsWithStrings;
+
+    /**
+     * The log index where the current partial started, or null if not streaming.
+     */
+    protected ?int $partialStartIndex = null;
+
+    /**
+     * Complete visible lines produced by the current partial.
+     *
+     * @var list<string>
+     */
+    private array $partialLines = [];
+
+    /**
+     * Visible tokens on the current line.
+     *
+     * @var list<array{text: string, width: int, codes: string, link: string}>
+     */
+    private array $partialLineTokens = [];
+
+    private int $partialLineWidth = 0;
+
+    private bool $partialLineUnset = true;
+
+    /**
+     * Tokens in the unfinished word.
+     *
+     * @var list<array{text: string, width: int, codes: string, link: string}>
+     */
+    private array $partialWordTokens = [];
+
+    private int $partialWordWidth = 0;
+
+    /**
+     * The real separator awaiting the next word, or null for a long-word cut.
+     *
+     * @var null|array{text: string, width: int, codes: string, link: string}
+     */
+    private ?array $partialJoinToken = null;
+
+    private string $partialInputBuffer = '';
+
+    /**
+     * Canonical active SGR sequences keyed by terminal attribute.
+     *
+     * @var array<string, string>
+     */
+    private array $partialSgr = [];
+
+    private string $partialLink = '';
+
+    private bool $partialHasUnfinishedLine = false;
+
+    /**
+     * Add a complete logical log message.
+     */
+    protected function addLogLines(string $line): void
+    {
+        $this->resetTaskOutputTracking();
+        $width = $this->taskOutputWidth();
+        $logicalLines = preg_split('/\r\n|\n/', $line);
+
+        foreach ($logicalLines as $logicalLine) {
+            array_push($this->logs, ...$this->ansiWordwrap($logicalLine, $width, cutLongWords: true));
+        }
+
+        $this->trimTaskLogs();
+    }
+
+    /**
+     * Replace the in-progress partial with a complete supplied prefix.
+     */
+    protected function replacePartialLines(string $text): void
+    {
+        if ($this->partialStartIndex !== null) {
+            $this->logs = array_slice($this->logs, 0, $this->partialStartIndex);
+        }
+
+        $this->resetTaskOutputTracking();
+        $this->consumePartialOutput($text);
+    }
+
+    /**
+     * Consume one new partial-output delta.
+     */
+    private function consumePartialOutput(string $chunk): void
+    {
+        if ($this->partialStartIndex === null) {
+            $this->partialStartIndex = count($this->logs);
+        }
+
+        $this->partialInputBuffer .= $chunk;
+        $this->drainPartialInput();
+        $this->synchronizePartialLogs();
+    }
+
+    /**
+     * Commit the current partial output as permanent log lines.
+     */
+    private function commitPartialOutput(): void
+    {
+        if ($this->partialStartIndex === null) {
+            return;
+        }
+
+        $this->drainPartialInput(final: true);
+
+        if ($this->partialHasUnfinishedLine) {
+            $this->finishPartialLogicalLine();
+        }
+
+        $this->synchronizePartialLogs(includePreview: false);
+        $this->resetTaskOutputTracking();
+    }
+
+    /**
+     * Reset all Task output tracking for a new operation.
+     */
+    private function resetTaskOutputTracking(): void
+    {
+        $this->partialStartIndex = null;
+        $this->partialLines = [];
+        $this->partialLineTokens = [];
+        $this->partialLineWidth = 0;
+        $this->partialLineUnset = true;
+        $this->partialWordTokens = [];
+        $this->partialWordWidth = 0;
+        $this->partialJoinToken = null;
+        $this->partialInputBuffer = '';
+        $this->partialSgr = [];
+        $this->partialLink = '';
+        $this->partialHasUnfinishedLine = false;
+    }
+
+    /**
+     * Parse every complete token currently buffered.
+     */
+    private function drainPartialInput(bool $final = false): void
+    {
+        $buffer = $this->partialInputBuffer;
+        $bufferLength = strlen($buffer);
+        $cursor = 0;
+
+        while ($cursor < $bufferLength) {
+            if ($buffer[$cursor] === "\e") {
+                $escape = $this->readPartialEscape($buffer, $cursor, $final);
+
+                if ($escape === null) {
+                    break;
+                }
+
+                if ($escape['complete']) {
+                    $this->applyPartialEscape($escape['sequence']);
+                } else {
+                    $this->consumePartialText($escape['sequence']);
+                }
+
+                $cursor += $escape['length'];
+
+                continue;
+            }
+
+            $escapePosition = strpos($buffer, "\e", $cursor);
+            $rawTextEnd = $escapePosition === false ? $bufferLength : $escapePosition;
+            $textEnd = $rawTextEnd;
+
+            // A trailing carriage return may be the first half of a split CRLF.
+            if (! $final && $textEnd === $bufferLength && $buffer[$textEnd - 1] === "\r") {
+                --$textEnd;
+            }
+
+            $text = substr($buffer, $cursor, $textEnd - $cursor);
+            $validLength = $this->validPartialTextLength($text, $final);
+
+            if ($validLength === 0) {
+                break;
+            }
+
+            $this->consumePartialText(substr($text, 0, $validLength));
+            $cursor += $validLength;
+
+            if ($cursor < $textEnd || $textEnd < $rawTextEnd) {
+                break;
+            }
+        }
+
+        $this->partialInputBuffer = substr($buffer, $cursor);
+    }
+
+    /**
+     * Read one terminal escape sequence without mutating the input buffer.
+     *
+     * @return null|array{sequence: string, length: int, complete: bool}
+     */
+    private function readPartialEscape(string $buffer, int $offset, bool $final): ?array
+    {
+        $length = strlen($buffer);
+        $remainingLength = $length - $offset;
+
+        if ($remainingLength === 1) {
+            if (! $final) {
+                return null;
+            }
+
+            return ['sequence' => "\e", 'length' => 1, 'complete' => false];
+        }
+
+        if ($buffer[$offset + 1] === '[') {
+            $position = $offset + 2;
+
+            while ($position < $length && ord($buffer[$position]) >= 0x30 && ord($buffer[$position]) <= 0x3F) {
+                ++$position;
+            }
+
+            while ($position < $length && ord($buffer[$position]) >= 0x20 && ord($buffer[$position]) <= 0x2F) {
+                ++$position;
+            }
+
+            if ($position >= $length || ord($buffer[$position]) < 0x40 || ord($buffer[$position]) > 0x7E) {
+                if (! $final) {
+                    return null;
+                }
+
+                return [
+                    'sequence' => substr($buffer, $offset),
+                    'length' => $remainingLength,
+                    'complete' => false,
+                ];
+            }
+
+            $escapeLength = $position - $offset + 1;
+
+            return [
+                'sequence' => substr($buffer, $offset, $escapeLength),
+                'length' => $escapeLength,
+                'complete' => true,
+            ];
+        }
+
+        if ($buffer[$offset + 1] === ']') {
+            $bell = strpos($buffer, "\x07", $offset + 2);
+            $stringTerminator = strpos($buffer, "\e\\", $offset + 2);
+            $end = match (true) {
+                $bell === false => $stringTerminator === false ? null : $stringTerminator + 2,
+                $stringTerminator === false => $bell + 1,
+                default => min($bell + 1, $stringTerminator + 2),
+            };
+
+            if ($end === null) {
+                if (! $final) {
+                    return null;
+                }
+
+                return [
+                    'sequence' => substr($buffer, $offset),
+                    'length' => $remainingLength,
+                    'complete' => false,
+                ];
+            }
+
+            $escapeLength = $end - $offset;
+
+            return [
+                'sequence' => substr($buffer, $offset, $escapeLength),
+                'length' => $escapeLength,
+                'complete' => true,
+            ];
+        }
+
+        return [
+            'sequence' => substr($buffer, $offset, 2),
+            'length' => 2,
+            'complete' => true,
+        ];
+    }
+
+    /**
+     * Return the complete UTF-8 prefix length available for parsing.
+     */
+    private function validPartialTextLength(string $text, bool $final): int
+    {
+        if ($text === '' || mb_check_encoding($text, 'UTF-8')) {
+            return strlen($text);
+        }
+
+        if (! $final) {
+            for ($suffixLength = 1; $suffixLength <= min(3, strlen($text)); ++$suffixLength) {
+                $prefix = substr($text, 0, -$suffixLength);
+
+                if ($prefix !== '' && mb_check_encoding($prefix, 'UTF-8')) {
+                    return strlen($prefix);
+                }
+            }
+
+            return 0;
+        }
+
+        return strlen($text);
+    }
+
+    /**
+     * Consume visible text using the current terminal attributes.
+     */
+    private function consumePartialText(string $text): void
+    {
+        preg_match_all('/\r\n|\n| /', $text, $matches, PREG_OFFSET_CAPTURE);
+        $offset = 0;
+
+        foreach ($matches[0] as [$separator, $separatorOffset]) {
+            if ($separatorOffset > $offset) {
+                $this->appendPartialWordText(substr($text, $offset, $separatorOffset - $offset));
+            }
+
+            if ($separator === ' ') {
+                $this->completePartialWord(includeEmpty: true);
+                $this->partialJoinToken = $this->partialToken(' ');
+                $this->partialHasUnfinishedLine = true;
+            } else {
+                $this->finishPartialLogicalLine();
+            }
+
+            $offset = $separatorOffset + strlen($separator);
+        }
+
+        if ($offset < strlen($text)) {
+            $this->appendPartialWordText(substr($text, $offset));
+        }
+    }
+
+    /**
+     * Apply a complete terminal escape sequence to subsequent visible text.
+     */
+    private function applyPartialEscape(string $escape): void
+    {
+        if (str_starts_with($escape, "\e[") && str_ends_with($escape, 'm')) {
+            $this->updateSgrState($this->partialSgr, $escape);
+
+            return;
+        }
+
+        $link = $this->resolveOsc8Link($escape);
+
+        if ($link !== null) {
+            $this->partialLink = $link;
+        }
+    }
+
+    /**
+     * Append text to the unfinished word, cutting only when it exceeds the width.
+     */
+    private function appendPartialWordText(string $text): void
+    {
+        $token = $this->partialToken($text);
+
+        if ($this->partialWordWidth + $token['width'] <= $this->taskOutputWidth()) {
+            $this->appendPartialWordToken($token);
+
+            return;
+        }
+
+        if (preg_match_all('/\X/u', $text, $matches) === false) {
+            $matches = [str_split($text)];
+        }
+
+        foreach ($matches[0] as $character) {
+            $token = $this->partialToken($character);
+
+            if ($this->partialWordTokens !== []
+                && $this->partialWordWidth + $token['width'] > $this->taskOutputWidth()) {
+                $this->completePartialWord();
+            }
+
+            $this->appendPartialWordToken($token);
+        }
+    }
+
+    /**
+     * Append one token to the unfinished word.
+     *
+     * @param array{text: string, width: int, codes: string, link: string} $token
+     */
+    private function appendPartialWordToken(array $token): void
+    {
+        $lastIndex = array_key_last($this->partialWordTokens);
+
+        if ($lastIndex !== null
+            && $this->partialWordTokens[$lastIndex]['codes'] === $token['codes']
+            && $this->partialWordTokens[$lastIndex]['link'] === $token['link']) {
+            $this->partialWordTokens[$lastIndex]['text'] .= $token['text'];
+            $this->partialWordTokens[$lastIndex]['width'] += $token['width'];
+        } else {
+            $this->partialWordTokens[] = $token;
+        }
+
+        $this->partialWordWidth += $token['width'];
+        $this->partialHasUnfinishedLine = true;
+    }
+
+    /**
+     * Complete the current word using mbWordwrap's implicit separator model.
+     */
+    private function completePartialWord(bool $includeEmpty = false): bool
+    {
+        if ($this->partialWordTokens === [] && ! $includeEmpty) {
+            return false;
+        }
+
+        $candidateWidth = $this->partialWordWidth;
+
+        if (! $this->partialLineUnset) {
+            $candidateWidth += $this->partialLineWidth + 1;
+        }
+
+        $wrapped = ! $this->partialLineUnset && $candidateWidth > $this->taskOutputWidth();
+
+        if ($wrapped) {
+            $this->storePartialLine();
+            $this->partialLineTokens = $this->partialWordTokens;
+            $this->partialLineWidth = $this->partialWordWidth;
+        } else {
+            if (! $this->partialLineUnset && $this->partialJoinToken !== null) {
+                $this->partialLineTokens[] = $this->partialJoinToken;
+            }
+
+            array_push($this->partialLineTokens, ...$this->partialWordTokens);
+            $this->partialLineWidth = $candidateWidth;
+        }
+
+        $this->partialLineUnset = false;
+        $this->partialWordTokens = [];
+        $this->partialWordWidth = 0;
+        $this->partialJoinToken = null;
+        $this->partialHasUnfinishedLine = true;
+
+        return $wrapped;
+    }
+
+    /**
+     * Finish one explicit or final logical line.
+     */
+    private function finishPartialLogicalLine(): void
+    {
+        $wrapped = $this->completePartialWord(includeEmpty: $this->partialJoinToken !== null);
+
+        // A trailing separator that caused a wrap does not create another blank line.
+        if (! $wrapped || $this->partialLineTokens !== []) {
+            $this->storePartialLine();
+        } else {
+            $this->resetPartialLine();
+        }
+    }
+
+    /**
+     * Create one visible token using the active terminal state.
+     *
+     * @return array{text: string, width: int, codes: string, link: string}
+     */
+    private function partialToken(string $text): array
+    {
+        return [
+            'text' => $text,
+            'width' => mb_strwidth($text),
+            'codes' => implode('', $this->partialSgr),
+            'link' => $this->partialLink,
+        ];
+    }
+
+    /**
+     * Store the current visible line in the bounded partial region.
+     */
+    private function storePartialLine(): void
+    {
+        $this->partialLines[] = $this->renderPartialTokens($this->partialLineTokens);
+        $this->resetPartialLine();
+
+        if (count($this->partialLines) > $this->limit) {
+            array_shift($this->partialLines);
+        }
+    }
+
+    /**
+     * Reset the current visible line.
+     */
+    private function resetPartialLine(): void
+    {
+        $this->partialLineTokens = [];
+        $this->partialLineWidth = 0;
+        $this->partialLineUnset = true;
+        $this->partialHasUnfinishedLine = false;
+    }
+
+    /**
+     * Synchronize the bounded partial region into Task's visible log buffer.
+     */
+    private function synchronizePartialLogs(bool $includePreview = true): void
+    {
+        $prefix = array_slice($this->logs, 0, $this->partialStartIndex ?? count($this->logs));
+        $partial = $this->partialLines;
+
+        if ($includePreview && $this->partialHasUnfinishedLine) {
+            array_push($partial, ...$this->partialPreviewLines());
+        }
+
+        $this->logs = [...$prefix, ...$partial];
+        $this->partialStartIndex = count($prefix);
+        $this->trimTaskLogs();
+    }
+
+    /**
+     * Render the unfinished word without mutating its cross-chunk state.
+     *
+     * @return list<string>
+     */
+    private function partialPreviewLines(): array
+    {
+        if ($this->partialLineUnset) {
+            return [$this->renderPartialTokens($this->partialWordTokens)];
+        }
+
+        $candidateWidth = $this->partialLineWidth + 1 + $this->partialWordWidth;
+
+        if ($candidateWidth <= $this->taskOutputWidth()) {
+            $tokens = $this->partialLineTokens;
+
+            if ($this->partialJoinToken !== null) {
+                $tokens[] = $this->partialJoinToken;
+            }
+
+            array_push($tokens, ...$this->partialWordTokens);
+
+            return [$this->renderPartialTokens($tokens)];
+        }
+
+        $lines = [$this->renderPartialTokens($this->partialLineTokens)];
+
+        if ($this->partialWordTokens !== []) {
+            $lines[] = $this->renderPartialTokens($this->partialWordTokens);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Render styled visible tokens into one terminal line.
+     *
+     * @param list<array{text: string, width: int, codes: string, link: string}> $tokens
+     */
+    private function renderPartialTokens(array $tokens): string
+    {
+        $line = '';
+        $codes = '';
+        $link = '';
+
+        foreach ($tokens as $token) {
+            if ($token['link'] !== $link) {
+                if ($link !== '') {
+                    $line .= "\e]8;;\e\\";
+                }
+
+                if ($token['link'] !== '') {
+                    $line .= $token['link'];
+                }
+
+                $link = $token['link'];
+            }
+
+            if ($token['codes'] !== $codes) {
+                if ($codes !== '') {
+                    $line .= "\e[0m";
+                }
+
+                if ($token['codes'] !== '') {
+                    $line .= $token['codes'];
+                }
+
+                $codes = $token['codes'];
+            }
+
+            $line .= $token['text'];
+        }
+
+        if ($codes !== '') {
+            $line .= "\e[0m";
+        }
+
+        if ($link !== '') {
+            $line .= "\e]8;;\e\\";
+        }
+
+        return $line;
+    }
+
+    /**
+     * Trim visible logs and keep the protected partial boundary aligned.
+     */
+    private function trimTaskLogs(): void
+    {
+        while (count($this->logs) > $this->limit) {
+            array_shift($this->logs);
+
+            if ($this->partialStartIndex !== null && $this->partialStartIndex > 0) {
+                --$this->partialStartIndex;
+            } elseif ($this->partialStartIndex === 0 && $this->partialLines !== []) {
+                array_shift($this->partialLines);
+            }
+        }
+    }
+
+    /**
+     * Return the usable width for Task log output.
+     */
+    private function taskOutputWidth(): int
+    {
+        return max(1, $this->terminal()->cols() - 10);
+    }
+}

--- a/src/prompts/src/DataTablePrompt.php
+++ b/src/prompts/src/DataTablePrompt.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Prompts;
 
 use Closure;
+use Hypervel\Prompts\Support\Utils;
 use Hypervel\Support\Collection;
 
 class DataTablePrompt extends Prompt
@@ -25,6 +26,13 @@ class DataTablePrompt extends Prompt
      * @var array<int|string, array<int, string>>
      */
     public array $rows;
+
+    /**
+     * Search-invariant natural column metrics.
+     *
+     * @var null|array{columns: int, widths: list<int>}
+     */
+    protected ?array $naturalColumnMetrics = null;
 
     /**
      * The cached filtered rows.
@@ -152,6 +160,76 @@ class DataTablePrompt extends Prompt
         $this->filteredCache = null;
         $this->highlighted = 0;
         $this->firstVisible = 0;
+    }
+
+    /**
+     * Get the search-invariant natural column metrics.
+     *
+     * @internal
+     * @return array{columns: int, widths: list<int>}
+     */
+    public function naturalColumnMetrics(): array
+    {
+        if ($this->naturalColumnMetrics !== null) {
+            return $this->naturalColumnMetrics;
+        }
+
+        $rowColumns = $this->rows === [] ? 0 : max(array_map(count(...), $this->rows));
+        $columns = max(count($this->headers), $rowColumns);
+
+        if ($columns === 0) {
+            return $this->naturalColumnMetrics = ['columns' => 0, 'widths' => []];
+        }
+
+        $headers = array_values($this->headers);
+        $headerWidths = array_fill(0, $columns, 0);
+
+        foreach ($headers as $index => $header) {
+            $text = is_array($header) ? implode(' ', $header) : $header;
+            $headerWidths[$index] = mb_strwidth(Utils::stripEscapeSequences($text));
+        }
+
+        $columnWidths = array_fill(0, $columns, []);
+
+        foreach ($this->rows as $row) {
+            foreach (array_values($row) as $index => $cell) {
+                $cellWidth = 0;
+
+                foreach (preg_split('/\r\n|\n/', $cell) as $line) {
+                    $cellWidth = max($cellWidth, mb_strwidth(Utils::stripEscapeSequences($line)));
+                }
+
+                if ($cellWidth > 0) {
+                    $columnWidths[$index][] = $cellWidth;
+                }
+            }
+        }
+
+        $naturalWidths = array_fill(0, $columns, 0);
+
+        foreach ($columnWidths as $index => $widths) {
+            if ($widths === []) {
+                $naturalWidths[$index] = $headerWidths[$index];
+
+                continue;
+            }
+
+            sort($widths, SORT_NUMERIC);
+            $percentileIndex = max(0, (int) ceil(count($widths) * 0.90) - 1);
+            $percentile = $widths[$percentileIndex];
+            $maximum = $widths[array_key_last($widths)];
+
+            // Use P90 only when the maximum is a clear outlier.
+            $naturalWidths[$index] = max(
+                $headerWidths[$index],
+                $maximum <= $percentile * 2 ? $maximum : $percentile,
+            );
+        }
+
+        return $this->naturalColumnMetrics = [
+            'columns' => $columns,
+            'widths' => $naturalWidths,
+        ];
     }
 
     /**

--- a/src/prompts/src/MultiSearchPrompt.php
+++ b/src/prompts/src/MultiSearchPrompt.php
@@ -54,8 +54,8 @@ class MultiSearchPrompt extends Prompt
         $this->initializeScrolling(null);
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(count($this->matches), true),
-            Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(count($this->matches), true),
+            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(count($this->matches()), true),
+            Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(count($this->matches()), true),
             Key::oneOf(Key::HOME, $key) => $this->highlighted !== null ? $this->highlight(0) : null,
             Key::oneOf(Key::END, $key) => $this->highlighted !== null ? $this->highlight(count($this->matches()) - 1) : null,
             Key::SPACE => $this->highlighted !== null ? $this->toggleHighlighted() : null,

--- a/src/prompts/src/MultiSearchPrompt.php
+++ b/src/prompts/src/MultiSearchPrompt.php
@@ -54,8 +54,8 @@ class MultiSearchPrompt extends Prompt
         $this->initializeScrolling(null);
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(count($this->matches), true),
-            Key::DOWN, Key::DOWN_ARROW, Key::TAB => $this->highlightNext(count($this->matches), true),
+            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(count($this->matches), true),
+            Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(count($this->matches), true),
             Key::oneOf(Key::HOME, $key) => $this->highlighted !== null ? $this->highlight(0) : null,
             Key::oneOf(Key::END, $key) => $this->highlighted !== null ? $this->highlight(count($this->matches()) - 1) : null,
             Key::SPACE => $this->highlighted !== null ? $this->toggleHighlighted() : null,

--- a/src/prompts/src/NumberPrompt.php
+++ b/src/prompts/src/NumberPrompt.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Hypervel\Prompts;
 
 use Closure;
-use RuntimeException;
+use InvalidArgumentException;
 
 class NumberPrompt extends Prompt
 {
     use Concerns\TypedValue;
+
+    private const string INTEGER_PATTERN = '/^[+-]?[0-9]+$/D';
 
     /**
      * Create a new NumberPrompt instance.
@@ -17,7 +19,7 @@ class NumberPrompt extends Prompt
     public function __construct(
         public string $label,
         public string $placeholder = '',
-        public string $default = '',
+        public int|string $default = '',
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
@@ -26,13 +28,15 @@ class NumberPrompt extends Prompt
         public ?int $max = null,
         public ?int $step = null,
     ) {
-        $this->trackTypedValue($default);
+        $this->trackTypedValue((string) $default);
 
         $this->step = max(1, $this->step ?? 1);
         $this->min ??= PHP_INT_MIN;
         $this->max ??= PHP_INT_MAX;
 
-        $this->validate = $this->wrapValidation($this->validate);
+        if ($this->min > $this->max) {
+            throw new InvalidArgumentException('The minimum value must not be greater than the maximum value.');
+        }
 
         $this->on('key', function (string $key) {
             match ($key) {
@@ -44,49 +48,78 @@ class NumberPrompt extends Prompt
     }
 
     /**
-     * Wrap the validation logic to include numeric checks.
+     * Parse a signed decimal integer.
      */
-    protected function wrapValidation(mixed $validate): callable
+    public static function parseInteger(string $value): ?int
     {
-        return function ($value) use ($validate) {
-            if ($value !== '' && ! is_numeric($value)) {
-                return 'Must be a number';
+        if (preg_match(self::INTEGER_PATTERN, $value) !== 1) {
+            return null;
+        }
+
+        $negative = $value[0] === '-';
+        $digits = ltrim(ltrim($value, '+-'), '0');
+
+        if ($digits === '') {
+            return 0;
+        }
+
+        $limit = $negative ? ltrim((string) PHP_INT_MIN, '-') : (string) PHP_INT_MAX;
+
+        if (strlen($digits) > strlen($limit)
+            || (strlen($digits) === strlen($limit) && strcmp($digits, $limit) > 0)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    // REMOVED: Laravel's wrapValidation() conflicts with centralized intrinsic validation.
+    // Override validateIntrinsic() instead.
+
+    /**
+     * Validate rules intrinsic to the number prompt.
+     */
+    public function validateIntrinsic(mixed $value): ?string
+    {
+        if ($value === '' || $value === null) {
+            return null;
+        }
+
+        if (is_int($value)) {
+            return $this->validateBounds($value);
+        }
+
+        if (is_string($value)) {
+            $integer = static::parseInteger($value);
+
+            if ($integer !== null) {
+                return $this->validateBounds($integer);
             }
 
-            if (is_numeric($value)) {
-                if ($value < $this->min) {
-                    return 'Must be at least ' . $this->min;
-                }
-
-                if ($value > $this->max) {
-                    return 'Must be less than ' . $this->max;
-                }
+            if (preg_match(self::INTEGER_PATTERN, $value) === 1) {
+                return $value[0] === '-'
+                    ? 'Must be at least ' . $this->min
+                    : 'Must be at most ' . $this->max;
             }
+        }
 
-            $validateUsing = static::getValidateUsing();
+        return 'Must be an integer';
+    }
 
-            if (! $validate && $validateUsing === null) {
-                return null;
-            }
+    /**
+     * Validate the integer against the configured bounds.
+     */
+    private function validateBounds(int $value): ?string
+    {
+        if ($value < $this->min) {
+            return 'Must be at least ' . $this->min;
+        }
 
-            if (is_callable($validate)) {
-                return $validate($value);
-            }
+        if ($value > $this->max) {
+            return 'Must be at most ' . $this->max;
+        }
 
-            if ($validateUsing !== null) {
-                $wrappedValidate = $this->validate;
-                // Expose the original rules while the generic validator reads $prompt->validate.
-                $this->validate = $validate;
-
-                try {
-                    return $validateUsing($this);
-                } finally {
-                    $this->validate = $wrappedValidate;
-                }
-            }
-
-            throw new RuntimeException('The validation logic is missing.');
-        };
+        return null;
     }
 
     /**
@@ -95,20 +128,19 @@ class NumberPrompt extends Prompt
     protected function increaseValue(): void
     {
         if ($this->typedValue === '') {
-            $this->typedValue = (string) ($this->min === PHP_INT_MIN ? 1 : $this->min);
-            ++$this->cursorPosition;
+            $value = $this->min === PHP_INT_MIN ? 1 : $this->min;
+            $this->typedValue = (string) min($this->max, max($this->min, $value));
+            $this->cursorPosition = mb_strlen($this->typedValue);
 
             return;
         }
 
-        if (is_numeric($this->typedValue)) {
-            $previousValueLength = mb_strlen($this->typedValue);
+        $value = static::parseInteger($this->typedValue);
 
-            $this->typedValue = (string) min($this->max, (int) $this->typedValue + $this->step);
-
-            if (mb_strlen($this->typedValue) > $previousValueLength) {
-                ++$this->cursorPosition;
-            }
+        if ($value !== null) {
+            $value = $value > PHP_INT_MAX - $this->step ? PHP_INT_MAX : $value + $this->step;
+            $this->typedValue = (string) min($this->max, $value);
+            $this->cursorPosition = mb_strlen($this->typedValue);
         }
     }
 
@@ -118,20 +150,19 @@ class NumberPrompt extends Prompt
     protected function decreaseValue(): void
     {
         if ($this->typedValue === '') {
-            $this->typedValue = (string) ($this->max === PHP_INT_MAX ? 0 : $this->max);
-            ++$this->cursorPosition;
+            $value = $this->max === PHP_INT_MAX ? 0 : $this->max;
+            $this->typedValue = (string) min($this->max, max($this->min, $value));
+            $this->cursorPosition = mb_strlen($this->typedValue);
 
             return;
         }
 
-        if (is_numeric($this->typedValue)) {
-            $previousValueLength = mb_strlen($this->typedValue);
+        $value = static::parseInteger($this->typedValue);
 
-            $this->typedValue = (string) max($this->min, (int) $this->typedValue - $this->step);
-
-            if (mb_strlen($this->typedValue) < $previousValueLength) {
-                --$this->cursorPosition;
-            }
+        if ($value !== null) {
+            $value = $value < PHP_INT_MIN + $this->step ? PHP_INT_MIN : $value - $this->step;
+            $this->typedValue = (string) max($this->min, $value);
+            $this->cursorPosition = mb_strlen($this->typedValue);
         }
     }
 
@@ -140,11 +171,9 @@ class NumberPrompt extends Prompt
      */
     public function value(): int|string
     {
-        if (is_numeric($this->typedValue)) {
-            return (int) $this->typedValue;
-        }
+        $value = static::parseInteger($this->typedValue);
 
-        return $this->typedValue;
+        return $value ?? $this->typedValue;
     }
 
     /**
@@ -152,10 +181,10 @@ class NumberPrompt extends Prompt
      */
     public function valueWithCursor(int $maxWidth): string
     {
-        if ($this->value() === '') {
+        if ($this->typedValue === '') {
             return $this->dim($this->addCursor($this->placeholder, 0, $maxWidth));
         }
 
-        return $this->addCursor((string) $this->value(), $this->cursorPosition, $maxWidth);
+        return $this->addCursor($this->typedValue, $this->cursorPosition, $maxWidth);
     }
 }

--- a/src/prompts/src/Progress.php
+++ b/src/prompts/src/Progress.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Prompts;
 
 use Closure;
+use Hypervel\Coroutine\Coroutine;
 use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
@@ -122,7 +123,7 @@ class Progress extends Prompt
         $this->prevFrame = '';
         $this->capturePreviousNewLines();
 
-        if (function_exists('pcntl_signal')) {
+        if (function_exists('pcntl_signal') && ! Coroutine::inCoroutine()) {
             $this->originalSignalHandler = pcntl_signal_get_handler(SIGINT);
             $this->originalAsync = pcntl_async_signals(true);
             $progress = WeakReference::create($this);

--- a/src/prompts/src/Prompt.php
+++ b/src/prompts/src/Prompt.php
@@ -91,6 +91,21 @@ abstract class Prompt
     protected bool $terminalStateRestored = true;
 
     /**
+     * Whether this prompt has already been invoked.
+     */
+    private bool $prompted = false;
+
+    /**
+     * The transformed value accepted by a successful submission.
+     */
+    private mixed $submittedValue = null;
+
+    /**
+     * The prompt state to restore after a transient error.
+     */
+    private ?string $stateBeforeTransientError = null;
+
+    /**
      * The custom validation callback.
      */
     protected static ?Closure $validateUsing = null;
@@ -105,12 +120,12 @@ abstract class Prompt
     /**
      * The output instance.
      */
-    protected static OutputInterface $output;
+    protected static ?OutputInterface $output = null;
 
     /**
      * The terminal instance.
      */
-    protected static Terminal $terminal;
+    protected static ?Terminal $terminal = null;
 
     /**
      * Get the value of the prompt.
@@ -118,10 +133,23 @@ abstract class Prompt
     abstract public function value(): mixed;
 
     /**
+     * Validate rules intrinsic to the prompt type.
+     */
+    public function validateIntrinsic(mixed $value): ?string
+    {
+        return null;
+    }
+
+    /**
      * Render the prompt and listen for input.
      */
     public function prompt(): mixed
     {
+        if ($this->prompted) {
+            throw new RuntimeException('This prompt has already been invoked.');
+        }
+
+        $this->prompted = true;
         $operationFailure = null;
 
         try {
@@ -175,7 +203,9 @@ abstract class Prompt
                         throw new FormRevertedException;
                     }
 
-                    return Result::from($this->transformedValue());
+                    return Result::from(
+                        $this->state === 'submit' ? $this->submittedValue : $this->transformedValue(),
+                    );
                 }
 
                 // Continue looping.
@@ -330,6 +360,8 @@ abstract class Prompt
 
     /**
      * Set the custom validation callback.
+     *
+     * @param Closure(Prompt, mixed): (null|string) $callback
      */
     public static function validateUsing(Closure $callback): void
     {
@@ -411,9 +443,12 @@ abstract class Prompt
      */
     protected function submit(): void
     {
-        $this->validate($this->transformedValue());
+        $value = $this->transformedValue();
+
+        $this->validate($value);
 
         if ($this->state !== 'error') {
+            $this->submittedValue = $value;
             $this->state = 'submit';
         }
     }
@@ -424,7 +459,8 @@ abstract class Prompt
     private function handleKeyPress(string $key): bool
     {
         if ($this->state === 'error') {
-            $this->state = 'active';
+            $this->state = $this->stateBeforeTransientError ?? 'active';
+            $this->stateBeforeTransientError = null;
         }
 
         $this->emit('key', $key);
@@ -435,6 +471,7 @@ abstract class Prompt
 
         if ($key === Key::CTRL_U) {
             if (! self::$revertUsing) {
+                $this->stateBeforeTransientError = $this->state;
                 $this->state = 'error';
                 $this->error = 'This cannot be reverted.';
 
@@ -496,17 +533,21 @@ abstract class Prompt
             return;
         }
 
-        $validateUsing = static::getValidateUsing();
+        $error = $this->validateIntrinsic($value);
 
-        if (! isset($this->validate) && $validateUsing === null) {
-            return;
+        if ($error === null) {
+            $validateUsing = static::getValidateUsing();
+
+            if (! isset($this->validate) && $validateUsing === null) {
+                return;
+            }
+
+            $error = match (true) {
+                is_callable($this->validate) => ($this->validate)($value),
+                $validateUsing !== null => $validateUsing($this, $value),
+                default => throw new RuntimeException('The validation logic is missing.'),
+            };
         }
-
-        $error = match (true) {
-            is_callable($this->validate) => ($this->validate)($value),
-            $validateUsing !== null => $validateUsing($this),
-            default => throw new RuntimeException('The validation logic is missing.'),
-        };
 
         if (! is_string($error) && ! is_null($error)) {
             throw new RuntimeException('The validator must return a string or null.');
@@ -544,8 +585,11 @@ abstract class Prompt
         static::$cancelUsing = null;
         static::$validateUsing = null;
         static::$revertUsing = null;
-        static::$output = new ConsoleOutput;
-        static::$terminal = new Terminal;
+        static::$output = null;
+        static::$terminal = null;
+
+        CoroutineContext::forget(self::OUTPUT_CONTEXT_KEY);
+        CoroutineContext::forget(self::VALIDATE_USING_CONTEXT_KEY);
 
         static::resetCursor();
         static::resetFallback();

--- a/src/prompts/src/Prompt.php
+++ b/src/prompts/src/Prompt.php
@@ -535,7 +535,7 @@ abstract class Prompt
 
         $error = $this->validateIntrinsic($value);
 
-        if ($error === null) {
+        if ($error === null || $error === '') {
             $validateUsing = static::getValidateUsing();
 
             if (! isset($this->validate) && $validateUsing === null) {

--- a/src/prompts/src/SearchPrompt.php
+++ b/src/prompts/src/SearchPrompt.php
@@ -46,8 +46,8 @@ class SearchPrompt extends Prompt
         $this->initializeScrolling(null);
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(count($this->matches), true),
-            Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(count($this->matches), true),
+            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(count($this->matches()), true),
+            Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(count($this->matches()), true),
             Key::oneOf([Key::HOME, Key::CTRL_A], $key) => $this->highlighted !== null ? $this->highlight(0) : null,
             Key::oneOf([Key::END, Key::CTRL_E], $key) => $this->highlighted !== null ? $this->highlight(count($this->matches()) - 1) : null,
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),

--- a/src/prompts/src/Spinner.php
+++ b/src/prompts/src/Spinner.php
@@ -6,6 +6,7 @@ namespace Hypervel\Prompts;
 
 use Closure;
 use Hypervel\Coroutine\Coroutine;
+use Hypervel\Prompts\Support\PromptAnimation;
 use RuntimeException;
 use Throwable;
 
@@ -53,23 +54,21 @@ class Spinner extends Prompt
             return $this->renderStatically($callback);
         }
 
-        /** @var bool $finished */
-        $finished = false;
+        $animation = null;
         $operationFailure = null;
 
         try {
             $this->hideCursor();
             $this->render();
 
-            Coroutine::fork(function () use (&$finished): void {
-                while (! $finished) {
-                    $this->render();
-
+            $animation = new PromptAnimation(
+                render: function (): void {
                     ++$this->count;
-
-                    usleep($this->interval * 1000);
-                }
-            });
+                    $this->render();
+                },
+                interval: $this->interval,
+            );
+            $animation->start();
 
             return $callback();
         } catch (Throwable $exception) {
@@ -77,11 +76,24 @@ class Spinner extends Prompt
 
             throw $exception;
         } finally {
-            $finished = true;
+            $animationFailure = null;
+
+            try {
+                $animationFailure = $animation?->stop();
+            } catch (Throwable $exception) {
+                $animationFailure = $exception;
+            }
+
             $cleanupFailure = $this->settleOperation();
 
-            if ($operationFailure === null && $cleanupFailure !== null) {
-                throw $cleanupFailure;
+            if ($operationFailure === null) {
+                if ($animationFailure !== null) {
+                    throw $animationFailure;
+                }
+
+                if ($cleanupFailure !== null) {
+                    throw $cleanupFailure;
+                }
             }
         }
     }

--- a/src/prompts/src/Support/InProcessLogger.php
+++ b/src/prompts/src/Support/InProcessLogger.php
@@ -23,68 +23,10 @@ class InProcessLogger extends Logger
     }
 
     /**
-     * Log a line to the task output.
+     * Write a message directly to the Task.
      */
-    public function line(string $message): void
+    protected function write(string $message, ?string $type = null): void
     {
-        $this->task->appendLogLine(rtrim($message));
-    }
-
-    /**
-     * Log a success message.
-     */
-    public function success(string $message): void
-    {
-        $this->task->addStableMessage('success', $message);
-    }
-
-    /**
-     * Log a warning message.
-     */
-    public function warning(string $message): void
-    {
-        $this->task->addStableMessage('warning', $message);
-    }
-
-    /**
-     * Log an error message.
-     */
-    public function error(string $message): void
-    {
-        $this->task->addStableMessage('error', $message);
-    }
-
-    /**
-     * Update the task label.
-     */
-    public function label(string $message): void
-    {
-        $this->task->updateLabel($message);
-    }
-
-    /**
-     * Update the task sub-label. Pass an empty string to clear.
-     */
-    public function subLabel(string $message): void
-    {
-        $this->task->updateSubLabel($message);
-    }
-
-    /**
-     * Append a chunk of text, accumulating on the current line(s).
-     */
-    public function partial(string $chunk): void
-    {
-        $this->streamBuffer .= $chunk;
-        $this->task->replacePartialText($this->streamBuffer);
-    }
-
-    /**
-     * Commit the accumulated partial text and start fresh.
-     */
-    public function commitPartial(): void
-    {
-        $this->streamBuffer = '';
-        $this->task->commitPartialText();
+        $this->task->applyMessage($type, $message);
     }
 }

--- a/src/prompts/src/Support/Logger.php
+++ b/src/prompts/src/Support/Logger.php
@@ -21,22 +21,23 @@ class Logger
     protected ?RuntimeException $transportFailure = null;
 
     /**
+     * The identifier retained for Laravel-compatible construction and subclass state.
+     */
+    protected string $identifier;
+
+    /**
      * Create a new Logger instance.
      *
      * @param null|resource $socket
      * @param float $writeTimeout seconds a write may wait for the renderer to accept output
      */
     public function __construct(
-        protected string $identifier,
+        string $identifier,
         protected $socket = null,
         protected float $writeTimeout = self::DEFAULT_WRITE_TIMEOUT_SECONDS,
     ) {
+        $this->identifier = $identifier;
     }
-
-    /**
-     * The buffer for streaming text.
-     */
-    protected string $streamBuffer = '';
 
     /**
      * Log a line to the process log.
@@ -47,16 +48,11 @@ class Logger
     }
 
     /**
-     * Append a chunk of text, accumulating on the current line(s).
+     * Append a chunk of text to the current partial output.
      */
     public function partial(string $chunk): void
     {
-        if ($this->socket === null) {
-            return;
-        }
-
-        $this->streamBuffer .= $chunk;
-        $this->write($this->streamBuffer, 'partial');
+        $this->write($chunk, 'partial');
     }
 
     /**
@@ -64,7 +60,6 @@ class Logger
      */
     public function commitPartial(): void
     {
-        $this->streamBuffer = '';
         $this->write('', 'commitpartial');
     }
 
@@ -113,20 +108,21 @@ class Logger
      */
     protected function write(string $message, ?string $type = null): void
     {
+        $frame = TaskFrame::encode($type, $message);
+
         if ($this->socket === null) {
             return;
         }
 
-        $payload = ($type !== null ? $this->prefix($type, $message) : $message) . PHP_EOL;
-
         try {
-            // Each protocol frame must be complete because stream writes may be partial.
-            Utils::writeAll($this->socket, $payload, $this->writeTimeout);
+            Utils::writeAll($this->socket, $frame, $this->writeTimeout);
         } catch (RuntimeException $exception) {
             $this->transportFailure ??= $exception;
             $this->socket = null;
         }
     }
+
+    // REMOVED: Binary framing cannot represent text prefixes. Override write() instead.
 
     /**
      * Get the first transport failure encountered while writing.
@@ -134,13 +130,5 @@ class Logger
     public function transportFailure(): ?RuntimeException
     {
         return $this->transportFailure;
-    }
-
-    /**
-     * Prefix a message with the identifier and type.
-     */
-    protected function prefix(string $type, string $message): string
-    {
-        return $this->identifier . '_' . $type . ':' . rtrim($message, PHP_EOL);
     }
 }

--- a/src/prompts/src/Support/PromptAnimation.php
+++ b/src/prompts/src/Support/PromptAnimation.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Prompts\Support;
+
+use Closure;
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Engine\Channel;
+use Throwable;
+
+/**
+ * Own one interruptible prompt animation coroutine and its render failure.
+ *
+ * @internal
+ */
+class PromptAnimation
+{
+    /**
+     * The stop signal consumed by the animation coroutine.
+     *
+     * @var Channel<true>
+     */
+    private Channel $stop;
+
+    private ?int $coroutineId = null;
+
+    private ?Throwable $renderFailure = null;
+
+    /**
+     * Create a new prompt animation owner.
+     */
+    public function __construct(
+        private readonly Closure $render,
+        private readonly int $interval,
+    ) {
+        $this->stop = new Channel(1);
+    }
+
+    /**
+     * Start the animation coroutine.
+     */
+    public function start(): void
+    {
+        $this->coroutineId = Coroutine::fork(function (): void {
+            try {
+                while ($this->stop->pop($this->interval / 1000) === false) {
+                    ($this->render)();
+                }
+            } catch (Throwable $exception) {
+                $this->renderFailure = $exception;
+            }
+        });
+    }
+
+    /**
+     * Stop and join the animation coroutine.
+     */
+    public function stop(): ?Throwable
+    {
+        if ($this->coroutineId === null) {
+            return $this->renderFailure;
+        }
+
+        $coroutineId = $this->coroutineId;
+        $this->coroutineId = null;
+
+        $this->stop->push(true);
+        Coroutine::join([$coroutineId]);
+
+        return $this->renderFailure;
+    }
+}

--- a/src/prompts/src/Support/TaskFrame.php
+++ b/src/prompts/src/Support/TaskFrame.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Prompts\Support;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Encode and incrementally decode Task transport frames.
+ *
+ * @internal
+ */
+class TaskFrame
+{
+    private const int HEADER_LENGTH = 5;
+
+    private const int COMPACTION_THRESHOLD = 8192;
+
+    /**
+     * @var array<string, int>
+     */
+    private const array TYPES = [
+        'line' => 1,
+        'success' => 2,
+        'warning' => 3,
+        'error' => 4,
+        'label' => 5,
+        'sublabel' => 6,
+        'reset' => 7,
+        'partial' => 8,
+        'commitpartial' => 9,
+    ];
+
+    private string $buffer = '';
+
+    private int $cursor = 0;
+
+    /**
+     * Encode a Task message.
+     */
+    public static function encode(?string $type, string $payload): string
+    {
+        $name = $type ?? 'line';
+        $identifier = self::TYPES[$name] ?? null;
+
+        if ($identifier === null) {
+            throw new InvalidArgumentException("Unknown task message type [{$name}].");
+        }
+
+        $length = strlen($payload);
+
+        if ($length > 0xFFFFFFFF) {
+            throw new InvalidArgumentException('Task message payload exceeds the protocol limit.');
+        }
+
+        return chr($identifier) . pack('N', $length) . $payload;
+    }
+
+    /**
+     * Append bytes received from the Task transport.
+     */
+    public function append(string $bytes): void
+    {
+        $this->buffer .= $bytes;
+    }
+
+    /**
+     * Decode the next complete Task message.
+     *
+     * @return null|array{type: ?string, payload: string}
+     */
+    public function next(): ?array
+    {
+        $remaining = strlen($this->buffer) - $this->cursor;
+
+        if ($remaining < self::HEADER_LENGTH) {
+            return null;
+        }
+
+        $identifier = ord($this->buffer[$this->cursor]);
+        $type = array_search($identifier, self::TYPES, true);
+
+        if ($type === false) {
+            throw new RuntimeException("Unknown task message type [{$identifier}].");
+        }
+
+        $length = unpack('Nlength', $this->buffer, $this->cursor + 1)['length'];
+
+        if ($remaining < self::HEADER_LENGTH + $length) {
+            return null;
+        }
+
+        $payload = substr($this->buffer, $this->cursor + self::HEADER_LENGTH, $length);
+        $this->cursor += self::HEADER_LENGTH + $length;
+        $this->compact();
+
+        return [
+            'type' => $type === 'line' ? null : $type,
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * Finish decoding after the transport reaches EOF.
+     */
+    public function finish(): void
+    {
+        if ($this->cursor !== strlen($this->buffer)) {
+            throw new RuntimeException('The prompt renderer received an incomplete task message.');
+        }
+
+        $this->reset();
+    }
+
+    /**
+     * Reset all decoder state.
+     */
+    public function reset(): void
+    {
+        $this->buffer = '';
+        $this->cursor = 0;
+    }
+
+    /**
+     * Discard a substantial consumed prefix without copying on every frame.
+     */
+    private function compact(): void
+    {
+        $length = strlen($this->buffer);
+
+        if ($this->cursor === $length) {
+            $this->reset();
+
+            return;
+        }
+
+        if ($this->cursor >= self::COMPACTION_THRESHOLD && $this->cursor >= intdiv($length, 2)) {
+            $this->buffer = substr($this->buffer, $this->cursor);
+            $this->cursor = 0;
+        }
+    }
+}

--- a/src/prompts/src/Support/Utils.php
+++ b/src/prompts/src/Support/Utils.php
@@ -12,6 +12,15 @@ use RuntimeException;
  */
 class Utils
 {
+    public const int MAX_UNBREAKABLE_BYTES = 4096;
+
+    private const string OSC8_PATTERN = '\x1B\]8;[^;\x07\x1B]*;[^\x07\x1B]*(?:\x07|\x1B\\\)';
+
+    /**
+     * The terminal formatting sequences preserved by decorated renderers.
+     */
+    public const string TERMINAL_FORMATTING_PATTERN = '(?:\x1B\[[\x30-\x3F]*[\x20-\x2F]*m|' . self::OSC8_PATTERN . ')';
+
     /**
      * The largest chunk offered to a single write attempt.
      */
@@ -69,15 +78,84 @@ class Utils
      */
     public static function stripEscapeSequences(string $text): string
     {
-        $text = preg_replace('/\e\[[\x30-\x3F]*[\x20-\x2F]*[\x40-\x7E]/', '', $text);
-        $text = preg_replace('/\e\][^\x07\e]*(?:\x07|\e\\\)/', '', $text);
-        $text = preg_replace('/<(info|comment|question|error)>(.*?)<\/\1>/', '$2', $text);
+        $text = self::filterTerminalControls($text, preserveFormatting: false);
+        $text = preg_replace(
+            '/(?<!\\\)<(?:\/?(?:info|comment|question|error)|\/|(?i:(?:(?:fg|bg|options|href)=(?:[^;\\\<>]|\\\.)+)(?:;(?:fg|bg|options|href)=(?:[^;\\\<>]|\\\.)+)*))>/',
+            '',
+            $text,
+        );
 
-        do {
-            $text = preg_replace('/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i', '$1', $text, -1, $count);
-        } while ($count > 0);
+        return str_replace(['\<', '\>'], ['<', '>'], $text);
+    }
 
-        return $text;
+    /**
+     * Split text into bounded Unicode grapheme units.
+     *
+     * @return list<string>
+     */
+    public static function graphemes(string $text): array
+    {
+        if (preg_match_all('/\X/u', $text, $matches) === false) {
+            return mb_str_split($text);
+        }
+
+        $graphemes = [];
+
+        foreach ($matches[0] as $grapheme) {
+            while (strlen($grapheme) > self::MAX_UNBREAKABLE_BYTES) {
+                $length = self::MAX_UNBREAKABLE_BYTES;
+
+                while ((ord($grapheme[$length]) & 0xC0) === 0x80) {
+                    --$length;
+                }
+
+                $graphemes[] = substr($grapheme, 0, $length);
+                $grapheme = substr($grapheme, $length);
+            }
+
+            $graphemes[] = $grapheme;
+        }
+
+        return $graphemes;
+    }
+
+    /**
+     * Return the byte length when a fragment continues the trailing grapheme.
+     */
+    public static function continuedGraphemeBytes(string $text, string $next): ?int
+    {
+        if (preg_match('/\X\z/u', $text, $matches) !== 1) {
+            return null;
+        }
+
+        $grapheme = $matches[0] . $next;
+
+        return preg_match('/\A\X\z/u', $grapheme) === 1 ? strlen($grapheme) : null;
+    }
+
+    /**
+     * Remove terminal controls other than SGR and OSC 8 formatting.
+     */
+    public static function sanitizeTerminalFormatting(string $text): string
+    {
+        return self::filterTerminalControls($text, preserveFormatting: true);
+    }
+
+    /**
+     * Resolve a complete OSC 8 sequence to its active hyperlink state.
+     */
+    public static function resolveOsc8Link(string $escape): ?string
+    {
+        if (preg_match('/\A' . self::OSC8_PATTERN . '\z/', $escape) !== 1) {
+            return null;
+        }
+
+        $body = str_ends_with($escape, "\x07")
+            ? substr($escape, 4, -1)
+            : substr($escape, 4, -2);
+        [, $uri] = explode(';', $body, 2);
+
+        return $uri === '' ? '' : $escape;
     }
 
     /**
@@ -174,5 +252,146 @@ class Utils
             $seconds,
             (int) round(($timeout - $seconds) * 1_000_000),
         );
+    }
+
+    /**
+     * Filter terminal controls with local recovery from malformed sequences.
+     */
+    private static function filterTerminalControls(string $text, bool $preserveFormatting): string
+    {
+        if (! str_contains($text, "\e")) {
+            return $text;
+        }
+
+        $filtered = '';
+        $length = strlen($text);
+        $cursor = 0;
+
+        while ($cursor < $length) {
+            $escapePosition = strpos($text, "\e", $cursor);
+
+            if ($escapePosition === false) {
+                $filtered .= substr($text, $cursor);
+
+                break;
+            }
+
+            if ($escapePosition > $cursor) {
+                $filtered .= substr($text, $cursor, $escapePosition - $cursor);
+                $cursor = $escapePosition;
+            }
+
+            if ($cursor + 1 >= $length) {
+                break;
+            }
+
+            $introducer = $text[$cursor + 1];
+
+            if ($introducer === '[') {
+                $position = $cursor + 2;
+
+                while ($position < $length && ord($text[$position]) >= 0x30 && ord($text[$position]) <= 0x3F) {
+                    ++$position;
+                }
+
+                while ($position < $length && ord($text[$position]) >= 0x20 && ord($text[$position]) <= 0x2F) {
+                    ++$position;
+                }
+
+                if ($position >= $length) {
+                    break;
+                }
+
+                if (ord($text[$position]) >= 0x40 && ord($text[$position]) <= 0x7E) {
+                    if ($preserveFormatting && $text[$position] === 'm') {
+                        $filtered .= substr($text, $cursor, $position - $cursor + 1);
+                    }
+
+                    $cursor = $position + 1;
+
+                    continue;
+                }
+
+                // Discard only the malformed prefix; the invalid byte may be visible text.
+                $cursor = $position;
+
+                continue;
+            }
+
+            if ($introducer === ']' || in_array($introducer, ['P', 'X', '^', '_'], true)) {
+                $osc = $introducer === ']';
+                $position = $cursor + 2;
+                $end = null;
+                $abortedAt = null;
+
+                while ($position < $length) {
+                    if ($text[$position] === "\x07") {
+                        $end = $position + 1;
+
+                        break;
+                    }
+
+                    if ($text[$position] === "\e") {
+                        if ($position + 1 >= $length) {
+                            break;
+                        }
+
+                        if ($text[$position + 1] === '\\') {
+                            $end = $position + 2;
+
+                            break;
+                        }
+
+                        $abortedAt = $position;
+
+                        break;
+                    }
+
+                    ++$position;
+                }
+
+                if ($end !== null) {
+                    $sequence = substr($text, $cursor, $end - $cursor);
+
+                    if ($preserveFormatting && $osc && self::resolveOsc8Link($sequence) !== null) {
+                        $filtered .= $sequence;
+                    }
+
+                    $cursor = $end;
+
+                    continue;
+                }
+
+                if ($abortedAt !== null) {
+                    // A bare ESC aborts the malformed string and starts a new control.
+                    $cursor = $abortedAt;
+
+                    continue;
+                }
+
+                break;
+            }
+
+            $position = $cursor + 1;
+
+            while ($position < $length && ord($text[$position]) >= 0x20 && ord($text[$position]) <= 0x2F) {
+                ++$position;
+            }
+
+            if ($position >= $length) {
+                break;
+            }
+
+            if (ord($text[$position]) >= 0x30 && ord($text[$position]) <= 0x7E) {
+                $cursor = $position + 1;
+
+                continue;
+            }
+
+            // Reprocess an invalid byte so repeated ESC controls always make progress.
+            $cursor = $position;
+        }
+
+        return $filtered;
     }
 }

--- a/src/prompts/src/Support/Utils.php
+++ b/src/prompts/src/Support/Utils.php
@@ -73,7 +73,11 @@ class Utils
         $text = preg_replace('/\e\][^\x07\e]*(?:\x07|\e\\\)/', '', $text);
         $text = preg_replace('/<(info|comment|question|error)>(.*?)<\/\1>/', '$2', $text);
 
-        return preg_replace('/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i', '$1', $text);
+        do {
+            $text = preg_replace('/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i', '$1', $text, -1, $count);
+        } while ($count > 0);
+
+        return $text;
     }
 
     /**

--- a/src/prompts/src/Task.php
+++ b/src/prompts/src/Task.php
@@ -8,15 +8,16 @@ use Closure;
 use Hypervel\Coroutine\Coroutine;
 use Hypervel\Prompts\Support\InProcessLogger;
 use Hypervel\Prompts\Support\Logger;
+use Hypervel\Prompts\Support\PromptAnimation;
+use Hypervel\Prompts\Support\TaskFrame;
 use Hypervel\Prompts\Support\Utils;
-use Hypervel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
 use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
 
 class Task extends Prompt
 {
-    use InteractsWithStrings;
+    use Concerns\TracksTaskOutput;
 
     /**
      * How long a Logger write may make no progress.
@@ -33,7 +34,10 @@ class Task extends Prompt
     protected const int RENDERER_SETTLEMENT_MARGIN_MILLISECONDS = 1000;
 
     /**
-     * The renderer settlement acknowledgement byte.
+     * The raw reverse-channel acknowledgement byte.
+     *
+     * Parent-to-renderer messages use TaskFrame; this single byte travels in
+     * the opposite direction only after the renderer has settled completely.
      */
     protected const string RENDERER_ACKNOWLEDGEMENT = "\x06";
 
@@ -99,7 +103,7 @@ class Task extends Prompt
     public int $maxStableMessages = 10;
 
     /**
-     * The identifier for the task.
+     * The identifier retained for Laravel-compatible Task and Logger extension state.
      */
     public string $identifier = '';
 
@@ -109,14 +113,9 @@ class Task extends Prompt
     public bool $finished = false;
 
     /**
-     * Buffer for incomplete lines from non-blocking socket reads.
+     * The incremental process-message decoder.
      */
-    protected string $buffer = '';
-
-    /**
-     * The log index where the current partial started, or null if not streaming.
-     */
-    protected ?int $partialStartIndex = null;
+    private TaskFrame $frameDecoder;
 
     /**
      * Create a new Task instance.
@@ -130,6 +129,7 @@ class Task extends Prompt
         $this->validateLimit();
 
         $this->identifier = uniqid();
+        $this->frameDecoder = new TaskFrame;
     }
 
     /**
@@ -188,176 +188,77 @@ class Task extends Prompt
      */
     protected function receiveMessages($socket): void
     {
-        $prefix = preg_quote($this->identifier, '/');
+        while (($data = fread($socket, 65536)) !== false && $data !== '') {
+            $this->frameDecoder->append($data);
 
-        while (($data = fgets($socket)) !== false) {
-            // Buffer incomplete lines from non-blocking reads.
-            if (! str_ends_with($data, PHP_EOL)) {
-                $this->buffer .= $data;
+            while (($message = $this->frameDecoder->next()) !== null) {
+                $this->applyMessage($message['type'], $message['payload']);
 
-                continue;
-            }
-
-            $line = rtrim($this->buffer . $data, PHP_EOL);
-            $this->buffer = '';
-
-            if ($line === '') {
-                continue;
-            }
-
-            // Check for typed messages: {id}_{type}:{content}
-            if (preg_match('/^' . $prefix . '_(success|warning|error|label|sublabel|reset|partial|commitpartial):(.*)/', $line, $matches)) {
-                $type = $matches[1];
-                $content = $matches[2];
-
-                if ($type === 'reset') {
-                    $this->resetTerminal($this->originalAsync ?? false, $content === '1');
-
+                if ($this->finished) {
                     return;
                 }
+            }
+        }
+    }
 
-                if ($type === 'partial') {
-                    $this->replacePartialLines($content);
+    /**
+     * Apply one decoded Task message.
+     *
+     * @internal
+     */
+    public function applyMessage(?string $type, string $payload): void
+    {
+        if ($type === null) {
+            $this->addLogLines($payload);
 
-                    continue;
-                }
+            return;
+        }
 
-                if ($type === 'commitpartial') {
-                    $this->partialStartIndex = null;
-
-                    continue;
-                }
-
-                if ($type === 'label') {
-                    $this->label = $content;
-                } elseif ($type === 'sublabel') {
-                    $this->subLabel = $content;
-                    $this->recalculateMaxStableMessages();
-                } else {
-                    $this->stableMessages[] = ['type' => $type, 'message' => $content];
-                    $this->logs = [];
-                    $this->partialStartIndex = null;
-                }
-
-                $this->trimStableMessages();
-
-                continue;
+        if ($type === 'reset') {
+            if ($payload !== "\x00" && $payload !== "\x01") {
+                throw new RuntimeException('The prompt renderer received an invalid settlement message.');
             }
 
-            // Regular log line — strip cursor-reset control sequences.
-            $line = preg_replace('/\e\[(?:1)?G\e\[2K/', '', $line);
+            $this->resetTerminal($this->originalAsync ?? false, $payload === "\x01");
 
-            // Wrap and add to ring buffer.
-            $this->addLogLines($line);
-        }
-    }
-
-    /**
-     * Wrap a log line and append to the ring buffer, trimming to the limit.
-     */
-    protected function addLogLines(string $line): void
-    {
-        $width = $this->terminal()->cols() - 10;
-        $plainText = $this->stripEscapeSequences($line);
-
-        if (mb_strwidth($plainText) > $width) {
-            $wrapped = $this->ansiWordwrap($line, $width);
-        } else {
-            $wrapped = [$line];
+            return;
         }
 
-        array_push($this->logs, ...$wrapped);
+        if ($type === 'partial') {
+            $this->consumePartialOutput($payload);
 
-        while (count($this->logs) > $this->limit) {
-            array_shift($this->logs);
-        }
-    }
-
-    /**
-     * Replace the in-progress partial lines with the full accumulated text.
-     */
-    protected function replacePartialLines(string $text): void
-    {
-        if ($this->partialStartIndex === null) {
-            $this->partialStartIndex = count($this->logs);
+            return;
         }
 
-        // Truncate back to where the partial started.
-        $this->logs = array_slice($this->logs, 0, $this->partialStartIndex);
+        if ($type === 'commitpartial') {
+            $this->commitPartialOutput();
 
-        // Wrap and append the full accumulated partial text.
-        $width = $this->terminal()->cols() - 10;
-        $plainText = $this->stripEscapeSequences($text);
-
-        if (mb_strwidth($plainText) > $width) {
-            $wrapped = $this->ansiWordwrap($text, $width);
-        } else {
-            $wrapped = [$text];
+            return;
         }
 
-        array_push($this->logs, ...$wrapped);
+        if ($type === 'label') {
+            $this->label = $payload;
 
-        while (count($this->logs) > $this->limit) {
-            array_shift($this->logs);
-            $this->partialStartIndex = max(0, $this->partialStartIndex - 1);
+            return;
         }
-    }
 
-    /**
-     * Append a log line to the scrolling output area.
-     */
-    public function appendLogLine(string $line): void
-    {
-        // Strip cursor-reset control sequences.
-        $line = preg_replace('/\e\[(?:1)?G\e\[2K/', '', $line);
+        if ($type === 'sublabel') {
+            $this->subLabel = $payload;
+            $this->recalculateMaxStableMessages();
+            $this->trimStableMessages();
 
-        $this->addLogLines($line);
-    }
+            return;
+        }
 
-    /**
-     * Add a stable status message (success, warning, error).
-     */
-    public function addStableMessage(string $type, string $message): void
-    {
-        $this->stableMessages[] = ['type' => $type, 'message' => $message];
+        if (! in_array($type, ['success', 'warning', 'error'], true)) {
+            throw new InvalidArgumentException("Unknown task message type [{$type}].");
+        }
+
+        $this->stableMessages[] = ['type' => $type, 'message' => $payload];
         $this->logs = [];
-        $this->partialStartIndex = null;
+        $this->resetTaskOutputTracking();
 
         $this->trimStableMessages();
-    }
-
-    /**
-     * Update the task label.
-     */
-    public function updateLabel(string $label): void
-    {
-        $this->label = $label;
-    }
-
-    /**
-     * Update the task sub-label.
-     */
-    public function updateSubLabel(string $subLabel): void
-    {
-        $this->subLabel = $subLabel;
-        $this->recalculateMaxStableMessages();
-        $this->trimStableMessages();
-    }
-
-    /**
-     * Replace the in-progress partial text with the full accumulated text.
-     */
-    public function replacePartialText(string $text): void
-    {
-        $this->replacePartialLines($text);
-    }
-
-    /**
-     * Commit the current partial text so it becomes permanent.
-     */
-    public function commitPartialText(): void
-    {
-        $this->partialStartIndex = null;
     }
 
     /**
@@ -390,8 +291,8 @@ class Task extends Prompt
         $this->finished = false;
         $this->logs = [];
         $this->stableMessages = [];
-        $this->buffer = '';
-        $this->partialStartIndex = null;
+        $this->frameDecoder->reset();
+        $this->resetTaskOutputTracking();
         $this->state = 'initial';
         $this->prevFrame = '';
     }
@@ -537,10 +438,9 @@ class Task extends Prompt
 
         if ($rendererFailure === null) {
             try {
-                // A truncated newline-framed message makes a later reset unrecoverable.
                 Utils::writeAll(
                     $this->socket,
-                    $this->identifier . '_reset:' . ($success ? '1' : '0') . PHP_EOL,
+                    TaskFrame::encode('reset', $success ? "\x01" : "\x00"),
                     static::LOGGER_WRITE_TIMEOUT_SECONDS,
                 );
                 $settlementTimeout = $rendererInterval + static::RENDERER_SETTLEMENT_MARGIN_MILLISECONDS;
@@ -580,6 +480,9 @@ class Task extends Prompt
     /**
      * Create the process renderer socket pair.
      *
+     * Subclasses and tests override this seam to exercise socket setup failures
+     * without replacing the process-rendering lifecycle.
+     *
      * @return array{resource, resource}|false
      */
     protected function createSocketPair(): array|false
@@ -589,6 +492,9 @@ class Task extends Prompt
 
     /**
      * Fork the process renderer.
+     *
+     * Subclasses and tests override this seam to exercise fork and reaping
+     * failures without injecting a process abstraction.
      */
     protected function forkProcess(): int
     {
@@ -620,7 +526,7 @@ class Task extends Prompt
                 }
 
                 if (feof($socket)) {
-                    $this->buffer = '';
+                    $this->frameDecoder->finish();
                     $this->resetTerminal($this->originalAsync ?? false, false);
 
                     break;
@@ -840,8 +746,7 @@ class Task extends Prompt
      */
     protected function renderInCoroutine(Closure $callback): mixed
     {
-        /** @var bool $animationFinished */
-        $animationFinished = false;
+        $animation = null;
         $result = null;
         $operationFailure = null;
         $success = false;
@@ -850,13 +755,14 @@ class Task extends Prompt
             $this->hideCursor();
             $this->render();
 
-            Coroutine::fork(function () use (&$animationFinished): void {
-                while (! $animationFinished) {
-                    $this->render();
+            $animation = new PromptAnimation(
+                render: function (): void {
                     ++$this->count;
-                    usleep($this->interval * 1000);
-                }
-            });
+                    $this->render();
+                },
+                interval: $this->interval,
+            );
+            $animation->start();
 
             $logger = new InProcessLogger($this);
 
@@ -864,14 +770,24 @@ class Task extends Prompt
             $success = true;
         } catch (Throwable $exception) {
             $operationFailure = $exception;
-        } finally {
-            $animationFinished = true;
+        }
+
+        $animationFailure = null;
+
+        try {
+            $animationFailure = $animation?->stop();
+        } catch (Throwable $exception) {
+            $animationFailure = $exception;
         }
 
         $cleanupFailure = $this->settleOperation(renderFinalFrame: true, success: $success);
 
         if ($operationFailure !== null) {
             throw $operationFailure;
+        }
+
+        if ($animationFailure !== null) {
+            throw $animationFailure;
         }
 
         if ($cleanupFailure !== null) {

--- a/src/prompts/src/Themes/Default/AutoCompletePromptRenderer.php
+++ b/src/prompts/src/Themes/Default/AutoCompletePromptRenderer.php
@@ -16,18 +16,19 @@ class AutoCompletePromptRenderer extends Renderer
     public function __invoke(AutoCompletePrompt $prompt): string
     {
         $maxWidth = $prompt->terminal()->cols() - 6;
+        $value = $prompt->value();
 
         return match ($prompt->state) {
             'submit' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->truncate($prompt->value(), $maxWidth),
+                    $this->truncate($value, $maxWidth),
                 ),
 
             'cancel' => (string) $this
                 ->box(
                     $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
-                    $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
+                    $this->strikethrough($this->dim($this->truncate($value === '' ? $prompt->placeholder : $value, $maxWidth))),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),

--- a/src/prompts/src/Themes/Default/CalloutRenderer.php
+++ b/src/prompts/src/Themes/Default/CalloutRenderer.php
@@ -22,6 +22,7 @@ class CalloutRenderer extends Renderer
      */
     public function __invoke(Callout $prompt): string
     {
+        $this->minWidth = max(1, min($this->minWidth, $prompt->terminal()->cols() - 6));
         $content = is_array($prompt->content) ? $prompt->content : [$prompt->content];
 
         $sections = [];

--- a/src/prompts/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/prompts/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -24,7 +24,7 @@ trait DrawsBoxes
         string $color = 'gray',
         string $info = '',
     ): self {
-        $this->minWidth = min($this->minWidth, Prompt::terminal()->cols() - 6);
+        $this->minWidth = max(1, min($this->minWidth, Prompt::terminal()->cols() - 6));
 
         $bodyLines = explode(PHP_EOL, $body);
         $footerLines = array_filter(explode(PHP_EOL, $footer));

--- a/src/prompts/src/Themes/Default/Concerns/DrawsScrollbars.php
+++ b/src/prompts/src/Themes/Default/Concerns/DrawsScrollbars.php
@@ -8,6 +8,8 @@ use Hypervel\Support\Collection;
 
 trait DrawsScrollbars
 {
+    use InteractsWithStrings;
+
     /**
      * Render a scrollbar beside the visible items.
      *
@@ -27,8 +29,8 @@ trait DrawsScrollbars
         $lines = $visible instanceof Collection ? $visible->all() : $visible;
 
         $result = array_map(fn ($line, $index) => match ($index) {
-            $scrollPosition => preg_replace('/.$/', $this->{$color}('┃'), $this->pad($line, $width)) ?? '',
-            default => preg_replace('/.$/', $this->gray('│'), $this->pad($line, $width)) ?? '',
+            $scrollPosition => $this->replaceLastVisibleGrapheme($this->pad($line, $width), $this->{$color}('┃')),
+            default => $this->replaceLastVisibleGrapheme($this->pad($line, $width), $this->gray('│')),
         }, array_values($lines), range(0, count($lines) - 1));
 
         return $visible instanceof Collection ? new Collection($result) : $result; // @phpstan-ignore return.type (https://github.com/phpstan/phpstan/issues/11663)

--- a/src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -44,14 +44,16 @@ trait InteractsWithStrings
             return $line;
         }
 
-        $pattern = '/(\X)((?:(?:\e\[[\x30-\x3F]*[\x20-\x2F]*[\x40-\x7E])|(?:\e\][^\x07\e]*(?:\x07|\e\\\))|(?:<\/(?:info|comment|question|error)>)|(?:<\/>))*)$/u';
+        // Scrollbar input is raw application text, not output from the ANSI parser.
+        $line = Utils::sanitizeTerminalFormatting($line);
+        $pattern = '/(?<grapheme>\X)(?<suffix>(?:' . Utils::TERMINAL_FORMATTING_PATTERN . '|<\/(?:info|comment|question|error)>|<\/>)*)$/u';
 
         if (preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE) !== 1) {
             return $line;
         }
 
-        [$grapheme, $offset] = $matches[1];
-        $suffix = $matches[2][0];
+        [$grapheme, $offset] = $matches['grapheme'];
+        $suffix = $matches['suffix'][0];
         $padding = str_repeat(' ', max(
             0,
             mb_strwidth($grapheme) - mb_strwidth($this->stripEscapeSequences($replacement)),
@@ -80,11 +82,13 @@ trait InteractsWithStrings
         string $break = "\n",
         bool $cut_long_words = false
     ): string {
+        $width = max(1, $width);
         $lines = explode($break, $string);
         $result = [];
 
         foreach ($lines as $originalLine) {
-            if (mb_strwidth($originalLine) <= $width) {
+            if (mb_strwidth($originalLine) <= $width
+                && strlen($originalLine) <= Utils::MAX_UNBREAKABLE_BYTES) {
                 $result[] = $originalLine;
 
                 continue;
@@ -96,15 +100,21 @@ trait InteractsWithStrings
 
             if ($cut_long_words) {
                 foreach ($words as $index => $word) {
-                    $characters = mb_str_split($word);
+                    if (mb_strwidth($word) <= $width
+                        && strlen($word) <= Utils::MAX_UNBREAKABLE_BYTES) {
+                        continue;
+                    }
+
                     $strings = [];
                     $str = '';
 
-                    foreach ($characters as $character) {
+                    foreach (Utils::graphemes($word) as $character) {
                         $tmp = $str . $character;
 
-                        if (mb_strwidth($tmp) > $width) {
+                        if ($str !== '' && (mb_strwidth($tmp) > $width
+                            || strlen($tmp) > Utils::MAX_UNBREAKABLE_BYTES)) {
                             $strings[] = $str;
+
                             $str = $character;
                         } else {
                             $str = $tmp;
@@ -123,11 +133,7 @@ trait InteractsWithStrings
 
             foreach ($words as $word) {
                 $tmp = ($line === null) ? $word : $line . ' ' . $word;
-
-                // Look for zero-width joiner characters (combined emojis)
-                preg_match('/\p{Cf}/u', $word, $joinerMatches);
-
-                $wordWidth = count($joinerMatches) > 0 ? 2 : mb_strwidth($word);
+                $wordWidth = mb_strwidth($word);
 
                 $lineWidth += $wordWidth;
 
@@ -136,10 +142,13 @@ trait InteractsWithStrings
                     ++$lineWidth;
                 }
 
-                if ($lineWidth <= $width) {
+                if ($line === null || $lineWidth <= $width) {
                     $line = $tmp;
                 } else {
-                    $result[] = $line;
+                    if ($line !== '') {
+                        $result[] = $line;
+                    }
+
                     $line = $word;
                     $lineWidth = $wordWidth;
                 }
@@ -190,10 +199,10 @@ trait InteractsWithStrings
             $lineChars = mb_str_split($plainLine);
 
             foreach ($lineChars as $lineChar) {
-                // Find matching character in original (handling spaces removed by wordwrap)
+                // Find the matching source character after wrapping removes separators.
                 while ($charIndex < count($chars) && $chars[$charIndex]['char'] !== $lineChar) {
-                    // Skip spaces that wordwrap removed
-                    if ($chars[$charIndex]['char'] === ' ') {
+                    // mbWordwrap never emits a source newline inside a returned line.
+                    if ($chars[$charIndex]['char'] === ' ' || $chars[$charIndex]['char'] === "\n") {
                         ++$charIndex;
                     } else {
                         break;
@@ -257,6 +266,7 @@ trait InteractsWithStrings
      */
     protected function parseAnsiText(string $text): array
     {
+        $text = Utils::sanitizeTerminalFormatting($text);
         $segments = [];
         $activeSgr = [];
         $currentLink = '';
@@ -339,7 +349,7 @@ trait InteractsWithStrings
                         continue;
                     }
 
-                    $link = $this->resolveOsc8Link($escapeSequence);
+                    $link = Utils::resolveOsc8Link($escapeSequence);
 
                     if ($link !== null) {
                         $currentLink = $link;
@@ -372,7 +382,9 @@ trait InteractsWithStrings
         $codes = $parameters === '' ? ['0'] : explode(';', $parameters);
 
         for ($index = 0; $index < count($codes); ++$index) {
-            $code = $codes[$index] === '' ? 0 : (int) $codes[$index];
+            $rawCode = $codes[$index] === '' ? '0' : $codes[$index];
+            $colon = str_contains($rawCode, ':');
+            $code = (int) ($colon ? strstr($rawCode, ':', before_needle: true) : $rawCode);
 
             if ($code === 0) {
                 $activeSgr = [];
@@ -380,7 +392,7 @@ trait InteractsWithStrings
                 continue;
             }
 
-            if ($code === 38 || $code === 48 || $code === 58) {
+            if (! $colon && ($code === 38 || $code === 48 || $code === 58)) {
                 $count = ($codes[$index + 1] ?? null) === '2' ? 5 : 3;
                 $value = implode(';', array_slice($codes, $index, $count));
                 $attribute = match ($code) {
@@ -403,40 +415,20 @@ trait InteractsWithStrings
                 $code === 8 || $code === 28 => 'conceal',
                 $code === 9 || $code === 29 => 'strike',
                 $code >= 10 && $code <= 19 => 'font',
-                ($code >= 30 && $code <= 37) || ($code >= 90 && $code <= 97) || $code === 39 => 'foreground',
-                ($code >= 40 && $code <= 47) || ($code >= 100 && $code <= 107) || $code === 49 => 'background',
+                ($code >= 30 && $code <= 38) || ($code >= 90 && $code <= 97) || $code === 39 => 'foreground',
+                ($code >= 40 && $code <= 48) || ($code >= 100 && $code <= 107) || $code === 49 => 'background',
                 $code === 51 || $code === 52 || $code === 54 => 'frame',
                 $code === 53 || $code === 55 => 'overline',
-                $code === 59 => 'underlineColor',
+                $code === 58 || $code === 59 => 'underlineColor',
                 default => 'other',
             };
 
             if (in_array($code, [22, 23, 24, 25, 27, 28, 29, 39, 49, 54, 55, 59], true)) {
                 unset($activeSgr[$attribute]);
             } else {
-                $activeSgr[$attribute] = "\e[{$code}m";
+                $value = $colon ? $rawCode : (string) $code;
+                $activeSgr[$attribute] = "\e[{$value}m";
             }
         }
-    }
-
-    /**
-     * Resolve a complete OSC 8 sequence to its active hyperlink state.
-     */
-    protected function resolveOsc8Link(string $escape): ?string
-    {
-        if (! str_starts_with($escape, "\e]8;")) {
-            return null;
-        }
-
-        $body = str_ends_with($escape, "\x07")
-            ? substr($escape, 4, -1)
-            : substr($escape, 4, -2);
-        $separator = strpos($body, ';');
-
-        if ($separator === false) {
-            return null;
-        }
-
-        return substr($body, $separator + 1) === '' ? '' : $escape;
     }
 }

--- a/src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/prompts/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -32,6 +32,35 @@ trait InteractsWithStrings
     }
 
     /**
+     * Replace the last visible grapheme while preserving trailing formatting.
+     */
+    protected function replaceLastVisibleGrapheme(string $line, string $replacement): string
+    {
+        if ($line === '' || ! mb_check_encoding($line, 'UTF-8')) {
+            return $line;
+        }
+
+        if (mb_strwidth($this->stripEscapeSequences($line)) === 0) {
+            return $line;
+        }
+
+        $pattern = '/(\X)((?:(?:\e\[[\x30-\x3F]*[\x20-\x2F]*[\x40-\x7E])|(?:\e\][^\x07\e]*(?:\x07|\e\\\))|(?:<\/(?:info|comment|question|error)>)|(?:<\/>))*)$/u';
+
+        if (preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE) !== 1) {
+            return $line;
+        }
+
+        [$grapheme, $offset] = $matches[1];
+        $suffix = $matches[2][0];
+        $padding = str_repeat(' ', max(
+            0,
+            mb_strwidth($grapheme) - mb_strwidth($this->stripEscapeSequences($replacement)),
+        ));
+
+        return substr($line, 0, $offset) . $padding . $replacement . $suffix;
+    }
+
+    /**
      * Strip ANSI escape sequences from the given text.
      */
     protected function stripEscapeSequences(string $text): string
@@ -131,7 +160,7 @@ trait InteractsWithStrings
      *
      * @return array<int, string>
      */
-    protected function ansiWordwrap(string $text, int $width): array
+    protected function ansiWordwrap(string $text, int $width, bool $cutLongWords = false): array
     {
         // Parse segments and build character array with codes
         $segments = $this->parseAnsiText($text);
@@ -147,7 +176,7 @@ trait InteractsWithStrings
         }
 
         // Word wrap the plain text
-        $wrappedLines = $this->mbWordwrap($plainText, $width, "\n", false);
+        $wrappedLines = $this->mbWordwrap($plainText, $width, "\n", $cutLongWords);
         $plainLines = explode("\n", $wrappedLines);
 
         // Rebuild each wrapped line with ANSI codes
@@ -229,7 +258,7 @@ trait InteractsWithStrings
     protected function parseAnsiText(string $text): array
     {
         $segments = [];
-        $currentCodes = '';
+        $activeSgr = [];
         $currentLink = '';
         $currentText = '';
         $i = 0;
@@ -240,7 +269,7 @@ trait InteractsWithStrings
                 if ($text[$i + 1] === '[') {
                     // Save current segment if it has text
                     if ($currentText !== '') {
-                        $segments[] = ['text' => $currentText, 'codes' => $currentCodes, 'link' => $currentLink];
+                        $segments[] = ['text' => $currentText, 'codes' => implode('', $activeSgr), 'link' => $currentLink];
                         $currentText = '';
                     }
 
@@ -263,7 +292,7 @@ trait InteractsWithStrings
                         ++$i;
 
                         if ($final === 'm') {
-                            $currentCodes = $escapeSequence === "\e[0m" ? '' : $escapeSequence;
+                            $this->updateSgrState($activeSgr, $escapeSequence);
                         }
 
                         continue;
@@ -277,7 +306,7 @@ trait InteractsWithStrings
                 if ($text[$i + 1] === ']') {
                     // Save current segment if it has text
                     if ($currentText !== '') {
-                        $segments[] = ['text' => $currentText, 'codes' => $currentCodes, 'link' => $currentLink];
+                        $segments[] = ['text' => $currentText, 'codes' => implode('', $activeSgr), 'link' => $currentLink];
                         $currentText = '';
                     }
 
@@ -310,16 +339,10 @@ trait InteractsWithStrings
                         continue;
                     }
 
-                    if (str_starts_with($escapeSequence, "\e]8;")) {
-                        // OSC 8 is "\e]8;<params>;<uri>"; an empty URI closes the hyperlink.
-                        $body = str_ends_with($escapeSequence, "\x07")
-                            ? substr($escapeSequence, 4, -1)
-                            : substr($escapeSequence, 4, -2);
-                        $separator = strpos($body, ';');
+                    $link = $this->resolveOsc8Link($escapeSequence);
 
-                        $currentLink = $separator === false || substr($body, $separator + 1) === ''
-                            ? ''
-                            : $escapeSequence;
+                    if ($link !== null) {
+                        $currentLink = $link;
                     }
 
                     continue;
@@ -332,9 +355,88 @@ trait InteractsWithStrings
 
         // Add final segment
         if ($currentText !== '') {
-            $segments[] = ['text' => $currentText, 'codes' => $currentCodes, 'link' => $currentLink];
+            $segments[] = ['text' => $currentText, 'codes' => implode('', $activeSgr), 'link' => $currentLink];
         }
 
         return $segments;
+    }
+
+    /**
+     * Update the bounded set of active SGR attributes.
+     *
+     * @param array<string, string> $activeSgr
+     */
+    protected function updateSgrState(array &$activeSgr, string $escape): void
+    {
+        $parameters = substr($escape, 2, -1);
+        $codes = $parameters === '' ? ['0'] : explode(';', $parameters);
+
+        for ($index = 0; $index < count($codes); ++$index) {
+            $code = $codes[$index] === '' ? 0 : (int) $codes[$index];
+
+            if ($code === 0) {
+                $activeSgr = [];
+
+                continue;
+            }
+
+            if ($code === 38 || $code === 48 || $code === 58) {
+                $count = ($codes[$index + 1] ?? null) === '2' ? 5 : 3;
+                $value = implode(';', array_slice($codes, $index, $count));
+                $attribute = match ($code) {
+                    38 => 'foreground',
+                    48 => 'background',
+                    58 => 'underlineColor',
+                };
+                $activeSgr[$attribute] = "\e[{$value}m";
+                $index += $count - 1;
+
+                continue;
+            }
+
+            $attribute = match (true) {
+                $code === 1 || $code === 2 || $code === 22 => 'intensity',
+                $code === 3 || $code === 23 => 'italic',
+                $code === 4 || $code === 21 || $code === 24 => 'underline',
+                $code === 5 || $code === 6 || $code === 25 => 'blink',
+                $code === 7 || $code === 27 => 'reverse',
+                $code === 8 || $code === 28 => 'conceal',
+                $code === 9 || $code === 29 => 'strike',
+                $code >= 10 && $code <= 19 => 'font',
+                ($code >= 30 && $code <= 37) || ($code >= 90 && $code <= 97) || $code === 39 => 'foreground',
+                ($code >= 40 && $code <= 47) || ($code >= 100 && $code <= 107) || $code === 49 => 'background',
+                $code === 51 || $code === 52 || $code === 54 => 'frame',
+                $code === 53 || $code === 55 => 'overline',
+                $code === 59 => 'underlineColor',
+                default => 'other',
+            };
+
+            if (in_array($code, [22, 23, 24, 25, 27, 28, 29, 39, 49, 54, 55, 59], true)) {
+                unset($activeSgr[$attribute]);
+            } else {
+                $activeSgr[$attribute] = "\e[{$code}m";
+            }
+        }
+    }
+
+    /**
+     * Resolve a complete OSC 8 sequence to its active hyperlink state.
+     */
+    protected function resolveOsc8Link(string $escape): ?string
+    {
+        if (! str_starts_with($escape, "\e]8;")) {
+            return null;
+        }
+
+        $body = str_ends_with($escape, "\x07")
+            ? substr($escape, 4, -1)
+            : substr($escape, 4, -2);
+        $separator = strpos($body, ';');
+
+        if ($separator === false) {
+            return null;
+        }
+
+        return substr($body, $separator + 1) === '' ? '' : $escape;
     }
 }

--- a/src/prompts/src/Themes/Default/DataTableRenderer.php
+++ b/src/prompts/src/Themes/Default/DataTableRenderer.php
@@ -34,7 +34,7 @@ class DataTableRenderer extends Renderer implements Scrolling
     protected function renderSubmit(DataTablePrompt $prompt, int $maxWidth): string
     {
         $row = $prompt->selectedRow();
-        $display = $row ? $this->truncate(implode(', ', $row), $maxWidth) : '';
+        $display = $row ? $this->truncate(str_replace("\r\n", "\n", implode(', ', $row)), $maxWidth) : '';
 
         return (string) $this
             ->box(
@@ -83,9 +83,10 @@ class DataTableRenderer extends Renderer implements Scrolling
         // Header cells (strikethrough + dim)
         if (! empty($prompt->headers)) {
             $headerCells = [];
+            $headers = array_values($prompt->headers);
 
             foreach ($widths as $i => $w) {
-                $header = $prompt->headers[$i] ?? '';
+                $header = $headers[$i] ?? '';
                 $text = is_array($header) ? implode(' ', $header) : $header;
                 $headerCells[] = $this->dim(' ' . $this->pad($this->strikethrough($this->truncate($text, $w)), $w) . ' ');
             }
@@ -152,9 +153,10 @@ class DataTableRenderer extends Renderer implements Scrolling
             // Header cells: │ Header │ Header   │
             if (! empty($prompt->headers)) {
                 $headerCells = [];
+                $headers = array_values($prompt->headers);
 
                 foreach ($widths as $i => $w) {
-                    $header = $prompt->headers[$i] ?? '';
+                    $header = $headers[$i] ?? '';
                     $text = is_array($header) ? implode(' ', $header) : $header;
                     $headerCells[] = $this->dim(' ' . $this->pad($this->truncate($text, $w), $w) . ' ');
                 }
@@ -241,20 +243,14 @@ class DataTableRenderer extends Renderer implements Scrolling
      */
     protected function resolveColumnWidths(DataTablePrompt $prompt, int $maxWidth): array
     {
-        $numCols = count($prompt->headers);
+        $metrics = $prompt->naturalColumnMetrics();
 
-        if ($numCols === 0) {
-            foreach ($prompt->rows as $row) {
-                $numCols = max($numCols, count($row));
-            }
-        }
-
-        if ($numCols === 0) {
+        if ($metrics['columns'] === 0) {
             // Keep an empty table wide enough for its search affordance.
             return [max(6, $maxWidth - 8)];
         }
 
-        return $this->computeColumnWidths($prompt->headers, $prompt->rows, $numCols, $maxWidth);
+        return $this->fitColumnWidths($metrics['widths'], $maxWidth);
     }
 
     /**
@@ -285,14 +281,15 @@ class DataTableRenderer extends Renderer implements Scrolling
 
         foreach ($visible as $key => $row) {
             $isHighlighted = ! $isSearching && ! $strikethrough && $key === $highlightedKey;
+            $rowValues = array_values($row);
 
             // Split each cell by newlines
             $cellLines = [];
             $maxSubRows = 1;
 
             foreach ($widths as $i => $w) {
-                $text = $row[$i] ?? '';
-                $subLines = explode(PHP_EOL, $text);
+                $text = $rowValues[$i] ?? '';
+                $subLines = preg_split('/\r\n|\n/', $text);
                 $cellLines[$i] = $subLines;
                 $maxSubRows = max($maxSubRows, count($subLines));
             }
@@ -385,107 +382,58 @@ class DataTableRenderer extends Renderer implements Scrolling
             }
 
             $dataLines = array_map(fn ($line, $index) => match ($index) {
-                $visualPos => preg_replace('/.$/', $this->cyan('┃'), $this->pad($line, $innerWidth)) ?? '',
-                default => preg_replace('/.$/', $this->gray('│'), $this->pad($line, $innerWidth)) ?? '',
+                $visualPos => $this->replaceLastVisibleGrapheme($this->pad($line, $innerWidth), $this->cyan('┃')),
+                default => $this->replaceLastVisibleGrapheme($this->pad($line, $innerWidth), $this->gray('│')),
             }, array_values($dataLines), range(0, $numVisual - 1));
         }
 
         return $dataLines;
     }
 
+    // REMOVED: Natural metrics and terminal fitting have different lifetimes. Override
+    // DataTablePrompt::naturalColumnMetrics() or fitColumnWidths() instead.
+
     /**
-     * Compute column widths that fit within maxWidth.
+     * Fit natural column widths within the live terminal width.
      *
-     * Columns get their natural (P85) width. Only shrink proportionally
-     * if the total exceeds available terminal space.
-     *
-     * @param array<int, array<int, string>|string> $headers
-     * @param array<int|string, array<int, string>> $allRows
-     * @return array<int, int>
+     * @param list<int> $naturalWidths
+     * @return list<int>
      */
-    protected function computeColumnWidths(array $headers, array $allRows, int $numCols, int $maxWidth): array
+    protected function fitColumnWidths(array $naturalWidths, int $maxWidth): array
     {
-        // Header widths serve as the floor for each column
-        $headerWidths = array_fill(0, $numCols, 0);
+        $columns = count($naturalWidths);
+        $naturalWidths = array_map(fn ($width) => max(1, $width), $naturalWidths);
 
-        foreach ($headers as $i => $header) {
-            $headerText = is_array($header) ? implode(' ', $header) : $header;
-            $headerWidths[$i] = mb_strwidth($headerText);
-        }
-
-        // Collect all cell widths per column (excluding blank cells)
-        $columnWidths = array_fill(0, $numCols, []);
-
-        foreach ($allRows as $row) {
-            foreach ($row as $i => $cell) {
-                $cellMax = 0;
-                foreach (explode(PHP_EOL, $cell) as $line) {
-                    $cellMax = max($cellMax, mb_strwidth($line));
-                }
-                if ($cellMax > 0) {
-                    $columnWidths[$i][] = $cellMax;
-                }
-            }
-        }
-
-        // Per-column width strategy:
-        // - Uniform columns (max <= P90 * 2): use max — all values are reasonable
-        // - Outlier columns (max > P90 * 2): use P90 — ignore extreme values
-        $natural = array_fill(0, $numCols, 0);
-
-        foreach ($columnWidths as $i => $widths) {
-            if (empty($widths)) {
-                $natural[$i] = $headerWidths[$i];
-
-                continue;
-            }
-
-            sort($widths);
-            $p90Index = (int) ceil(count($widths) * 0.90) - 1;
-            $p90 = $widths[max(0, $p90Index)];
-            $colMax = end($widths);
-
-            $natural[$i] = max($headerWidths[$i], $colMax <= $p90 * 2 ? $colMax : $p90);
-        }
-
-        // Available width for cell content:
-        // Each column has 1 space padding on each side = 2 per column
-        // Columns separated by │ = numCols - 1 separators
-        // Scrollbar area = 2 chars on the right
-        // Outer frame = 4 chars (` │` left + ` │` right)
-        $overhead = ($numCols * 2) + ($numCols - 1) + 2 + 4;
+        // Cell padding, separators, scrollbar area, and the outer frame.
+        $overhead = ($columns * 2) + ($columns - 1) + 2 + 4;
         $available = $maxWidth - $overhead;
 
-        if ($available <= 0) {
-            return array_fill(0, $numCols, 1);
+        if ($available < $columns) {
+            return array_fill(0, $columns, 1);
         }
 
-        $totalNatural = array_sum($natural);
-
-        // If natural widths fit, use them directly (comfortable width)
-        if ($totalNatural <= $available) {
-            return $natural;
+        if (array_sum($naturalWidths) <= $available) {
+            return $naturalWidths;
         }
 
-        // Otherwise, shrink proportionally
-        $widths = array_fill(0, $numCols, 0);
+        $remaining = $available - $columns;
+        $weights = array_map(fn ($width) => $width - 1, $naturalWidths);
+        $totalWeight = array_sum($weights);
+        $widths = [];
 
-        foreach ($natural as $i => $w) {
-            $widths[$i] = max($headerWidths[$i], (int) floor($available * $w / $totalNatural));
+        foreach ($weights as $weight) {
+            $widths[] = 1 + (int) floor($remaining * $weight / $totalWeight);
         }
 
-        // Distribute any remaining pixels from rounding
         $remainder = $available - array_sum($widths);
 
-        if ($remainder > 0) {
-            $order = range(0, $numCols - 1);
-            usort($order, fn ($a, $b) => $natural[$b] <=> $natural[$a]);
+        foreach ($widths as $index => $width) {
+            if ($remainder === 0) {
+                break;
+            }
 
-            foreach ($order as $i) {
-                if ($remainder <= 0) {
-                    break;
-                }
-                ++$widths[$i];
+            if ($width < $naturalWidths[$index]) {
+                ++$widths[$index];
                 --$remainder;
             }
         }

--- a/src/prompts/src/Themes/Default/GridRenderer.php
+++ b/src/prompts/src/Themes/Default/GridRenderer.php
@@ -25,12 +25,17 @@ class GridRenderer extends Renderer
             return (string) $this;
         }
 
-        $maxWidth = $grid->maxWidth - 2;
-        $cellWidth = max(array_map(fn ($item) => mb_strwidth($this->stripEscapeSequences($item)), $grid->items)) + 4;
-        $maxColumns = max(1, (int) floor(($maxWidth - 1) / ($cellWidth + 1)));
-        $columnCount = max(1, $this->balancedColumnCount(count($grid->items), $maxColumns));
+        $items = array_map(
+            fn ($item) => $this->truncate($item, max(1, $grid->maxWidth - 5)),
+            $grid->items,
+        );
 
-        $rows = $this->buildRowsWithSeparators($grid->items, $columnCount);
+        $maxWidth = $grid->maxWidth - 2;
+        $cellWidth = max(array_map(fn ($item) => mb_strwidth($this->stripEscapeSequences($item)), $items)) + 4;
+        $maxColumns = max(1, (int) floor(($maxWidth - 1) / ($cellWidth + 1)));
+        $columnCount = max(1, $this->balancedColumnCount(count($items), $maxColumns));
+
+        $rows = $this->buildRowsWithSeparators($items, $columnCount);
 
         $tableStyle = (new TableStyle)
             ->setHorizontalBorderChars('─')

--- a/src/prompts/src/Themes/Default/GridRenderer.php
+++ b/src/prompts/src/Themes/Default/GridRenderer.php
@@ -26,12 +26,12 @@ class GridRenderer extends Renderer
         }
 
         $items = array_map(
-            fn ($item) => $this->truncate($item, max(1, $grid->maxWidth - 5)),
+            fn (string $item): string => $this->truncate($item, max(1, $grid->maxWidth - 5)),
             $grid->items,
         );
 
         $maxWidth = $grid->maxWidth - 2;
-        $cellWidth = max(array_map(fn ($item) => mb_strwidth($this->stripEscapeSequences($item)), $items)) + 4;
+        $cellWidth = max(array_map(fn (string $item): int => mb_strwidth($this->stripEscapeSequences($item)), $items)) + 4;
         $maxColumns = max(1, (int) floor(($maxWidth - 1) / ($cellWidth + 1)));
         $columnCount = max(1, $this->balancedColumnCount(count($items), $maxColumns));
 

--- a/src/prompts/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -18,6 +18,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
     public function __invoke(MultiSearchPrompt $prompt): string
     {
         $maxWidth = $prompt->terminal()->cols() - 6;
+        $searchValue = $prompt->searchValue();
 
         return match ($prompt->state) {
             'submit' => (string) $this
@@ -29,7 +30,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
             'cancel' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->strikethrough($this->dim($this->truncate($prompt->searchValue() ?: $prompt->placeholder, $maxWidth))),
+                    $this->strikethrough($this->dim($this->truncate($searchValue === '' ? $prompt->placeholder : $searchValue, $maxWidth))),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),

--- a/src/prompts/src/Themes/Default/NumberPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/NumberPromptRenderer.php
@@ -20,18 +20,19 @@ class NumberPromptRenderer extends Renderer
     public function __invoke(NumberPrompt $prompt): string
     {
         $maxWidth = $prompt->terminal()->cols() - 6;
+        $value = (string) $prompt->value();
 
         return match ($prompt->state) {
             'submit' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->truncate((string) $prompt->value(), $maxWidth),
+                    $this->truncate($value, $maxWidth),
                 ),
 
             'cancel' => (string) $this
                 ->box(
                     $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
-                    $this->strikethrough($this->dim($this->truncate((string) $prompt->value() ?: $prompt->placeholder, $maxWidth))),
+                    $this->strikethrough($this->dim($this->truncate($value === '' ? $prompt->placeholder : $value, $maxWidth))),
                     color: 'red',
                 )
                 ->error('Cancelled.'),
@@ -64,7 +65,8 @@ class NumberPromptRenderer extends Renderer
     {
         $arrows = $this->getArrows($prompt, $color);
         $valueLength = mb_strwidth($this->stripEscapeSequences((string) $value));
-        $padding = $this->minWidth - $valueLength - mb_strwidth($this->stripEscapeSequences($arrows));
+        $minimumWidth = min($this->minWidth, $prompt->terminal()->cols() - 6);
+        $padding = max(0, $minimumWidth - $valueLength - mb_strwidth($this->stripEscapeSequences($arrows)));
 
         return $value . str_repeat(' ', $padding) . $arrows;
     }
@@ -76,25 +78,26 @@ class NumberPromptRenderer extends Renderer
     {
         $upArrow = $this->upArrow;
         $downArrow = $this->downArrow;
+        $value = $prompt->value();
 
         if ($color) {
             $upArrow = $this->{$color}($upArrow);
             $downArrow = $this->{$color}($downArrow);
         }
 
-        if (is_numeric($prompt->value())) {
-            if ((int) $prompt->value() === $prompt->min) {
+        if (is_int($value)) {
+            if ($value === $prompt->min) {
                 $downArrow = $this->dim($downArrow);
             }
 
-            if ((int) $prompt->value() === $prompt->max) {
+            if ($value === $prompt->max) {
                 $upArrow = $this->dim($upArrow);
             }
 
             return $upArrow . $downArrow;
         }
 
-        if ($prompt->value() === '') {
+        if ($value === '') {
             return $upArrow . $downArrow;
         }
 

--- a/src/prompts/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/SearchPromptRenderer.php
@@ -18,6 +18,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
     public function __invoke(SearchPrompt $prompt): string
     {
         $maxWidth = $prompt->terminal()->cols() - 6;
+        $searchValue = $prompt->searchValue();
 
         return match ($prompt->state) {
             'submit' => (string) $this
@@ -29,7 +30,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
             'cancel' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->strikethrough($this->dim($this->truncate($prompt->searchValue() ?: $prompt->placeholder, $maxWidth))),
+                    $this->strikethrough($this->dim($this->truncate($searchValue === '' ? $prompt->placeholder : $searchValue, $maxWidth))),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),

--- a/src/prompts/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/SuggestPromptRenderer.php
@@ -18,18 +18,19 @@ class SuggestPromptRenderer extends Renderer implements Scrolling
     public function __invoke(SuggestPrompt $prompt): string
     {
         $maxWidth = $prompt->terminal()->cols() - 6;
+        $value = $prompt->value();
 
         return match ($prompt->state) {
             'submit' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->truncate($prompt->value(), $maxWidth),
+                    $this->truncate($value, $maxWidth),
                 ),
 
             'cancel' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
+                    $this->strikethrough($this->dim($this->truncate($value === '' ? $prompt->placeholder : $value, $maxWidth))),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),

--- a/src/prompts/src/Themes/Default/TextPromptRenderer.php
+++ b/src/prompts/src/Themes/Default/TextPromptRenderer.php
@@ -16,18 +16,19 @@ class TextPromptRenderer extends Renderer
     public function __invoke(TextPrompt $prompt): string
     {
         $maxWidth = $prompt->terminal()->cols() - 6;
+        $value = $prompt->value();
 
         return match ($prompt->state) {
             'submit' => (string) $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->truncate($prompt->value(), $maxWidth),
+                    $this->truncate($value, $maxWidth),
                 ),
 
             'cancel' => (string) $this
                 ->box(
                     $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
-                    $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
+                    $this->strikethrough($this->dim($this->truncate($value === '' ? $prompt->placeholder : $value, $maxWidth))),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),

--- a/src/prompts/src/helpers.php
+++ b/src/prompts/src/helpers.php
@@ -34,7 +34,7 @@ if (! function_exists('\Hypervel\Prompts\number')) {
     /**
      * Prompt the user for number input.
      */
-    function number(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?int $min = null, ?int $max = null, ?int $step = null): int|string
+    function number(string $label, string $placeholder = '', int|string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?int $min = null, ?int $max = null, ?int $step = null, ?Closure $transform = null): int|string
     {
         return (new NumberPrompt(...get_defined_vars()))->prompt();
     }

--- a/tests/Console/ConfiguresPromptsTest.php
+++ b/tests/Console/ConfiguresPromptsTest.php
@@ -10,6 +10,7 @@ use Hypervel\Console\OutputStyle;
 use Hypervel\Console\View\Components\Factory;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Foundation\Application;
+use Hypervel\Prompts\PausePrompt;
 use Hypervel\Prompts\Prompt;
 use Hypervel\Prompts\TextPrompt;
 use Hypervel\Support\Facades\Artisan;
@@ -22,11 +23,17 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
 use function Hypervel\Prompts\autocomplete;
+use function Hypervel\Prompts\confirm;
 use function Hypervel\Prompts\datatable;
+use function Hypervel\Prompts\multisearch;
 use function Hypervel\Prompts\multiselect;
 use function Hypervel\Prompts\number;
+use function Hypervel\Prompts\password;
+use function Hypervel\Prompts\search;
 use function Hypervel\Prompts\select;
 use function Hypervel\Prompts\suggest;
+use function Hypervel\Prompts\text;
+use function Hypervel\Prompts\textarea;
 
 class ConfiguresPromptsTest extends TestCase
 {
@@ -157,6 +164,270 @@ class ConfiguresPromptsTest extends TestCase
 
         $this->assertSame(Command::FAILURE, $status);
         $this->assertNull($command->answer);
+    }
+
+    #[DataProvider('fallbackTransformDataProvider')]
+    public function testEveryFallbackTransformsItsAnswerExactlyOnce(
+        Closure $prompt,
+        Closure $expectations,
+        mixed $expected,
+    ): void {
+        Prompt::fallbackWhen(true);
+
+        $this->assertSame($expected, $this->runPrompt($prompt, $expectations));
+    }
+
+    public static function fallbackTransformDataProvider(): array
+    {
+        return [
+            'text' => [
+                fn () => text('Test', transform: fn (string $value): string => $value . '!'),
+                fn ($components) => $components->expects('ask')->with('Test', null)->andReturn('value'),
+                'value!',
+            ],
+            'textarea' => [
+                fn () => textarea('Test', transform: fn (string $value): string => $value . '!'),
+                fn ($components) => $components->expects('ask')->with('Test', null, multiline: true)->andReturn('value'),
+                'value!',
+            ],
+            'number' => [
+                fn () => number('Test', transform: fn (int $value): int => $value + 1),
+                fn ($components) => $components->expects('ask')->with('Test', null)->andReturn('1'),
+                2,
+            ],
+            'password' => [
+                fn () => password('Test', transform: fn (string $value): string => $value . '!'),
+                fn ($components) => $components->expects('secret')->with('Test')->andReturn('value'),
+                'value!',
+            ],
+            'pause' => [
+                function (): bool {
+                    $prompt = new PausePrompt('Test');
+                    $prompt->transform = fn (bool $value): bool => ! $value;
+
+                    return $prompt->prompt();
+                },
+                fn ($components) => $components->expects('ask')->with('Test')->andReturnNull(),
+                true,
+            ],
+            'confirm' => [
+                fn () => confirm('Test', transform: fn (bool $value): bool => ! $value),
+                fn ($components) => $components->expects('confirm')->with('Test', true)->andReturnTrue(),
+                false,
+            ],
+            'select' => [
+                fn () => select('Test', ['a'], transform: fn (string $value): string => $value . '!'),
+                fn ($components) => $components->expects('choice')->with('Test', ['a'], null)->andReturn('a'),
+                'a!',
+            ],
+            'multiselect' => [
+                fn () => multiselect('Test', ['a'], transform: fn (array $values): array => [...$values, 'b']),
+                fn ($components) => $components->expects('choice')->with('Test', ['None', 'a'], 'None', null, true)->andReturn(['a']),
+                ['a', 'b'],
+            ],
+            'datatable' => [
+                fn () => datatable(['Name'], [['Taylor']], label: 'Test', transform: fn (int $value): string => "row-{$value}"),
+                fn ($components) => $components->expects('choice')->with('Test', [1 => '1: Name: Taylor'])->andReturn('1'),
+                'row-0',
+            ],
+            'suggest' => [
+                fn () => suggest('Test', ['value'], transform: fn (string $value): string => $value . '!'),
+                fn ($components) => $components->expects('askWithCompletion')->with('Test', ['value'], null)->andReturn('value'),
+                'value!',
+            ],
+            'autocomplete' => [
+                fn () => autocomplete('Test', ['value'], transform: fn (string $value): string => $value . '!'),
+                fn ($components) => $components->expects('askWithCompletion')->with('Test', ['value'], null)->andReturn('value'),
+                'value!',
+            ],
+            'search' => [
+                fn () => search('Test', fn (): array => ['a'], transform: fn (string $value): string => $value . '!'),
+                function ($components): void {
+                    $components->expects('ask')->with('Test')->andReturn('query');
+                    $components->expects('choice')->with('Test', ['a'], null)->andReturn('a');
+                },
+                'a!',
+            ],
+            'multisearch' => [
+                fn () => multisearch('Test', fn (): array => ['a'], transform: fn (array $values): array => [...$values, 'b']),
+                function ($components): void {
+                    $components->expects('ask')->with('Test')->andReturn('query');
+                    $components->expects('choice')->with('Test', ['None', 'a'], 'None', null, true)->andReturn(['a']);
+                },
+                ['a', 'b'],
+            ],
+        ];
+    }
+
+    #[DataProvider('zeroDefaultDataProvider')]
+    public function testFallbackReadersPreserveZeroDefaults(Closure $prompt, Closure $expectations, mixed $expected): void
+    {
+        Prompt::fallbackWhen(true);
+
+        $this->assertSame($expected, $this->runPrompt($prompt, $expectations));
+    }
+
+    public static function zeroDefaultDataProvider(): array
+    {
+        return [
+            'text' => [
+                fn () => text('Test', default: '0'),
+                fn ($components) => $components->expects('ask')->with('Test', '0')->andReturn('answer'),
+                'answer',
+            ],
+            'textarea' => [
+                fn () => textarea('Test', default: '0'),
+                fn ($components) => $components->expects('ask')->with('Test', '0', multiline: true)->andReturn('answer'),
+                'answer',
+            ],
+            'number' => [
+                fn () => number('Test', default: 0),
+                fn ($components) => $components->expects('ask')->with('Test', 0)->andReturn('1'),
+                1,
+            ],
+            'suggest' => [
+                fn () => suggest('Test', ['answer'], default: '0'),
+                fn ($components) => $components->expects('askWithCompletion')->with('Test', ['answer'], '0')->andReturn('answer'),
+                'answer',
+            ],
+            'autocomplete' => [
+                fn () => autocomplete('Test', ['answer'], default: '0'),
+                fn ($components) => $components->expects('askWithCompletion')->with('Test', ['answer'], '0')->andReturn('answer'),
+                'answer',
+            ],
+        ];
+    }
+
+    public function testFrameworkRulesValidateTheTransformedFallbackAnswer(): void
+    {
+        Prompt::fallbackWhen(true);
+
+        $command = new class extends Command {
+            public mixed $answer = null;
+
+            public mixed $validatedValue = null;
+
+            public mixed $validatedRules = null;
+
+            public function handle(): void
+            {
+                $this->answer = text(
+                    'Test',
+                    validate: ['required'],
+                    transform: fn (string $value): string => $value . '!',
+                );
+            }
+
+            protected function validatePrompt(mixed $value, mixed $rules): ?string
+            {
+                $this->validatedValue = $value;
+                $this->validatedRules = $rules;
+
+                return null;
+            }
+        };
+
+        $this->runCommand(
+            $command,
+            fn ($components) => $components->expects('ask')->with('Test', null)->andReturn('value'),
+        );
+
+        $this->assertSame('value!', $command->answer);
+        $this->assertSame('value!', $command->validatedValue);
+        $this->assertSame(['required'], $command->validatedRules);
+    }
+
+    public function testIntrinsicFallbackValidationPrecedesFrameworkRules(): void
+    {
+        Prompt::fallbackWhen(true);
+
+        $command = new class extends Command {
+            public int $validationCalls = 0;
+
+            public function handle(): void
+            {
+                number('Test', validate: ['integer'], min: 1);
+            }
+
+            protected function validatePrompt(mixed $value, mixed $rules): ?string
+            {
+                ++$this->validationCalls;
+
+                return null;
+            }
+        };
+
+        $status = $this->runCommand(
+            $command,
+            function ($components): void {
+                $components->expects('ask')->with('Test', null)->andReturn('0');
+                $components->expects('error')->with('Must be at least 1');
+            },
+            runningUnitTests: true,
+        );
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertSame(0, $command->validationCalls);
+    }
+
+    #[DataProvider('requiredFallbackDataProvider')]
+    public function testFallbackRequiredValidationUsesInteractiveEmptySemantics(
+        bool|string $required,
+        mixed $value,
+        string $message,
+    ): void {
+        Prompt::fallbackWhen(true);
+
+        $command = new class($required, $value) extends Command {
+            public function __construct(
+                private bool|string $requiredValue,
+                private mixed $value,
+            ) {
+                parent::__construct();
+            }
+
+            public function handle(): void
+            {
+                $this->promptUntilValid(fn (): mixed => $this->value, $this->requiredValue, null);
+            }
+        };
+
+        $status = $this->runCommand(
+            $command,
+            fn ($components) => $components->expects('error')->with($message),
+            runningUnitTests: true,
+        );
+
+        $this->assertSame(Command::FAILURE, $status);
+    }
+
+    public static function requiredFallbackDataProvider(): array
+    {
+        return [
+            'null' => [true, null, 'Required.'],
+            'empty custom message' => ['', '', 'Required.'],
+            'zero custom message' => ['0', '', '0'],
+            'false value' => [true, false, 'Required.'],
+            'empty array' => [true, [], 'Required.'],
+        ];
+    }
+
+    public function testFalseRequiredFlagAllowsFalseFallbackAnswers(): void
+    {
+        Prompt::fallbackWhen(true);
+
+        $command = new class extends Command {
+            public mixed $answer = null;
+
+            public function handle(): void
+            {
+                $this->answer = $this->promptUntilValid(fn (): bool => false, false, null);
+            }
+        };
+
+        $this->runCommand($command, fn (): null => null);
+
+        $this->assertFalse($command->answer);
     }
 
     public function testAutoCompleteFallbackWithArrayOptions(): void
@@ -422,7 +693,9 @@ class ConfiguresPromptsNestedParentCommand extends Command
 
         $validation = (new ReflectionMethod(Prompt::class, 'getValidateUsing'))->invoke(null);
 
-        $validation(new TextPrompt('Test', validate: 'required'));
+        $prompt = new TextPrompt('Test', validate: 'required');
+
+        $validation($prompt, $prompt->value());
     }
 
     protected function validatePrompt(mixed $value, mixed $rules): ?string

--- a/tests/Console/ConfiguresPromptsTest.php
+++ b/tests/Console/ConfiguresPromptsTest.php
@@ -370,6 +370,26 @@ class ConfiguresPromptsTest extends TestCase
         $this->assertSame(0, $command->validationCalls);
     }
 
+    public function testEmptyIntrinsicFallbackResultContinuesToFrameworkValidation(): void
+    {
+        $command = new class extends Command {
+            public int $validationCalls = 0;
+
+            protected function validatePrompt(mixed $value, mixed $rules): ?string
+            {
+                ++$this->validationCalls;
+
+                return "Rejected [{$value}].";
+            }
+        };
+        $prompt = new ConfiguresPromptsEmptyIntrinsicTextPrompt('Test', validate: ['required']);
+
+        $error = (new ReflectionMethod($command, 'validateFallbackPrompt'))->invoke($command, $prompt, 'value');
+
+        $this->assertSame('Rejected [value].', $error);
+        $this->assertSame(1, $command->validationCalls);
+    }
+
     #[DataProvider('requiredFallbackDataProvider')]
     public function testFallbackRequiredValidationUsesInteractiveEmptySemantics(
         bool|string $required,
@@ -666,6 +686,17 @@ class ConfiguresPromptsTest extends TestCase
         $expectations($factory);
 
         return $command->run(new ArrayInput([]), new NullOutput);
+    }
+}
+
+class ConfiguresPromptsEmptyIntrinsicTextPrompt extends TextPrompt
+{
+    /**
+     * Validate rules intrinsic to the prompt type.
+     */
+    public function validateIntrinsic(mixed $value): ?string
+    {
+        return '';
     }
 }
 

--- a/tests/Console/ConfiguresPromptsTest.php
+++ b/tests/Console/ConfiguresPromptsTest.php
@@ -390,6 +390,30 @@ class ConfiguresPromptsTest extends TestCase
         $this->assertSame(1, $command->validationCalls);
     }
 
+    #[DataProvider('invalidFallbackValidatorResultDataProvider')]
+    public function testFallbackRejectsInvalidValidatorResults(mixed $result): void
+    {
+        Prompt::fallbackWhen(true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The validator must return a string or null.');
+
+        $this->runPrompt(
+            fn () => text('Test', validate: fn (): mixed => $result),
+            fn ($components) => $components->expects('ask')->with('Test', null)->andReturn('value'),
+        );
+    }
+
+    public static function invalidFallbackValidatorResultDataProvider(): array
+    {
+        return [
+            'false' => [false],
+            'true' => [true],
+            'integer' => [0],
+            'array' => [['error']],
+        ];
+    }
+
     #[DataProvider('requiredFallbackDataProvider')]
     public function testFallbackRequiredValidationUsesInteractiveEmptySemantics(
         bool|string $required,

--- a/tests/Prompts/AnsiWordwrapTest.php
+++ b/tests/Prompts/AnsiWordwrapTest.php
@@ -113,6 +113,15 @@ class AnsiWordwrapTest extends TestCase
         ], $result);
     }
 
+    public function testPreservesColonFormAttributesAndTheirSelectiveResets(): void
+    {
+        $result = $this->getInstance()->wrap("\e[4:3;38:2:255:0:0;1mstyled\e[24:0m colored\e[39;22m plain", 80);
+
+        $this->assertSame([
+            "\e[4:3m\e[38:2:255:0:0m\e[1mstyled\e[0m\e[38:2:255:0:0m\e[1m colored\e[0m plain",
+        ], $result);
+    }
+
     public function testPreservesUnstyledTextThatDoesNotNeedWrapping(): void
     {
         $result = $this->getInstance()->wrap('Short', 80);
@@ -143,6 +152,30 @@ class AnsiWordwrapTest extends TestCase
         $this->assertStringEndsWith("\e]8;;\e\\", $result[1]);
     }
 
+    public function testPreservesFormattingAcrossExplicitNewlines(): void
+    {
+        $this->assertSame(
+            ["\e[31mred\e[0m", "\e[31mstill red\e[0m"],
+            $this->getInstance()->wrap("\e[31mred\nstill red\e[0m", 80),
+        );
+        $this->assertSame(
+            ['a', "\e[31mb\e[0m"],
+            $this->getInstance()->wrap("a\n\e[31mb\e[0m", 80),
+        );
+        $this->assertSame(
+            ['a', "\e]8;;https://example.com\e\\b\e]8;;\e\\"],
+            $this->getInstance()->wrap("a\n\e]8;;https://example.com\e\\b\e]8;;\e\\", 80),
+        );
+    }
+
+    public function testAlignsFormattingAfterANewlineWhenTheFollowingLineWraps(): void
+    {
+        $this->assertSame(
+            ['aaa', "\e[31mbb\e[0m", "\e[31mbb\e[0m", "\e[31mbb\e[0m"],
+            $this->getInstance()->wrap("aaa\n\e[31mbb bb bb\e[0m", 4, cutLongWords: true),
+        );
+    }
+
     public function testHandlesOsc8HyperlinkWithAnsiCodesInside(): void
     {
         $result = $this->getInstance()->wrap("\e]8;;https://example.com\e\\\e[4mLink Text\e[0m\e]8;;\e\\", 80);
@@ -153,12 +186,21 @@ class AnsiWordwrapTest extends TestCase
         $this->assertStringContainsString('Link Text', $result[0]);
     }
 
-    public function testPreservesUnterminatedEscapeSequencesAsLiteralText(): void
+    public function testDiscardsUnterminatedControlSequences(): void
     {
-        $this->assertSame(["abc\e[31"], $this->getInstance()->wrap("abc\e[31", 80));
+        $this->assertSame(['abc'], $this->getInstance()->wrap("abc\e[31", 80));
+        $this->assertSame(['abc'], $this->getInstance()->wrap("abc\e]8;;https://hypervel.org", 80));
+        $this->assertSame(['abc'], $this->getInstance()->wrap("abc\ePsecret", 80));
+    }
+
+    public function testDiscardsCompleteControlsAndRecoversFromMalformedControls(): void
+    {
         $this->assertSame(
-            ["abc\e]8;;https://hypervel.org"],
-            $this->getInstance()->wrap("abc\e]8;;https://hypervel.org", 80),
+            ['abcd', "text \e[31mred\e[0m \e[32mgreen\e[0m"],
+            $this->getInstance()->wrap(
+                "a\e7b\e(Bc\ePsecret\e\\d\e[12\ntext \e]title\e[31mred\e[0m \e\e[32mgreen",
+                80,
+            ),
         );
     }
 

--- a/tests/Prompts/AnsiWordwrapTest.php
+++ b/tests/Prompts/AnsiWordwrapTest.php
@@ -86,6 +86,33 @@ class AnsiWordwrapTest extends TestCase
         $this->assertStringContainsString('Blue', $result[2]);
     }
 
+    public function testPreservesCombinedAttributesAppliedInSeparateSequences(): void
+    {
+        $result = $this->getInstance()->wrap("\e[1mBold \e[31mred\e[0m", 80);
+
+        $this->assertSame([
+            "\e[1mBold \e[0m\e[1m\e[31mred\e[0m",
+        ], $result);
+    }
+
+    public function testSelectiveResetsRemoveOnlyTheirMatchingAttribute(): void
+    {
+        $result = $this->getInstance()->wrap("\e[1;31mbold red\e[22m red\e[39m plain", 80);
+
+        $this->assertSame([
+            "\e[1m\e[31mbold red\e[0m\e[31m red\e[0m plain",
+        ], $result);
+    }
+
+    public function testPreservesUnderlineColorWithoutInterpretingColorComponentsAsAttributes(): void
+    {
+        $result = $this->getInstance()->wrap("\e[4;58;2;255;0;0mred\e[59m underline", 80);
+
+        $this->assertSame([
+            "\e[4m\e[58;2;255;0;0mred\e[0m\e[4m underline\e[0m",
+        ], $result);
+    }
+
     public function testPreservesUnstyledTextThatDoesNotNeedWrapping(): void
     {
         $result = $this->getInstance()->wrap('Short', 80);
@@ -135,6 +162,14 @@ class AnsiWordwrapTest extends TestCase
         );
     }
 
+    public function testCanSplitLongWordsAtTheRequestedWidth(): void
+    {
+        $this->assertSame(
+            ['abcd', 'efgh', 'ij'],
+            $this->getInstance()->wrap('abcdefghij', 4, cutLongWords: true),
+        );
+    }
+
     private function getInstance(): object
     {
         return new class {
@@ -142,9 +177,9 @@ class AnsiWordwrapTest extends TestCase
 
             protected int $minWidth = 0;
 
-            public function wrap(string $text, int $width): array
+            public function wrap(string $text, int $width, bool $cutLongWords = false): array
             {
-                return $this->ansiWordwrap($text, $width);
+                return $this->ansiWordwrap($text, $width, $cutLongWords);
             }
         };
     }

--- a/tests/Prompts/AutoCompletePromptTest.php
+++ b/tests/Prompts/AutoCompletePromptTest.php
@@ -164,6 +164,19 @@ class AutoCompletePromptTest extends TestCase
         Prompt::assertOutputContains('Please enter your name.');
     }
 
+    public function testCancelledZeroIsRenderedInsteadOfThePlaceholder(): void
+    {
+        Prompt::fake(['0', Key::CTRL_C]);
+
+        autocomplete('Value', ['One'], placeholder: 'placeholder');
+
+        $output = Prompt::strippedContent();
+        $cancelFrame = substr($output, strrpos($output, ' ┌'));
+
+        $this->assertStringContainsString('│ 0 ', $cancelFrame);
+        $this->assertStringNotContainsString('placeholder', $cancelFrame);
+    }
+
     public function testCanFallBack()
     {
         Prompt::fallbackWhen(true);

--- a/tests/Prompts/CalloutTest.php
+++ b/tests/Prompts/CalloutTest.php
@@ -258,6 +258,30 @@ class CalloutTest extends TestCase
         $this->assertSame(['123  Value'], $lines);
     }
 
+    public function testNarrowCalloutsWrapEveryContentTypeBeforeDrawingTheBox(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(20); // @phpstan-ignore-line
+
+        callout('Narrow', [
+            'plain content wraps here',
+            Element::bulletedList(['bullet content wraps here']),
+            Element::numberedList(['number content wraps here']),
+            Element::keyValueList(['K' => 'value content wraps here']),
+        ]);
+
+        $content = Prompt::strippedContent();
+
+        $this->assertStringContainsString('plain content', $content);
+        $this->assertStringContainsString('· bullet', $content);
+        $this->assertStringContainsString('1. number', $content);
+        $this->assertStringContainsString('K  value', $content);
+
+        foreach (explode(PHP_EOL, $content) as $line) {
+            $this->assertLessThanOrEqual(20, mb_strwidth($line), "Callout line exceeded the terminal width: [{$line}]");
+        }
+    }
+
     public function testCanFallBack(): void
     {
         Prompt::fallbackWhen(true);

--- a/tests/Prompts/CoroutineSafetyTest.php
+++ b/tests/Prompts/CoroutineSafetyTest.php
@@ -17,10 +17,11 @@ use Hypervel\Prompts\Terminal;
 use Hypervel\Prompts\TextPrompt;
 use Hypervel\Tests\TestCase;
 use ReflectionProperty;
+use RuntimeException;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
-use function Hypervel\Coroutine\go;
+use function Hypervel\Coroutine\parallel;
 use function Hypervel\Prompts\spin;
 use function Hypervel\Prompts\task;
 
@@ -42,157 +43,158 @@ class CoroutineSafetyTest extends TestCase
         return Closure::bind(fn () => Prompt::getValidateUsing(), null, Prompt::class)();
     }
 
-    public function testOutputIsIsolatedBetweenCoroutines()
+    /**
+     * Wait for a coroutine ordering signal.
+     */
+    private function waitForCoroutineSignal(Channel $barrier): void
+    {
+        // This is a deadlock bound, not a scheduling timing expectation.
+        if ($barrier->pop(5) !== true) {
+            throw new RuntimeException('Timed out waiting for a coroutine ordering signal.');
+        }
+    }
+
+    public function testOutputIsIsolatedBetweenCoroutines(): void
     {
         $outputA = new BufferedOutput;
         $outputB = new NullOutput;
 
-        $channel = new Channel(2);
         $barrier = new Channel(1);
 
-        go(function () use ($outputA, $channel, $barrier) {
-            Prompt::setOutput($outputA);
-            $barrier->pop(); // Wait for coroutine B to set its output
-            $channel->push($this->getPromptOutput());
-        });
+        $results = parallel([
+            'a' => function () use ($outputA, $barrier): mixed {
+                Prompt::setOutput($outputA);
+                $this->waitForCoroutineSignal($barrier);
 
-        go(function () use ($outputB, $channel, $barrier) {
-            Prompt::setOutput($outputB);
-            $barrier->push(true); // Signal coroutine A
-            $channel->push($this->getPromptOutput());
-        });
+                return $this->getPromptOutput();
+            },
+            'b' => function () use ($outputB, $barrier): mixed {
+                Prompt::setOutput($outputB);
+                $barrier->push(true);
 
-        $results = [$channel->pop(), $channel->pop()];
+                return $this->getPromptOutput();
+            },
+        ]);
 
-        $this->assertContains($outputA, $results);
-        $this->assertContains($outputB, $results);
-        $this->assertNotSame($results[0], $results[1]);
+        $this->assertSame($outputA, $results['a']);
+        $this->assertSame($outputB, $results['b']);
     }
 
-    public function testInteractivityIsIsolatedBetweenCoroutines()
+    public function testInteractivityIsIsolatedBetweenCoroutines(): void
     {
-        $channel = new Channel(2);
         $barrier = new Channel(1);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::interactive(true);
-            $barrier->pop(); // Wait for coroutine B
-            $channel->push(Prompt::isInteractive());
-        });
+        $results = parallel([
+            'a' => function () use ($barrier): ?bool {
+                Prompt::interactive(true);
+                $this->waitForCoroutineSignal($barrier);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::interactive(false);
-            $barrier->push(true); // Signal coroutine A
-            $channel->push(Prompt::isInteractive());
-        });
+                return Prompt::isInteractive();
+            },
+            'b' => function () use ($barrier): ?bool {
+                Prompt::interactive(false);
+                $barrier->push(true);
 
-        $results = [$channel->pop(), $channel->pop()];
+                return Prompt::isInteractive();
+            },
+        ]);
 
-        $this->assertContains(true, $results);
-        $this->assertContains(false, $results);
+        $this->assertTrue($results['a']);
+        $this->assertFalse($results['b']);
     }
 
-    public function testValidateUsingIsIsolatedBetweenCoroutines()
+    public function testValidateUsingIsIsolatedBetweenCoroutines(): void
     {
-        $channel = new Channel(2);
         $barrier = new Channel(1);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::validateUsing(fn () => 'error-a');
-            $barrier->pop(); // Wait for coroutine B
-            $callback = $this->getPromptValidateUsing();
-            $channel->push($callback ? $callback() : null);
-        });
+        $results = parallel([
+            'a' => function () use ($barrier): mixed {
+                Prompt::validateUsing(fn () => 'error-a');
+                $this->waitForCoroutineSignal($barrier);
+                $callback = $this->getPromptValidateUsing();
 
-        go(function () use ($channel, $barrier) {
-            Prompt::validateUsing(fn () => 'error-b');
-            $barrier->push(true); // Signal coroutine A
-            $callback = $this->getPromptValidateUsing();
-            $channel->push($callback ? $callback() : null);
-        });
+                return $callback ? $callback() : null;
+            },
+            'b' => function () use ($barrier): mixed {
+                Prompt::validateUsing(fn () => 'error-b');
+                $barrier->push(true);
+                $callback = $this->getPromptValidateUsing();
 
-        $results = [$channel->pop(), $channel->pop()];
+                return $callback ? $callback() : null;
+            },
+        ]);
 
-        $this->assertContains('error-a', $results);
-        $this->assertContains('error-b', $results);
+        $this->assertSame('error-a', $results['a']);
+        $this->assertSame('error-b', $results['b']);
     }
 
-    public function testFallbackWhenIsIsolatedBetweenCoroutines()
+    public function testFallbackWhenIsIsolatedBetweenCoroutines(): void
     {
-        $channel = new Channel(2);
         $barrier = new Channel(1);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::fallbackWhen(true);
-            TextPrompt::fallbackUsing(fn () => 'fallback-a');
-            $barrier->pop(); // Wait for coroutine B
-            $channel->push(TextPrompt::shouldFallback());
-        });
+        $results = parallel([
+            'a' => function () use ($barrier): bool {
+                Prompt::fallbackWhen(true);
+                TextPrompt::fallbackUsing(fn () => 'fallback-a');
+                $this->waitForCoroutineSignal($barrier);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::fallbackWhen(false);
-            TextPrompt::fallbackUsing(fn () => 'fallback-b');
-            $barrier->push(true); // Signal coroutine A
-            $channel->push(TextPrompt::shouldFallback());
-        });
+                return TextPrompt::shouldFallback();
+            },
+            'b' => function () use ($barrier): bool {
+                Prompt::fallbackWhen(false);
+                TextPrompt::fallbackUsing(fn () => 'fallback-b');
+                $barrier->push(true);
 
-        $results = [$channel->pop(), $channel->pop()];
+                return TextPrompt::shouldFallback();
+            },
+        ]);
 
-        // Coroutine A has fallbackWhen(true), coroutine B has fallbackWhen(false)
-        $this->assertContains(true, $results);
-        $this->assertContains(false, $results);
+        $this->assertTrue($results['a']);
+        $this->assertFalse($results['b']);
     }
 
-    public function testFallbackClosuresAreIsolatedBetweenCoroutines()
+    public function testFallbackClosuresAreIsolatedBetweenCoroutines(): void
     {
-        $channel = new Channel(2);
         $barrier = new Channel(1);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::fallbackWhen(true);
-            SelectPrompt::fallbackUsing(fn () => 'select-a');
-            $barrier->pop(); // Wait for coroutine B
-            $channel->push(SelectPrompt::shouldFallback());
-        });
+        $results = parallel([
+            'a' => function () use ($barrier): bool {
+                Prompt::fallbackWhen(true);
+                SelectPrompt::fallbackUsing(fn () => 'select-a');
+                $this->waitForCoroutineSignal($barrier);
 
-        go(function () use ($channel, $barrier) {
-            Prompt::fallbackWhen(true);
-            ConfirmPrompt::fallbackUsing(fn () => 'confirm-b');
-            // SelectPrompt should NOT have a fallback in this coroutine
-            $barrier->push(true); // Signal coroutine A
-            $channel->push(SelectPrompt::shouldFallback());
-        });
+                return SelectPrompt::shouldFallback();
+            },
+            'b' => function () use ($barrier): bool {
+                Prompt::fallbackWhen(true);
+                ConfirmPrompt::fallbackUsing(fn () => 'confirm-b');
+                $barrier->push(true);
 
-        $results = [$channel->pop(), $channel->pop()];
+                return SelectPrompt::shouldFallback();
+            },
+        ]);
 
-        // Coroutine A has SelectPrompt fallback, Coroutine B does not
-        $this->assertContains(true, $results);
-        $this->assertContains(false, $results);
+        $this->assertTrue($results['a']);
+        $this->assertFalse($results['b']);
     }
 
-    public function testFallbackWhenIsAdditiveWithinCoroutineContext()
+    public function testFallbackWhenIsAdditiveWithinCoroutineContext(): void
     {
         TextPrompt::fallbackUsing(fn () => 'result');
 
         Prompt::fallbackWhen(true);
         $this->assertTrue(TextPrompt::shouldFallback());
 
-        // Once enabled, fallbackWhen(false) should NOT disable it (additive behavior)
+        // Once enabled, fallbackWhen(false) should not disable it (additive behavior)
         Prompt::fallbackWhen(false);
         $this->assertTrue(TextPrompt::shouldFallback());
     }
 
-    public function testChildCoroutineDoesNotLeakToParent()
+    public function testChildCoroutineDoesNotLeakToParent(): void
     {
-        $channel = new Channel(1);
-
-        // Set a value in a child coroutine
-        go(function () use ($channel) {
+        parallel([function (): void {
             Prompt::setOutput(new BufferedOutput);
-            $channel->push(true);
-        });
-
-        $channel->pop();
+        }]);
 
         // The parent coroutine should have its own Context, not affected by the child
         $output = $this->getPromptOutput();
@@ -201,7 +203,7 @@ class CoroutineSafetyTest extends TestCase
         $this->assertNotInstanceOf(BufferedOutput::class, $output);
     }
 
-    public function testSpinnerAnimationCoroutineInheritsPromptContext()
+    public function testSpinnerAnimationCoroutineInheritsPromptContext(): void
     {
         $output = new BufferedConsoleOutput(decorated: true);
 
@@ -220,7 +222,7 @@ class CoroutineSafetyTest extends TestCase
         $this->assertStringContainsString('Loading context', $output->content());
     }
 
-    public function testTaskAnimationCoroutineInheritsPromptContext()
+    public function testTaskAnimationCoroutineInheritsPromptContext(): void
     {
         $output = new BufferedConsoleOutput(decorated: true);
 
@@ -250,30 +252,26 @@ class CoroutineSafetyTest extends TestCase
         $taskB = new Task(label: 'Task B');
         $loggerA = new InProcessLogger($taskA);
         $loggerB = new InProcessLogger($taskB);
-        $channel = new Channel(2);
+        $results = parallel([
+            'a' => function () use ($loggerA, $taskA, $taskB): array {
+                $loggerA->subLabel('Building assets');
+                usleep(5000);
 
-        go(function () use ($loggerA, $taskA, $taskB, $channel) {
-            $loggerA->subLabel('Building assets');
-            usleep(5000);
+                return [$taskA->subLabel, $taskB->subLabel];
+            },
+            'b' => function () use ($loggerB, $taskA, $taskB): array {
+                $loggerB->subLabel('Running migrations');
+                usleep(5000);
 
-            $channel->push([$taskA->subLabel, $taskB->subLabel]);
-        });
+                return [$taskA->subLabel, $taskB->subLabel];
+            },
+        ]);
 
-        go(function () use ($loggerB, $taskA, $taskB, $channel) {
-            $loggerB->subLabel('Running migrations');
-            usleep(5000);
-
-            $channel->push([$taskA->subLabel, $taskB->subLabel]);
-        });
-
-        $first = $channel->pop();
-        $second = $channel->pop();
-
-        $this->assertSame(['Building assets', 'Running migrations'], $first);
-        $this->assertSame(['Building assets', 'Running migrations'], $second);
+        $this->assertSame(['Building assets', 'Running migrations'], $results['a']);
+        $this->assertSame(['Building assets', 'Running migrations'], $results['b']);
     }
 
-    public function testTerminalFlushStateResetsTerminalCaches()
+    public function testTerminalFlushStateResetsTerminalCaches(): void
     {
         $trueColorSupport = new ReflectionProperty(Terminal::class, 'trueColorSupport');
         $foregroundColor = new ReflectionProperty(Terminal::class, 'foregroundColor');

--- a/tests/Prompts/DataTablePromptTest.php
+++ b/tests/Prompts/DataTablePromptTest.php
@@ -7,7 +7,10 @@ namespace Hypervel\Tests\Prompts;
 use Hypervel\Prompts\DataTablePrompt;
 use Hypervel\Prompts\Key;
 use Hypervel\Prompts\Prompt;
+use Hypervel\Prompts\Support\Utils;
+use Hypervel\Prompts\Themes\Default\DataTableRenderer;
 use Hypervel\Tests\TestCase;
+use ReflectionMethod;
 
 use function Hypervel\Prompts\datatable;
 
@@ -593,5 +596,182 @@ class DataTablePromptTest extends TestCase
             $dataLineCount = $dataEnd - $dataStart - 1;
             $this->assertSame(5, $dataLineCount);
         }
+    }
+
+    public function testRestoresBrowseStateAfterANonRevertibleError(): void
+    {
+        Prompt::fake([Key::CTRL_U, Key::DOWN, Key::ENTER]);
+
+        $result = (new DataTablePrompt(
+            headers: ['Name'],
+            rows: ['a' => ['Alice'], 'b' => ['Bob']],
+        ))->prompt();
+
+        $this->assertSame('b', $result);
+        Prompt::assertStrippedOutputContains('This cannot be reverted.');
+    }
+
+    public function testRestoresSearchStateAfterANonRevertibleError(): void
+    {
+        Prompt::fake(['/', Key::CTRL_U, 'b', Key::ENTER, Key::ENTER]);
+        $prompt = new DataTablePrompt(
+            headers: ['Name'],
+            rows: ['a' => ['Alice'], 'b' => ['Bob']],
+        );
+
+        $result = $prompt->prompt();
+
+        $this->assertSame('b', $result);
+        $this->assertSame('b', $prompt->searchValue());
+        Prompt::assertStrippedOutputContains('This cannot be reverted.');
+    }
+
+    public function testOrdinaryValidationErrorsStillRestoreActiveState(): void
+    {
+        Prompt::fake([Key::ENTER, Key::DOWN, Key::ENTER]);
+
+        $result = (new DataTablePrompt(
+            headers: ['Name'],
+            rows: ['a' => ['Alice'], 'b' => ['Bob']],
+            validate: fn ($value) => $value === 'a' ? 'Choose another row.' : null,
+        ))->prompt();
+
+        $this->assertSame('b', $result);
+        Prompt::assertStrippedOutputContains('Choose another row.');
+    }
+
+    public function testNaturalMetricsHandleRaggedRowsMultilineCellsAndStyledText(): void
+    {
+        $prompt = new DataTablePrompt(
+            headers: [['First', 'Name'], 'Status'],
+            rows: [
+                ["\e[31mAlice\e[0m", '<fg=green>Ready</>', "short\r\nlonger"],
+                ['Bob'],
+            ],
+        );
+
+        $this->assertSame(
+            ['columns' => 3, 'widths' => [10, 6, 6]],
+            $prompt->naturalColumnMetrics(),
+        );
+    }
+
+    public function testSparseIntegerHeaderAndRowKeysRemainPositionalDuringLayout(): void
+    {
+        Prompt::fake();
+        $prompt = new DataTablePrompt(
+            headers: [1 => 'Name', 4 => 'Status'],
+            rows: [[2 => 'Alice', 5 => 'Ready']],
+        );
+
+        $this->assertSame(
+            ['columns' => 2, 'widths' => [5, 6]],
+            $prompt->naturalColumnMetrics(),
+        );
+
+        $activeOutput = Utils::stripEscapeSequences((new DataTableRenderer($prompt))($prompt));
+        $prompt->state = 'cancel';
+        $cancelOutput = Utils::stripEscapeSequences((new DataTableRenderer($prompt))($prompt));
+
+        foreach ([$activeOutput, $cancelOutput] as $output) {
+            $this->assertStringContainsString('Name', $output);
+            $this->assertStringContainsString('Status', $output);
+            $this->assertStringContainsString('Alice', $output);
+            $this->assertStringContainsString('Ready', $output);
+        }
+
+        $this->assertSame([2 => 'Alice', 5 => 'Ready'], $prompt->selectedRow());
+    }
+
+    public function testNaturalMetricsApplyTheP90OutlierRule(): void
+    {
+        $rows = array_fill(0, 9, ['short']);
+        $rows[] = [str_repeat('x', 100)];
+        $prompt = new DataTablePrompt(headers: ['Name'], rows: $rows);
+
+        $this->assertSame(
+            ['columns' => 1, 'widths' => [5]],
+            $prompt->naturalColumnMetrics(),
+        );
+    }
+
+    public function testNaturalMetricsAreMemoizedForThePromptLifetime(): void
+    {
+        $prompt = new DataTablePrompt(headers: ['Name'], rows: [['Alice']]);
+        $metrics = $prompt->naturalColumnMetrics();
+
+        $prompt->rows = [[str_repeat('x', 1000)]];
+
+        $this->assertSame($metrics, $prompt->naturalColumnMetrics());
+    }
+
+    public function testEmptyTableHasNoNaturalColumns(): void
+    {
+        $this->assertSame(
+            ['columns' => 0, 'widths' => []],
+            (new DataTablePrompt)->naturalColumnMetrics(),
+        );
+    }
+
+    public function testFittedWidthsHonorMinimaAndTheExactTerminalBudget(): void
+    {
+        $prompt = new DataTablePrompt(headers: ['A', 'B', 'C'], rows: [['a', 'b', 'c']]);
+        $renderer = new DataTableRenderer($prompt);
+        $fitColumnWidths = new ReflectionMethod($renderer, 'fitColumnWidths');
+
+        $widths = $fitColumnWidths->invoke($renderer, [100, 50, 25], 74);
+
+        $this->assertSame(60, array_sum($widths));
+        $this->assertSame([34, 18, 8], $widths);
+
+        foreach ($widths as $width) {
+            $this->assertIsInt($width);
+        }
+
+        $this->assertGreaterThanOrEqual(1, min($widths));
+    }
+
+    public function testScrollbarPreservesTrailingAnsiResetAfterReplacingVisibleContent(): void
+    {
+        $renderer = new DataTableRenderer(new DataTablePrompt);
+        $scrollbar = new ReflectionMethod($renderer, 'scrollbar');
+
+        [$line] = $scrollbar->invoke($renderer, ["\e[2mabcdefghij\e[22m"], 0, 1, 2, 10);
+
+        $this->assertSame('abcdefghi┃', Utils::stripEscapeSequences($line));
+        $this->assertStringEndsWith("\e[22m", $line);
+    }
+
+    public function testLongHeadersShrinkToFitAnEightyColumnTerminal(): void
+    {
+        Prompt::fake([Key::ENTER]);
+
+        datatable(
+            label: 'Users',
+            headers: [str_repeat('A', 100), str_repeat('B', 100)],
+            rows: [['Alice', 'Developer']],
+        );
+
+        $maximumWidth = max(array_map(
+            mb_strwidth(...),
+            explode("\n", Prompt::strippedContent()),
+        ));
+
+        $this->assertLessThanOrEqual(80, $maximumWidth);
+    }
+
+    public function testRendersLfAndCrlfMultilineCells(): void
+    {
+        Prompt::fake([Key::ENTER]);
+
+        datatable(
+            headers: ['Name', 'Roles'],
+            rows: [['Alice', "Owner\r\nDeveloper\nReviewer"]],
+        );
+
+        Prompt::assertStrippedOutputContains('Owner');
+        Prompt::assertStrippedOutputContains('Developer');
+        Prompt::assertStrippedOutputContains('Reviewer');
+        $this->assertStringNotContainsString("\r", Prompt::strippedContent());
     }
 }

--- a/tests/Prompts/EraseTest.php
+++ b/tests/Prompts/EraseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Prompts;
+
+use Hypervel\Prompts\Prompt;
+use Hypervel\Tests\TestCase;
+
+class EraseTest extends TestCase
+{
+    public function testEraseLinesWritesExactMovementForPositiveCountsOnly(): void
+    {
+        Prompt::fake();
+
+        $prompt = new class extends Prompt {
+            public function value(): mixed
+            {
+                return null;
+            }
+        };
+
+        $prompt->eraseLines(-1);
+        $prompt->eraseLines(0);
+
+        $this->assertSame('', Prompt::content());
+
+        $prompt->eraseLines(1);
+
+        $this->assertSame("\e[2K\e[G", Prompt::content());
+
+        $prompt->eraseLines(3);
+
+        $this->assertSame(
+            "\e[2K\e[G\e[2K\e[1A\e[2K\e[1A\e[2K\e[G",
+            Prompt::content(),
+        );
+    }
+}

--- a/tests/Prompts/GridTest.php
+++ b/tests/Prompts/GridTest.php
@@ -260,4 +260,38 @@ class GridTest extends TestCase
         Prompt::assertStrippedOutputContains('│ using-fluxui                 │ using-folio-routing  │ using-tailwindcss │');
         Prompt::assertStrippedOutputContains('└──────────────────────────────┴──────────────────────┴───────────────────┘');
     }
+
+    public function testTruncatesItemsThatAreWiderThanTheGrid(): void
+    {
+        Prompt::fake();
+
+        (new Grid([str_repeat('a', 200)], maxWidth: 80))->display();
+
+        $widest = max(array_map(
+            fn (string $line): int => mb_strwidth(rtrim($line)),
+            explode(PHP_EOL, Prompt::strippedContent()),
+        ));
+
+        $this->assertLessThanOrEqual(80, $widest);
+        Prompt::assertStrippedOutputContains('…');
+    }
+
+    public function testNarrowGridStillUsesAPositiveTruncationWidth(): void
+    {
+        Prompt::fake();
+
+        (new Grid(['long item'], maxWidth: 2))->display();
+
+        Prompt::assertStrippedOutputContains('…');
+    }
+
+    public function testLeavesItemsThatAlreadyFitUntouched(): void
+    {
+        Prompt::fake();
+
+        (new Grid(['item1', 'item2'], maxWidth: 80))->display();
+
+        Prompt::assertStrippedOutputContains('│ item1 │ item2 │');
+        Prompt::assertStrippedOutputDoesntContain('…');
+    }
 }

--- a/tests/Prompts/InteractsWithStringsTest.php
+++ b/tests/Prompts/InteractsWithStringsTest.php
@@ -54,6 +54,39 @@ class InteractsWithStringsTest extends TestCase
         ];
     }
 
+    #[DataProvider('rawControlLines')]
+    public function testSanitizesRawTerminalControlsBeforeReplacingTheLastGrapheme(string $line, string $expected): void
+    {
+        $result = $this->getInstance()->replace($line, '┃');
+
+        $this->assertSame($expected, $result);
+        $this->assertSame(
+            mb_strwidth(Utils::stripEscapeSequences($line)),
+            mb_strwidth(Utils::stripEscapeSequences($result)),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function rawControlLines(): array
+    {
+        return [
+            'incomplete CSI' => ["abc\e[31", 'ab┃'],
+            'incomplete OSC' => ["abc\e]8;;https://example.com", 'ab┃'],
+            'malformed complete OSC 8' => ["abc\e]8;not-a-link\e\\", 'ab┃'],
+            'malformed OSC followed by formatting' => [
+                "a\e]8;;https://example.com\e[31mbc\e[0m",
+                "a\e[31mb┃\e[0m",
+            ],
+            'generic ESC control' => ["ab\e7c", 'ab┃'],
+            'charset designation' => ["ab\e(Bc", 'ab┃'],
+            'DCS payload' => ["ab\ePsecret\e\\c", 'ab┃'],
+            'APC payload' => ["ab\e_secret\e\\c", 'ab┃'],
+            'non-formatting CSI suffix' => ["abc\e[2K", 'ab┃'],
+        ];
+    }
+
     #[DataProvider('linesWithoutVisibleContent')]
     public function testLeavesLinesWithoutVisibleContentUnchanged(string $line): void
     {

--- a/tests/Prompts/InteractsWithStringsTest.php
+++ b/tests/Prompts/InteractsWithStringsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Prompts;
+
+use Hypervel\Prompts\Support\Utils;
+use Hypervel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
+use Hypervel\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class InteractsWithStringsTest extends TestCase
+{
+    public function testReplacesTheLastVisibleGrapheme(): void
+    {
+        $this->assertSame('ab┃', $this->getInstance()->replace('abc', '┃'));
+    }
+
+    public function testPreservesTrailingAnsiFormattingAndDisplayWidth(): void
+    {
+        $line = "\e[2mabcdefghij\e[22m";
+        $replacement = "\e[36m┃\e[39m";
+        $result = $this->getInstance()->replace($line, $replacement);
+
+        $this->assertSame("\e[2mabcdefghi{$replacement}\e[22m", $result);
+        $this->assertSame(
+            mb_strwidth(Utils::stripEscapeSequences($line)),
+            mb_strwidth(Utils::stripEscapeSequences($result)),
+        );
+    }
+
+    #[DataProvider('formattedLines')]
+    public function testPreservesTrailingHyperlinkAndStyleClosers(string $line, string $expected): void
+    {
+        $this->assertSame($expected, $this->getInstance()->replace($line, '┃'));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function formattedLines(): array
+    {
+        return [
+            'OSC 8 string terminator' => [
+                "\e]8;;https://example.com\e\\link\e]8;;\e\\",
+                "\e]8;;https://example.com\e\\lin┃\e]8;;\e\\",
+            ],
+            'OSC 8 bell terminator' => [
+                "\e]8;;https://example.com\x07link\e]8;;\x07",
+                "\e]8;;https://example.com\x07lin┃\e]8;;\x07",
+            ],
+            'named style' => ['<info>abc</info>', '<info>ab┃</info>'],
+            'inline style' => ['<fg=red>abc</>', '<fg=red>ab┃</>'],
+        ];
+    }
+
+    #[DataProvider('linesWithoutVisibleContent')]
+    public function testLeavesLinesWithoutVisibleContentUnchanged(string $line): void
+    {
+        $this->assertSame($line, $this->getInstance()->replace($line, '┃'));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function linesWithoutVisibleContent(): array
+    {
+        return [
+            'empty' => [''],
+            'ANSI reset' => ["\e[0m"],
+            'OSC link open and close' => ["\e]8;;https://example.com\e\\\e]8;;\e\\"],
+            'named style' => ['<info></info>'],
+            'inline style' => ['<fg=red></>'],
+        ];
+    }
+
+    public function testReplacesAWholeWideOrCombinedGrapheme(): void
+    {
+        $instance = $this->getInstance();
+
+        $wide = $instance->replace('a界', '┃');
+        $combined = $instance->replace("xe\u{0301}", '┃');
+        $emoji = $instance->replace('x👨‍👩‍👧‍👦', '┃');
+
+        $this->assertSame('a ┃', $wide);
+        $this->assertSame(mb_strwidth('a界'), mb_strwidth($wide));
+        $this->assertStringStartsWith('x', $combined);
+        $this->assertStringNotContainsString("\u{0301}", $combined);
+        $this->assertStringStartsWith('x', $emoji);
+        $this->assertStringNotContainsString('👨', $emoji);
+    }
+
+    public function testLeavesInvalidUtf8Unchanged(): void
+    {
+        $line = "valid\xff";
+
+        $this->assertSame($line, $this->getInstance()->replace($line, '┃'));
+    }
+
+    private function getInstance(): object
+    {
+        return new class {
+            use InteractsWithStrings;
+
+            protected int $minWidth = 0;
+
+            public function replace(string $line, string $replacement): string
+            {
+                return $this->replaceLastVisibleGrapheme($line, $replacement);
+            }
+        };
+    }
+}

--- a/tests/Prompts/LoggerTest.php
+++ b/tests/Prompts/LoggerTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Prompts;
 
 use Hypervel\Prompts\Support\Logger;
+use Hypervel\Prompts\Support\TaskFrame;
 use Hypervel\Prompts\Support\Utils;
 use Hypervel\Tests\TestCase;
-use ReflectionProperty;
+use InvalidArgumentException;
 use RuntimeException;
 
 class LoggerTest extends TestCase
@@ -23,8 +24,8 @@ class LoggerTest extends TestCase
             $logger->line('plain');
             $logger->success('done');
 
-            $this->assertSame("plain\n", fgets($sockets[1]));
-            $this->assertSame("abc123_success:done\n", fgets($sockets[1]));
+            $this->assertSame(TaskFrame::encode(null, 'plain'), fread($sockets[1], 10));
+            $this->assertSame(TaskFrame::encode('success', 'done'), fread($sockets[1], 9));
             $this->assertNull($logger->transportFailure());
         } finally {
             fclose($sockets[0]);
@@ -55,14 +56,13 @@ class LoggerTest extends TestCase
 
         $this->assertTrue(pcntl_wifexited($status));
         $this->assertSame(0, pcntl_wexitstatus($status));
-        $this->assertSame($payload . PHP_EOL, $received);
+        $this->assertSame(TaskFrame::encode(null, $payload), $received);
     }
 
     public function testPeerClosureLatchesFailureAndStopsLaterWrites(): void
     {
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
         $logger = new Logger('abc123', $sockets[0]);
-        $streamBuffer = new ReflectionProperty($logger, 'streamBuffer');
         $firstChunk = str_repeat('x', 1024 * 1024);
         fclose($sockets[1]);
 
@@ -71,13 +71,11 @@ class LoggerTest extends TestCase
             $failure = $logger->transportFailure();
 
             $this->assertNotNull($failure);
-            $this->assertSame($firstChunk, $streamBuffer->getValue($logger));
 
             $logger->line('ignored');
             $logger->partial(' ignored');
 
             $this->assertSame($failure, $logger->transportFailure());
-            $this->assertSame($firstChunk, $streamBuffer->getValue($logger));
         } finally {
             fclose($sockets[0]);
         }
@@ -104,7 +102,7 @@ class LoggerTest extends TestCase
             $received = stream_get_contents($sockets[1]);
 
             $this->assertNotSame('', $received);
-            $this->assertLessThan(strlen($payload), strlen($received));
+            $this->assertLessThan(strlen(TaskFrame::encode(null, $payload)), strlen($received));
         } finally {
             fclose($sockets[0]);
             fclose($sockets[1]);
@@ -132,7 +130,7 @@ class LoggerTest extends TestCase
 
             fclose($sockets[1]);
 
-            exit($received === $payload . PHP_EOL ? 0 : 1);
+            exit($received === TaskFrame::encode(null, $payload) ? 0 : 1);
         }
 
         $this->assertGreaterThan(0, $pid);
@@ -216,8 +214,47 @@ class LoggerTest extends TestCase
         $logger->label('Updated');
         $logger->subLabel('detail');
 
-        $streamBuffer = new ReflectionProperty($logger, 'streamBuffer');
+        $this->assertNull($logger->transportFailure());
+    }
 
-        $this->assertSame('', $streamBuffer->getValue($logger));
+    public function testPartialWritesOnlyTheNewChunk(): void
+    {
+        $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        $logger = new Logger('abc123', $sockets[0]);
+
+        try {
+            $logger->partial('first');
+            $logger->partial(' second');
+            $logger->commitPartial();
+
+            $this->assertSame(TaskFrame::encode('partial', 'first'), fread($sockets[1], 10));
+            $this->assertSame(TaskFrame::encode('partial', ' second'), fread($sockets[1], 12));
+            $this->assertSame(TaskFrame::encode('commitpartial', ''), fread($sockets[1], 5));
+        } finally {
+            fclose($sockets[0]);
+            fclose($sockets[1]);
+        }
+    }
+
+    public function testRejectsUnknownProtectedTypesBeforeWriting(): void
+    {
+        $stream = fopen('php://memory', 'w+');
+        $logger = new class('abc123', $stream) extends Logger {
+            public function debug(string $message): void
+            {
+                $this->write($message, 'debug');
+            }
+        };
+
+        try {
+            $logger->debug('message');
+            $this->fail('Expected the unknown message type to be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Unknown task message type [debug].', $exception->getMessage());
+        }
+
+        rewind($stream);
+        $this->assertSame('', stream_get_contents($stream));
+        fclose($stream);
     }
 }

--- a/tests/Prompts/MultiByteWordWrapTest.php
+++ b/tests/Prompts/MultiByteWordWrapTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Prompts;
 
+use Hypervel\Prompts\Support\Utils;
 use Hypervel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
 use Hypervel\Tests\TestCase;
 
@@ -193,7 +194,8 @@ class MultiByteWordWrapTest extends TestCase
         I'll tell you
         how I became
         the prince of
-        a 👨‍👩‍👧‍👦 called
+        a 👨‍👩‍👧‍👦
+        called
         Bel-Air
         RESULT;
 
@@ -228,6 +230,59 @@ class MultiByteWordWrapTest extends TestCase
         RESULT;
 
         $this->assertSame($mbResult, $expectedResult);
+    }
+
+    public function testCutsLongWordsAtGraphemeBoundaries(): void
+    {
+        $instance = $this->getInstance();
+
+        foreach (["e\u{0301}", '👨‍👩‍👧', '👍🏽', '🇺🇸', '1️⃣', '가', 'का'] as $grapheme) {
+            $this->assertSame($grapheme, $instance->wordwrap($grapheme, 1, "\n", true));
+        }
+
+        $this->assertSame("é\n€\n😀", $instance->wordwrap('é € 😀', 1, "\n", true));
+    }
+
+    public function testSplitsOversizedGraphemesLosslesslyAtTheSharedCeiling(): void
+    {
+        $instance = $this->getInstance();
+        $grapheme = 'a' . str_repeat("\u{0301}", 3000);
+        $lines = explode("\n", $instance->wordwrap($grapheme, 1, "\n", true));
+
+        $this->assertGreaterThan(1, count($lines));
+        $this->assertSame($grapheme, implode('', $lines));
+
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(Utils::MAX_UNBREAKABLE_BYTES, strlen($line));
+        }
+    }
+
+    public function testDoesNotEmitLeadingOrOverflowBlankLines(): void
+    {
+        $instance = $this->getInstance();
+
+        $this->assertSame('abcdefgh', $instance->wordwrap('abcdefgh', 3, "\n", false));
+        $this->assertSame('😀', $instance->wordwrap('😀', 1, "\n", false));
+        $this->assertSame('😀', $instance->wordwrap('😀', 1, "\n", true));
+        $this->assertSame("aa\naa\nbb\nbb", $instance->wordwrap('aaaa  bbbb', 2, "\n", true));
+        $this->assertSame("aaaa\nbbbb", $instance->wordwrap('aaaa  bbbb', 2, "\n", false));
+        $this->assertSame('abcdef', $instance->wordwrap(' abcdef', 4, "\n", false));
+    }
+
+    public function testNormalizesNonPositiveWidthsAndPreservesWhitespaceLines(): void
+    {
+        $instance = $this->getInstance();
+
+        $this->assertSame("a\nb\nc", $instance->wordwrap('abc', 0, "\n", true));
+        $this->assertSame("a\nb\nc", $instance->wordwrap('abc', -1, "\n", true));
+        $this->assertSame("  \n  ", $instance->wordwrap('     ', 2, "\n", true));
+    }
+
+    public function testRetainsMalformedUtf8FallbackWhenCuttingLongWords(): void
+    {
+        $instance = $this->getInstance();
+
+        $this->assertSame("a\n\xFF\nb", $instance->wordwrap("a\xFFb", 1, "\n", true));
     }
 
     protected function getInstance()

--- a/tests/Prompts/MultiSearchPromptTest.php
+++ b/tests/Prompts/MultiSearchPromptTest.php
@@ -348,6 +348,23 @@ class MultiSearchPromptTest extends TestCase
         $this->assertSame(['red'], $result);
     }
 
+    public function testNavigationPopulatesMatchesWhenACustomRendererDoesNotReadThem(): void
+    {
+        Prompt::fake([Key::DOWN, Key::SPACE, Key::ENTER]);
+        Prompt::addTheme('without-multisearch-matches', [MultiSearchPrompt::class => MultiSearchPromptRendererWithoutMatches::class]);
+        Prompt::theme('without-multisearch-matches');
+        $calls = 0;
+
+        $result = multisearch('Colors', function () use (&$calls): array {
+            ++$calls;
+
+            return ['red' => 'Red', 'blue' => 'Blue'];
+        });
+
+        $this->assertSame(['red'], $result);
+        $this->assertSame(1, $calls);
+    }
+
     public function testSupportsTheHomeAndEndKeysWhileNavigatingOptions()
     {
         Prompt::fake([Key::DOWN, Key::END[0], Key::SPACE, Key::HOME[0], Key::SPACE, Key::ENTER]);
@@ -441,5 +458,23 @@ class MultiSearchPromptTest extends TestCase
         );
 
         $this->assertSame([], $result);
+    }
+}
+
+class MultiSearchPromptRendererWithoutMatches
+{
+    /**
+     * Create a new renderer instance.
+     */
+    public function __construct(protected MultiSearchPrompt $prompt)
+    {
+    }
+
+    /**
+     * Render the prompt without reading its matches.
+     */
+    public function __invoke(): string
+    {
+        return '';
     }
 }

--- a/tests/Prompts/MultiSearchPromptTest.php
+++ b/tests/Prompts/MultiSearchPromptTest.php
@@ -319,6 +319,35 @@ class MultiSearchPromptTest extends TestCase
         Prompt::assertOutputContains('Please choose green.');
     }
 
+    public function testCancelledZeroIsRenderedInsteadOfThePlaceholder(): void
+    {
+        Prompt::fake(['0', Key::CTRL_C]);
+
+        multisearch('Value', fn (): array => [], placeholder: 'placeholder');
+
+        $output = Prompt::strippedContent();
+        $cancelFrame = substr($output, strrpos($output, ' ┌'));
+
+        $this->assertStringContainsString('│ 0 ', $cancelFrame);
+        $this->assertStringNotContainsString('placeholder', $cancelFrame);
+    }
+
+    public function testSupportsEmacsNavigationKeys(): void
+    {
+        Prompt::fake([Key::CTRL_N, Key::CTRL_N, Key::CTRL_P, Key::SPACE, Key::ENTER]);
+
+        $result = multisearch(
+            'Colors',
+            fn (): array => [
+                'red' => 'Red',
+                'green' => 'Green',
+                'blue' => 'Blue',
+            ],
+        );
+
+        $this->assertSame(['red'], $result);
+    }
+
     public function testSupportsTheHomeAndEndKeysWhileNavigatingOptions()
     {
         Prompt::fake([Key::DOWN, Key::END[0], Key::SPACE, Key::HOME[0], Key::SPACE, Key::ENTER]);

--- a/tests/Prompts/NumberPromptTest.php
+++ b/tests/Prompts/NumberPromptTest.php
@@ -9,7 +9,12 @@ use Hypervel\Prompts\Exceptions\NonInteractiveValidationException;
 use Hypervel\Prompts\Key;
 use Hypervel\Prompts\NumberPrompt;
 use Hypervel\Prompts\Prompt;
+use Hypervel\Prompts\Support\Utils;
 use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use ReflectionProperty;
 
 use function Hypervel\Prompts\number;
 
@@ -36,7 +41,7 @@ class NumberPromptTest extends TestCase
         $this->assertSame(10, $result);
     }
 
-    public function testValidates()
+    public function testValidates(): void
     {
         Prompt::fake(['n', 'o', Key::ENTER, Key::BACKSPACE, Key::BACKSPACE, '1', '0', Key::ENTER]);
 
@@ -46,7 +51,7 @@ class NumberPromptTest extends TestCase
 
         $this->assertSame(10, $result);
 
-        Prompt::assertOutputContains('Must be a number');
+        Prompt::assertOutputContains('Must be an integer');
     }
 
     public function testValidatesMinimumValue()
@@ -63,7 +68,7 @@ class NumberPromptTest extends TestCase
         Prompt::assertOutputContains('Must be at least 1');
     }
 
-    public function testValidatesMaximumValue()
+    public function testValidatesMaximumValue(): void
     {
         Prompt::fake([
             '1', '0', '0',
@@ -80,10 +85,10 @@ class NumberPromptTest extends TestCase
 
         $this->assertSame(99, $result);
 
-        Prompt::assertOutputContains('Must be less than 99');
+        Prompt::assertOutputContains('Must be at most 99');
     }
 
-    public function testFallsThroughToOriginalValidation()
+    public function testFallsThroughToOriginalValidation(): void
     {
         Prompt::fake([
             '1', '0', '0',
@@ -104,16 +109,16 @@ class NumberPromptTest extends TestCase
 
         $this->assertSame(99, $result);
 
-        Prompt::assertOutputContains('Must be less than 99');
+        Prompt::assertOutputContains('Must be at most 99');
         Prompt::assertOutputContains('Must be 99');
     }
 
-    public function testFallsThroughToOriginalValidationWithValidateUsing()
+    public function testFallsThroughToOriginalValidationWithValidateUsing(): void
     {
-        Prompt::validateUsing(function (Prompt $prompt) {
+        Prompt::validateUsing(function (Prompt $prompt, mixed $value) {
             $this->assertSame('required|int|min:99', $prompt->validate);
 
-            return $prompt->value() !== 99 ? 'Must be 99' : null;
+            return $value !== 99 ? 'Must be 99' : null;
         });
 
         Prompt::fake([
@@ -135,6 +140,197 @@ class NumberPromptTest extends TestCase
         Prompt::assertOutputContains('Must be 99');
 
         Prompt::validateUsing(fn () => null);
+    }
+
+    #[DataProvider('validIntegerValues')]
+    public function testParsesStrictSignedDecimalIntegers(string $value, int $expected): void
+    {
+        $this->assertSame($expected, NumberPrompt::parseInteger($value));
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     */
+    public static function validIntegerValues(): array
+    {
+        return [
+            'zero' => ['0', 0],
+            'positive sign' => ['+7', 7],
+            'negative sign' => ['-7', -7],
+            'leading zeroes' => ['+0007', 7],
+            'negative zero' => ['-000', 0],
+            'maximum' => [(string) PHP_INT_MAX, PHP_INT_MAX],
+            'minimum' => [(string) PHP_INT_MIN, PHP_INT_MIN],
+        ];
+    }
+
+    #[DataProvider('invalidIntegerValues')]
+    public function testRejectsAnythingOutsideTheIntegerGrammarOrRange(string $value): void
+    {
+        $this->assertNull(NumberPrompt::parseInteger($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidIntegerValues(): array
+    {
+        return [
+            'empty' => [''],
+            'positive overflow' => [((string) PHP_INT_MAX) . '0'],
+            'negative overflow' => [((string) PHP_INT_MIN) . '0'],
+            'fraction' => ['1.5'],
+            'exponent' => ['1e3'],
+            'leading whitespace' => [' 1'],
+            'trailing whitespace' => ['1 '],
+            'sign only' => ['+'],
+            'non-ASCII digits' => ['１２'],
+        ];
+    }
+
+    #[DataProvider('intrinsicValidationFailures')]
+    public function testIntrinsicValidationRunsWithoutExternalRules(
+        string $value,
+        string $message,
+        ?int $min = null,
+        ?int $max = null,
+    ): void {
+        Prompt::interactive(false);
+
+        $this->expectException(NonInteractiveValidationException::class);
+        $this->expectExceptionMessage($message);
+
+        number('Value', default: $value, min: $min, max: $max);
+    }
+
+    /**
+     * @return array<string, array{string, string, ?int, ?int}>
+     */
+    public static function intrinsicValidationFailures(): array
+    {
+        return [
+            'syntax' => ['1.5', 'Must be an integer', null, null],
+            'positive overflow' => [((string) PHP_INT_MAX) . '0', 'Must be at most ' . PHP_INT_MAX, null, null],
+            'negative overflow' => [((string) PHP_INT_MIN) . '0', 'Must be at least ' . PHP_INT_MIN, null, null],
+            'minimum' => ['0', 'Must be at least 1', 1, null],
+            'maximum' => ['10', 'Must be at most 9', null, 9],
+        ];
+    }
+
+    public function testBoundsAreInclusive(): void
+    {
+        $prompt = new NumberPrompt('Value', min: -2, max: 2);
+
+        $this->assertNull($prompt->validateIntrinsic(-2));
+        $this->assertNull($prompt->validateIntrinsic(2));
+    }
+
+    public function testRejectsAnInvertedRange(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The minimum value must not be greater than the maximum value.');
+
+        new NumberPrompt('Value', min: 2, max: 1);
+    }
+
+    public function testTransformRunsOnceBeforeIntrinsicAndCallerValidation(): void
+    {
+        Prompt::interactive(false);
+        $transformCalls = 0;
+        $validatedValue = null;
+
+        $result = number(
+            label: 'Value',
+            default: ' 7 ',
+            validate: function (mixed $value) use (&$validatedValue): ?string {
+                $validatedValue = $value;
+
+                return null;
+            },
+            transform: function (string $value) use (&$transformCalls): string {
+                ++$transformCalls;
+
+                return trim($value);
+            },
+        );
+
+        $this->assertSame('7', $result);
+        $this->assertSame('7', $validatedValue);
+        $this->assertSame(1, $transformCalls);
+    }
+
+    public function testAcceptsAnIntegerDefault(): void
+    {
+        Prompt::interactive(false);
+
+        $this->assertSame(7, number('Value', default: 7));
+    }
+
+    public function testNormalizesNonpositiveSteps(): void
+    {
+        Prompt::fake(['1', Key::UP, Key::ENTER]);
+
+        $this->assertSame(2, number('Value', step: 0));
+    }
+
+    public function testArrowArithmeticSaturatesAtIntegerBoundaries(): void
+    {
+        Prompt::fake([Key::UP, Key::ENTER]);
+
+        $this->assertSame(PHP_INT_MAX, number('Value', default: PHP_INT_MAX, step: PHP_INT_MAX));
+
+        Prompt::fake([Key::DOWN, Key::ENTER]);
+
+        $this->assertSame(PHP_INT_MIN, number('Value', default: PHP_INT_MIN, step: PHP_INT_MAX));
+    }
+
+    public function testEmptyArrowSeedsAreClampedIntoTheConfiguredRange(): void
+    {
+        Prompt::fake([Key::UP, Key::ENTER]);
+
+        $this->assertSame(0, number('Value', max: 0));
+
+        Prompt::fake([Key::DOWN, Key::ENTER]);
+
+        $this->assertSame(1, number('Value', min: 1));
+    }
+
+    public function testArrowMutationRecomputesTheCursorFromTheCompleteValue(): void
+    {
+        $prompt = new NumberPrompt('Value', default: -9, step: 10);
+
+        (new ReflectionMethod($prompt, 'increaseValue'))->invoke($prompt);
+
+        $this->assertSame(1, $prompt->value());
+        $this->assertSame(1, (new ReflectionProperty($prompt, 'cursorPosition'))->getValue($prompt));
+    }
+
+    public function testCursorRenderingPreservesTheRawTypedInteger(): void
+    {
+        $prompt = new NumberPrompt('Value', default: '+007');
+
+        $this->assertSame('+007 ', Utils::stripEscapeSequences($prompt->valueWithCursor(20)));
+    }
+
+    public function testCancelledZeroIsRenderedInsteadOfThePlaceholder(): void
+    {
+        Prompt::fake(['0', Key::CTRL_C]);
+
+        number(label: 'Value', placeholder: 'placeholder');
+
+        $output = Prompt::strippedContent();
+        $cancelFrame = substr($output, strrpos($output, ' ┌'));
+
+        $this->assertStringContainsString('│ 0 ', $cancelFrame);
+        $this->assertStringNotContainsString('placeholder', $cancelFrame);
+    }
+
+    public function testNarrowTerminalsDoNotProduceNegativeArrowPadding(): void
+    {
+        Prompt::fake([Key::ENTER]);
+        Prompt::terminal()->shouldReceive('cols')->andReturn(8); // @phpstan-ignore-line
+
+        $this->assertSame(1, number('Value', default: 1));
     }
 
     public function testStartsWithMinimumValueWhenUpArrowPressedAndValueIsEmpty()

--- a/tests/Prompts/ParseAnsiTextTest.php
+++ b/tests/Prompts/ParseAnsiTextTest.php
@@ -85,6 +85,17 @@ class ParseAnsiTextTest extends TestCase
         ], $segments);
     }
 
+    public function testPreservesColonFormAttributesWithoutConsumingLaterSemicolonAttributes(): void
+    {
+        $segments = $this->getInstance()->parse("\e[4:3;38:2:255:0:0;1mstyled\e[24:0m colored\e[39;22m plain");
+
+        $this->assertSame([
+            ['text' => 'styled', 'codes' => "\e[4:3m\e[38:2:255:0:0m\e[1m", 'link' => ''],
+            ['text' => ' colored', 'codes' => "\e[38:2:255:0:0m\e[1m", 'link' => ''],
+            ['text' => ' plain', 'codes' => '', 'link' => ''],
+        ], $segments);
+    }
+
     public function testParsesEmptyString(): void
     {
         $segments = $this->getInstance()->parse('');
@@ -161,7 +172,7 @@ class ParseAnsiTextTest extends TestCase
         ], $belSegments);
     }
 
-    public function testMalformedHyperlinkSequenceDoesNotCloseTheActiveLink(): void
+    public function testMalformedHyperlinkIsRemovedWithoutClosingTheActiveLink(): void
     {
         $link = "\e]8;;https://hypervel.org\e\\";
         $segments = $this->getInstance()->parse(
@@ -169,12 +180,11 @@ class ParseAnsiTextTest extends TestCase
         );
 
         $this->assertSame([
-            ['text' => 'link', 'codes' => '', 'link' => $link],
-            ['text' => 'tail', 'codes' => '', 'link' => $link],
+            ['text' => 'linktail', 'codes' => '', 'link' => $link],
         ], $segments);
     }
 
-    public function testPreservesSemicolonsInHyperlinkUris(): void
+    public function testPreservesHyperlinkUrisEndingInASemicolon(): void
     {
         $segments = $this->getInstance()->parse("Click \e]8;;https://hypervel.org/?first=1;second=2;\e\\here\e]8;;\e\\.");
 
@@ -195,23 +205,46 @@ class ParseAnsiTextTest extends TestCase
         ], $segments);
     }
 
-    public function testPreservesUnterminatedCsiAsText(): void
+    public function testDiscardsUnterminatedCsi(): void
     {
         $segments = $this->getInstance()->parse("abc\e[31");
 
         $this->assertSame([
             ['text' => 'abc', 'codes' => '', 'link' => ''],
-            ['text' => "\e[31", 'codes' => '', 'link' => ''],
         ], $segments);
     }
 
-    public function testPreservesUnterminatedOscAsText(): void
+    public function testDiscardsUnterminatedOsc(): void
     {
         $segments = $this->getInstance()->parse("abc\e]8;;https://hypervel.org");
 
         $this->assertSame([
             ['text' => 'abc', 'codes' => '', 'link' => ''],
-            ['text' => "\e]8;;https://hypervel.org", 'codes' => '', 'link' => ''],
+        ], $segments);
+    }
+
+    public function testDiscardsGenericAndStringControlsWithoutLosingLaterText(): void
+    {
+        $segments = $this->getInstance()->parse(
+            "a\e7b\e(Bc\ePsecret\e\\d\e_secret\e\\e",
+        );
+
+        $this->assertSame([
+            ['text' => 'abcde', 'codes' => '', 'link' => ''],
+        ], $segments);
+    }
+
+    public function testRecoversLocallyFromMalformedControls(): void
+    {
+        $segments = $this->getInstance()->parse(
+            "a\e[12\ntext \e]8;;https://example.com\e[31mred\e[0m \e\e[32mgreen",
+        );
+
+        $this->assertSame([
+            ['text' => "a\ntext ", 'codes' => '', 'link' => ''],
+            ['text' => 'red', 'codes' => "\e[31m", 'link' => ''],
+            ['text' => ' ', 'codes' => '', 'link' => ''],
+            ['text' => 'green', 'codes' => "\e[32m", 'link' => ''],
         ], $segments);
     }
 

--- a/tests/Prompts/ParseAnsiTextTest.php
+++ b/tests/Prompts/ParseAnsiTextTest.php
@@ -51,6 +51,40 @@ class ParseAnsiTextTest extends TestCase
         ], $segments);
     }
 
+    public function testCombinesSequentialAttributesAndReplacesOnlyMatchingAttributes(): void
+    {
+        $segments = $this->getInstance()->parse("\e[1mBold \e[31mred \e[32mgreen");
+
+        $this->assertSame([
+            ['text' => 'Bold ', 'codes' => "\e[1m", 'link' => ''],
+            ['text' => 'red ', 'codes' => "\e[1m\e[31m", 'link' => ''],
+            ['text' => 'green', 'codes' => "\e[1m\e[32m", 'link' => ''],
+        ], $segments);
+    }
+
+    public function testSelectiveResetsPreserveUnrelatedAttributes(): void
+    {
+        $segments = $this->getInstance()->parse("\e[1;31mbold red\e[22m red\e[39m plain");
+
+        $this->assertSame([
+            ['text' => 'bold red', 'codes' => "\e[1m\e[31m", 'link' => ''],
+            ['text' => ' red', 'codes' => "\e[31m", 'link' => ''],
+            ['text' => ' plain', 'codes' => '', 'link' => ''],
+        ], $segments);
+    }
+
+    public function testParsesIndexedAndRgbUnderlineColorsWithoutTreatingComponentsAsAttributes(): void
+    {
+        $segments = $this->getInstance()->parse("\e[4;58;5;196mindexed\e[59m underline \e[58;2;255;0;0mrgb\e[59m end");
+
+        $this->assertSame([
+            ['text' => 'indexed', 'codes' => "\e[4m\e[58;5;196m", 'link' => ''],
+            ['text' => ' underline ', 'codes' => "\e[4m", 'link' => ''],
+            ['text' => 'rgb', 'codes' => "\e[4m\e[58;2;255;0;0m", 'link' => ''],
+            ['text' => ' end', 'codes' => "\e[4m", 'link' => ''],
+        ], $segments);
+    }
+
     public function testParsesEmptyString(): void
     {
         $segments = $this->getInstance()->parse('');
@@ -74,7 +108,7 @@ class ParseAnsiTextTest extends TestCase
         $this->assertSame([
             ['text' => 'alpha ', 'codes' => '', 'link' => ''],
             ['text' => 'beta', 'codes' => "\e[32m", 'link' => ''],
-            ['text' => ' gamma', 'codes' => "\e[39m", 'link' => ''],
+            ['text' => ' gamma', 'codes' => '', 'link' => ''],
         ], $segments);
     }
 
@@ -125,6 +159,19 @@ class ParseAnsiTextTest extends TestCase
             ['text' => 'here', 'codes' => '', 'link' => "\e]8;id=hypervel;https://hypervel.org\x07"],
             ['text' => '.', 'codes' => '', 'link' => ''],
         ], $belSegments);
+    }
+
+    public function testMalformedHyperlinkSequenceDoesNotCloseTheActiveLink(): void
+    {
+        $link = "\e]8;;https://hypervel.org\e\\";
+        $segments = $this->getInstance()->parse(
+            $link . "link\e]8;garbage\e\\tail\e]8;;\e\\",
+        );
+
+        $this->assertSame([
+            ['text' => 'link', 'codes' => '', 'link' => $link],
+            ['text' => 'tail', 'codes' => '', 'link' => $link],
+        ], $segments);
     }
 
     public function testPreservesSemicolonsInHyperlinkUris(): void

--- a/tests/Prompts/ProgressSignalTest.php
+++ b/tests/Prompts/ProgressSignalTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use RuntimeException;
 
+use function Hypervel\Coroutine\run;
+
 class ProgressSignalTest extends TestCase
 {
     protected bool $runTestsInCoroutine = false;
@@ -110,5 +112,32 @@ class ProgressSignalTest extends TestCase
         $this->assertSame(0, pcntl_wexitstatus($status));
         $this->assertFileExists($observationPath);
         $this->assertSame('1:1:1:1:0', file_get_contents($observationPath));
+    }
+
+    #[RunInSeparateProcess]
+    public function testCoroutineProgressLeavesProcessSignalStateUntouched(): void
+    {
+        Prompt::fake();
+        $previousHandler = static function (): void {
+        };
+
+        pcntl_signal(SIGINT, $previousHandler);
+        pcntl_async_signals(false);
+
+        run(function () use ($previousHandler): void {
+            $progress = new Progress('Working', 1);
+            $progress->start();
+
+            $this->assertSame($previousHandler, pcntl_signal_get_handler(SIGINT));
+            $this->assertFalse(pcntl_async_signals());
+
+            $progress->finish();
+
+            $this->assertSame($previousHandler, pcntl_signal_get_handler(SIGINT));
+            $this->assertFalse(pcntl_async_signals());
+        });
+
+        $this->assertSame($previousHandler, pcntl_signal_get_handler(SIGINT));
+        $this->assertFalse(pcntl_async_signals());
     }
 }

--- a/tests/Prompts/PromptLifecycleTest.php
+++ b/tests/Prompts/PromptLifecycleTest.php
@@ -75,6 +75,25 @@ class PromptLifecycleTest extends TestCase
         $this->assertSame(1, $transformCalls);
     }
 
+    public function testEmptyIntrinsicResultContinuesToConfiguredValidation(): void
+    {
+        $validationCalls = 0;
+        $prompt = new EmptyIntrinsicTextPrompt(
+            label: 'Value',
+            validate: function (string $value) use (&$validationCalls): string {
+                ++$validationCalls;
+
+                return "Rejected [{$value}].";
+            },
+        );
+
+        (new ReflectionMethod(Prompt::class, 'validate'))->invoke($prompt, 'a');
+
+        $this->assertSame(1, $validationCalls);
+        $this->assertSame('error', (new ReflectionProperty(Prompt::class, 'state'))->getValue($prompt));
+        $this->assertSame('Rejected [a].', (new ReflectionProperty(Prompt::class, 'error'))->getValue($prompt));
+    }
+
     public function testCancellationReturnsTheCurrentTransformedValueWithoutASubmission(): void
     {
         Prompt::fake([Key::CTRL_C]);
@@ -246,5 +265,16 @@ class PromptLifecycleTest extends TestCase
         $this->assertNotSame($previousOutput, $currentOutput = $output->invoke(null));
         $this->assertInstanceOf(ConsoleOutput::class, $currentOutput);
         $this->assertNotSame($previousTerminal, Prompt::terminal());
+    }
+}
+
+class EmptyIntrinsicTextPrompt extends TextPrompt
+{
+    /**
+     * Validate rules intrinsic to the prompt type.
+     */
+    public function validateIntrinsic(mixed $value): ?string
+    {
+        return '';
     }
 }

--- a/tests/Prompts/PromptLifecycleTest.php
+++ b/tests/Prompts/PromptLifecycleTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Prompts;
 
+use Hypervel\Context\CoroutineContext;
+use Hypervel\Prompts\Exceptions\NonInteractiveValidationException;
 use Hypervel\Prompts\Key;
 use Hypervel\Prompts\Output\BufferedConsoleOutput;
+use Hypervel\Prompts\Output\ConsoleOutput;
 use Hypervel\Prompts\Prompt;
 use Hypervel\Prompts\Spinner;
 use Hypervel\Prompts\TextPrompt;
@@ -18,6 +21,117 @@ use function Hypervel\Prompts\text;
 
 class PromptLifecycleTest extends TestCase
 {
+    public function testInteractiveValidationReceivesTheSingleTransformedSubmission(): void
+    {
+        Prompt::fake(['a', Key::ENTER]);
+        $transformCalls = 0;
+        $validatedValue = null;
+
+        Prompt::validateUsing(function (Prompt $prompt, mixed $value) use (&$validatedValue): ?string {
+            $this->assertSame('rules', $prompt->validate);
+            $validatedValue = $value;
+
+            return null;
+        });
+
+        $result = (new TextPrompt(
+            label: 'Value',
+            validate: 'rules',
+            transform: function (string $value) use (&$transformCalls): string {
+                ++$transformCalls;
+
+                return strtoupper($value);
+            },
+        ))->prompt();
+
+        $this->assertSame('A', $result);
+        $this->assertSame('A', $validatedValue);
+        $this->assertSame(1, $transformCalls);
+    }
+
+    public function testNonInteractiveValidationReturnsTheSingleTransformedDefault(): void
+    {
+        Prompt::interactive(false);
+        $transformCalls = 0;
+        $validatedValue = null;
+
+        $result = (new TextPrompt(
+            label: 'Value',
+            default: ' value ',
+            validate: function (mixed $value) use (&$validatedValue): ?string {
+                $validatedValue = $value;
+
+                return null;
+            },
+            transform: function (string $value) use (&$transformCalls): string {
+                ++$transformCalls;
+
+                return trim($value);
+            },
+        ))->prompt();
+
+        $this->assertSame('value', $result);
+        $this->assertSame('value', $validatedValue);
+        $this->assertSame(1, $transformCalls);
+    }
+
+    public function testCancellationReturnsTheCurrentTransformedValueWithoutASubmission(): void
+    {
+        Prompt::fake([Key::CTRL_C]);
+
+        $result = (new TextPrompt(
+            label: 'Value',
+            default: ' value ',
+            transform: trim(...),
+        ))->prompt();
+
+        $this->assertSame('value', $result);
+    }
+
+    public function testInputPromptCannotBeInvokedTwiceAfterSuccess(): void
+    {
+        Prompt::interactive(false);
+        $prompt = new TextPrompt('Value', default: 'value');
+
+        $this->assertSame('value', $prompt->prompt());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This prompt has already been invoked.');
+
+        $prompt->prompt();
+    }
+
+    public function testInputPromptCannotBeInvokedTwiceAfterFallback(): void
+    {
+        Prompt::fallbackWhen(true);
+        TextPrompt::fallbackUsing(fn (): string => 'fallback');
+        $prompt = new TextPrompt('Value');
+
+        $this->assertSame('fallback', $prompt->prompt());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This prompt has already been invoked.');
+
+        $prompt->prompt();
+    }
+
+    public function testInputPromptCannotBeInvokedTwiceAfterFailure(): void
+    {
+        Prompt::interactive(false);
+        $prompt = new TextPrompt('Value', required: true);
+
+        try {
+            $prompt->prompt();
+            $this->fail('Expected non-interactive validation to fail.');
+        } catch (NonInteractiveValidationException) {
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This prompt has already been invoked.');
+
+        $prompt->prompt();
+    }
+
     public function testUndecoratedInteractivePromptAppendsPlainFrames(): void
     {
         Prompt::fake(['a', 'b', Key::ENTER]);
@@ -110,5 +224,27 @@ class PromptLifecycleTest extends TestCase
         $this->assertFalse(
             (new ReflectionProperty(Prompt::class, 'cursorHidden'))->getValue(),
         );
+    }
+
+    public function testFlushStateForgetsPromptOverridesAndLazilyRecreatesSharedDependencies(): void
+    {
+        Prompt::fake();
+        Prompt::validateUsing(fn (): null => null);
+        CoroutineContext::set('prompts.lifecycle.sentinel', 'preserved');
+
+        $output = new ReflectionMethod(Prompt::class, 'output');
+        $validation = new ReflectionMethod(Prompt::class, 'getValidateUsing');
+        $previousOutput = $output->invoke(null);
+        $previousTerminal = Prompt::terminal();
+
+        $this->assertNotNull($validation->invoke(null));
+
+        Prompt::flushState();
+
+        $this->assertSame('preserved', CoroutineContext::get('prompts.lifecycle.sentinel'));
+        $this->assertNull($validation->invoke(null));
+        $this->assertNotSame($previousOutput, $currentOutput = $output->invoke(null));
+        $this->assertInstanceOf(ConsoleOutput::class, $currentOutput);
+        $this->assertNotSame($previousTerminal, Prompt::terminal());
     }
 }

--- a/tests/Prompts/SearchPromptTest.php
+++ b/tests/Prompts/SearchPromptTest.php
@@ -210,6 +210,23 @@ class SearchPromptTest extends TestCase
         $this->assertSame('blue', $result);
     }
 
+    public function testNavigationPopulatesMatchesWhenACustomRendererDoesNotReadThem(): void
+    {
+        Prompt::fake([Key::DOWN, Key::ENTER]);
+        Prompt::addTheme('without-search-matches', [SearchPrompt::class => SearchPromptRendererWithoutMatches::class]);
+        Prompt::theme('without-search-matches');
+        $calls = 0;
+
+        $result = search('Color', function () use (&$calls): array {
+            ++$calls;
+
+            return ['red' => 'Red', 'blue' => 'Blue'];
+        });
+
+        $this->assertSame('red', $result);
+        $this->assertSame(1, $calls);
+    }
+
     public function testFailsWhenNonInteractive(): void
     {
         $this->expectException(NonInteractiveValidationException::class);
@@ -252,5 +269,23 @@ class SearchPromptTest extends TestCase
         Prompt::assertOutputContains('Please choose green.');
 
         Prompt::validateUsing(fn () => null);
+    }
+}
+
+class SearchPromptRendererWithoutMatches
+{
+    /**
+     * Create a new renderer instance.
+     */
+    public function __construct(protected SearchPrompt $prompt)
+    {
+    }
+
+    /**
+     * Render the prompt without reading its matches.
+     */
+    public function __invoke(): string
+    {
+        return '';
     }
 }

--- a/tests/Prompts/SearchPromptTest.php
+++ b/tests/Prompts/SearchPromptTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Prompts;
 
+use Exception;
 use Hypervel\Prompts\Exceptions\NonInteractiveValidationException;
 use Hypervel\Prompts\Key;
 use Hypervel\Prompts\Prompt;
@@ -145,6 +146,28 @@ class SearchPromptTest extends TestCase
 
         $this->assertSame('green', $result);
         Prompt::assertOutputContains('Please choose green.');
+    }
+
+    public function testCancelledZeroIsRenderedInsteadOfThePlaceholder(): void
+    {
+        $cancelled = new Exception('Cancelled.');
+        Prompt::cancelUsing(fn () => throw $cancelled);
+        Prompt::fake(['0', Key::CTRL_C]);
+
+        $thrown = null;
+
+        try {
+            search('Value', fn (): array => [], placeholder: 'placeholder');
+        } catch (Exception $exception) {
+            $thrown = $exception;
+        }
+
+        $output = Prompt::strippedContent();
+        $cancelFrame = substr($output, strrpos($output, ' ┌'));
+
+        $this->assertSame($cancelled, $thrown);
+        $this->assertStringContainsString('│ 0 ', $cancelFrame);
+        $this->assertStringNotContainsString('placeholder', $cancelFrame);
     }
 
     public function testCanFallBack(): void

--- a/tests/Prompts/SpinnerTest.php
+++ b/tests/Prompts/SpinnerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Prompts;
 
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Engine\Channel;
 use Hypervel\Prompts\Output\BufferedConsoleOutput;
 use Hypervel\Prompts\Prompt;
 use Hypervel\Prompts\Spinner;
@@ -101,5 +103,118 @@ class SpinnerTest extends TestCase
             $this->assertFalse($spinner->static);
             $this->assertGreaterThan(0, $spinner->count);
         });
+    }
+
+    public function testWaitsForAnInFlightAnimationBeforeSettling(): void
+    {
+        Prompt::fake();
+        $spinner = new SpinnerAnimationFixture('Running');
+        $spinner->interval = 1;
+
+        $result = $spinner->spin(function () use ($spinner): string {
+            $this->assertTrue($spinner->renderStarted->pop(1));
+
+            Coroutine::fork(function () use ($spinner): void {
+                usleep(20_000);
+                $spinner->renderRelease->push(true);
+            });
+
+            return 'done';
+        });
+
+        $this->assertSame('done', $result);
+        $this->assertFalse($spinner->rendering);
+        $renderCalls = $spinner->renderCalls;
+        usleep(150_000);
+        $this->assertSame($renderCalls, $spinner->renderCalls);
+    }
+
+    public function testSurfacesAnimationRenderFailureAfterSuccessfulCallback(): void
+    {
+        Prompt::fake();
+        $failure = new RuntimeException('animation failed');
+        $spinner = new SpinnerAnimationFixture('Running');
+        $spinner->interval = 1;
+        $spinner->renderFailure = $failure;
+        $callbackRan = false;
+        $thrown = null;
+
+        try {
+            $spinner->spin(function () use (&$callbackRan): void {
+                $callbackRan = true;
+                usleep(5_000);
+            });
+        } catch (RuntimeException $exception) {
+            $thrown = $exception;
+        }
+
+        $this->assertSame($failure, $thrown);
+        $this->assertTrue($callbackRan);
+    }
+
+    public function testCallbackFailureRemainsPrimaryWhenAnimationAlsoFails(): void
+    {
+        Prompt::fake();
+        $callbackFailure = new RuntimeException('callback failed');
+        $spinner = new SpinnerAnimationFixture('Running');
+        $spinner->interval = 1;
+        $spinner->renderFailure = new RuntimeException('animation failed');
+        $thrown = null;
+
+        try {
+            $spinner->spin(function () use ($callbackFailure): never {
+                usleep(5_000);
+
+                throw $callbackFailure;
+            });
+        } catch (RuntimeException $exception) {
+            $thrown = $exception;
+        }
+
+        $this->assertSame($callbackFailure, $thrown);
+    }
+}
+
+class SpinnerAnimationFixture extends Spinner
+{
+    /** @var Channel<true> */
+    public Channel $renderStarted;
+
+    /** @var Channel<true> */
+    public Channel $renderRelease;
+
+    public int $renderCalls = 0;
+
+    public bool $rendering = false;
+
+    public ?RuntimeException $renderFailure = null;
+
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+
+        $this->renderStarted = new Channel(1);
+        $this->renderRelease = new Channel(1);
+    }
+
+    /**
+     * Render the spinner while exposing animation lifecycle checkpoints.
+     */
+    protected function render(): void
+    {
+        ++$this->renderCalls;
+
+        if ($this->renderCalls === 1) {
+            return;
+        }
+
+        if ($this->renderFailure !== null) {
+            throw $this->renderFailure;
+        }
+
+        $this->rendering = true;
+        $this->renderStarted->push(true);
+        $this->renderRelease->pop();
+        $this->rendering = false;
     }
 }

--- a/tests/Prompts/SpinnerTest.php
+++ b/tests/Prompts/SpinnerTest.php
@@ -214,7 +214,12 @@ class SpinnerAnimationFixture extends Spinner
 
         $this->rendering = true;
         $this->renderStarted->push(true);
-        $this->renderRelease->pop();
+        // This is a deadlock bound, not a rendering timing expectation.
+        $released = $this->renderRelease->pop(5);
         $this->rendering = false;
+
+        if ($released !== true) {
+            throw new RuntimeException('Timed out waiting to release the spinner animation render.');
+        }
     }
 }

--- a/tests/Prompts/SuggestPromptTest.php
+++ b/tests/Prompts/SuggestPromptTest.php
@@ -113,6 +113,19 @@ class SuggestPromptTest extends TestCase
         Prompt::assertOutputContains('Please enter your name.');
     }
 
+    public function testCancelledZeroIsRenderedInsteadOfThePlaceholder(): void
+    {
+        Prompt::fake(['0', Key::CTRL_C]);
+
+        suggest('Value', ['One'], placeholder: 'placeholder');
+
+        $output = Prompt::strippedContent();
+        $cancelFrame = substr($output, strrpos($output, ' ┌'));
+
+        $this->assertStringContainsString('│ 0 ', $cancelFrame);
+        $this->assertStringNotContainsString('placeholder', $cancelFrame);
+    }
+
     public function testCanFallBack(): void
     {
         Prompt::fallbackWhen(true);

--- a/tests/Prompts/TaskFrameTest.php
+++ b/tests/Prompts/TaskFrameTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Prompts;
+
+use Hypervel\Prompts\Support\TaskFrame;
+use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+
+class TaskFrameTest extends TestCase
+{
+    public function testEncodesExactBinaryFrameBytes(): void
+    {
+        $this->assertSame("\x01\x00\x00\x00\x03a\n\0", TaskFrame::encode(null, "a\n\0"));
+    }
+
+    #[DataProvider('messageTypes')]
+    public function testRoundTripsEveryMessageType(?string $type): void
+    {
+        $payload = "first\n\nsecond\0tail";
+        $decoder = new TaskFrame;
+
+        $decoder->append(TaskFrame::encode($type, $payload));
+
+        $this->assertSame(['type' => $type, 'payload' => $payload], $decoder->next());
+        $this->assertNull($decoder->next());
+        $decoder->finish();
+    }
+
+    /**
+     * @return array<string, array{?string}>
+     */
+    public static function messageTypes(): array
+    {
+        return [
+            'line' => [null],
+            'success' => ['success'],
+            'warning' => ['warning'],
+            'error' => ['error'],
+            'label' => ['label'],
+            'sublabel' => ['sublabel'],
+            'reset' => ['reset'],
+            'partial' => ['partial'],
+            'partial commit' => ['commitpartial'],
+        ];
+    }
+
+    public function testDecodesSplitHeadersAndPayloads(): void
+    {
+        $frame = TaskFrame::encode('partial', "chunk\0\n");
+        $decoder = new TaskFrame;
+
+        foreach (str_split($frame) as $index => $byte) {
+            $decoder->append($byte);
+
+            if ($index < strlen($frame) - 1) {
+                $this->assertNull($decoder->next());
+            }
+        }
+
+        $this->assertSame(
+            ['type' => 'partial', 'payload' => "chunk\0\n"],
+            $decoder->next(),
+        );
+        $decoder->finish();
+    }
+
+    public function testDecodesMultipleFramesFromOneRead(): void
+    {
+        $decoder = new TaskFrame;
+        $decoder->append(
+            TaskFrame::encode(null, 'line')
+            . TaskFrame::encode('commitpartial', '')
+            . TaskFrame::encode('reset', "\x01"),
+        );
+
+        $this->assertSame(['type' => null, 'payload' => 'line'], $decoder->next());
+        $this->assertSame(['type' => 'commitpartial', 'payload' => ''], $decoder->next());
+        $this->assertSame(['type' => 'reset', 'payload' => "\x01"], $decoder->next());
+        $this->assertNull($decoder->next());
+        $decoder->finish();
+    }
+
+    public function testRejectsAnUnknownEncodedType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown task message type [debug].');
+
+        TaskFrame::encode('debug', 'message');
+    }
+
+    public function testRejectsAnUnknownDecodedType(): void
+    {
+        $decoder = new TaskFrame;
+        $decoder->append("\xff\x00\x00\x00\x00");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown task message type [255].');
+
+        $decoder->next();
+    }
+
+    public function testRejectsAnIncompleteFrameAtEof(): void
+    {
+        $decoder = new TaskFrame;
+        $decoder->append(substr(TaskFrame::encode('success', 'done'), 0, -1));
+
+        $this->assertNull($decoder->next());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The prompt renderer received an incomplete task message.');
+
+        $decoder->finish();
+    }
+
+    public function testResetDiscardsAnIncompleteFrame(): void
+    {
+        $decoder = new TaskFrame;
+        $decoder->append("\x01\x00");
+
+        $decoder->reset();
+        $decoder->finish();
+
+        $this->assertNull($decoder->next());
+    }
+}

--- a/tests/Prompts/TaskProcessTest.php
+++ b/tests/Prompts/TaskProcessTest.php
@@ -413,7 +413,7 @@ class TaskChildFailureFixture extends TaskProcessFixture
     protected function runRendererProcess($socket): never
     {
         stream_set_blocking($socket, true);
-        fgets($socket);
+        fread($socket, 5);
         fclose($socket);
 
         exit(1);
@@ -493,7 +493,7 @@ class TaskInterruptedWaitFixture extends TaskProcessFixture
     protected function runRendererProcess($socket): never
     {
         stream_set_blocking($socket, true);
-        fgets($socket);
+        fread($socket, 5);
         fclose($socket);
         sleep(2);
 

--- a/tests/Prompts/TaskTest.php
+++ b/tests/Prompts/TaskTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Prompts;
 
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Engine\Channel;
 use Hypervel\Prompts\Output\BufferedConsoleOutput;
 use Hypervel\Prompts\Prompt;
+use Hypervel\Prompts\Support\InProcessLogger;
 use Hypervel\Prompts\Support\Logger;
+use Hypervel\Prompts\Support\TaskFrame;
 use Hypervel\Prompts\Task;
 use Hypervel\Prompts\Themes\Default\TaskRenderer;
 use Hypervel\Tests\TestCase;
@@ -143,7 +147,7 @@ class TaskTest extends TestCase
     {
         Prompt::fake();
         $task = new Task(label: 'My Task', limit: 10);
-        $task->appendLogLine('kept');
+        (new InProcessLogger($task))->line('kept');
         $task->limit = -1;
         $callbackRuns = 0;
 
@@ -331,7 +335,7 @@ class TaskTest extends TestCase
         Prompt::assertOutputContains('Assets built');
     }
 
-    public function testCoroutinePathHandlesPartialLogging()
+    public function testCoroutinePathHandlesPartialLogging(): void
     {
         Prompt::fake();
 
@@ -339,7 +343,7 @@ class TaskTest extends TestCase
             label: 'Running...',
             callback: function (Logger $logger) {
                 $logger->partial('hello ');
-                $logger->partial('hello world');
+                $logger->partial('world');
                 $logger->commitPartial();
                 $logger->line('after commit');
 
@@ -410,42 +414,54 @@ class TaskTest extends TestCase
         $this->assertSame('hello world', $task->logs[1]);
     }
 
-    public function testCommitsPartialLinesSoTheyBecomePermanent()
+    public function testCommitsPartialLinesSoTheyBecomePermanent(): void
     {
         Prompt::fake();
 
         $task = new Task(label: 'Test', limit: 10);
 
-        $addLogLines = new ReflectionMethod($task, 'addLogLines');
-        $replacePartialLines = new ReflectionMethod($task, 'replacePartialLines');
-
-        $replacePartialLines->invoke($task, 'streamed text');
-
-        // Simulate commitpartial by clearing the index
+        $logger = new InProcessLogger($task);
         $partialStartIndex = new ReflectionProperty($task, 'partialStartIndex');
-        $partialStartIndex->setValue($task, null);
 
-        // Now add a new line — it should append, not replace
-        $addLogLines->invoke($task, 'new line');
+        $logger->partial('streamed text');
+        $this->assertSame(0, $partialStartIndex->getValue($task));
+
+        $logger->commitPartial();
+        $this->assertNull($partialStartIndex->getValue($task));
+
+        $logger->line('new line');
 
         $this->assertCount(2, $task->logs);
         $this->assertSame('streamed text', $task->logs[0]);
         $this->assertSame('new line', $task->logs[1]);
     }
 
-    public function testClearsLogsWhenStableMessageReceived()
+    public function testCommittedPartialLinesAreNotReplayedByTheNextPartial(): void
+    {
+        Prompt::fake();
+        $task = new Task(label: 'Test', limit: 10);
+        $logger = new InProcessLogger($task);
+
+        $logger->partial('first');
+        $logger->commitPartial();
+        $logger->partial('second');
+        $logger->commitPartial();
+
+        $this->assertSame(['first', 'second'], $task->logs);
+    }
+
+    public function testClearsLogsWhenStableMessageReceived(): void
     {
         Prompt::fake();
 
         $task = new Task(label: 'Test', limit: 10);
 
-        $addLogLines = new ReflectionMethod($task, 'addLogLines');
-        $addLogLines->invoke($task, 'log line');
+        $logger = new InProcessLogger($task);
+        $logger->line('log line');
 
         $this->assertCount(1, $task->logs);
 
-        $task->stableMessages[] = ['type' => 'success', 'message' => 'Done!'];
-        $task->logs = [];
+        $logger->success('Done!');
 
         $this->assertEmpty($task->logs);
         $this->assertCount(1, $task->stableMessages);
@@ -453,25 +469,22 @@ class TaskTest extends TestCase
         $this->assertSame('Done!', $task->stableMessages[0]['message']);
     }
 
-    public function testTrimsStableMessagesToMaxStableMessages()
+    public function testTrimsStableMessagesToMaxStableMessages(): void
     {
         $task = new Task(label: 'Test', limit: 10);
         $task->maxStableMessages = 2;
+        $logger = new InProcessLogger($task);
 
-        $task->stableMessages[] = ['type' => 'success', 'message' => 'First'];
-        $task->stableMessages[] = ['type' => 'success', 'message' => 'Second'];
-        $task->stableMessages[] = ['type' => 'success', 'message' => 'Third'];
-
-        while (count($task->stableMessages) > $task->maxStableMessages) {
-            array_shift($task->stableMessages);
-        }
+        $logger->success('First');
+        $logger->success('Second');
+        $logger->success('Third');
 
         $this->assertCount(2, $task->stableMessages);
         $this->assertSame('Second', $task->stableMessages[0]['message']);
         $this->assertSame('Third', $task->stableMessages[1]['message']);
     }
 
-    public function testReceivesMessagesThroughSocketProtocol()
+    public function testReceivesMessagesThroughSocketProtocol(): void
     {
         Prompt::fake();
 
@@ -482,13 +495,14 @@ class TaskTest extends TestCase
         // Create a socket pair to simulate IPC
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
-        $id = $task->identifier;
-
-        // Write messages from the "parent" side
-        fwrite($sockets[1], "plain log line\n");
-        fwrite($sockets[1], "{$id}_label:New Label\n");
-        fwrite($sockets[1], "another log line\n");
-        fwrite($sockets[1], "{$id}_success:Step complete\n");
+        fwrite(
+            $sockets[1],
+            TaskFrame::encode(null, "plain\nlog\0line")
+            . TaskFrame::encode('label', 'New Label')
+            . TaskFrame::encode(null, 'another log line')
+            . TaskFrame::encode('success', 'Step complete')
+            . TaskFrame::encode(null, "after\nsettlement\0line"),
+        );
         fclose($sockets[1]);
 
         stream_set_blocking($sockets[0], false);
@@ -498,11 +512,10 @@ class TaskTest extends TestCase
         $this->assertSame('New Label', $task->label);
         $this->assertCount(1, $task->stableMessages);
         $this->assertSame(['type' => 'success', 'message' => 'Step complete'], $task->stableMessages[0]);
-        // Logs cleared when stable message received, so only post-stable logs remain
-        $this->assertEmpty($task->logs);
+        $this->assertSame(['after', "settlement\0line"], $task->logs);
     }
 
-    public function testHandlesPartialMessagesThroughSocketProtocol()
+    public function testHandlesPartialMessagesThroughSocketProtocol(): void
     {
         Prompt::fake();
 
@@ -512,13 +525,14 @@ class TaskTest extends TestCase
 
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
-        $id = $task->identifier;
-
-        fwrite($sockets[1], "existing line\n");
-        fwrite($sockets[1], "{$id}_partial:hello \n");
-        fwrite($sockets[1], "{$id}_partial:hello world \n");
-        fwrite($sockets[1], "{$id}_commitpartial:\n");
-        fwrite($sockets[1], "after commit\n");
+        fwrite(
+            $sockets[1],
+            TaskFrame::encode(null, 'existing line')
+            . TaskFrame::encode('partial', 'hello ')
+            . TaskFrame::encode('partial', 'world ')
+            . TaskFrame::encode('commitpartial', '')
+            . TaskFrame::encode(null, 'after commit'),
+        );
         fclose($sockets[1]);
 
         stream_set_blocking($sockets[0], false);
@@ -531,7 +545,7 @@ class TaskTest extends TestCase
         $this->assertSame('after commit', $task->logs[2]);
     }
 
-    public function testStripsCursorResetControlSequencesFromLogLines()
+    public function testStripsCursorResetControlSequencesFromLogLines(): void
     {
         Prompt::fake();
 
@@ -541,7 +555,7 @@ class TaskTest extends TestCase
 
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
-        fwrite($sockets[1], "before\e[1G\e[2Kafter\n");
+        fwrite($sockets[1], TaskFrame::encode(null, "before\e[1G\e[2Kafter"));
         fclose($sockets[1]);
 
         stream_set_blocking($sockets[0], false);
@@ -551,7 +565,7 @@ class TaskTest extends TestCase
         $this->assertSame('beforeafter', $task->logs[0]);
     }
 
-    public function testUpdatesLabelThroughSocketProtocol()
+    public function testUpdatesLabelThroughSocketProtocol(): void
     {
         Prompt::fake();
 
@@ -561,9 +575,7 @@ class TaskTest extends TestCase
 
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
-        $id = $task->identifier;
-
-        fwrite($sockets[1], "{$id}_label:Updated Label\n");
+        fwrite($sockets[1], TaskFrame::encode('label', 'Updated Label'));
         fclose($sockets[1]);
 
         stream_set_blocking($sockets[0], false);
@@ -588,8 +600,7 @@ class TaskTest extends TestCase
         $receiveMessages = new ReflectionMethod($task, 'receiveMessages');
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
-        $id = $task->identifier;
-        fwrite($sockets[1], "{$id}_sublabel:Now doing a thing\n");
+        fwrite($sockets[1], TaskFrame::encode('sublabel', 'Now doing a thing'));
         fclose($sockets[1]);
 
         stream_set_blocking($sockets[0], false);
@@ -603,7 +614,7 @@ class TaskTest extends TestCase
         $previousBudget = $task->maxStableMessages;
 
         $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
-        fwrite($sockets[1], "{$id}_sublabel:\n");
+        fwrite($sockets[1], TaskFrame::encode('sublabel', ''));
         fclose($sockets[1]);
         stream_set_blocking($sockets[0], false);
         $receiveMessages->invoke($task, $sockets[0]);
@@ -625,7 +636,8 @@ class TaskTest extends TestCase
             ['type' => 'success', 'message' => 'three'],
         ];
 
-        $task->updateSubLabel('Now doing a thing');
+        $logger = new InProcessLogger($task);
+        $logger->subLabel('Now doing a thing');
 
         $this->assertSame('Now doing a thing', $task->subLabel);
         $this->assertLessThan(3, $task->maxStableMessages);
@@ -633,10 +645,253 @@ class TaskTest extends TestCase
 
         $previousBudget = $task->maxStableMessages;
 
-        $task->updateSubLabel('');
+        $logger->subLabel('');
 
         $this->assertSame('', $task->subLabel);
         $this->assertSame($previousBudget + 1, $task->maxStableMessages);
+    }
+
+    public function testProcessAndInProcessMessagesProduceTheSameTaskState(): void
+    {
+        Prompt::fake();
+
+        $inProcessTask = new Task(label: 'Initial', limit: 10);
+        $logger = new InProcessLogger($inProcessTask);
+        $logger->label('Updated');
+        $logger->subLabel('Working');
+        $logger->line("first\n\nsecond");
+        $logger->partial('streamed ');
+        $logger->partial('output');
+        $logger->commitPartial();
+        $logger->warning('Done');
+        $logger->line('after');
+
+        $processTask = new Task(label: 'Initial', limit: 10);
+        $receiveMessages = new ReflectionMethod($processTask, 'receiveMessages');
+        $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        fwrite(
+            $sockets[1],
+            TaskFrame::encode('label', 'Updated')
+            . TaskFrame::encode('sublabel', 'Working')
+            . TaskFrame::encode(null, "first\n\nsecond")
+            . TaskFrame::encode('partial', 'streamed ')
+            . TaskFrame::encode('partial', 'output')
+            . TaskFrame::encode('commitpartial', '')
+            . TaskFrame::encode('warning', 'Done')
+            . TaskFrame::encode(null, 'after'),
+        );
+        fclose($sockets[1]);
+        stream_set_blocking($sockets[0], false);
+        $receiveMessages->invoke($processTask, $sockets[0]);
+        fclose($sockets[0]);
+
+        $this->assertSame($inProcessTask->label, $processTask->label);
+        $this->assertSame($inProcessTask->subLabel, $processTask->subLabel);
+        $this->assertSame($inProcessTask->logs, $processTask->logs);
+        $this->assertSame($inProcessTask->stableMessages, $processTask->stableMessages);
+    }
+
+    public function testPreservesBlankLinesInCompleteAndPartialOutput(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 10);
+        $logger = new InProcessLogger($task);
+
+        $logger->line("a\n\nb");
+        $this->assertSame(['a', '', 'b'], $task->logs);
+
+        $logger->partial("c\n\nd");
+        $this->assertSame(['a', '', 'b', 'c', '', 'd'], $task->logs);
+
+        $logger->commitPartial();
+        $this->assertSame(['a', '', 'b', 'c', '', 'd'], $task->logs);
+    }
+
+    public function testIncrementalPartialParsingHandlesSplitUtf8AnsiAndHyperlinks(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 10);
+        $logger = new InProcessLogger($task);
+        $character = 'é';
+
+        $logger->partial(substr($character, 0, 1));
+        $logger->partial(substr($character, 1) . " \e[31");
+        $logger->partial("mred\e[0m \e]8;;https://example.com\e");
+        $logger->partial("\\link\e]8;;\e\\");
+
+        $this->assertSame(
+            "é \e[31mred\e[0m \e]8;;https://example.com\e\\link\e]8;;\e\\",
+            $task->logs[0],
+        );
+    }
+
+    public function testIncrementalPartialWrappingMatchesCompleteWordWrapping(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(13); // @phpstan-ignore-line
+
+        $cases = [
+            'abc d' => ['abc', 'd'],
+            'ab cd' => ['ab', 'cd'],
+            'abc ' => ['abc'],
+            'a  b' => ['a ', 'b'],
+            'abcdef gh' => ['abc', 'def', 'gh'],
+        ];
+
+        foreach ($cases as $input => $expected) {
+            $task = new Task(limit: 10);
+            $logger = new InProcessLogger($task);
+            $logger->partial($input);
+            $logger->commitPartial();
+
+            $this->assertSame($expected, $task->logs, "Failed wrapping [{$input}].");
+        }
+    }
+
+    public function testIncrementalPartialParsingHandlesCrLfSplitAcrossChunks(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 10);
+        $logger = new InProcessLogger($task);
+
+        $logger->partial("first\r");
+        $logger->partial("\nsecond");
+        $logger->commitPartial();
+
+        $this->assertSame(['first', 'second'], $task->logs);
+    }
+
+    public function testIncrementalPartialCommitPreservesIncompleteEscapesLiterally(): void
+    {
+        Prompt::fake();
+
+        $csiTask = new Task(limit: 10);
+        $csiLogger = new InProcessLogger($csiTask);
+        $csiLogger->partial("abc\e[31");
+        $csiLogger->commitPartial();
+
+        $oscTask = new Task(limit: 10);
+        $oscLogger = new InProcessLogger($oscTask);
+        $oscLogger->partial("abc\e]8;;https://hypervel.org");
+        $oscLogger->commitPartial();
+
+        $this->assertSame(["abc\e[31"], $csiTask->logs);
+        $this->assertSame(["abc\e]8;;https://hypervel.org"], $oscTask->logs);
+    }
+
+    public function testCompleteNonFormattingControlsAreRemovedFromEveryTaskOutputPath(): void
+    {
+        Prompt::fake();
+
+        $completeTask = new Task(limit: 10);
+        (new ReflectionMethod($completeTask, 'addLogLines'))
+            ->invoke($completeTask, "before\e[1G\e[2Kafter\e]0;title\x07");
+
+        $partialTask = new Task(limit: 10);
+        $partialLogger = new InProcessLogger($partialTask);
+        $partialLogger->partial("before\e[1G\e[2Kafter\e]0;title\x07");
+        $partialLogger->commitPartial();
+
+        $this->assertSame(['beforeafter'], $completeTask->logs);
+        $this->assertSame($completeTask->logs, $partialTask->logs);
+    }
+
+    public function testIncrementalPartialParsingUsesSharedEffectiveSgrState(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 10);
+        $logger = new InProcessLogger($task);
+
+        $logger->partial("\e[1mBold \e[58;2;255;0;0munderlined\e[59m text");
+        $logger->commitPartial();
+
+        $this->assertSame([
+            "\e[1mBold \e[0m\e[1m\e[58;2;255;0;0munderlined\e[0m\e[1m text\e[0m",
+        ], $task->logs);
+    }
+
+    public function testIncrementalPartialStateIsBoundedByVisibleOutput(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(14); // @phpstan-ignore-line
+        $task = new Task(limit: 3);
+        $logger = new InProcessLogger($task);
+
+        for ($index = 0; $index < 1000; ++$index) {
+            $logger->partial('x');
+        }
+
+        $this->assertSame(['xxxx', 'xxxx', 'xxxx'], $task->logs);
+        $this->assertSame('', (new ReflectionProperty($task, 'partialInputBuffer'))->getValue($task));
+        $this->assertLessThanOrEqual(3, count((new ReflectionProperty($task, 'partialLines'))->getValue($task)));
+        $this->assertLessThanOrEqual(4, count((new ReflectionProperty($task, 'partialLineTokens'))->getValue($task)));
+        $this->assertLessThanOrEqual(4, count((new ReflectionProperty($task, 'partialWordTokens'))->getValue($task)));
+    }
+
+    public function testPartialBoundaryTracksRingBufferTrimmingAndResetsOnStableOutput(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 2);
+        $logger = new InProcessLogger($task);
+        $partialStartIndex = new ReflectionProperty($task, 'partialStartIndex');
+
+        $logger->line('prefix');
+        $logger->partial("one\ntwo\nthree");
+
+        $this->assertSame(['two', 'three'], $task->logs);
+        $this->assertSame(0, $partialStartIndex->getValue($task));
+
+        $logger->success('complete');
+
+        $this->assertSame([], $task->logs);
+        $this->assertNull($partialStartIndex->getValue($task));
+    }
+
+    public function testCoroutineTaskWaitsForAnInFlightAnimationBeforeSettling(): void
+    {
+        Prompt::fake();
+        $task = new TaskAnimationFixture('Running');
+        $task->interval = 1;
+
+        $result = $task->run(function (Logger $logger) use ($task): string {
+            $this->assertTrue($task->renderStarted->pop(1));
+
+            Coroutine::fork(function () use ($task): void {
+                usleep(20_000);
+                $task->renderRelease->push(true);
+            });
+
+            return 'done';
+        });
+
+        $this->assertSame('done', $result);
+        $this->assertFalse($task->rendering);
+        $renderCalls = $task->renderCalls;
+        usleep(150_000);
+        $this->assertSame($renderCalls, $task->renderCalls);
+    }
+
+    public function testCoroutineTaskSurfacesAnimationRenderFailure(): void
+    {
+        Prompt::fake();
+        $failure = new RuntimeException('animation failed');
+        $task = new TaskAnimationFixture('Running');
+        $task->interval = 1;
+        $task->renderFailure = $failure;
+        $callbackRan = false;
+        $thrown = null;
+
+        try {
+            $task->run(function (Logger $logger) use (&$callbackRan): void {
+                $callbackRan = true;
+                usleep(5_000);
+            });
+        } catch (RuntimeException $exception) {
+            $thrown = $exception;
+        }
+
+        $this->assertSame($failure, $thrown);
+        $this->assertTrue($callbackRan);
     }
 
     public function testRendererDisplaysSubLabel(): void
@@ -734,5 +989,49 @@ class TaskTest extends TestCase
         $finishRendering->invoke($task);
 
         $this->assertStringContainsString("\e[J", Prompt::content());
+    }
+}
+
+class TaskAnimationFixture extends Task
+{
+    /** @var Channel<true> */
+    public Channel $renderStarted;
+
+    /** @var Channel<true> */
+    public Channel $renderRelease;
+
+    public int $renderCalls = 0;
+
+    public bool $rendering = false;
+
+    public ?RuntimeException $renderFailure = null;
+
+    public function __construct(string $label)
+    {
+        parent::__construct($label);
+
+        $this->renderStarted = new Channel(1);
+        $this->renderRelease = new Channel(1);
+    }
+
+    /**
+     * Render the task while exposing animation lifecycle checkpoints.
+     */
+    protected function render(): void
+    {
+        ++$this->renderCalls;
+
+        if ($this->renderCalls !== 2) {
+            return;
+        }
+
+        if ($this->renderFailure !== null) {
+            throw $this->renderFailure;
+        }
+
+        $this->rendering = true;
+        $this->renderStarted->push(true);
+        $this->renderRelease->pop();
+        $this->rendering = false;
     }
 }

--- a/tests/Prompts/TaskTest.php
+++ b/tests/Prompts/TaskTest.php
@@ -11,6 +11,7 @@ use Hypervel\Prompts\Prompt;
 use Hypervel\Prompts\Support\InProcessLogger;
 use Hypervel\Prompts\Support\Logger;
 use Hypervel\Prompts\Support\TaskFrame;
+use Hypervel\Prompts\Support\Utils;
 use Hypervel\Prompts\Task;
 use Hypervel\Prompts\Themes\Default\TaskRenderer;
 use Hypervel\Tests\TestCase;
@@ -761,7 +762,7 @@ class TaskTest extends TestCase
         $this->assertSame(['first', 'second'], $task->logs);
     }
 
-    public function testIncrementalPartialCommitPreservesIncompleteEscapesLiterally(): void
+    public function testIncrementalPartialCommitDiscardsIncompleteControls(): void
     {
         Prompt::fake();
 
@@ -775,25 +776,354 @@ class TaskTest extends TestCase
         $oscLogger->partial("abc\e]8;;https://hypervel.org");
         $oscLogger->commitPartial();
 
-        $this->assertSame(["abc\e[31"], $csiTask->logs);
-        $this->assertSame(["abc\e]8;;https://hypervel.org"], $oscTask->logs);
+        $dcsTask = new Task(limit: 10);
+        $dcsLogger = new InProcessLogger($dcsTask);
+        $dcsLogger->partial("abc\ePsecret");
+        $dcsLogger->commitPartial();
+
+        $this->assertSame(['abc'], $csiTask->logs);
+        $this->assertSame(['abc'], $oscTask->logs);
+        $this->assertSame(['abc'], $dcsTask->logs);
     }
 
     public function testCompleteNonFormattingControlsAreRemovedFromEveryTaskOutputPath(): void
     {
         Prompt::fake();
 
+        $output = "a\e7b\e(Bc\ePsecret\e\\d\e_secret\e\\e\e[1G\e[2Kf\e]0;title\x07";
+
         $completeTask = new Task(limit: 10);
         (new ReflectionMethod($completeTask, 'addLogLines'))
-            ->invoke($completeTask, "before\e[1G\e[2Kafter\e]0;title\x07");
+            ->invoke($completeTask, $output);
 
         $partialTask = new Task(limit: 10);
         $partialLogger = new InProcessLogger($partialTask);
-        $partialLogger->partial("before\e[1G\e[2Kafter\e]0;title\x07");
+        $partialLogger->partial($output);
         $partialLogger->commitPartial();
 
-        $this->assertSame(['beforeafter'], $completeTask->logs);
+        $this->assertSame(['abcdef'], $completeTask->logs);
         $this->assertSame($completeTask->logs, $partialTask->logs);
+    }
+
+    public function testIncrementalControlsMatchCompleteOutputAcrossEveryChunkBoundary(): void
+    {
+        Prompt::fake();
+
+        $cases = [
+            "a\e[31mred\e[0mb",
+            "a\e]8;;https://example.com\e\\link\e]8;;\e\\b",
+            "a\e(Bb",
+            "a\ePsecret\e\\b",
+            "a\e_secret\e\\b",
+            "a\e[12\ntext",
+            "a\e]title\e[31mred\e[0m",
+            "a\e\e[32mgreen",
+        ];
+
+        foreach ($cases as $output) {
+            $completeTask = new Task(limit: 10);
+            (new ReflectionMethod($completeTask, 'addLogLines'))->invoke($completeTask, $output);
+
+            for ($offset = 1; $offset < strlen($output); ++$offset) {
+                $partialTask = new Task(limit: 10);
+                $logger = new InProcessLogger($partialTask);
+                $logger->partial(substr($output, 0, $offset));
+                $logger->partial(substr($output, $offset));
+                $logger->commitPartial();
+
+                $this->assertSame(
+                    $completeTask->logs,
+                    $partialTask->logs,
+                    "Failed split at byte {$offset} for " . json_encode($output),
+                );
+            }
+        }
+    }
+
+    public function testCompleteAndIncrementalLogicalLinesMatchAcrossEveryChunkBoundary(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(14); // @phpstan-ignore-line
+
+        // Task Logger formatting covers terminal controls, not Symfony style markup.
+        $cases = [
+            '',
+            "a\n",
+            "\n",
+            "a\n\n",
+            "a\r\n",
+            "\e[31mred\nstill red\e[0m",
+            "a\n\e[31mb\e[0m",
+            "a\n\e]8;;https://example.com\e\\b\e]8;;\e\\",
+            "aaa\n\e[31mbb bb bb\e[0m",
+        ];
+
+        foreach ($cases as $output) {
+            $completeTask = new Task(limit: 10);
+            (new ReflectionMethod($completeTask, 'addLogLines'))->invoke($completeTask, $output);
+
+            for ($offset = 0; $offset <= strlen($output); ++$offset) {
+                $partialTask = new Task(limit: 10);
+                $logger = new InProcessLogger($partialTask);
+                $logger->partial(substr($output, 0, $offset));
+                $logger->partial(substr($output, $offset));
+                $logger->commitPartial();
+
+                $this->assertSame(
+                    $completeTask->logs,
+                    $partialTask->logs,
+                    "Failed logical-line split at byte {$offset} for " . json_encode($output),
+                );
+            }
+        }
+    }
+
+    public function testCompleteAndIncrementalGraphemeWrappingMatchesAcrossEveryChunkBoundary(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(11); // @phpstan-ignore-line
+
+        foreach ([
+            "e\u{0301}",
+            '👩‍👩‍👧‍👦',
+            '👍🏽',
+            '🇺🇸',
+            '1️⃣',
+            "\u{1100}\u{1161}",
+            'का',
+        ] as $grapheme) {
+            $completeTask = new Task(limit: 10);
+            (new ReflectionMethod($completeTask, 'addLogLines'))->invoke($completeTask, $grapheme);
+
+            for ($offset = 0; $offset <= strlen($grapheme); ++$offset) {
+                $partialTask = new Task(limit: 10);
+                $logger = new InProcessLogger($partialTask);
+                $logger->partial(substr($grapheme, 0, $offset));
+                $logger->partial(substr($grapheme, $offset));
+                $logger->commitPartial();
+
+                $this->assertSame(
+                    $completeTask->logs,
+                    $partialTask->logs,
+                    "Failed grapheme split at byte {$offset} for " . json_encode($grapheme),
+                );
+            }
+        }
+    }
+
+    public function testOversizedGraphemesStayLosslessBoundedAndConsistentAcrossOutputPaths(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(20); // @phpstan-ignore-line
+        $grapheme = 'e' . str_repeat("\u{0301}", 3000);
+        $limit = 3;
+
+        $completeTask = new Task(limit: $limit);
+        $addLogLines = new ReflectionMethod($completeTask, 'addLogLines');
+
+        for ($index = 0; $index < $limit + 2; ++$index) {
+            $addLogLines->invoke($completeTask, $grapheme);
+        }
+
+        $partialTask = new Task(limit: $limit);
+        $singleChunkLogger = new InProcessLogger($partialTask);
+        $singleChunkLogger->partial($grapheme);
+        $singleChunkLogger->commitPartial();
+
+        $streamedTask = new Task(limit: $limit);
+        $streamedLogger = new InProcessLogger($streamedTask);
+
+        foreach (str_split($grapheme, 97) as $chunk) {
+            $streamedLogger->partial($chunk);
+        }
+
+        $streamedLogger->commitPartial();
+
+        $expected = new Task(limit: $limit);
+        $addLogLines->invoke($expected, $grapheme);
+
+        $this->assertSame($expected->logs, $partialTask->logs);
+        $this->assertSame($expected->logs, $streamedTask->logs);
+        $this->assertSame($grapheme, implode('', $expected->logs));
+
+        foreach ([$completeTask, $partialTask, $streamedTask] as $task) {
+            $this->assertLessThanOrEqual($limit, count($task->logs));
+            $this->assertLessThanOrEqual(
+                $limit * Utils::MAX_UNBREAKABLE_BYTES,
+                array_sum(array_map(strlen(...), $task->logs)),
+            );
+
+            foreach ($task->logs as $line) {
+                $this->assertLessThanOrEqual(Utils::MAX_UNBREAKABLE_BYTES, strlen($line));
+            }
+        }
+    }
+
+    public function testWordWrapOverflowNeverCreatesBlankPartialRowsAcrossEveryChunkBoundary(): void
+    {
+        Prompt::fake();
+        Prompt::terminal()->shouldReceive('cols')->andReturn(12); // @phpstan-ignore-line
+
+        $cases = [
+            'aaaa  bbbb',
+            ' aaaa',
+            'aaaa bbbb',
+            'a  b',
+            '     ',
+        ];
+
+        foreach ($cases as $output) {
+            $completeTask = new Task(limit: 10);
+            (new ReflectionMethod($completeTask, 'addLogLines'))->invoke($completeTask, $output);
+
+            for ($offset = 0; $offset <= strlen($output); ++$offset) {
+                $partialTask = new Task(limit: 10);
+                $logger = new InProcessLogger($partialTask);
+                $prefix = substr($output, 0, $offset);
+
+                $logger->partial($prefix);
+
+                if ($prefix !== '') {
+                    $this->assertNotContains(
+                        '',
+                        $partialTask->logs,
+                        "Blank row after prefix at byte {$offset} for " . json_encode($output),
+                    );
+                }
+
+                $logger->partial(substr($output, $offset));
+
+                $this->assertNotContains(
+                    '',
+                    $partialTask->logs,
+                    "Blank row after final chunk at byte {$offset} for " . json_encode($output),
+                );
+                $this->assertSame(
+                    $completeTask->logs,
+                    $partialTask->logs,
+                    "Preview mismatch at byte {$offset} for " . json_encode($output),
+                );
+
+                $logger->commitPartial();
+
+                $this->assertSame(
+                    $completeTask->logs,
+                    $partialTask->logs,
+                    "Commit mismatch at byte {$offset} for " . json_encode($output),
+                );
+            }
+        }
+    }
+
+    public function testCommittingWithoutStartingPartialOutputIsANoOp(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 10);
+        $logger = new InProcessLogger($task);
+
+        $logger->commitPartial();
+
+        $this->assertSame([], $task->logs);
+    }
+
+    public function testGenericEscFinalsAreNotReinterpretedAsSpecializedIntroducers(): void
+    {
+        Prompt::fake();
+
+        foreach (['(', '()'] as $intermediates) {
+            foreach (['P', 'X', '[', ']', '^', '_'] as $final) {
+                $output = "a\e{$intermediates}{$final}Z";
+                $completeTask = new Task(limit: 10);
+                (new ReflectionMethod($completeTask, 'addLogLines'))->invoke($completeTask, $output);
+
+                $this->assertSame(['aZ'], $completeTask->logs);
+
+                for ($offset = 1; $offset < strlen($output); ++$offset) {
+                    $partialTask = new Task(limit: 10);
+                    $logger = new InProcessLogger($partialTask);
+                    $logger->partial(substr($output, 0, $offset));
+                    $logger->partial(substr($output, $offset));
+                    $logger->commitPartial();
+
+                    $this->assertSame(
+                        $completeTask->logs,
+                        $partialTask->logs,
+                        "Failed generic ESC split at byte {$offset} for " . json_encode($output),
+                    );
+                }
+            }
+        }
+    }
+
+    public function testIncrementalParserRecoversLocallyFromMalformedControlsAndRepeatedEscapes(): void
+    {
+        Prompt::fake();
+        $task = new Task(limit: 10);
+        $logger = new InProcessLogger($task);
+
+        $logger->partial("a\e[12\ntext \e]8;;https://example.com\e[31mred\e[0m \e\e[32mgreen");
+        $logger->commitPartial();
+
+        $this->assertSame([
+            'a',
+            "text \e[31mred\e[0m \e[32mgreen\e[0m",
+        ], $task->logs);
+    }
+
+    public function testIncrementalControlStateHasAFixedCeilingAndRecoversAfterTermination(): void
+    {
+        Prompt::fake();
+
+        foreach (["\e[" . str_repeat('1', 5000), "\e]0;" . str_repeat('x', 5000)] as $control) {
+            $task = new Task(limit: 10);
+            $logger = new InProcessLogger($task);
+
+            foreach (str_split($control, 17) as $chunk) {
+                $logger->partial($chunk);
+            }
+
+            $this->assertLessThanOrEqual(
+                4096,
+                strlen((new ReflectionProperty($task, 'partialControlBuffer'))->getValue($task)),
+            );
+            $this->assertLessThanOrEqual(3, strlen((new ReflectionProperty($task, 'partialInputBuffer'))->getValue($task)));
+
+            $logger->partial(str_starts_with($control, "\e[") ? 'mvisible' : "\x07visible");
+            $logger->commitPartial();
+
+            $this->assertSame(['visible'], $task->logs);
+            $this->assertNull((new ReflectionProperty($task, 'partialControlMode'))->getValue($task));
+            $this->assertSame('', (new ReflectionProperty($task, 'partialControlBuffer'))->getValue($task));
+        }
+
+        $zeroLimitTask = new Task(limit: 0);
+        $zeroLimitLogger = new InProcessLogger($zeroLimitTask);
+
+        foreach (str_split("\e]0;" . str_repeat('x', 5000), 17) as $chunk) {
+            $zeroLimitLogger->partial($chunk);
+        }
+
+        $this->assertSame([], $zeroLimitTask->logs);
+        $this->assertSame('', (new ReflectionProperty($zeroLimitTask, 'partialControlBuffer'))->getValue($zeroLimitTask));
+    }
+
+    public function testInvalidUtf8DoesNotStallBeforeSplitCodepoints(): void
+    {
+        Prompt::fake();
+
+        foreach (['é', '€', '😀'] as $character) {
+            $task = new Task(limit: 10);
+            $logger = new InProcessLogger($task);
+            $split = strlen($character) - 1;
+
+            $logger->partial("a\xffb" . substr($character, 0, $split));
+            $this->assertLessThanOrEqual(3, strlen((new ReflectionProperty($task, 'partialInputBuffer'))->getValue($task)));
+
+            $logger->partial(substr($character, $split) . "c\x80");
+            $logger->commitPartial();
+
+            $this->assertSame(["a\xffb{$character}c\x80"], $task->logs);
+        }
     }
 
     public function testIncrementalPartialParsingUsesSharedEffectiveSgrState(): void

--- a/tests/Prompts/TaskTest.php
+++ b/tests/Prompts/TaskTest.php
@@ -1361,7 +1361,12 @@ class TaskAnimationFixture extends Task
 
         $this->rendering = true;
         $this->renderStarted->push(true);
-        $this->renderRelease->pop();
+        // This is a deadlock bound, not a rendering timing expectation.
+        $released = $this->renderRelease->pop(5);
         $this->rendering = false;
+
+        if ($released !== true) {
+            throw new RuntimeException('Timed out waiting to release the task animation render.');
+        }
     }
 }

--- a/tests/Prompts/TextPromptTest.php
+++ b/tests/Prompts/TextPromptTest.php
@@ -61,6 +61,19 @@ class TextPromptTest extends TestCase
         Prompt::assertOutputContains('Cancelled.');
     }
 
+    public function testCancelledZeroIsRenderedInsteadOfThePlaceholder(): void
+    {
+        Prompt::fake(['0', Key::CTRL_C]);
+
+        text(label: 'Value', placeholder: 'placeholder');
+
+        $output = Prompt::strippedContent();
+        $cancelFrame = substr($output, strrpos($output, ' ┌'));
+
+        $this->assertStringContainsString('│ 0 ', $cancelFrame);
+        $this->assertStringNotContainsString('placeholder', $cancelFrame);
+    }
+
     public function testBackspaceKeyRemovesCharacter(): void
     {
         Prompt::fake(['J', 'e', 'z', Key::BACKSPACE, 's', 's', Key::ENTER]);

--- a/tests/Prompts/UtilsTest.php
+++ b/tests/Prompts/UtilsTest.php
@@ -47,6 +47,10 @@ class UtilsTest extends TestCase
         yield 'unterminated OSC' => ["Ready\e]8;;https://hypervel.org", "Ready\e]8;;https://hypervel.org"];
         yield 'Symfony named tag' => ['<info>Ready</info>', 'Ready'];
         yield 'Symfony inline tag' => ['<fg=green;options=bold>Ready</>', 'Ready'];
+        yield 'nested Symfony inline tags' => ['<fg=green>Your action, <fg=yellow>UserName</>?</>', 'Your action, UserName?'];
+        yield 'deeply nested Symfony inline tags' => ['<fg=green>A<fg=yellow>B<fg=red>C</>D</>E</>', 'ABCDE'];
+        yield 'sibling nested Symfony inline tags' => ['<fg=green>Hello <fg=yellow>World</></> and <fg=red>Foo <fg=blue>Bar</></>', 'Hello World and Foo Bar'];
+        yield 'ordinary angle brackets' => ['Use <value> or <other>.', 'Use <value> or <other>.'];
         yield 'plain text' => ['Ready', 'Ready'];
     }
 }

--- a/tests/Prompts/UtilsTest.php
+++ b/tests/Prompts/UtilsTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Prompts;
 use Hypervel\Prompts\Support\Utils;
 use Hypervel\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 
 class UtilsTest extends TestCase
 {
@@ -43,14 +44,66 @@ class UtilsTest extends TestCase
         yield 'non-SGR CSI followed by visible m' => ["\e[2Kmaximum", 'maximum'];
         yield 'BEL-terminated OSC title' => ["\e]0;Hypervel\x07Ready", 'Ready'];
         yield 'ST-terminated OSC hyperlink' => ["\e]8;;https://hypervel.org\e\\Hypervel\e]8;;\e\\", 'Hypervel'];
-        yield 'unterminated CSI' => ["Ready\e[31", "Ready\e[31"];
-        yield 'unterminated OSC' => ["Ready\e]8;;https://hypervel.org", "Ready\e]8;;https://hypervel.org"];
+        yield 'generic ESC control' => ["a\e7b", 'ab'];
+        yield 'charset designation' => ["a\e(Bb", 'ab'];
+        yield 'DCS payload' => ["a\eP1;2|secret\e\\b", 'ab'];
+        yield 'SOS payload' => ["a\eXsecret\e\\b", 'ab'];
+        yield 'PM payload' => ["a\e^secret\e\\b", 'ab'];
+        yield 'APC payload' => ["a\e_secret\e\\b", 'ab'];
+        yield 'BEL recovers malformed DCS' => ["a\ePsecret\x07b", 'ab'];
+        yield 'malformed CSI recovers at invalid byte' => ["a\e[12\ntext", "a\ntext"];
+        yield 'malformed OSC recovers at the next escape' => ["a\e]8;;http://x\e[31mtext\e[0m", 'atext'];
+        yield 'repeated ESC makes forward progress' => ["a\e\e[31mb", 'ab'];
+        yield 'unterminated CSI' => ["Ready\e[31", 'Ready'];
+        yield 'unterminated OSC' => ["Ready\e]8;;https://hypervel.org", 'Ready'];
+        yield 'unterminated charset designation' => ["Ready\e(", 'Ready'];
+        yield 'unterminated DCS' => ["Ready\ePsecret", 'Ready'];
         yield 'Symfony named tag' => ['<info>Ready</info>', 'Ready'];
         yield 'Symfony inline tag' => ['<fg=green;options=bold>Ready</>', 'Ready'];
+        yield 'Symfony hexadecimal color' => ['<fg=#ff00aa>Ready</>', 'Ready'];
+        yield 'Symfony bright and hexadecimal colors' => ['<fg=bright-red;bg=#00ff00>Ready</>', 'Ready'];
+        yield 'Symfony combined inline attributes' => ['<fg=blue;bg=bright-yellow;options=bold,underscore>Ready</>', 'Ready'];
+        yield 'Symfony hyperlink' => ['<href=https://hypervel.org/docs>Ready</>', 'Ready'];
+        yield 'Symfony hyperlink with escaped angle bracket' => ['<href=https://example.com/a\>b>Ready</>', 'Ready'];
         yield 'nested Symfony inline tags' => ['<fg=green>Your action, <fg=yellow>UserName</>?</>', 'Your action, UserName?'];
         yield 'deeply nested Symfony inline tags' => ['<fg=green>A<fg=yellow>B<fg=red>C</>D</>E</>', 'ABCDE'];
         yield 'sibling nested Symfony inline tags' => ['<fg=green>Hello <fg=yellow>World</></> and <fg=red>Foo <fg=blue>Bar</></>', 'Hello World and Foo Bar'];
+        yield 'escaped angle brackets' => ['\<info\>Ready\</info\>', '<info>Ready</info>'];
+        yield 'unregistered named style remains visible' => ['<fire>Ready</fire>', '<fire>Ready</fire>'];
         yield 'ordinary angle brackets' => ['Use <value> or <other>.', 'Use <value> or <other>.'];
         yield 'plain text' => ['Ready', 'Ready'];
+    }
+
+    #[DataProvider('symfonyStyleProvider')]
+    public function testStyleTagStrippingAgreesWithSymfony(string $text): void
+    {
+        $formatter = new OutputFormatter(decorated: false);
+
+        $this->assertSame($formatter->format($text), Utils::stripEscapeSequences($text));
+    }
+
+    /**
+     * Provide representative Symfony style grammar boundaries.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function symfonyStyleProvider(): iterable
+    {
+        yield 'unclosed named style' => ['<info>Ready'];
+        yield 'unclosed inline style' => ['<fg=red>Ready'];
+        yield 'named styles are case-sensitive' => ['<INFO>Ready</INFO>'];
+        yield 'inline styles are case-insensitive' => ['<FG=RED>Ready</>'];
+        yield 'escaped opening tag' => ['\<info>Ready'];
+        yield 'escaped inline value' => ['<href=https://example.com/a\>b>Ready'];
+        yield 'nested inline styles' => ['<fg=green>A<fg=yellow>B</>C</>'];
+        yield 'unknown named style' => ['<fire>Ready</fire>'];
+    }
+
+    public function testTerminalFormattingPatternCanBeEmbeddedMoreThanOnce(): void
+    {
+        $pattern = '/\A' . Utils::TERMINAL_FORMATTING_PATTERN
+            . 'text' . Utils::TERMINAL_FORMATTING_PATTERN . '\z/';
+
+        $this->assertSame(1, preg_match($pattern, "\e[1mtext\e]8;;https://hypervel.org\e\\"));
     }
 }


### PR DESCRIPTION
## Summary

This PR improves the Prompts package in three areas: correctness, internal structure, and repeated rendering performance.

The main changes are:

- validate the same transformed value across interactive prompts, non-interactive defaults, and Symfony Console fallbacks;
- make `NumberPrompt` a strict signed-integer prompt with overflow-safe parsing and arrow behavior;
- replace Task's newline and regex IPC protocol with fixed binary frames;
- send Task partial-output deltas and lay them out incrementally with bounded state;
- stop and join prompt animation coroutines before final rendering or terminal restoration;
- cache DataTable natural metrics for the prompt lifetime and fit them to each live terminal width;
- preserve effective ANSI and OSC 8 state through wrapping, streaming, and scrollbar rendering;
- fix coroutine Progress signal ownership, transient prompt-state restoration, erasure counts, Grid sizing, zero-valued cancellation output, and MultiSearch keyboard navigation.

## Task output

Task output previously accumulated and resent the complete partial prefix for every chunk. The renderer then rewrapped that prefix from the beginning. This made a stream of small writes quadratic and retained more state than the visible output required.

Task messages now use a five-byte binary header followed by the exact payload bytes. The same message boundary drives process and in-process rendering. Partial messages contain only the new bytes.

The renderer keeps only:

- visible lines up to the configured Task limit;
- the current line and unfinished word;
- an incomplete UTF-8 or terminal escape suffix;
- bounded effective SGR and OSC 8 hyperlink state.

This also removes the old identifier, regex, newline framing, whole-prefix buffer, duplicate mutation methods, and duplicate reset paths.

Animation ownership is explicit and operation-local. Spinner and coroutine Task render frame zero synchronously, wait between later frames, and join the animation coroutine before settlement. Render failures are surfaced without replacing a callback failure.

## Validation and Number input

Prompt transforms now run once for each submitted candidate. Required validation, prompt-intrinsic validation, caller validation, and the returned value all use that same candidate.

`NumberPrompt` accepts signed decimal integers only. It handles `PHP_INT_MIN` and `PHP_INT_MAX` without parsing through floats, rejects overflow, preserves the user's typed representation while editing, and uses saturating arithmetic for arrow changes.

Console fallbacks use the same transform and intrinsic-validation order as interactive prompts. Valid `"0"` and `0` defaults are preserved instead of being treated as empty.

## DataTable rendering

DataTable now computes search-invariant natural column metrics once per prompt. The scan strips ANSI and Symfony inline markup, handles multiline and ragged cells, applies the existing outlier rule, and treats sparse integer keys as positional layout metadata without changing the selected row returned to the caller.

Each render only fits the cached widths to the current terminal width. Header widths are no longer unshrinkable floors, every column keeps a one-character minimum, and rounding is deterministic.

The first scan now measures visible styled text correctly, which costs more than the previous raw byte-width scan. Search keystrokes and terminal redraws no longer rescan or sort the source rows.

## Performance

Representative local PHP 8.4 runs on the same machine, executed back-to-back:

| Task partial chunks | `0.4` | This branch |
|---:|---:|---:|
| 1,000 | 147.306 ms | 8.278 ms |
| 2,000 | 584.250 ms | 14.879 ms |
| 4,000 | 2,343.980 ms | 31.961 ms |

The base implementation grows by roughly four times when the chunk count doubles. The new implementation grows linearly.

For a 10,000-row, three-column DataTable:

| Render | `0.4` | This branch |
|---|---:|---:|
| First | 9.017 ms | 20.576 ms |
| Repeated | 7.272 ms | 0.136 ms |

The first render performs the corrected ANSI- and markup-aware source scan. Later renders reuse those natural metrics and do only column fitting plus visible-row rendering.

## Compatibility

Laravel public APIs and named arguments remain intact.

Three protected extension points change because their old contracts cannot be honored by the corrected design:

- `Logger::prefix()` is replaced by overriding `write()` because Task messages are binary frames, not prefixed text lines.
- `NumberPrompt::wrapValidation()` is replaced by `validateIntrinsic()` because validation is centralized in the base prompt lifecycle.
- `DataTableRenderer::computeColumnWidths()` is split into `DataTablePrompt::naturalColumnMetrics()` and `DataTableRenderer::fitColumnWidths()` because source metrics and terminal fitting have different lifetimes.

These differences and their replacement seams are documented in the package README.

## Verification

- `composer fix`
- focused Prompts and Console fallback tests
- process and in-process Task parity tests
- fragmented and coalesced binary frame tests
- exhaustive partial-output versus complete-line comparisons across plain text, whitespace, CRLF, Unicode, SGR, OSC 8, and incomplete terminal sequences
- local scaling probes for plain and escape-heavy Task output
- full diff review for Laravel signatures, cleanup paths, bounded state, and dead code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Number prompts support strict signed integers, inclusive bounds, integer defaults, transformations, and safer stepping.
  * Multi-search prompts support Ctrl+N and Ctrl+P navigation.
  * Task output supports bounded incremental logs, partial lines, and improved terminal styling.
  * Data tables provide faster, more reliable sizing for multiline and wide content.

* **Bug Fixes**
  * Preserved entered values such as `0` when cancelling prompts.
  * Improved validation, prompt recovery, grid sizing, wrapping, scrollbar rendering, and escape-sequence handling.
  * Improved animation completion and error handling.

* **Documentation**
  * Updated prompt behavior and package differences documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->