### PR TITLE
Make permission caching transaction safe

### DIFF
--- a/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
@@ -55,7 +55,7 @@ Record the boot-baseline/execution-override semantic shared by Notification, Num
 - Hypervel worker singletons retain only boot-time immutable/baseline state. Request, job, command, and test overrides belong in CoroutineContext and are cleaned at execution boundaries. This is an architectural adaptation, not a port of Laravel's process-per-request mutable-static assumptions.
 - Framework-owned pooled database/auth objects retain resolvers and names, never borrowed connections. The Laravel-compatible direct ConnectionInterface constructor form remains available for non-pooled callers and test doubles.
 - Most fixes remove work, bound memory by correct lifetime, preserve a fast path, or add only constant-time state checks.
-- Finding 43 coordinates only cache misses and mutations; its cache-hit path remains lock-free. Findings 78-79 replace an unverifiable freshness shortcut with one authoritative row read per existing node at a structural mutation boundary; ordinary tree reads remain unchanged. Reverb recovery is an operator command with zero steady-state cost. Queue timeout behavior remains unchanged because the proposed drain would weaken its safety contract.
+- Findings 78-79 replace an unverifiable freshness shortcut with one authoritative row read per existing node at a structural mutation boundary; ordinary tree reads remain unchanged. Reverb recovery is an operator command with zero steady-state cost. Queue timeout behavior remains unchanged because the proposed drain would weaken its safety contract.
 - No fix may add periodic polling, arbitrary eviction thresholds, a distributed lock on every request/cache hit, metadata shortcuts with delayed correctness, or a new abstraction whose only purpose is an unsupported failure mode.
 - Performance and scalability claims must be measured during implementation for the affected hot paths. A fix does not land if its package benchmark/load test shows a material regression that is not inherent to the required correctness guarantee; revise the design instead.
 - Load tests must cover high-cardinality input and long worker lifetimes, not only request latency: retained memory must converge to the natural live/configured keyspace, and temporary request/job state must disappear at execution teardown.
@@ -104,7 +104,7 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 | 34 | Port current Laravel's array-capable multibyte Str::substrReplace implementation, including array offset/length/replacement behavior and key preservation. Correct the scalar negative-length calculation as part of the port: the current Str::substrReplace('Hello', 'X', 2, -1) produces HeXello instead of HeXo. | Scalar parity including the explicit negative-length example; arrays with scalar and array replacements; offset/length arrays; associative keys; negative offsets and lengths; multibyte strings; mismatched replacement lengths. |
 | 35 | For built-in UUID/ULID codecs, identify binary values by the unambiguous 16-byte storage length and validate textual 36/26-byte forms separately. Leave the generic public BinaryCodec heuristic available to custom codecs. Runtime sampling confirmed that roughly one in sixteen thousand random v4-shaped UUID payloads can be valid UTF-8 and NUL-free, so this is ordinary data loss at scale rather than a purely theoretical collision. | Deterministic valid-UTF-8, NUL-free 16-byte UUID/ULID payloads round-trip through casts and database bindings; a fixed previously misclassified v4 payload; textual forms; invalid lengths; custom codec behavior unchanged. |
 
-### Scout, permission, Sentry, Telescope, and foundation
+### Scout, Sentry, Telescope, and foundation
 
 | ID | Proposed implementation | Required tests |
 |---:|---|---|
@@ -115,11 +115,6 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 | 40 | Remove the silent Typesense per-page clamp. Validate the documented Typesense maximum before sending and throw a descriptive InvalidArgumentException when callers request more than the engine supports, so paginator metadata can never disagree with the query. | Exact-limit pagination; over-limit failure before network call; page/current/total metadata for valid values; simple and length-aware paths. |
 | 41 | Restrict the primary-key integer fast path to models whose Scout key name equals their Eloquent primary key name. Within that path, use the primary key name, type, and qualified column consistently, and validate decimal strings against PHP_INT_MAX without casting first. Models with a custom Scout key use the normal search path; there is no getScoutKeyType API from which to infer a safe custom-key optimization. The audit's claim that upstream consistently used getKeyName was wrong, but the mixed identities are still semantically broken. | PostgreSQL overflow string produces no integer-cast query error; max boundary; ordinary integer-primary-key fast path; custom Scout key name bypasses the primary-key optimization; string/UUID primary key; result identity mapping. |
 | 42 | Assign the callback-transformed raw result before mapping models and before computing total/hasMore. Make rawResult, models, and paginator metadata describe the same payload. | Callback changes hits and count; length-aware and simple pagination; raw result exposure and mapped models agree; unchanged callback path. |
-| 43 | Centralize permission cache settlement on the mutation's actual connection. Outside a transaction, invalidate immediately. Inside one, clear current execution hydration, mark affected catalog/model keys dirty so reads bypass shared and execution memos, and invalidate shared keys only after commit; rollback only clears dirty/runtime state. Serialize assignment-cache misses and their exact committed invalidations with per-key locks; hits remain lock-free. Keep nested rollback bookkeeping scoped to the actual transaction record. Do not replace exact invalidation with the existing partition-global assignment token: shared keys already include that token, and bumping it per model mutation would invalidate every model in the partition and orphan old entries until TTL. Validate lock support only when this cache is enabled. | The mutating transaction sees its own grant/revoke without publishing it; concurrent executions keep pre-commit state; commit invalidates even after a forced stale re-prime; rollback never publishes uncommitted rows and restores fresh reads; fill-vs-commit barriers; nested savepoint rollback; catalog, role, permission, team, partition, and pivot paths; cache hits perform no lock or new remote operation; cold-fill lock cost is measured. |
-| 44 | Add an execution-local memo for hydrated direct permissions, parallel to the via-role memo. Memoize only non-loaded hydration and clear it from every model permission/assignment invalidation path. | One hasPermissionTo call hydrates direct permissions once; repeated calls query once; invalidation, team change, partition change, and sibling execution isolation. |
-| 45 | Apply role team filtering in the shared fallback/filter path so every catalog bypass retains the current-team boundary, including both a requested role-class mismatch and the complex-parameter/catalog fallback. Include only global roles and roles for the current team. | Same role name on another team never matches through either fallback; class-mismatch and complex-parameter cases; current-team and global roles match; null-team behavior follows the explicit policy from 47. |
-| 46 | Use the cached catalog when the configured role class is compatible with the requested base class. For a genuinely incompatible valid class, memoize one class/partition catalog per execution and then apply current-team filtering. | Compatible subclass uses the shared cache; incompatible class makes one query per execution; invalidation clears it; team and cache partition separation. |
-| 47 | Make team-scoped writes fail early with a named package exception when no team is selected, matching the shipped non-nullable assignment pivots. Keep null-team reads fail-closed as an empty relation so checks cannot leak assignments from another team; document that nullable team IDs apply to global Role records, not subject-assignment pivots. | assignRole, givePermissionTo, sync operations, queued model writes, and direct pivot paths with no team; configured team success; null-team reads return no subject assignments and never broaden the query; exception and docs name the missing team context. |
 | 48 | Port both Sentry Monolog handlers fully to Monolog 3 LogRecord APIs. Use isHandling and Level comparisons; create modified records with LogRecord::with; make doWrite consume LogRecord and strip exception data from a local context copy. | Single and batch records; highest handled level; context enrichment survives; exception context is handled once; below-threshold records drop; immutable original record remains valid. |
 | 49 | Give Hub an explicit mutable baseline Scope and consult `Application::isBooted()` through the Application contract. `configureScope` before boot completes mutates the baseline; after boot during an execution it mutates the cloned context scope. Do not add a Sentry-specific boot predicate or infer lifecycle from coroutine presence. | AppServiceProvider/Sentry provider boot tags and user data appear in later requests; sibling request mutations are isolated; nested push/pop scopes; queue/console/HTTP execution entry; flush resets baseline and context; shared porting-guide entry documents the semantic. |
 | 50 | Null-guard internal trace frames in sentry:test before reading filename or line. | Trace containing internal/null-file frame; ordinary frame formatting; command still sends the diagnostic event. |
@@ -228,15 +223,14 @@ Use package-sized commits that remain reviewable and bisectable. The following o
 
 1. Worker-default and execution-state primitives: 25, 33, 49, 103.
 2. Pool/resource ownership: 10-12, 22, 27-29, 81, 155.
-3. Transaction/cache consistency: 43-47, using their package-specific lock and publication designs.
-4. Nested-set authoritative mutation preparation and relation guards: 78-80.
-5. Mail and data representation: 21, 30-35, 82, 94-98.
-6. Search and request pipelines: 36-42, 71-77, 99-102.
-7. Observability: 48-55.
-8. Reverb recovery command and runbook: 112, with no runtime state-model change.
-9. Queue cleanup: only the two valid parts of 154; 153 deliberately stays unchanged.
-10. Vonage notification channel port followed by Horizon wiring: 160.
-11. Remaining package-local correctness work by package, followed by performance/docs/cleanup.
+3. Nested-set authoritative mutation preparation and relation guards: 78-80.
+4. Mail and data representation: 21, 30-35, 82, 94-98.
+5. Search and request pipelines: 36-42, 71-77, 99-102.
+6. Observability: 48-55.
+7. Reverb recovery command and runbook: 112, with no runtime state-model change.
+8. Queue cleanup: only the two valid parts of 154; 153 deliberately stays unchanged.
+9. Vonage notification channel port followed by Horizon wiring: 160.
+10. Remaining package-local correctness work by package, followed by performance/docs/cleanup.
 
 Do not combine unrelated packages merely because their findings have the same severity.
 
@@ -247,7 +241,7 @@ For every changed test file:
 1. From the components repository root, run that exact test file immediately with `./vendor/bin/phpunit --no-progress path/to/Test.php`.
 2. For deterministic concurrency tests, run the exact file repeatedly and under the parallel runner where supported.
 3. Run the complete affected package test directory after its individual files pass.
-4. Run integration suites for every affected external system: MySQL/MariaDB and PostgreSQL for permission/database semantics; Redis for Reverb/cache; filesystem cloud adapter tests where credentials/fixtures are provided.
+4. Run integration suites for every affected external system: MySQL/MariaDB and PostgreSQL for database semantics; Redis for Reverb/cache; filesystem cloud adapter tests where credentials/fixtures are provided.
 
 Additional required checks:
 

--- a/docs/plans/2026-08-27-0953-components-permission-audit-remediation-plan.md
+++ b/docs/plans/2026-08-27-0953-components-permission-audit-remediation-plan.md
@@ -1,0 +1,468 @@
+# Permission Audit Remediation Plan
+
+## Objective
+
+Resolve permission audit findings 43–47 and the directly related defects exposed while tracing them. The result must preserve Spatie-style public APIs, remain safe in Hypervel's long-lived coroutine runtime, keep cache hits lock-free, and avoid broad invalidation when the affected subjects are known.
+
+The work covers:
+
+- transaction-safe permission catalog and assignment caching;
+- one authoritative database connection for permission tables, pivot work, and cache settlement;
+- correct pivot-model and transactional relation behavior when relation endpoints use different connection names;
+- direct-permission hydration reuse within one coroutine;
+- team filtering on every role-catalog path;
+- configured custom model compatibility for both roles and permissions;
+- fail-fast team selection on all supported write paths;
+- exact invalidation for targeted reverse model mutations and safe generation rotation for bulk replacement and hard deletion;
+- safe cache-store topology validation at the shared coordinator boundary;
+- narrow assignment-generation rotation;
+- custom primary-key normalization.
+
+The matching findings in `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md` must be removed after implementation because this plan becomes their detailed source of truth. The Passport-related permission TODOs in `docs/todo.md` remain: Passport is not currently ported, so those test gaps are not completed by this work.
+
+## References
+
+- Audit findings 43–47 in `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`.
+- Current Hypervel permission source under `src/permission/src/`.
+- Current cache coordination under `src/cache/src/ModelCacheCoordinator.php` and `src/cache/src/MemoizedStore.php`.
+- Current permission documentation in `src/docs/permission.md`.
+- Current package upstream under `examples/laravel-permission` in the monorepo.
+- Hypervel transaction settlement under `src/database/src/DatabaseTransactionsManager.php`, `src/database/src/Concerns/ManagesTransactions.php`, and `src/foundation/src/Testing/DatabaseTransactionsManager.php`.
+
+## Verified defects
+
+| Finding | Defect | Required result |
+|---|---|---|
+| 43 | Catalog and assignment cache entries are forgotten immediately inside database transactions. A same-transaction read can publish uncommitted state; rollback then leaves false grants or revocations cached for the full TTL. A concurrent read can also republish stale committed state between immediate invalidation and commit. | Coordinate cold fills and committed invalidation per exact cache key, keep dirty transaction reads coroutine-local, and settle shared cache state only after commit. |
+| 44 | Direct permission rows are memoized, but every non-loaded read rebuilds permission models and morph pivots. A single permission check can repeat this hydration. | Memoize the hydrated direct-permission collection per coroutine and invalidate it with the same exact assignment boundaries. |
+| 45 | The incompatible-class and non-indexed role fallbacks omit the current-team filter. They can return a role from another team, including as the first result for `$onlyOne`. | Apply the same team predicate before result selection on every fallback path without slowing the indexed path. |
+| 46 | Requesting a base role or permission class while a compatible configured subclass is active bypasses the shared catalog and queries repeatedly. Requested and configured primary-key names can also differ. | Normalize compatible class requests to the configured catalog and primary key; memoize genuinely incompatible catalogs once per coroutine and partition. |
+| 47 | Team-enabled write paths accept a missing current team until a database constraint fails, and SQLite can store a null pivot. Reads already fail closed. | Throw one package exception before role/permission lookup or mutation on every supported high-level and direct relation write path. Keep reads and global roles unchanged. |
+
+Tracing also confirmed these same-root defects:
+
+- `HasAssignedModels::syncModels()` originally rotated the partition-wide assignment generation, but replacing that with exact invalidation introduced a concurrent phantom hole. The old-identity query runs before normalization and before the replacement transaction begins; a subject assigned after that query can be deleted by the later bulk replacement without entering the invalidation set. Moving the query into the transaction cannot prevent a new row that was absent from the query. The bulk operation therefore cannot enumerate every removed subject exactly across all supported databases.
+- Deferred assignment-generation rotation originally left the committed token active inside bulk synchronization and hard deletion. A subject read after pivot mutation could publish the uncommitted assignment view under that active namespace; rollback then left the poisoned entry addressable for the full TTL. Catalog filtering can discard stale extra IDs after a committed deletion, but it cannot restore an ID missing from a rollback-poisoned assignment payload.
+- Role and permission save events rotate the assignment generation even for creates, renames, and role-permission edge changes that only affect the catalog. This causes needless global invalidation.
+- `ModelCacheCoordinator` sees `MemoizedStore`, not the real configured store. Unsafe stack and failover stores can therefore pass capability checks even though their value and lock operations do not share one coherence boundary.
+- Permission pivot ownership changes with relation direction and pivot implementation. Default pivots write through the related builder, custom pivots use the parent connection, package transaction wrappers frequently use the subject connection, and cache settlement follows the subject model. A rollback can therefore leave committed assignments and stale cache state when the same logical database is exposed through different connection names.
+- Subject cleanup runs from `deleting` on the subject connection. It can remove assignments before a delete that later fails, and it targets the wrong database when permission storage uses another connection. Queued assignments can likewise commit to permission storage before a subject transaction commits.
+- The database relation layer has the same default/custom pivot split, and every `*OrFail` pivot wrapper transacts the parent connection even when the pivot query writes elsewhere.
+
+## Design invariants
+
+1. Cache hits remain lock-free.
+2. A shared value is published only while holding the exact cache-key lock.
+3. Shared invalidation uses the same exact lock as publication.
+4. An open transaction never publishes its uncommitted view to shared cache.
+5. Dirty transaction reads query at most once per cache key and source connection identity until another mutation changes the view.
+6. Each mutation clears the current coroutine's raw and hydrated values for its affected keys before any later read.
+7. Commit invalidates the shared key immediately, even when a different connection still has an open mutation for that key. Rollback removes only its own dirty marker and does not invalidate shared state.
+8. Catalog changes do not rotate the assignment generation unless existing subject assignments can no longer be enumerated exactly.
+9. Known subject changes invalidate exact subject keys; they do not rotate a partition-wide token.
+10. Team filtering happens before `$onlyOne` selection.
+11. Compatible configured model subclasses share the configured catalog. Genuinely incompatible model classes keep their own coroutine-local catalog.
+12. Missing-team guards apply to writes only. Null-team reads stay empty and global roles remain valid.
+13. Every permission table, pivot query, pivot model, package transaction, and assignment-cache settlement uses the configured Permission model's connection. Role and Permission models must resolve to that same connection name; subject models may use another connection.
+14. Deferred subject lifecycle work captures durable scalar identity and context only; it never reads later-mutated model state.
+
+## 1. Validate the real cache topology in `ModelCacheCoordinator`
+
+Add a read-only `MemoizedStore::getInnerStore()` accessor for its wrapped store. `CacheManager::memo()` wraps one normal store, so no recursive unwrapping or generic store-inspection abstraction is needed.
+
+Keep `CacheManager::forgetDriver()` internally consistent for its caller by also forgetting that coroutine's memo wrapper for the driver. The manager's store map is worker-scoped while memo wrappers are coroutine-local; replacing only the manager entry leaves the calling coroutine attached to the discarded store. Other live coroutines may still hold their existing wrappers, as documented, and do not justify a cross-coroutine registry.
+
+At the lazy coordination boundary in `ModelCacheCoordinator::lock()`:
+
+1. Read the repository's store.
+2. If it is `MemoizedStore`, unwrap it once for topology validation.
+3. Reject `StackStore` and `FailoverStore` with a clear configuration exception.
+4. Retain the existing `LockProvider` capability check and verify that `lock()` returns a `RefreshableLock`.
+5. Acquire the lock directly from the validated inner store. `MemoizedStore::lock()` forwards to that same store, so routing through the wrapper adds no behavior.
+
+Stack and failover stores are unsafe here because cache values and locks are not guaranteed to use the same backend for the whole protocol. This is different from model serialization validation: do not call `ModelCacheStoreValidator`, which rejects stores that are valid for permission arrays and checks unrelated Eloquent serialization requirements.
+
+Validation remains lazy. A cache hit must not inspect the store or acquire a lock. This also avoids resolving the permission cache at application boot, which would freeze stale configuration in a long-lived worker.
+
+Tests must cover direct and memoized stack/failover stores, valid lock providers, invalid lock return types, and a hot hit that performs no topology or lock work.
+
+## 2. Coordinate permission cache fills and transaction settlement
+
+### Permission storage connection
+
+Treat the configured Permission model's connection as the owner of all five permission tables. The shipped schema creates them together and `role_has_permissions` has foreign keys to both Role and Permission, so Role and Permission cannot live on different physical databases under the supported schema. Require their models to resolve to the same connection name as well: relation reads compile on the Role connection while pivot writes and transaction settlement use the Permission connection, so separate aliases break read-your-own-writes and cache settlement even when they point at one database.
+
+Expose that connection once as `PermissionRegistrar::getPermissionConnection()`. Do not add a configuration key, a Role/Permission equality validator, or call-site connection inference.
+
+Add one protected `getPivotConnection()` seam at the shared database relation boundary. Default relations return their related query connection; `EnforcesPermissionPartition` overrides it with the registrar's permission connection. Route `newPivotStatement()`, stock and custom pivot models, and every transactional pivot wrapper through that seam. Route every other package-owned raw permission-table query and transaction wrapper through the same registrar accessor. This is smaller and harder to drift than overriding each pivot primitive in the package relation.
+
+Subject models may use another connection name. This keeps forward assignment reads and permission-owned mutation paths coherent when subjects live on another database. It does not claim that reverse relation joins or subject query scopes work across physical databases; those compile one SQL statement on the subject builder and cannot be repaired by pivot ownership. Do not add cross-database relation machinery.
+
+Fail before Role or Permission model persistence or deletion when the actual model connection name differs from the configured Permission connection. Put the comparison on `PermissionRegistrar`, throw a named package exception, and call it first from `RefreshesPermissionCache` `saving` and `deleting` listeners before any settlement registration. This covers every eventful model mutation without adding read-path validation. Quiet methods and query-builder writes remain normal Eloquent event bypasses.
+
+### Shared fills and invalidation
+
+Replace `remember()`-based publication for the permission catalog and raw model-role/model-permission assignments with `ModelCacheCoordinator::fill()`:
+
+```php
+return $coordinator->fill(
+    cache: $cache,
+    key: $key,
+    ttl: $this->cacheExpirationTime,
+    read: fn () => $this->loadFromSource(...),
+);
+```
+
+Do not add a caller-side cache pre-check. `fill()` owns envelope detection and the hot-hit path; a null check would both duplicate work and misread a legitimately cached null. Cold fill holds one per-key lock across source read, lease refresh, and publication. A committed invalidation acquires the same lock before forgetting the key. This prevents a stale reader from publishing after a newer committed mutation.
+
+Keep passing the permission package's memoized repository to the coordinator. `MemoizedStore::put()` clears its local memo before writing the inner store, so the first lookup after a cold fill performs one remote read and later execution-local lookups hit the memo. Do not add package-owned memo state or claim that cold fill removes that one repository read.
+
+### Dirty transaction state
+
+Store transaction-local cache state in `CoroutineContext`. Use opaque, package-owned keys and plain arrays; do not add transaction objects, a registry, or cleanup listeners.
+
+Maintain two distinct maps:
+
+```php
+// Exact shared cache key => normalized mutation connection => retained settlement.
+$dirtyTokens[$cacheKey][$mutationConnectionName] = $settlement;
+
+// Exact shared cache key => normalized source identity => raw database value.
+$dirtyValues[$cacheKey][$sourceIdentity] = $rawValue;
+```
+
+Normalize a connection name as `$connection->getName() ?? ''`. Resolve this source identity lazily only after a dirty-key check; clean permission reads must not instantiate the configured Permission model merely to compute an unused map key. Do not cache connection names across operations: Eloquent's default connection and custom model connection resolution may change within one coroutine. One `PermissionCacheSettlement` retains the name resolved for its own lifetime so commit and rollback use the identity that registered them.
+
+Assignment token and source identities both use the permission connection because all assignment reads and writes use permission storage. Catalog token and source identity use the same connection: Role and Permission share permission storage under the supported schema. Do not retain a serialized connection pair or delimiter-collision machinery.
+
+### Mutation algorithm
+
+Compute every affected exact cache key before registering settlement so callbacks capture the assignment token used by the mutation. For every affected exact key:
+
+1. Clear all dirty raw source values for that key.
+2. Clear the related hydrated runtime memo for that key.
+3. Register assignment settlement through `afterCommitOrNow()` on the permission connection. Role and Permission lifecycle mutations use their model connection after the lifecycle guard proves that it has the same normalized name as the configured Permission connection.
+4. Use a callback flag to detect whether settlement ran immediately. Do not infer deferral from raw transaction depth because `RefreshDatabase` deliberately wraps the test connection.
+5. If the callback ran immediately, coordinated-invalidate the key and do not retain a dirty token.
+6. If deferred and no settlement exists for the exact key and normalized mutation connection, retain the typed `PermissionCacheSettlement`. It carries the connection name and any provisional assignment namespace; its existing commit callback is the sole shared-invalidation callback for that key/connection. Compare the retained object directly with `===`; do not generate a ULID or reduce it to a reusable numeric id.
+7. Register an owner rollback callback on the same transaction record. It clears the key's dirty raw and hydrated values and removes only that exact retained settlement.
+8. For every later deferred mutation while the owner token exists, register an idempotent rollback cleanup callback on the current transaction record. It clears the key's dirty raw and hydrated values but never removes the owner token or invalidates shared cache.
+
+Commit settlement:
+
+- remove only the committing connection's token;
+- clear all dirty raw values for the key;
+- clear related hydrated runtime values;
+- coordinated-invalidate the exact shared key immediately, even when another connection token remains.
+
+Rollback settlement:
+
+- remove only the rolling-back connection's token;
+- clear all dirty raw values for the key;
+- clear related hydrated runtime values;
+- do not invalidate the shared cache.
+
+The cache key remains dirty while any connection token exists.
+
+One owner token and commit callback per key and connection is sufficient for shared settlement because `DatabaseTransactionRecord` owns callback movement and rollback at each transaction level. A rollback cleanup is still required on every nested record that mutates the key: otherwise a savepoint rollback can leave that record's locally memoized view visible under the surviving outer token. Repeated mutations on one record may register repeated idempotent cleanup callbacks. Add one short WHY comment that this bounded rollback-only work deliberately avoids a transaction-record identity map.
+
+The commit callback must be registered before immediate versus deferred execution is known. Detect this with one small typed settlement-state object rather than raw transaction depth: `RefreshDatabase` deliberately wraps testing connections, so `transactionLevel()` does not identify whether package settlement should run. The same retained object is the owner identity, so this adds no allocation beyond the identity already required and avoids an untyped dynamic-property bag. A later mutation with an existing owner still registers on its current record so a nested rollback can clear that record's view while the original owner retains commit responsibility.
+
+If a transaction is abandoned without settlement, the stale token is bounded by the coroutine lifetime and safely forces uncached reads for the rest of that coroutine. Add one concise WHY comment at that branch; do not add recovery machinery.
+
+Keep current explicit public cache-reset methods immediate. Package mutation paths derive the permission connection from the registrar rather than the subject or relation direction. Add the narrow domain-named registrar seam needed for catalog-only settlement; do not overload the public full-reset method or introduce a general transaction coordinator.
+
+### Dirty read algorithm
+
+When an exact cache key is dirty:
+
+1. Never read or publish through shared cache.
+2. Return a previously stored raw value for the exact key and source identity when present.
+3. Otherwise read the source once, store only that raw value in `CoroutineContext`, and return it.
+4. Allow existing hydrated runtime memoization to reuse the model collection derived from that raw value.
+
+Every mutation and commit/rollback settlement clears all raw source identities for the affected key, so a later read observes the current transaction view. A read from a connection with no open transaction still bypasses shared publication while another connection has a dirty token; database truth may be committed for that source, but publication before the other connection settles would make cache correctness depend on commit order.
+
+The catalog has one source connection. A deliberately different Role connection contradicts the shipped foreign-key schema and does not justify another cache identity or coordination protocol.
+
+### Transaction-local assignment-generation rotation
+
+Bulk `syncModels()` cannot enumerate every affected subject, and hard deletion can temporarily hide a Role or Permission from assignment reads before its transaction settles. Both operations must leave the committed assignment namespace before exposing their uncommitted view:
+
+1. Register bulk rotation as the first statement inside the same permission-storage transaction as the delete/attach work. Register hard-delete rotation from `deleting`, before the row disappears; gate only this rotation on the hard-delete predicate.
+2. Store one provisional assignment token directly on the retained `PermissionCacheSettlement` owner for the token key and permission connection. The marker and provisional namespace therefore share one lifetime and cannot be cleared independently.
+3. Make `modelAssignmentCacheToken()` look up only the settlement for the current permission connection before its normal raw `rememberForever()` path. A connection with no open rotation continues using the committed token; a data-key dirty read remains connection-agnostic.
+4. Every later rotation on the same connection replaces the owner's provisional token.
+5. An inner savepoint rollback installs a fresh provisional token while the exact owner marker remains. This makes cache entries written under the rolled-back namespace unreachable without retaining a per-record token stack.
+6. Commit removes the owner and publishes a newly generated token that was never visible inside the transaction. A provisional namespace may contain transaction-warmed entries, so publishing it would make cache completion order capable of restoring state from an earlier database commit. Root rollback removes the owner without publishing.
+
+Do not route the clean token through `ModelCacheCoordinator::fill()`: the token is a raw permanent namespace value, not a TTL-bound model-cache envelope. Do not add an ordered publisher or token lock; every committed token names an empty namespace, so completion order cannot expose stale warmed entries.
+
+### Subject lifecycle ordering
+
+Add one small registrar helper used by queued assignment flush and assignment cleanup:
+
+- when the subject and permission connection names match, run the permission-storage mutation immediately so it remains inside the subject transaction;
+- when they differ, register the mutation through `afterCommitOrNow()` on the subject connection. With no open subject transaction it runs immediately; with an open transaction it runs only after commit.
+
+Queued assignments clear their queued state only after the permission-connection transaction succeeds. Do not register rollback cleanup: rollback drops the deferred callback, leaving the queue available when `transaction($callback, $attempts)` retries. Multiple saves may register multiple callbacks; the first successful callback flushes and clears the queue and later callbacks safely see it empty.
+
+Keep assignment cleanup in `deleted` for ordinary subjects, Roles, and Permissions. This prevents a failed or vetoed delete from stripping a surviving model. Ordinary subjects may defer cleanup from their connection to permission storage; Role and Permission cleanup always takes the immediate same-connection branch. Keep explicit Role/Permission pivot deletion even though the shipped foreign keys cascade, because SQLite foreign-key enforcement can be disabled.
+
+Before deletion, validate that a hard-deleted model has a key and that a Role or Permission record belongs to the current persisted partition. This listener performs no cleanup and stores no state, so a later listener may still veto deletion without changing assignments.
+
+Register Role and Permission catalog invalidation in both `deleting` and `deleted`. The pre-delete registration is deliberately not restricted to hard deletes: it marks transactional soft or hard deletion dirty before any earlier `deleted` listener can publish the uncommitted catalog. In that same `deleting` listener, register assignment-token rotation only for hard deletes so no read after the row disappears can publish a false revocation under the committed namespace. The post-delete catalog registration remains required for non-transactional soft deletes and for different subject/permission connection names, where the pre-delete registration runs immediately before the statement. Transactional same-connection deletion deduplicates both catalog registrations to one committed invalidation. Do not add a post-delete rotation; a hard delete is transaction-wrapped, and the pre-delete registration already owns its provisional namespace.
+
+Override `delete(): int|bool|null` once in `HasPermissions` to make each hard deletion atomic with its `deleted` cleanup. Non-existing models and ordinary soft deletes call `parent::delete()` directly. Every hard delete wraps `parent::delete()` in the subject connection transaction, including when another transaction is already open. The nested savepoint lets a caller catch a cleanup exception and continue its outer transaction without committing the row deletion or leaving PostgreSQL's transaction aborted. This restores the pre-existing deletion contract after moving cleanup to `deleted`; it is not extra defensive machinery. A veto returns `false` before cleanup and commits an empty savepoint harmlessly. Do not override `deleteOrFail()` merely to avoid its one nested savepoint. Extract the hard-delete predicate used by this override, pre-delete validation, and both cleanup listeners rather than duplicating the `isForceDeleting()` check.
+
+A model-defined `delete()` overrides the trait method, and another consumed trait that defines `delete()` requires normal PHP trait-conflict resolution. Document that a custom delete implementation must preserve the transaction boundary. `deleteQuietly()` deliberately suppresses validation and cleanup through Laravel's event bypass and may leave morph pivots behind; do not add interception machinery for it.
+
+At event time, decide whether a soft-deleting model requires cleanup and capture durable scalar inputs: model key, morph class, force-delete decision, partition, and team context where needed. Do not capture the mutable Model for later identity or force-delete reads. Read distinct partition/team scopes from the pivot table inside deferred cleanup because those rows remain available: assignment pivots have no subject foreign key.
+
+Mass query-builder deletes do not fire model events and remain the normal Laravel escape hatch. Do not add interception machinery or document cleanup as guaranteed through that bypass.
+
+### Database relation correction
+
+Fix the underlying relation inconsistency in `InteractsWithPivotTable` and its `MorphToMany::newPivot()` override:
+
+- add the protected `getPivotConnection()` owner described above;
+- after constructing a stock or custom pivot in either `newPivot()` implementation, set its connection from that owner;
+- build `newPivotStatement()` from that owner;
+- make `attachOrFail`, `detachOrFail`, `toggleOrFail`, `syncOrFail`, `syncWithoutDetachingOrFail`, `syncWithPivotValuesOrFail`, and `updateExistingPivotOrFail` transact that owner.
+
+This preserves every public signature and named argument. It makes custom pivots match default pivot reads/writes and makes the transactional wrappers atomic for pivot work. It does not promise distributed atomicity for `touchIfTouching()` when parent and related models live on other physical connections.
+
+### Transaction test mechanics
+
+The always-available regression uses two named SQLite connections to one file under `ParallelTesting::tempDir()`:
+
+- create the schema once through alias A;
+- resolve both aliases inside the test coroutine, after `RefreshDatabase` has rebound the testing transaction manager;
+- assign a fresh production `Hypervel\Database\DatabaseTransactionsManager` to both resolved connection objects;
+- mutate only through alias A while alias B reads the committed pre-transaction view;
+- keep the test free of reconnects, because reconnecting asks the container for `db.transactions` and would reinstall the testing manager;
+- do not add the aliases to `connectionsToTransact`, because wrapper savepoints would prevent alias A's commit from becoming visible to alias B.
+
+The production and testing manager instances share transaction records through `CoroutineContext`; they are not isolated. The setup is safe because callback registration, commit, and rollback filter records by normalized connection name. The production manager is required for a different reason: the testing manager treats level one as settled for `RefreshDatabase`-wrapped connections, while an unwrapped alias must settle only at level zero. Using the testing manager would fire callbacks when a nested transaction releases to level one, before its outer transaction commits.
+
+Add a PostgreSQL service-backed counterpart under `tests/Integration/Permission/Database/Postgres/` using two aliases to the same logical database. One server database and SQLite are enough: the behavior being tested is permission cache settlement and transaction-manager ordering, not driver-specific SQL syntax.
+
+Configure the shared cache store before coroutine setup and rely on the permission test case's configured-store reset. Do not rebuild a driver after the current coroutine has memoized it: a memo wrapper is coroutine-local while the manager's resolved store map is shared.
+
+Test real commit visibility, rollback, same-transaction rereads, stale concurrent fills, repeated same-connection mutations, nested savepoint commit and rollback, outer mutation after inner rollback, and independent connections where one commits and the other rolls back. Pin the raw-memo regression explicitly: mutate/read at L1, mutate/read at L2, roll L2 back, then prove the next read returns the surviving L1 view while the L1 token remains dirty until outer settlement.
+
+Pin generation-namespace rollback for bulk `syncModels()` and hard deletion: read an affected subject inside each transaction, roll back, and prove a sibling coroutine sees committed assignments rather than the transaction-local cache entry. Register an earlier `deleted` listener that reads assignments to prove hard-delete rotation is active before the row disappears. Also cover repeated rotations with a read between them, an outer provisional token followed by an inner rotation and savepoint rollback, alias-specific token ownership, and two open alias rotations settling independently. A committed token must differ from every transaction provisional and must not expose entries written under any provisional namespace.
+
+Also prove that forward and reverse permission mutation APIs, raw cleanup, transaction wrappers, cache tokens, and custom pivots all use the permission alias; a subject-alias rollback undoes or defers permission work as designed; queued work survives a retry; plain `delete()` and `deleteOrFail()` both preserve a live model and its assignments when row deletion fails; and committed subject deletion cleans its assignments. Register a later vetoing `deleting` listener both inside and outside an existing transaction and prove the Role plus both assignment tables remain unchanged. Explicitly catch a cleanup failure inside an application transaction, continue to its commit, and prove the Role plus both assignment tables remain unchanged; cover this on SQLite and PostgreSQL so the PostgreSQL aborted-transaction recovery is pinned. Also prove that rolling back the delete savepoint discards its staged cache invalidations rather than publishing them at the outer commit. Update the custom Role and Permission cleanup tests to observe zero pivots from a later `deleted` listener: those tests own cleanup and query-count behavior, not the superseded pre-delete phase. Do not use separate physical databases or imply complete cross-database relation-query support.
+
+## 3. Narrow invalidation and assignment-generation rotation
+
+Separate catalog invalidation from the public full reset behavior.
+
+### Catalog-only invalidation
+
+The following operations invalidate only the catalog cache and related coroutine runtime state:
+
+- role or permission creation;
+- role or permission updates, including renames;
+- role-permission edge attachment, detachment, and synchronization;
+- soft deletion, because the existing assignment cleanup hooks intentionally leave pivots intact.
+
+These operations must not rotate the assignment generation. Existing subject assignment payloads remain addressable and valid; only the catalog's model representation changed.
+
+### Full generation rotation
+
+Rotate the partition's assignment generation when an uncommitted assignment read must not publish under the committed namespace, or when affected subject keys cannot be enumerated exactly:
+
+- bulk replacement through `HasAssignedModels::syncModels()`, because concurrent inserts prevent exact enumeration of every removed subject across all supported databases;
+- hard or force deletion of a Role or Permission, because a read after the row or its pivots disappear can publish a false revocation that survives rollback under the committed namespace;
+- the explicit public `forgetCachedPermissions()` / cache-reset surface.
+
+Catalog filtering makes stale extra IDs harmless after a committed hard delete, but it cannot restore an assignment ID omitted by an uncommitted read before rollback. The provisional namespace prevents that false revocation from reaching shared cache. Accept the rare partition-wide cold fill rather than adding a second settlement mode solely to restore the old namespace after commit.
+
+Generation-token writes use `afterCommitOrNow()` on the actual mutation connection and share the same per-token-key/per-connection deduplication rule as exact invalidations. Rollback leaves the prior token in place. When the token changes, do not enumerate or forget subject keys that are now unreachable by design.
+
+### Exact subject invalidation
+
+Normal subject mutations invalidate only their exact model-role and model-permission keys. They never rotate the partition-wide token.
+
+`assignToModels()` and `removeFromModels()` know their affected subjects and keep exact invalidation. `syncModels()` performs one bulk replacement and registers partition-generation rotation inside that transaction for settlement after commit. Do not query old subject identities: a concurrent insert can occur after any portable select and still be removed by the bulk delete. Do not constrain deletion to the discovered identities; that would let concurrent assignments survive a replacement and would create an unbounded `IN` predicate. Portable `DELETE ... RETURNING` is unavailable on MySQL and MariaDB, while locking every assignment path would add hot-path coordination solely to preserve a write-side cache optimization.
+
+Tests must prove that creates, renames, role-permission changes, and soft deletes preserve the generation token; hard/force deletes, `syncModels()`, and explicit reset rotate it; rollback never publishes a provisional token; exact subject mutations leave unrelated warm entries available; and generation rotation remains isolated to the current partition. Also prove a transactional soft delete cannot publish a rolled-back catalog and a same-connection hard delete performs one committed catalog invalidation despite pre/post registration. Do not add timing-based interleaving tests or production test seams for the phantom window.
+
+## 4. Memoize hydrated direct permissions per coroutine
+
+Add direct-permission hydration memoization parallel to the existing via-role permission memo:
+
+- use domain-named public methods on `PermissionRegistrar`, not a public string-kind parameter or registry;
+- share a small private helper only if both direct and via-role paths genuinely use it;
+- memoize only the non-loaded relation path;
+- key by the existing exact subject assignment identity, partition, and team runtime context;
+- store the hydrated collection as-is, matching the existing via-role object-sharing behavior;
+- clear it from exact assignment invalidation, catalog invalidation, and full runtime resets. Ambient team and partition changes naturally select another slot through the existing runtime key; do not clear unrelated slots merely because context changed.
+
+Do not add a roles hydration memo without evidence. The direct permission path reconstructs permission models plus morph pivots and is the measured repeated work; the roles path is cheaper and does not justify more state.
+
+Tests must prove one hydration for repeated `hasPermissionTo()` work in the same coroutine, refresh after mutation/invalidation, separation by team and partition, and isolation between sibling coroutines.
+
+## 5. Make class compatibility, primary keys, and team filtering consistent
+
+### Compatible configured classes
+
+At the entry to both `getRoles()` and `getPermissions()`:
+
+1. Determine whether the configured class is the requested class or is a subclass of it.
+2. For compatible requests, use the configured catalog rather than querying the requested base class.
+3. Normalize a primary-key filter written with the requested class's key name to the configured class's key name before indexed lookup and fallback filtering.
+4. Preserve all other filters and public argument shapes.
+
+This keeps custom configured subclasses on the shared catalog and fixes models whose requested and configured primary-key names differ. Genuinely incompatible valid classes retain their own key and query behavior.
+
+Apply this symmetrically to roles and permissions. Permissions need the same fix and have a larger avoidable cost because their catalog eager-loads roles.
+
+Do not manually mark eager-loaded permission-role relations. `PartitionedMorphToMany::initRelation()` and `match()` already set the relation and provenance; an extra hydration marker would duplicate existing behavior.
+
+### Incompatible class catalogs
+
+For genuinely incompatible model classes, query once per coroutine, class, and partition, then filter the resulting collection. Clear these class-specific catalogs with catalog and runtime invalidation. This bounds repeated query work without adding worker-lifetime state.
+
+### Team filtering
+
+Add one `teamScopedRoles(Collection $roles): Collection` helper and apply it to:
+
+- the configured catalog's non-indexed fallback;
+- the incompatible role-class catalog fallback.
+
+Apply the team filter before `$onlyOne`. Keep the indexed path's existing O(1) `roleMatchesCurrentTeam()` lookup unchanged. With a null current team, only global roles match.
+
+Tests must cover:
+
+- compatible base-class requests against custom role and permission subclasses;
+- custom primary-key names on indexed and fallback paths;
+- genuinely incompatible classes querying once per coroutine/class/partition;
+- cache clearing after catalog mutation;
+- identical role names in global, current-team, and other-team rows;
+- null-team filtering;
+- complex parameter filters and `$onlyOne` ordering.
+
+## 6. Fail fast when a team-scoped write has no selected team
+
+Add `TeamNotSelected extends RuntimeException` under `src/permission/src/Exceptions/`. Give it a named constructor with a direct message explaining that a current team must be selected before changing team-scoped roles or permissions. This matches the package's runtime-context failure style; `BadMethodCallException` remains reserved for calling team APIs while teams are disabled.
+
+Add one registrar guard that throws only when teams are enabled and the current team is null.
+
+Call the guard at the top of each package mutation entry point, before role or permission lookup and before empty-input early returns:
+
+- assign, remove, and synchronize roles;
+- give, deny, revoke, and synchronize direct permissions and permission effects;
+- queued permission changes and their flush path;
+- reverse assign, remove, and synchronize model operations.
+
+Place one concise comment where needed to preserve the ordering rule: missing team context must not be misreported as `RoleDoesNotExist` or `PermissionDoesNotExist`.
+
+Retain non-persisted queued behavior, but require the selected team to be captured before queueing.
+
+Enforce the same invariant for direct relation writes in `EnforcesPermissionPartition`:
+
+- reject actual writes from `formatAttachRecord()` and `updateExistingPivot()` when the relation is team-scoped and no team is selected;
+- override `detach()` to apply the same guard;
+- rely on inherited `attach`, `sync`, and `toggle` flows through those existing primitives rather than adding another relation class.
+
+The high-level guard must also cover raw bulk updates such as `is_denied` changes and the raw deletion inside `syncModels()`.
+
+Do not guard reads or relation construction. A null-team read remains empty, and assigning a global `Role` whose team column is null remains valid where the operation is not a team-scoped subject write.
+
+Tests must cover every high-level mutation family, empty sync calls, queued changes, reverse model APIs, raw permission-effect updates, and direct `attach`, `updateExistingPivot`, `detach`, `sync`, and `toggle`. Also prove reads remain fail-closed, global roles remain usable, and the same writes succeed once a team is selected.
+
+## 7. Documentation and plan cleanup
+
+Update only the canonical permission documentation in `src/docs/permission.md`:
+
+- explain that team-enabled writes require a selected current team;
+- show the normal selection flow before mutation;
+- list `TeamNotSelected` with the permission exceptions in Laravel-style prose;
+- update both the Caching and Performance statements that currently say ordinary catalog mutations advance the assignment token. Catalog mutations invalidate only that partition's catalog; hard/force Role or Permission deletion, bulk `syncModels()`, and explicit cache reset advance the assignment token.
+- explain that targeted reverse assignment mutations invalidate exact subjects while bulk `syncModels()` advances only the active partition's assignment token for portable concurrency correctness;
+- explain that assignment cleanup follows a successful row deletion; same-connection hard deletes wrap the row plus cleanup in one transaction, while different connection names defer cleanup until the subject transaction commits. A consuming model's own `delete()` implementation must preserve the subject transaction boundary, while `deleteQuietly()` intentionally skips validation and cleanup.
+- explain that Role and Permission models must use the configured Permission model's connection name because relation reads, pivot writes, and cache settlement must share one transaction identity; subject models may use another connection, but physically separate subject/permission databases cannot support reverse joins or subject query scopes compiled as one SQL statement;
+- explain that coordinated permission caching requires one lock-capable backend for values and refreshable locks, so stack and failover stores are rejected on the first cold fill.
+
+Keep the existing partition-isolation statement that changing a Role in one workspace does not clear another workspace's catalog or token; that statement remains accurate.
+
+Do not add this correctness fix to the package README's `Differences From Laravel` section or to `src/docs/porting-from-laravel.md`. The permission package tracks Spatie rather than a Laravel framework API, and a clearer failure for invalid teamless writes does not change a normal porter decision.
+
+Keep the README's existing undefined-cache-store difference. Upstream deliberately falls back to the `array` store for an unknown configured cache store; Hypervel deliberately fails fast, so this remains a lasting configuration contract difference.
+
+After the focused implementation and tests are complete, remove findings 43–47 from the master remediation plan. Do not remove the Passport-related permission TODOs.
+
+## 8. Test ownership and verification
+
+Prefer existing test owners and avoid scattering one behavior across many new files.
+
+| Area | Primary test location |
+|---|---|
+| Coordinator topology and lock-free hit | `tests/Cache/ModelCacheCoordinatorTest.php` and, only if useful for its public accessor contract, `tests/Cache/CacheMemoizedStoreTest.php` |
+| Permission cache payloads, invalidation, generation tokens, runtime hydration | `tests/Permission/CacheTest.php` and existing partition cache tests |
+| Coherent transaction and concurrency cases | A focused `tests/Permission/PermissionCacheTransactionTest.php` |
+| PostgreSQL cross-connection settlement | `tests/Integration/Permission/Database/Postgres/PermissionCacheTransactionTest.php` |
+| Compatible/incompatible model catalogs and query counts | Existing permission registrar and custom-model test files |
+| Team filtering and high-level guards | Existing team role, permission, and assigned-model trait tests |
+| Direct pivot write guards and relation hydration | Existing custom pivot and partition relation tests |
+| Generic pivot connection and `*OrFail` transactions | Existing database belongs-to-many and custom pivot tests |
+| Documentation contract | Existing documentation checks, if any; otherwise source behavior tests are authoritative |
+
+When the coordinator introduces a presence envelope, update any test that intentionally inspects the raw catalog cache entry to assert the honest envelope shape. Do not add a production test-only accessor.
+
+Run each changed test file immediately after editing it. Run the focused permission and cache coordinator suites after each coherent slice. The existing database runner already discovers `tests/Integration/Permission/Database/Postgres/`; no workflow change is needed.
+
+At completion, run `composer fix` once. After it is green:
+
+1. Re-read every changed source file and trace callers and invalidation paths.
+2. Verify cache hits perform no lock or store-topology work.
+3. Verify all shared publications and invalidations use one coordinator boundary.
+4. Verify every dirty map is coroutine-scoped and bounded by exact keys used in the current operation.
+5. Verify rollback cannot publish, forget, or rotate shared state.
+6. Verify no catalog-only mutation rotates the assignment generation.
+7. Verify all teamless write paths fail before lookup or database work.
+8. Check Laravel/Spatie-facing signatures, named arguments, and protected extension points remain intact.
+9. Remove stale helpers, superseded invalidation paths, duplicate comments, and dead tests.
+
+## Performance checks
+
+The implementation should improve steady-state work while adding coordination only where correctness requires it:
+
+- hot cache reads remain one memo/shared lookup with no lock;
+- cold fills add one lock but prevent dogpiles and stale publication;
+- committed mutations add one exact lock and forget, while transaction-local repeated reads avoid repeated queries through the raw memo;
+- direct permission checks avoid repeated model and pivot hydration;
+- compatible custom classes reuse the indexed catalog;
+- incompatible classes query once per coroutine and partition;
+- indexed team matching remains O(1);
+- targeted reverse mutations retain exact invalidation, while bulk `syncModels()` removes its old-identity query and rotates one partition token after commit for portable concurrency correctness.
+
+Add deterministic query, lock, and cache-operation assertions where the tests already expose those boundaries. Record a small local before/after measurement for the repeated direct-permission hydration and compatible custom-class paths. Do not add timing assertions, a new benchmark harness, production counters, retry loops, or size thresholds.
+
+Pin that repeated clean role checks do not instantiate the configured Permission model merely to derive a source identity. The identity is needed only for transaction-local dirty reads and must remain lazy.
+
+## Expected source changes
+
+- `src/cache/src/MemoizedStore.php`
+- `src/cache/src/CacheManager.php`
+- `src/cache/src/ModelCacheCoordinator.php`
+- `src/permission/src/Exceptions/PermissionConnectionMismatch.php`
+- `src/permission/src/Exceptions/TeamNotSelected.php`
+- `src/permission/src/PermissionRegistrar.php`
+- `src/permission/src/PermissionServiceProvider.php`
+- `src/permission/src/Support/PermissionCacheSettlement.php`
+- `src/permission/src/Traits/EnforcesPermissionPartition.php`
+- `src/permission/src/Traits/RefreshesPermissionCache.php`
+- `src/permission/src/Traits/HasRoles.php`
+- `src/permission/src/Traits/HasPermissions.php`
+- `src/permission/src/Traits/HasAssignedModels.php`
+- `src/database/src/Eloquent/Relations/Concerns/InteractsWithPivotTable.php`
+- `src/database/src/Eloquent/Relations/MorphToMany.php`
+- `src/docs/permission.md`
+- focused existing and new tests listed above
+- the master remediation plan after completion
+
+The exact file set may grow when an existing mutation owner or test owner is discovered during implementation. Any such change must preserve these invariants and be folded into this plan before implementation continues.

--- a/docs/plans/2026-08-27-0953-components-permission-audit-remediation-plan.md
+++ b/docs/plans/2026-08-27-0953-components-permission-audit-remediation-plan.md
@@ -18,11 +18,10 @@ The work covers:
 - narrow assignment-generation rotation;
 - custom primary-key normalization.
 
-The matching findings in `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md` must be removed after implementation because this plan becomes their detailed source of truth. The Passport-related permission TODOs in `docs/todo.md` remain: Passport is not currently ported, so those test gaps are not completed by this work.
+The Passport-related permission TODOs in `docs/todo.md` remain: Passport is not currently ported, so those test gaps are not completed by this work.
 
 ## References
 
-- Audit findings 43–47 in `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`.
 - Current Hypervel permission source under `src/permission/src/`.
 - Current cache coordination under `src/cache/src/ModelCacheCoordinator.php` and `src/cache/src/MemoizedStore.php`.
 - Current permission documentation in `src/docs/permission.md`.
@@ -113,7 +112,7 @@ return $coordinator->fill(
 );
 ```
 
-Do not add a caller-side cache pre-check. `fill()` owns envelope detection and the hot-hit path; a null check would both duplicate work and misread a legitimately cached null. Cold fill holds one per-key lock across source read, lease refresh, and publication. A committed invalidation acquires the same lock before forgetting the key. This prevents a stale reader from publishing after a newer committed mutation.
+Do not add a caller-side cache pre-check. `fill()` owns envelope detection and the hot-hit path; a null check would both duplicate work and misread a legitimately cached null. Cold fill holds one per-key lock across source read, lease refresh, and publication. A committed invalidation acquires the same lock, so it waits for an in-flight fill and removes any value that fill published before releasing the lock. A fill that read before the commit can still publish, and a concurrent hit can observe that value before invalidation removes it. Closing that interval would require version stamps, tombstones, or locking cache hits; none justify losing lock-free hits for this narrow window.
 
 Keep passing the permission package's memoized repository to the coordinator. `MemoizedStore::put()` clears its local memo before writing the inner store, so the first lookup after a cold fill performs one remote read and later execution-local lookups hit the memo. Do not add package-owned memo state or claim that cold fill removes that one repository read.
 
@@ -170,7 +169,7 @@ The commit callback must be registered before immediate versus deferred executio
 
 If a transaction is abandoned without settlement, the stale token is bounded by the coroutine lifetime and safely forces uncached reads for the rest of that coroutine. Add one concise WHY comment at that branch; do not add recovery machinery.
 
-Keep current explicit public cache-reset methods immediate. Package mutation paths derive the permission connection from the registrar rather than the subject or relation direction. Add the narrow domain-named registrar seam needed for catalog-only settlement; do not overload the public full-reset method or introduce a general transaction coordinator.
+Route the explicit public full reset through the same assignment-token rotation and catalog-invalidation settlement paths as model mutations. Normalize an explicit nullable partition once before clearing runtime state or building either shared key, so both halves of the reset target the same resolved partition. Outside a transaction it remains immediate and returns the catalog backend's invalidation result. Inside a transaction it returns `true` once registered or deduplicated against an existing owner, publishes only after commit, and is discarded on rollback. Remove the public immediate token-bump methods: they have no upstream counterpart or production consumer and would remain an unsafe way to publish an uncommitted namespace. Package mutation paths derive the permission connection from the registrar rather than the subject or relation direction. Keep the catalog-only settlement seam domain-named; do not introduce a general transaction coordinator.
 
 ### Dirty read algorithm
 
@@ -276,11 +275,11 @@ Rotate the partition's assignment generation when an uncommitted assignment read
 
 - bulk replacement through `HasAssignedModels::syncModels()`, because concurrent inserts prevent exact enumeration of every removed subject across all supported databases;
 - hard or force deletion of a Role or Permission, because a read after the row or its pivots disappear can publish a false revocation that survives rollback under the committed namespace;
-- the explicit public `forgetCachedPermissions()` / cache-reset surface.
+- the explicit public `forgetCachedPermissions()` / cache-reset surface, settled on the permission connection.
 
 Catalog filtering makes stale extra IDs harmless after a committed hard delete, but it cannot restore an assignment ID omitted by an uncommitted read before rollback. The provisional namespace prevents that false revocation from reaching shared cache. Accept the rare partition-wide cold fill rather than adding a second settlement mode solely to restore the old namespace after commit.
 
-Generation-token writes use `afterCommitOrNow()` on the actual mutation connection and share the same per-token-key/per-connection deduplication rule as exact invalidations. Rollback leaves the prior token in place. When the token changes, do not enumerate or forget subject keys that are now unreachable by design.
+Generation-token writes use `afterCommitOrNow()` on the actual mutation connection and share the same per-token-key/per-connection deduplication rule as exact invalidations. This includes explicit resets: commit publishes the reset, while rollback leaves the prior token and shared catalog in place. When the token changes, do not enumerate or forget subject keys that are now unreachable by design.
 
 ### Exact subject invalidation
 
@@ -288,7 +287,7 @@ Normal subject mutations invalidate only their exact model-role and model-permis
 
 `assignToModels()` and `removeFromModels()` know their affected subjects and keep exact invalidation. `syncModels()` performs one bulk replacement and registers partition-generation rotation inside that transaction for settlement after commit. Do not query old subject identities: a concurrent insert can occur after any portable select and still be removed by the bulk delete. Do not constrain deletion to the discovered identities; that would let concurrent assignments survive a replacement and would create an unbounded `IN` predicate. Portable `DELETE ... RETURNING` is unavailable on MySQL and MariaDB, while locking every assignment path would add hot-path coordination solely to preserve a write-side cache optimization.
 
-Tests must prove that creates, renames, role-permission changes, and soft deletes preserve the generation token; hard/force deletes, `syncModels()`, and explicit reset rotate it; rollback never publishes a provisional token; exact subject mutations leave unrelated warm entries available; and generation rotation remains isolated to the current partition. Also prove a transactional soft delete cannot publish a rolled-back catalog and a same-connection hard delete performs one committed catalog invalidation despite pre/post registration. Do not add timing-based interleaving tests or production test seams for the phantom window.
+Tests must prove that creates, renames, role-permission changes, and soft deletes preserve the generation token; hard/force deletes, `syncModels()`, and explicit reset rotate it; rollback never publishes a provisional token; exact subject mutations leave unrelated warm entries available; and generation rotation remains isolated to the current partition. Prove that an explicit reset settles after a root commit, is discarded by a root rollback, and is also discarded when its inner savepoint rolls back before an otherwise unchanged outer commit. The savepoint regression must inspect the shared repository payload and token directly because reset registration intentionally clears coroutine-local runtime state. Also prove a transactional soft delete cannot publish a rolled-back catalog and a same-connection hard delete performs one committed catalog invalidation despite pre/post registration. Do not add timing-based interleaving tests or production test seams for the phantom window.
 
 ## 4. Memoize hydrated direct permissions per coroutine
 
@@ -386,6 +385,7 @@ Update only the canonical permission documentation in `src/docs/permission.md`:
 - explain that assignment cleanup follows a successful row deletion; same-connection hard deletes wrap the row plus cleanup in one transaction, while different connection names defer cleanup until the subject transaction commits. A consuming model's own `delete()` implementation must preserve the subject transaction boundary, while `deleteQuietly()` intentionally skips validation and cleanup.
 - explain that Role and Permission models must use the configured Permission model's connection name because relation reads, pivot writes, and cache settlement must share one transaction identity; subject models may use another connection, but physically separate subject/permission databases cannot support reverse joins or subject query scopes compiled as one SQL statement;
 - explain that coordinated permission caching requires one lock-capable backend for values and refreshable locks, so stack and failover stores are rejected on the first cold fill.
+- explain that an explicit reset inside a transaction is published after commit, discarded on rollback, and reports success once registered.
 
 Keep the existing partition-isolation statement that changing a Role in one workspace does not clear another workspace's catalog or token; that statement remains accurate.
 
@@ -393,7 +393,7 @@ Do not add this correctness fix to the package README's `Differences From Larave
 
 Keep the README's existing undefined-cache-store difference. Upstream deliberately falls back to the `array` store for an unknown configured cache store; Hypervel deliberately fails fast, so this remains a lasting configuration contract difference.
 
-After the focused implementation and tests are complete, remove findings 43–47 from the master remediation plan. Do not remove the Passport-related permission TODOs.
+Do not remove the Passport-related permission TODOs.
 
 ## 8. Test ownership and verification
 
@@ -463,6 +463,5 @@ Pin that repeated clean role checks do not instantiate the configured Permission
 - `src/database/src/Eloquent/Relations/MorphToMany.php`
 - `src/docs/permission.md`
 - focused existing and new tests listed above
-- the master remediation plan after completion
 
 The exact file set may grow when an existing mutation owner or test owner is discovered during implementation. Any such change must preserve these invariants and be folded into this plan before implementation continues.

--- a/src/cache/src/CacheManager.php
+++ b/src/cache/src/CacheManager.php
@@ -466,6 +466,8 @@ class CacheManager implements FactoryContract
             if (isset($this->stores[$cacheName])) {
                 unset($this->stores[$cacheName]);
             }
+
+            CoroutineContext::forget(self::MEMOIZED_CONTEXT_KEY_PREFIX . $cacheName);
         }
 
         return $this;

--- a/src/cache/src/MemoizedStore.php
+++ b/src/cache/src/MemoizedStore.php
@@ -33,6 +33,14 @@ class MemoizedStore implements CanFlushLocks, LockProvider, RawReadable, Store
     }
 
     /**
+     * Get the underlying cache store.
+     */
+    public function getInnerStore(): Store
+    {
+        return $this->repository->getStore();
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * Store contract method — returns the value with sentinels unwrapped to null,

--- a/src/cache/src/ModelCacheCoordinator.php
+++ b/src/cache/src/ModelCacheCoordinator.php
@@ -100,9 +100,9 @@ class ModelCacheCoordinator
     /**
      * Invalidate an exact shared model cache entry.
      */
-    public function invalidate(CacheRepository $cache, string $key): void
+    public function invalidate(CacheRepository $cache, string $key): bool
     {
-        $this->lock($cache, $key)
+        return (bool) $this->lock($cache, $key)
             ->betweenBlockedAttemptsSleepFor(self::INVALIDATION_RETRY_MILLISECONDS)
             ->block(
                 self::INVALIDATION_WAIT_SECONDS,
@@ -142,20 +142,30 @@ class ModelCacheCoordinator
     private function lock(CacheRepository $cache, string $key): RefreshableLock
     {
         $store = $cache->getStore();
+        $validatedStore = $store instanceof MemoizedStore
+            ? $store->getInnerStore()
+            : $store;
 
-        if (! $store instanceof LockProvider) {
+        if ($validatedStore instanceof StackStore || $validatedStore instanceof FailoverStore) {
             throw new UnsupportedModelCacheStoreException(sprintf(
-                'Model caching does not support cache store [%s] because it does not provide atomic locks.',
-                $store::class,
+                'Model caching does not support cache store [%s] because stack and failover stores cannot guarantee that cached values and locks use the same backend.',
+                $validatedStore::class,
             ));
         }
 
-        $lock = $store->lock($this->lockKey($key), self::FILL_LOCK_SECONDS);
+        if (! $validatedStore instanceof LockProvider) {
+            throw new UnsupportedModelCacheStoreException(sprintf(
+                'Model caching does not support cache store [%s] because it does not provide atomic locks.',
+                $validatedStore::class,
+            ));
+        }
+
+        $lock = $validatedStore->lock($this->lockKey($key), self::FILL_LOCK_SECONDS);
 
         if (! $lock instanceof RefreshableLock) {
             throw new UnsupportedModelCacheStoreException(sprintf(
                 'Model caching does not support cache store [%s] because it does not provide refreshable atomic locks.',
-                $store::class,
+                $validatedStore::class,
             ));
         }
 

--- a/src/database/src/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/database/src/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Database\Eloquent\Relations\Concerns;
 
 use BackedEnum;
+use Hypervel\Database\ConnectionInterface;
 use Hypervel\Database\Eloquent\Collection as EloquentCollection;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\Pivot;
@@ -70,7 +71,7 @@ trait InteractsWithPivotTable
      */
     public function toggleOrFail(mixed $ids, bool $touch = true): array
     {
-        return $this->parent->getConnection()->transaction(fn () => $this->toggle($ids, $touch));
+        return $this->getPivotConnection()->transaction(fn () => $this->toggle($ids, $touch));
     }
 
     /**
@@ -161,7 +162,7 @@ trait InteractsWithPivotTable
      */
     public function syncOrFail(BaseCollection|Model|array|int|string|null $ids, bool $detaching = true): array
     {
-        return $this->parent->getConnection()->transaction(fn () => $this->sync($ids, $detaching));
+        return $this->getPivotConnection()->transaction(fn () => $this->sync($ids, $detaching));
     }
 
     /**
@@ -185,7 +186,7 @@ trait InteractsWithPivotTable
      */
     public function syncWithPivotValuesOrFail(BaseCollection|Model|array|int|string|null $ids, array $values, bool $detaching = true): array
     {
-        return $this->parent->getConnection()->transaction(fn () => $this->syncWithPivotValues($ids, $values, $detaching));
+        return $this->getPivotConnection()->transaction(fn () => $this->syncWithPivotValues($ids, $values, $detaching));
     }
 
     /**
@@ -266,7 +267,7 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivotOrFail(mixed $id, array $attributes, bool $touch = true): int
     {
-        return $this->parent->getConnection()->transaction(fn () => $this->updateExistingPivot($id, $attributes, $touch));
+        return $this->getPivotConnection()->transaction(fn () => $this->updateExistingPivot($id, $attributes, $touch));
     }
 
     /**
@@ -318,7 +319,7 @@ trait InteractsWithPivotTable
      */
     public function attachOrFail(mixed $ids, array $attributes = [], bool $touch = true): void
     {
-        $this->parent->getConnection()->transaction(fn () => $this->attach($ids, $attributes, $touch));
+        $this->getPivotConnection()->transaction(fn () => $this->attach($ids, $attributes, $touch));
     }
 
     /**
@@ -482,7 +483,7 @@ trait InteractsWithPivotTable
      */
     public function detachOrFail(mixed $ids = null, bool $touch = true): int
     {
-        return $this->parent->getConnection()->transaction(fn () => $this->detach($ids, $touch));
+        return $this->getPivotConnection()->transaction(fn () => $this->detach($ids, $touch));
     }
 
     /**
@@ -540,6 +541,7 @@ trait InteractsWithPivotTable
         );
 
         $pivot = $pivot
+            ->setConnection($this->getPivotConnection()->getName())
             ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
             ->setRelatedModel($this->related);
 
@@ -568,7 +570,15 @@ trait InteractsWithPivotTable
      */
     public function newPivotStatement(): QueryBuilder
     {
-        return $this->query->getQuery()->newQuery()->from($this->table);
+        return $this->getPivotConnection()->table($this->table);
+    }
+
+    /**
+     * Get the connection that owns the pivot table.
+     */
+    protected function getPivotConnection(): ConnectionInterface
+    {
+        return $this->query->getQuery()->getConnection();
     }
 
     /**

--- a/src/database/src/Eloquent/Relations/MorphToMany.php
+++ b/src/database/src/Eloquent/Relations/MorphToMany.php
@@ -137,7 +137,8 @@ class MorphToMany extends BelongsToMany
             ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
             : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
 
-        $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
+        $pivot->setConnection($this->getPivotConnection()->getName())
+            ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
             ->setRelatedModel($this->related)
             ->setMorphType($this->morphType)
             ->setMorphClass($this->morphClass);

--- a/src/docs/permission.md
+++ b/src/docs/permission.md
@@ -49,7 +49,9 @@
 - [Wildcard Permissions](#wildcard-permissions)
 - [Polymorphic Models](#polymorphic-models)
 - [Custom Models](#custom-models)
+    - [Permission Database Connection](#permission-database-connection)
     - [Custom Pivot Models](#custom-pivot-models)
+    - [Deleting Models](#deleting-models)
 - [UUID and ULID Keys](#uuid-and-ulid-keys)
 - [Caching](#caching)
 - [Testing and Seeding](#testing-and-seeding)
@@ -1144,6 +1146,8 @@ setPermissionsTeamId($team->getKey());
 $user->assignRole('writer');
 ```
 
+Select the current team before changing a model's roles or direct permissions, including when assigning a global role. Every assignment belongs to the active team, so a missing selection throws `TeamNotSelected` before the package queries or writes authorization data.
+
 You may also pass a team model:
 
 ```php
@@ -1277,6 +1281,13 @@ After creating custom models, update the permission configuration:
 ],
 ```
 
+<a name="permission-database-connection"></a>
+### Permission Database Connection
+
+All five permission tables, including pivot writes, use the configured Permission model's database connection. The configured Role and Permission models must use that same connection name. Role relation reads use the Role connection, while pivot writes and cache settlement use the Permission connection, so separate connection names would break transaction consistency even when they point to the same database.
+
+A subject model may use another connection. When it lives in a physically separate database, reverse relations and subject query scopes are unavailable because they compile joins to the permission tables on the subject connection.
+
 <a name="custom-pivot-models"></a>
 ### Custom Pivot Models
 
@@ -1320,6 +1331,15 @@ If you use a custom role or permission model that uses `SoftDeletes`, soft-delet
 
 Use hard deletes for roles and permissions when assignments should be removed permanently.
 
+<a name="deleting-models"></a>
+### Deleting Models
+
+When you hard delete a subject model that uses `HasRoles` or `HasPermissions`, the package removes its assignments after the model row is deleted successfully. When the subject and permission storage use the same connection, the row deletion and assignment cleanup run in one transaction. When they use different connection names, assignment cleanup runs only after the subject transaction commits. If another transaction is already open on the subject connection, the delete uses a savepoint so a same-connection cleanup failure rolls back only that delete operation.
+
+If your model defines its own `delete` method, it overrides the transaction supplied by the permission trait. Keep the model deletion and its events inside one transaction so the row and assignment cleanup cannot settle separately.
+
+The `deleteQuietly` method intentionally skips model events, including permission validation and cleanup. Subject assignment tables do not have a foreign key to the subject model, so a quiet delete may leave assignment rows behind. Use the normal `delete` method when those assignments should be removed.
+
 <a name="uuid-and-ulid-keys"></a>
 ## UUID and ULID Keys
 
@@ -1358,6 +1378,8 @@ Integer, UUID, and ULID Role, Permission, partition, and subject keys are suppor
 
 The permission registrar caches role and permission metadata using the configured cache store. Hot checks also use Hypervel's memo cache layer for the current coroutine, so repeated checks in one request or job avoid repeated cache-store reads.
 
+The cache store must keep cached values and refreshable atomic locks on the same backend. Stack and failover stores are not supported because their values and locks may use different backends. Hypervel validates this requirement on the first cache miss, while cache hits remain lock-free.
+
 By default, cache identities are application-wide. When [row partitioning](#row-partitioning) is enabled, every relevant shared and coroutine-local identity includes the current partition automatically. Cache namespacing alone is not row isolation; use `resolvePartitionUsing` so database queries, pivot writes, relations, commands, cache entries, and invalidation all share the same fail-closed boundary.
 
 Built-in mutation methods refresh the relevant cache automatically:
@@ -1379,7 +1401,7 @@ $user->syncPermissionEffects(
 );
 ```
 
-Exact subject assignment mutations forget that subject's affected assignment entry. Role or Permission catalog mutations invalidate only the affected partition and advance only that partition's assignment token. Raw or bulk writes bypass lifecycle invalidation and require an explicit reset in each affected established partition.
+Exact subject assignment mutations forget that subject's affected assignment entry. Replacing every subject assigned to a Role or Permission through `syncModels` advances the active partition's assignment token because a concurrent assignment cannot be enumerated safely across every supported database. Role or Permission catalog mutations invalidate only the affected partition's catalog. Hard or force deletion of a Role or Permission, and an explicit cache reset, also advance only that partition's assignment token. Raw or bulk writes bypass lifecycle invalidation and require an explicit reset in each affected established partition.
 
 You may clear cached permission data with the command:
 
@@ -1472,7 +1494,7 @@ Prefer policies and Gate checks when authorization depends on both the user and 
 
 Permission checks use cached role and permission data after the first lookup. Model role assignments and direct permission assignments have their own cache keys. Those keys include the model type, model key, active partition when enabled, active team when team-scoped, and the partition-specific assignment token.
 
-Warm authorization checks execute no database queries. A cold catalog uses three queries. Enabling row partitioning does not add queries: it adds one bound, indexed predicate to existing SQL and one value to pivot inserts. The partition resolver is an in-memory Context lookup. Exact subject mutations forget exact cache identities, while catalog-wide changes advance only the affected partition's assignment token so older entries expire naturally through the configured TTL.
+Warm authorization checks execute no database queries. A cold catalog uses three queries. Enabling row partitioning does not add queries: it adds one bound, indexed predicate to existing SQL and one value to pivot inserts. The partition resolver is an in-memory Context lookup. Exact subject mutations forget exact cache identities. Catalog changes invalidate only the affected catalog, while bulk reverse synchronization, hard or force deletion, and explicit cache resets advance the affected partition's assignment token so older entries expire naturally through the configured TTL.
 
 Saved permission replacements perform one additional relationship query only when assignment events are enabled and a listener is registered for `PermissionDetachedEvent`. When a custom pivot is configured, methods that return Permission models load the relationship once for the model in the current coroutine and reuse it on later calls. Authorization and permission-name checks remain query-free after the permission cache is warm.
 
@@ -1507,12 +1529,14 @@ $exception->getRequiredRoles();
 $exception->getRequiredPermissions();
 ```
 
-Partition registration and isolation failures use focused exceptions:
+Configuration and context failures use focused exceptions:
 
+- `PermissionConnectionMismatch` when a Role or Permission model write uses a different connection name from the configured Permission model;
 - `PermissionPartitionAlreadyConfigured` when registration is repeated or occurs after registrar initialization;
 - `PermissionPartitionNotResolved` when enabled partition context is missing;
 - `PermissionPartitionViolation` when a model or pivot conflicts with its captured partition, attempts to change an immutable partition, or lacks a valid persisted partition value;
-- `PermissionPartitionModelNotSupported` when partition mode is configured with a Role or Permission model that does not extend the package base.
+- `PermissionPartitionModelNotSupported` when partition mode is configured with a Role or Permission model that does not extend the package base;
+- `TeamNotSelected` when teams are enabled and a write is attempted without a selected current team.
 
 <a name="differences-from-spatie-laravel-permission"></a>
 ## Differences From Spatie Laravel Permission

--- a/src/docs/permission.md
+++ b/src/docs/permission.md
@@ -1419,6 +1419,8 @@ use Hypervel\Permission\PermissionRegistrar;
 app(PermissionRegistrar::class)->forgetCachedPermissions();
 ```
 
+If you reset the cache inside a database transaction, Hypervel applies the reset after the transaction commits and discards it when the transaction rolls back. The method returns `true` once a transactional reset has been registered.
+
 <a name="testing-and-seeding"></a>
 ## Testing and Seeding
 

--- a/src/permission/src/Exceptions/PermissionConnectionMismatch.php
+++ b/src/permission/src/Exceptions/PermissionConnectionMismatch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Permission\Exceptions;
+
+use Hypervel\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+class PermissionConnectionMismatch extends InvalidArgumentException
+{
+    /**
+     * Create a new permission connection mismatch exception.
+     */
+    public static function forModel(Model $model, string $expectedConnection): static
+    {
+        return new static(__('Model `:model` uses database connection `:actual`, but Role and Permission models must use permission connection `:expected`.', [
+            'model' => $model::class,
+            'actual' => $model->getConnection()->getName() ?? '',
+            'expected' => $expectedConnection,
+        ]));
+    }
+}

--- a/src/permission/src/Exceptions/TeamNotSelected.php
+++ b/src/permission/src/Exceptions/TeamNotSelected.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Permission\Exceptions;
+
+use RuntimeException;
+
+class TeamNotSelected extends RuntimeException
+{
+    /**
+     * Create a new team not selected exception.
+     */
+    public static function create(): static
+    {
+        return new static(__('A current team must be selected before changing team-scoped roles or permissions.'));
+    }
+}

--- a/src/permission/src/PermissionRegistrar.php
+++ b/src/permission/src/PermissionRegistrar.php
@@ -6,6 +6,7 @@ namespace Hypervel\Permission;
 
 use Closure;
 use Hypervel\Cache\CacheManager;
+use Hypervel\Cache\ModelCacheCoordinator;
 use Hypervel\Container\Container as BaseContainer;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Auth\Access\Authorizable;
@@ -14,6 +15,7 @@ use Hypervel\Contracts\Cache\Repository;
 use Hypervel\Contracts\Cache\Store;
 use Hypervel\Contracts\Config\Repository as ConfigRepository;
 use Hypervel\Contracts\Container\Container;
+use Hypervel\Database\Connection;
 use Hypervel\Database\Eloquent\Collection;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\BelongsToMany;
@@ -21,12 +23,15 @@ use Hypervel\Database\Eloquent\Relations\Pivot;
 use Hypervel\Permission\Contracts\Permission as PermissionContract;
 use Hypervel\Permission\Contracts\PermissionsTeamResolver;
 use Hypervel\Permission\Contracts\Role as RoleContract;
+use Hypervel\Permission\Exceptions\PermissionConnectionMismatch;
 use Hypervel\Permission\Exceptions\PermissionPartitionAlreadyConfigured;
 use Hypervel\Permission\Exceptions\PermissionPartitionModelNotSupported;
 use Hypervel\Permission\Exceptions\PermissionPartitionNotResolved;
 use Hypervel\Permission\Exceptions\PermissionPartitionViolation;
+use Hypervel\Permission\Exceptions\TeamNotSelected;
 use Hypervel\Permission\Models\Permission;
 use Hypervel\Permission\Models\Role;
+use Hypervel\Permission\Support\PermissionCacheSettlement;
 use Hypervel\Permission\Support\PermissionPartition;
 use Hypervel\Permission\Support\PermissionRelationContext;
 use Hypervel\Support\Arr;
@@ -63,6 +68,14 @@ class PermissionRegistrar
     public const string WILDCARD_PERMISSION_INDEX_CONTEXT_KEY = '__permission.wildcard_index';
 
     public const string MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY = '__permission.model_via_role_permissions';
+
+    protected const string MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY = '__permission.model_direct_permissions';
+
+    protected const string MODEL_CLASS_CATALOG_CONTEXT_KEY = '__permission.model_class_catalog';
+
+    protected const string DIRTY_CACHE_TOKENS_CONTEXT_KEY = '__permission.dirty_cache_tokens';
+
+    protected const string DIRTY_CACHE_VALUES_CONTEXT_KEY = '__permission.dirty_cache_values';
 
     protected static ?string $partitionColumn = null;
 
@@ -116,6 +129,7 @@ class PermissionRegistrar
         protected CacheManager $cacheManager,
         protected ConfigRepository $config,
         protected Container $app,
+        protected ModelCacheCoordinator $modelCacheCoordinator,
     ) {
         static::$initialized = true;
         $this->loadedRelationProvenance = new WeakMap;
@@ -233,6 +247,18 @@ class PermissionRegistrar
 
         if (! $partition->matches($actual)) {
             throw PermissionPartitionViolation::forModel($model, $partition, $actual);
+        }
+    }
+
+    /**
+     * Ensure a Role or Permission model uses the permission storage connection.
+     */
+    public function ensureModelUsesPermissionConnection(Model $model): void
+    {
+        $expectedConnection = $this->getPermissionConnection()->getName() ?? '';
+
+        if (($model->getConnection()->getName() ?? '') !== $expectedConnection) {
+            throw PermissionConnectionMismatch::forModel($model, $expectedConnection);
         }
     }
 
@@ -408,6 +434,213 @@ class PermissionRegistrar
     }
 
     /**
+     * Remember a shared value unless its transaction-local view is dirty.
+     *
+     * @param Closure(): mixed $read
+     */
+    private function rememberSharedOrDirtyValue(
+        string $cacheKey,
+        Closure $read,
+    ): mixed {
+        if (! $this->cacheKeyIsDirty($cacheKey)) {
+            return $this->modelCacheCoordinator->fill(
+                $this->cacheRepository(),
+                $cacheKey,
+                $this->cacheExpirationTime,
+                $read,
+            );
+        }
+
+        return $this->rememberDirtyCacheValue(
+            $cacheKey,
+            $this->permissionConnectionIdentity(),
+            $read,
+        );
+    }
+
+    /**
+     * Remember a transaction-local source value for an exact cache key.
+     *
+     * @param Closure(): mixed $read
+     */
+    private function rememberDirtyCacheValue(
+        string $cacheKey,
+        string $sourceIdentity,
+        Closure $read,
+    ): mixed {
+        $values = CoroutineContext::get(self::DIRTY_CACHE_VALUES_CONTEXT_KEY, []);
+
+        if (array_key_exists($sourceIdentity, $values[$cacheKey] ?? [])) {
+            return $values[$cacheKey][$sourceIdentity];
+        }
+
+        $value = $read();
+        $values[$cacheKey][$sourceIdentity] = $value;
+        CoroutineContext::set(self::DIRTY_CACHE_VALUES_CONTEXT_KEY, $values);
+
+        return $value;
+    }
+
+    /**
+     * Settle one exact cache invalidation on the mutation connection.
+     *
+     * @param Closure(): void $clearRuntime
+     */
+    private function settleCacheMutation(
+        string $cacheKey,
+        Closure $clearRuntime,
+    ): void {
+        $this->clearDirtyCacheValues($cacheKey);
+        $clearRuntime();
+
+        $this->afterCommitOnce(
+            $cacheKey,
+            function (PermissionCacheSettlement $settlement) use ($cacheKey, $clearRuntime): void {
+                $this->clearDirtyCacheValues($cacheKey);
+                $clearRuntime();
+                $this->modelCacheCoordinator->invalidate($this->cacheRepository(), $cacheKey);
+            },
+            function (PermissionCacheSettlement $settlement) use ($cacheKey, $clearRuntime): void {
+                $this->clearDirtyCacheValues($cacheKey);
+                $clearRuntime();
+            },
+        );
+    }
+
+    /**
+     * Run one settlement callback per key and mutation connection.
+     *
+     * @param Closure(PermissionCacheSettlement): void $commit
+     * @param Closure(PermissionCacheSettlement): void $rollBack
+     */
+    private function afterCommitOnce(
+        string $cacheKey,
+        Closure $commit,
+        Closure $rollBack,
+    ): PermissionCacheSettlement {
+        $connection = $this->getPermissionConnection();
+        $connectionName = $connection->getName() ?? '';
+        $settlement = new PermissionCacheSettlement($connectionName);
+
+        // Registration must happen before execution mode is known; RefreshDatabase makes raw depth unreliable.
+        $connection->afterCommitOrNow(function () use (
+            $cacheKey,
+            $commit,
+            $connectionName,
+            $settlement,
+        ): void {
+            $settlement->callbackRanImmediately = true;
+
+            if (! $settlement->deferred) {
+                $commit($settlement);
+
+                return;
+            }
+
+            if (! $settlement->ownsToken || ! $this->settlementTokenMatches($cacheKey, $connectionName, $settlement)) {
+                return;
+            }
+
+            $this->removeSettlementToken($cacheKey, $connectionName);
+            $commit($settlement);
+        });
+
+        if ($settlement->callbackRanImmediately) {
+            return $settlement;
+        }
+
+        $settlement->deferred = true;
+        $tokens = CoroutineContext::get(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, []);
+
+        if (($owner = $tokens[$cacheKey][$connectionName] ?? null) instanceof PermissionCacheSettlement) {
+            // Each nested record owns rollback cleanup without requiring a transaction-record identity map.
+            $connection->afterRollBack(fn () => $rollBack($owner));
+
+            return $owner;
+        }
+
+        // The context retains the object, so direct identity cannot be reused while this marker is live.
+        $tokens[$cacheKey][$connectionName] = $settlement;
+        CoroutineContext::set(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, $tokens);
+        $settlement->ownsToken = true;
+
+        // An abandoned transaction leaves this key safely dirty only until its coroutine ends.
+        $connection->afterRollBack(function () use (
+            $cacheKey,
+            $connectionName,
+            $settlement,
+            $rollBack,
+        ): void {
+            if (! $this->settlementTokenMatches($cacheKey, $connectionName, $settlement)) {
+                return;
+            }
+
+            $this->removeSettlementToken($cacheKey, $connectionName);
+            $rollBack($settlement);
+        });
+
+        return $settlement;
+    }
+
+    /**
+     * Determine whether an exact cache key has an unsettled mutation.
+     */
+    private function cacheKeyIsDirty(string $cacheKey): bool
+    {
+        $tokens = CoroutineContext::get(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, []);
+
+        return ($tokens[$cacheKey] ?? []) !== [];
+    }
+
+    /**
+     * Determine whether a mutation still owns its settlement token.
+     */
+    private function settlementTokenMatches(string $cacheKey, string $connection, object $owner): bool
+    {
+        $tokens = CoroutineContext::get(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, []);
+
+        return ($tokens[$cacheKey][$connection] ?? null) === $owner;
+    }
+
+    /**
+     * Get the settlement owned by a connection for an exact cache key.
+     */
+    private function settlementForConnection(
+        string $cacheKey,
+        string $connection,
+    ): ?PermissionCacheSettlement {
+        $tokens = CoroutineContext::get(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, []);
+        $settlement = $tokens[$cacheKey][$connection] ?? null;
+
+        return $settlement instanceof PermissionCacheSettlement ? $settlement : null;
+    }
+
+    /**
+     * Remove one mutation settlement token.
+     */
+    private function removeSettlementToken(string $cacheKey, string $connection): void
+    {
+        $tokens = CoroutineContext::get(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, []);
+        unset($tokens[$cacheKey][$connection]);
+
+        if (($tokens[$cacheKey] ?? []) === []) {
+            unset($tokens[$cacheKey]);
+        }
+
+        CoroutineContext::set(self::DIRTY_CACHE_TOKENS_CONTEXT_KEY, $tokens);
+    }
+
+    /**
+     * Clear transaction-local source values for an exact cache key.
+     */
+    private function clearDirtyCacheValues(string $cacheKey): void
+    {
+        $values = CoroutineContext::get(self::DIRTY_CACHE_VALUES_CONTEXT_KEY, []);
+        unset($values[$cacheKey]);
+        CoroutineContext::set(self::DIRTY_CACHE_VALUES_CONTEXT_KEY, $values);
+    }
+
+    /**
      * Set the current permissions team id.
      */
     public function setPermissionsTeamId(int|string|Model|null $id): void
@@ -421,6 +654,22 @@ class PermissionRegistrar
     public function getPermissionsTeamId(): int|string|null
     {
         return $this->teamResolver->getPermissionsTeamId();
+    }
+
+    /**
+     * Ensure a team-scoped mutation has a selected team.
+     */
+    public function ensureTeamIsSelectedForMutation(?PermissionRelationContext $context = null): void
+    {
+        if (! $this->teams || ($context !== null && ! $context->teamScoped)) {
+            return;
+        }
+
+        $team = $context === null ? $this->getPermissionsTeamId() : $context->team;
+
+        if ($team === null) {
+            throw TeamNotSelected::create();
+        }
     }
 
     /**
@@ -461,9 +710,52 @@ class PermissionRegistrar
         $this->clearPermissionRuntimeStateFor($partition);
         $this->bumpModelAssignmentCacheTokenFor($partition);
 
-        return $this->cacheRepository()->forget(
+        return $this->modelCacheCoordinator->invalidate(
+            $this->cacheRepository(),
             $this->partitionedCacheKey($this->cacheKey, $partition),
         );
+    }
+
+    /**
+     * Invalidate the permission catalog after a model mutation settles.
+     */
+    public function invalidatePermissionCatalogAfterMutation(
+        ?PermissionPartition $partition,
+    ): void {
+        $this->settleCacheMutation(
+            $this->partitionedCacheKey($this->cacheKey, $partition),
+            fn () => $this->clearPermissionRuntimeStateFor($partition),
+        );
+    }
+
+    /**
+     * Rotate the model assignment cache namespace after a model mutation settles.
+     */
+    public function rotateModelAssignmentCacheTokenAfterMutation(
+        ?PermissionPartition $partition,
+    ): void {
+        $partition = $this->resolvedPartitionArgument($partition);
+        $cacheKey = $this->partitionedCacheKey($this->modelCacheTokenKey, $partition);
+
+        $settlement = $this->afterCommitOnce(
+            $cacheKey,
+            function (PermissionCacheSettlement $settlement) use ($cacheKey): void {
+                $this->cacheRepository()->forever(
+                    $cacheKey,
+                    $this->newModelAssignmentCacheToken(),
+                );
+            },
+            function (PermissionCacheSettlement $settlement) use ($cacheKey): void {
+                // A surviving outer mutation needs a fresh namespace after this savepoint's view is discarded.
+                if ($this->settlementTokenMatches($cacheKey, $settlement->connectionName, $settlement)) {
+                    $settlement->provisionalToken = $this->newModelAssignmentCacheToken();
+                }
+            },
+        );
+
+        if ($settlement->deferred) {
+            $settlement->provisionalToken = $this->newModelAssignmentCacheToken();
+        }
     }
 
     /**
@@ -505,20 +797,26 @@ class PermissionRegistrar
     ): void {
         $cache = $this->cacheRepository();
 
-        $cache->forget($this->modelCacheKeyForIdentity(
-            $this->modelRolesCacheKeyPrefix,
-            $morphType,
-            $modelKey,
-            $partition,
-            $team,
-        ));
-        $cache->forget($this->modelCacheKeyForIdentity(
-            $this->modelPermissionsCacheKeyPrefix,
-            $morphType,
-            $modelKey,
-            $partition,
-            $team,
-        ));
+        $this->modelCacheCoordinator->invalidate(
+            $cache,
+            $this->modelCacheKeyForIdentity(
+                $this->modelRolesCacheKeyPrefix,
+                $morphType,
+                $modelKey,
+                $partition,
+                $team,
+            ),
+        );
+        $this->modelCacheCoordinator->invalidate(
+            $cache,
+            $this->modelCacheKeyForIdentity(
+                $this->modelPermissionsCacheKeyPrefix,
+                $morphType,
+                $modelKey,
+                $partition,
+                $team,
+            ),
+        );
 
         $runtimeKey = $this->modelRuntimeCacheKeyForIdentity(
             $morphType,
@@ -528,7 +826,53 @@ class PermissionRegistrar
         );
 
         $this->forgetRuntimeCacheItem(self::MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
+        $this->forgetRuntimeCacheItem(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
         $this->forgetRuntimeCacheItem(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY, $runtimeKey);
+    }
+
+    /**
+     * Invalidate assignment caches after a model mutation settles.
+     */
+    public function invalidateModelAssignmentCacheAfterMutation(
+        Model $model,
+        ?PermissionPartition $partition,
+        int|string|null $team,
+    ): void {
+        $this->invalidateModelAssignmentCacheForIdentityAfterMutation(
+            $model->getMorphClass(),
+            (string) $model->getKey(),
+            $partition,
+            $team,
+        );
+    }
+
+    /**
+     * Invalidate assignment caches for an exact identity after a mutation settles.
+     */
+    public function invalidateModelAssignmentCacheForIdentityAfterMutation(
+        string $morphType,
+        int|string $modelKey,
+        ?PermissionPartition $partition,
+        int|string|null $team,
+    ): void {
+        $runtimeKey = $this->modelRuntimeCacheKeyForIdentity(
+            $morphType,
+            $modelKey,
+            $partition,
+            $team,
+        );
+        $clearRuntime = function () use ($runtimeKey): void {
+            $this->forgetRuntimeCacheItem(self::MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
+            $this->forgetRuntimeCacheItem(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
+            $this->forgetRuntimeCacheItem(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY, $runtimeKey);
+        };
+
+        foreach ([$this->modelRolesCacheKeyPrefix, $this->modelPermissionsCacheKeyPrefix] as $prefix) {
+            $this->settleCacheMutation(
+                $this->modelCacheKeyForIdentity($prefix, $morphType, $modelKey, $partition, $team),
+                $clearRuntime,
+            );
+        }
     }
 
     /**
@@ -551,13 +895,16 @@ class PermissionRegistrar
         ?PermissionPartition $partition,
         int|string|null $team,
     ): void {
-        $this->cacheRepository()->forget($this->modelCacheKeyForIdentity(
-            $this->modelRolesCacheKeyPrefix,
-            $model->getMorphClass(),
-            (string) $model->getKey(),
-            $partition,
-            $team,
-        ));
+        $this->modelCacheCoordinator->invalidate(
+            $this->cacheRepository(),
+            $this->modelCacheKeyForIdentity(
+                $this->modelRolesCacheKeyPrefix,
+                $model->getMorphClass(),
+                (string) $model->getKey(),
+                $partition,
+                $team,
+            ),
+        );
 
         $runtimeKey = $this->modelRuntimeCacheKeyForIdentity(
             $model->getMorphClass(),
@@ -568,6 +915,53 @@ class PermissionRegistrar
 
         $this->forgetRuntimeCacheItem(self::MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
         $this->forgetRuntimeCacheItem(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY, $runtimeKey);
+    }
+
+    /**
+     * Invalidate a model's role cache after a mutation settles.
+     */
+    public function invalidateModelRoleCacheAfterMutation(
+        Model $model,
+        ?PermissionPartition $partition,
+        int|string|null $team,
+    ): void {
+        $this->invalidateModelRoleCacheForIdentityAfterMutation(
+            $model->getMorphClass(),
+            (string) $model->getKey(),
+            $partition,
+            $team,
+        );
+    }
+
+    /**
+     * Invalidate an exact model identity's role cache after a mutation settles.
+     */
+    public function invalidateModelRoleCacheForIdentityAfterMutation(
+        string $morphType,
+        int|string $modelKey,
+        ?PermissionPartition $partition,
+        int|string|null $team,
+    ): void {
+        $runtimeKey = $this->modelRuntimeCacheKeyForIdentity(
+            $morphType,
+            $modelKey,
+            $partition,
+            $team,
+        );
+
+        $this->settleCacheMutation(
+            $this->modelCacheKeyForIdentity(
+                $this->modelRolesCacheKeyPrefix,
+                $morphType,
+                $modelKey,
+                $partition,
+                $team,
+            ),
+            function () use ($runtimeKey): void {
+                $this->forgetRuntimeCacheItem(self::MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
+                $this->forgetRuntimeCacheItem(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY, $runtimeKey);
+            },
+        );
     }
 
     /**
@@ -590,13 +984,16 @@ class PermissionRegistrar
         ?PermissionPartition $partition,
         int|string|null $team,
     ): void {
-        $this->cacheRepository()->forget($this->modelCacheKeyForIdentity(
-            $this->modelPermissionsCacheKeyPrefix,
-            $model->getMorphClass(),
-            (string) $model->getKey(),
-            $partition,
-            $team,
-        ));
+        $this->modelCacheCoordinator->invalidate(
+            $this->cacheRepository(),
+            $this->modelCacheKeyForIdentity(
+                $this->modelPermissionsCacheKeyPrefix,
+                $model->getMorphClass(),
+                (string) $model->getKey(),
+                $partition,
+                $team,
+            ),
+        );
 
         $runtimeKey = $this->modelRuntimeCacheKeyForIdentity(
             $model->getMorphClass(),
@@ -605,7 +1002,55 @@ class PermissionRegistrar
             $team,
         );
 
+        $this->forgetRuntimeCacheItem(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
         $this->forgetRuntimeCacheItem(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY, $runtimeKey);
+    }
+
+    /**
+     * Invalidate a model's permission cache after a mutation settles.
+     */
+    public function invalidateModelPermissionCacheAfterMutation(
+        Model $model,
+        ?PermissionPartition $partition,
+        int|string|null $team,
+    ): void {
+        $this->invalidateModelPermissionCacheForIdentityAfterMutation(
+            $model->getMorphClass(),
+            (string) $model->getKey(),
+            $partition,
+            $team,
+        );
+    }
+
+    /**
+     * Invalidate an exact model identity's permission cache after a mutation settles.
+     */
+    public function invalidateModelPermissionCacheForIdentityAfterMutation(
+        string $morphType,
+        int|string $modelKey,
+        ?PermissionPartition $partition,
+        int|string|null $team,
+    ): void {
+        $runtimeKey = $this->modelRuntimeCacheKeyForIdentity(
+            $morphType,
+            $modelKey,
+            $partition,
+            $team,
+        );
+
+        $this->settleCacheMutation(
+            $this->modelCacheKeyForIdentity(
+                $this->modelPermissionsCacheKeyPrefix,
+                $morphType,
+                $modelKey,
+                $partition,
+                $team,
+            ),
+            function () use ($runtimeKey): void {
+                $this->forgetRuntimeCacheItem(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY, $runtimeKey);
+                $this->forgetRuntimeCacheItem(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY, $runtimeKey);
+            },
+        );
     }
 
     /**
@@ -640,6 +1085,26 @@ class PermissionRegistrar
     }
 
     /**
+     * Remember a model's hydrated direct permissions.
+     *
+     * @param Closure(): BaseCollection $callback
+     */
+    public function rememberModelDirectPermissions(Model $model, Closure $callback): BaseCollection
+    {
+        $key = $this->modelRuntimeCacheKey($model);
+        $items = CoroutineContext::get(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY, []);
+
+        if (isset($items[$key]) && $items[$key] instanceof BaseCollection) {
+            return $items[$key];
+        }
+
+        $items[$key] = $callback();
+        CoroutineContext::set(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY, $items);
+
+        return $items[$key];
+    }
+
+    /**
      * Remember a model's role assignment ids.
      *
      * @param Closure(): array<int, array<string, mixed>> $callback
@@ -647,9 +1112,11 @@ class PermissionRegistrar
      */
     public function rememberModelRoleAssignments(Model $model, Closure $callback): array
     {
-        return $this->cacheRepository()->remember(
-            $this->modelCacheKey($this->modelRolesCacheKeyPrefix, $model),
-            $this->cacheExpirationTime,
+        $cacheKey = $this->modelCacheKey($this->modelRolesCacheKeyPrefix, $model);
+
+        /** @var array<int, array<string, mixed>> */
+        return $this->rememberSharedOrDirtyValue(
+            $cacheKey,
             $callback,
         );
     }
@@ -662,9 +1129,11 @@ class PermissionRegistrar
      */
     public function rememberModelPermissionAssignments(Model $model, Closure $callback): array
     {
-        return $this->cacheRepository()->remember(
-            $this->modelCacheKey($this->modelPermissionsCacheKeyPrefix, $model),
-            $this->cacheExpirationTime,
+        $cacheKey = $this->modelCacheKey($this->modelPermissionsCacheKeyPrefix, $model);
+
+        /** @var array<int, array{is_denied: bool, ...<string, int|string>}> */
+        return $this->rememberSharedOrDirtyValue(
+            $cacheKey,
             $callback,
         );
     }
@@ -739,9 +1208,25 @@ class PermissionRegistrar
     public function modelAssignmentCacheToken(?PermissionPartition $partition = null): string
     {
         $partition = $this->resolvedPartitionArgument($partition);
+        $cacheKey = $this->partitionedCacheKey($this->modelCacheTokenKey, $partition);
+
+        if ($this->cacheKeyIsDirty($cacheKey)) {
+            $settlement = $this->settlementForConnection(
+                $cacheKey,
+                $this->permissionConnectionIdentity(),
+            );
+
+            if ($settlement !== null) {
+                if ($settlement->provisionalToken === null) {
+                    throw new LogicException('The provisional permission cache token must be a string.');
+                }
+
+                return $settlement->provisionalToken;
+            }
+        }
 
         return $this->cacheRepository()->rememberForever(
-            $this->partitionedCacheKey($this->modelCacheTokenKey, $partition),
+            $cacheKey,
             fn (): string => $this->newModelAssignmentCacheToken(),
         );
     }
@@ -882,6 +1367,8 @@ class PermissionRegistrar
         CoroutineContext::forget(self::PERMISSION_CATALOG_CONTEXT_KEY);
         CoroutineContext::forget(self::WILDCARD_PERMISSION_INDEX_CONTEXT_KEY);
         CoroutineContext::forget(self::MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY);
+        CoroutineContext::forget(self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY);
+        CoroutineContext::forget(self::MODEL_CLASS_CATALOG_CONTEXT_KEY);
     }
 
     /**
@@ -905,6 +1392,14 @@ class PermissionRegistrar
         );
         $this->forgetRuntimeCacheItemsForPartition(
             self::MODEL_VIA_ROLE_PERMISSIONS_CONTEXT_KEY,
+            $partition,
+        );
+        $this->forgetRuntimeCacheItemsForPartition(
+            self::MODEL_DIRECT_PERMISSIONS_CONTEXT_KEY,
+            $partition,
+        );
+        $this->forgetRuntimeCacheItemsForPartition(
+            self::MODEL_CLASS_CATALOG_CONTEXT_KEY,
             $partition,
         );
     }
@@ -1024,10 +1519,9 @@ class PermissionRegistrar
         }
 
         /** @var array{permissions: array<int, array<string, mixed>>, roles: array<int, array<string, mixed>>, hasDeniedRolePermissions: bool} $payload */
-        $payload = $this->cacheRepository()->remember(
+        $payload = $this->rememberSharedOrDirtyValue(
             $contextKey,
-            $this->cacheExpirationTime,
-            fn () => $this->getSerializedPermissionsForCache(),
+            fn (): array => $this->getSerializedPermissionsForCache(),
         );
 
         $roles = $this->getHydratedRoleCollection($payload['roles']);
@@ -1058,15 +1552,29 @@ class PermissionRegistrar
      */
     public function getPermissions(array $params = [], bool $onlyOne = false, ?string $permissionClass = null): Collection
     {
-        if ($permissionClass !== null && $permissionClass !== $this->permissionClass) {
-            $this->validatePermissionClass($permissionClass);
+        $permissionClass ??= $this->permissionClass;
 
+        if ($permissionClass !== $this->permissionClass) {
+            $this->validatePermissionClass($permissionClass);
+        }
+
+        if (! is_a($this->permissionClass, $permissionClass, true)) {
             return $this->filterModels(
-                $this->getPermissionsWithRoles($permissionClass),
+                $this->modelClassCatalog(
+                    'permission',
+                    $permissionClass,
+                    fn (): Collection => $this->getPermissionsWithRoles($permissionClass),
+                ),
                 $params,
                 $onlyOne,
             );
         }
+
+        $params = $this->normalizeConfiguredModelKeyFilter(
+            $params,
+            $permissionClass,
+            $this->permissionClass,
+        );
 
         $indexed = $this->indexedModels($params, $onlyOne, 'permission');
 
@@ -1084,15 +1592,29 @@ class PermissionRegistrar
      */
     public function getRoles(array $params = [], bool $onlyOne = false, ?string $roleClass = null): Collection
     {
-        if ($roleClass !== null && $roleClass !== $this->roleClass) {
-            $this->validateRoleClass($roleClass);
+        $roleClass ??= $this->roleClass;
 
+        if ($roleClass !== $this->roleClass) {
+            $this->validateRoleClass($roleClass);
+        }
+
+        if (! is_a($this->roleClass, $roleClass, true)) {
             return $this->filterModels(
-                $roleClass::select()->get(),
+                $this->teamScopedRoles($this->modelClassCatalog(
+                    'role',
+                    $roleClass,
+                    fn (): Collection => $roleClass::select()->get(),
+                )),
                 $params,
                 $onlyOne,
             );
         }
+
+        $params = $this->normalizeConfiguredModelKeyFilter(
+            $params,
+            $roleClass,
+            $this->roleClass,
+        );
 
         $indexed = $this->indexedModels($params, $onlyOne, 'role');
 
@@ -1100,7 +1622,73 @@ class PermissionRegistrar
             return $indexed;
         }
 
-        return $this->filterModels($this->permissionCatalog()['roles'], $params, $onlyOne);
+        return $this->filterModels(
+            $this->teamScopedRoles($this->permissionCatalog()['roles']),
+            $params,
+            $onlyOne,
+        );
+    }
+
+    /**
+     * Get a class-specific catalog for the current coroutine and partition.
+     *
+     * @param Closure(): Collection $load
+     */
+    private function modelClassCatalog(string $type, string $modelClass, Closure $load): Collection
+    {
+        $key = implode(':', [
+            $this->partitionRuntimePrefix($this->resolvePartition()),
+            $type,
+            PermissionPartition::encodeCacheSegment($modelClass),
+        ]);
+        $catalogs = CoroutineContext::get(self::MODEL_CLASS_CATALOG_CONTEXT_KEY, []);
+
+        if (isset($catalogs[$key]) && $catalogs[$key] instanceof Collection) {
+            return $catalogs[$key];
+        }
+
+        $catalogs[$key] = $load();
+        CoroutineContext::set(self::MODEL_CLASS_CATALOG_CONTEXT_KEY, $catalogs);
+
+        return $catalogs[$key];
+    }
+
+    /**
+     * Normalize a requested base model's primary-key filter to the configured model.
+     *
+     * @param array<string, mixed> $params
+     * @param class-string $requestedClass
+     * @param class-string $configuredClass
+     * @return array<string, mixed>
+     */
+    private function normalizeConfiguredModelKeyFilter(
+        array $params,
+        string $requestedClass,
+        string $configuredClass,
+    ): array {
+        $requestedKey = Guard::getModelKeyName($requestedClass);
+        $configuredKey = Guard::getModelKeyName($configuredClass);
+
+        if ($requestedKey === $configuredKey || ! array_key_exists($requestedKey, $params)) {
+            return $params;
+        }
+
+        $params[$configuredKey] = $params[$requestedKey];
+        unset($params[$requestedKey]);
+
+        return $params;
+    }
+
+    /**
+     * Filter roles to the current team boundary.
+     */
+    private function teamScopedRoles(Collection $roles): Collection
+    {
+        if (! $this->teams) {
+            return $roles;
+        }
+
+        return $roles->filter(fn (Model $role): bool => $this->roleMatchesCurrentTeam($role));
     }
 
     /**
@@ -1258,6 +1846,40 @@ class PermissionRegistrar
     }
 
     /**
+     * Get the connection that owns permission storage.
+     */
+    public function getPermissionConnection(): Connection
+    {
+        return (new $this->permissionClass)->getConnection();
+    }
+
+    /**
+     * Get the normalized identity of the permission storage connection.
+     */
+    private function permissionConnectionIdentity(): string
+    {
+        return $this->getPermissionConnection()->getName() ?? '';
+    }
+
+    /**
+     * Run a permission-storage mutation in step with its subject transaction.
+     *
+     * @param Closure(): void $mutation
+     */
+    public function runPermissionStorageMutationAfterSubjectCommit(
+        Connection $subjectConnection,
+        Closure $mutation,
+    ): void {
+        if (($subjectConnection->getName() ?? '') === ($this->getPermissionConnection()->getName() ?? '')) {
+            $mutation();
+
+            return;
+        }
+
+        $subjectConnection->afterCommitOrNow($mutation);
+    }
+
+    /**
      * Get the current global permission cache key.
      */
     public function getCacheKey(): string
@@ -1389,7 +2011,7 @@ class PermissionRegistrar
     }
 
     /**
-     * Get the cache repository.
+     * Get the unmemoized repository for observing committed shared cache state.
      */
     public function getCacheRepository(): Repository
     {

--- a/src/permission/src/PermissionRegistrar.php
+++ b/src/permission/src/PermissionRegistrar.php
@@ -489,22 +489,33 @@ class PermissionRegistrar
     private function settleCacheMutation(
         string $cacheKey,
         Closure $clearRuntime,
-    ): void {
+    ): bool {
         $this->clearDirtyCacheValues($cacheKey);
         $clearRuntime();
 
+        $invalidationResult = null;
+
         $this->afterCommitOnce(
             $cacheKey,
-            function (PermissionCacheSettlement $settlement) use ($cacheKey, $clearRuntime): void {
+            function (PermissionCacheSettlement $settlement) use (
+                $cacheKey,
+                $clearRuntime,
+                &$invalidationResult,
+            ): void {
                 $this->clearDirtyCacheValues($cacheKey);
                 $clearRuntime();
-                $this->modelCacheCoordinator->invalidate($this->cacheRepository(), $cacheKey);
+                $invalidationResult = $this->modelCacheCoordinator->invalidate(
+                    $this->cacheRepository(),
+                    $cacheKey,
+                );
             },
             function (PermissionCacheSettlement $settlement) use ($cacheKey, $clearRuntime): void {
                 $this->clearDirtyCacheValues($cacheKey);
                 $clearRuntime();
             },
         );
+
+        return $invalidationResult ?? true;
     }
 
     /**
@@ -696,6 +707,9 @@ class PermissionRegistrar
 
     /**
      * Flush the permission cache.
+     *
+     * Return the backend result when settled immediately, or true once the
+     * reset is registered against an open transaction.
      */
     public function forgetCachedPermissions(): bool
     {
@@ -707,12 +721,12 @@ class PermissionRegistrar
      */
     public function forgetCachedPermissionsFor(?PermissionPartition $partition): bool
     {
-        $this->clearPermissionRuntimeStateFor($partition);
-        $this->bumpModelAssignmentCacheTokenFor($partition);
+        $partition = $this->resolvedPartitionArgument($partition);
+        $this->rotateModelAssignmentCacheTokenAfterMutation($partition);
 
-        return $this->modelCacheCoordinator->invalidate(
-            $this->cacheRepository(),
+        return $this->settleCacheMutation(
             $this->partitionedCacheKey($this->cacheKey, $partition),
+            fn () => $this->clearPermissionRuntimeStateFor($partition),
         );
     }
 
@@ -1229,30 +1243,6 @@ class PermissionRegistrar
             $cacheKey,
             fn (): string => $this->newModelAssignmentCacheToken(),
         );
-    }
-
-    /**
-     * Bump the model assignment cache token.
-     */
-    public function bumpModelAssignmentCacheToken(): string
-    {
-        return $this->bumpModelAssignmentCacheTokenFor($this->resolvePartition());
-    }
-
-    /**
-     * Bump the model assignment cache token for an explicit partition.
-     */
-    public function bumpModelAssignmentCacheTokenFor(?PermissionPartition $partition): string
-    {
-        $partition = $this->resolvedPartitionArgument($partition);
-        $token = $this->newModelAssignmentCacheToken();
-
-        $this->cacheRepository()->forever(
-            $this->partitionedCacheKey($this->modelCacheTokenKey, $partition),
-            $token,
-        );
-
-        return $token;
     }
 
     /**

--- a/src/permission/src/PermissionServiceProvider.php
+++ b/src/permission/src/PermissionServiceProvider.php
@@ -6,6 +6,7 @@ namespace Hypervel\Permission;
 
 use Composer\InstalledVersions;
 use Hypervel\Cache\CacheManager;
+use Hypervel\Cache\ModelCacheCoordinator;
 use Hypervel\Container\Container;
 use Hypervel\Contracts\Auth\Access\Gate as GateContract;
 use Hypervel\Contracts\Auth\Factory as AuthFactory;
@@ -42,6 +43,7 @@ class PermissionServiceProvider extends ServiceProvider
             $app->make(CacheManager::class),
             $app->make('config'),
             $app,
+            $app->make(ModelCacheCoordinator::class),
         ));
 
         $this->registerModelBindings();

--- a/src/permission/src/Support/PermissionCacheSettlement.php
+++ b/src/permission/src/Support/PermissionCacheSettlement.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Permission\Support;
+
+/**
+ * Track registration and ownership for one permission cache settlement.
+ */
+class PermissionCacheSettlement
+{
+    public bool $callbackRanImmediately = false;
+
+    public bool $deferred = false;
+
+    public bool $ownsToken = false;
+
+    public ?string $provisionalToken = null;
+
+    /**
+     * Create a permission cache settlement.
+     */
+    public function __construct(public readonly string $connectionName)
+    {
+    }
+}

--- a/src/permission/src/Traits/EnforcesPermissionPartition.php
+++ b/src/permission/src/Traits/EnforcesPermissionPartition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Permission\Traits;
 
+use Hypervel\Database\ConnectionInterface;
 use Hypervel\Database\Eloquent\Collection as EloquentCollection;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Permission\Exceptions\PermissionPartitionViolation;
@@ -37,6 +38,14 @@ trait EnforcesPermissionPartition
     }
 
     /**
+     * Get the connection that owns permission pivots.
+     */
+    protected function getPivotConnection(): ConnectionInterface
+    {
+        return $this->permissionPartitionRegistrar->getPermissionConnection();
+    }
+
+    /**
      * Format an attachment record without allowing partition overrides.
      */
     protected function formatAttachRecord(
@@ -45,6 +54,7 @@ trait EnforcesPermissionPartition
         array $attributes,
         bool $hasTimestamps,
     ): array {
+        $this->ensureTeamIsSelectedForPivotMutation();
         $partition = $this->permissionRelationContext->partition;
 
         if (! $partition) {
@@ -65,6 +75,7 @@ trait EnforcesPermissionPartition
      */
     public function updateExistingPivot(mixed $id, array $attributes, bool $touch = true): int
     {
+        $this->ensureTeamIsSelectedForPivotMutation();
         $partition = $this->permissionRelationContext->partition;
 
         if (! $partition) {
@@ -75,6 +86,16 @@ trait EnforcesPermissionPartition
         unset($attributes[$partition->column]);
 
         return parent::updateExistingPivot($id, $attributes, $touch);
+    }
+
+    /**
+     * Detach pivot records within the captured permission context.
+     */
+    public function detach(mixed $ids = null, bool $touch = true): int
+    {
+        $this->ensureTeamIsSelectedForPivotMutation();
+
+        return parent::detach($ids, $touch);
     }
 
     /**
@@ -139,6 +160,16 @@ trait EnforcesPermissionPartition
                 $attributes[$partition->column],
             );
         }
+    }
+
+    /**
+     * Ensure a team-scoped pivot mutation has a selected team.
+     */
+    private function ensureTeamIsSelectedForPivotMutation(): void
+    {
+        $this->permissionPartitionRegistrar->ensureTeamIsSelectedForMutation(
+            $this->permissionRelationContext,
+        );
     }
 
     /**

--- a/src/permission/src/Traits/HasAssignedModels.php
+++ b/src/permission/src/Traits/HasAssignedModels.php
@@ -34,6 +34,7 @@ trait HasAssignedModels
 
         $registrar = Container::getInstance()->make(PermissionRegistrar::class);
         $context = $this->assignedModelRelationContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $groupedModels = $this->groupModelsByMorphClass($models, $modelClass, $registrar, $context->partition);
 
         if ($groupedModels !== []) {
@@ -55,7 +56,7 @@ trait HasAssignedModels
             if (count($groupedModels) === 1) {
                 $assignGroups();
             } else {
-                $this->getConnection()->transaction($assignGroups);
+                $registrar->getPermissionConnection()->transaction($assignGroups);
             }
         }
 
@@ -82,6 +83,7 @@ trait HasAssignedModels
 
         $registrar = Container::getInstance()->make(PermissionRegistrar::class);
         $context = $this->assignedModelRelationContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $groupedModels = $this->groupModelsByMorphClass($models, $modelClass, $registrar, $context->partition);
 
         if ($groupedModels !== []) {
@@ -94,7 +96,7 @@ trait HasAssignedModels
             if (count($groupedModels) === 1) {
                 $removeGroups();
             } else {
-                $this->getConnection()->transaction($removeGroups);
+                $registrar->getPermissionConnection()->transaction($removeGroups);
             }
         }
 
@@ -121,9 +123,12 @@ trait HasAssignedModels
 
         $registrar = Container::getInstance()->make(PermissionRegistrar::class);
         $context = $this->assignedModelRelationContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $groupedModels = $this->groupModelsByMorphClass($models, $modelClass, $registrar, $context->partition);
 
-        $this->getConnection()->transaction(function () use ($context, $groupedModels): void {
+        $registrar->getPermissionConnection()->transaction(function () use ($context, $groupedModels, $registrar): void {
+            $registrar->rotateModelAssignmentCacheTokenAfterMutation($context->partition);
+
             $this->newPivotQueryForRole($context)->delete();
 
             foreach ($groupedModels as $groupedModelClass => $ids) {
@@ -132,7 +137,6 @@ trait HasAssignedModels
         });
 
         $this->unsetRelation('users');
-        $registrar->bumpModelAssignmentCacheTokenFor($context->partition);
 
         return $this;
     }
@@ -256,7 +260,7 @@ trait HasAssignedModels
         $morphType = (new $modelClass)->getMorphClass();
 
         foreach ($ids as $id) {
-            $registrar->forgetModelAssignmentCacheForIdentity(
+            $registrar->invalidateModelAssignmentCacheForIdentityAfterMutation(
                 $morphType,
                 $id,
                 $context->partition,
@@ -270,9 +274,10 @@ trait HasAssignedModels
      */
     private function newPivotQueryForRole(PermissionRelationContext $context): Builder
     {
-        $query = $this->getConnection()
+        $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+        $query = $registrar->getPermissionConnection()
             ->table(Config::modelHasRolesTable())
-            ->where(Container::getInstance()->make(PermissionRegistrar::class)->pivotRole, $this->getKey());
+            ->where($registrar->pivotRole, $this->getKey());
 
         if ($context->partition) {
             $query->where($context->partition->column, $context->partition->value);

--- a/src/permission/src/Traits/HasPermissions.php
+++ b/src/permission/src/Traits/HasPermissions.php
@@ -71,7 +71,23 @@ trait HasPermissions
     public static function bootHasPermissions(): void
     {
         static::deleting(function (Model $model): void {
-            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+            if (! static::shouldDeletePermissionAssignments($model)) {
+                return;
+            }
+
+            // Validate only so a later deleting listener can still veto before assignments are touched.
+            static::requireDeletionModelKey($model);
+
+            if ($model instanceof Permission || $model instanceof Role) {
+                static::permissionRecordDeletionPartition(
+                    $model,
+                    Container::getInstance()->make(PermissionRegistrar::class),
+                );
+            }
+        });
+
+        static::deleted(function (Model $model): void {
+            if (! static::shouldDeletePermissionAssignments($model)) {
                 return;
             }
 
@@ -80,42 +96,111 @@ trait HasPermissions
             }
 
             $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+            $modelKey = static::requireDeletionModelKey($model);
 
             if ($model instanceof Role) {
-                static::deletePermissionRecordAssignments(
-                    $model,
-                    Config::modelHasRolesTable(),
-                    $registrar->pivotRole,
+                $partition = static::permissionRecordDeletionPartition($model, $registrar);
+
+                $registrar->runPermissionStorageMutationAfterSubjectCommit(
+                    $model->getConnection(),
+                    static fn () => $registrar->getPermissionConnection()->transaction(
+                        static fn () => static::deletePermissionRecordAssignments(
+                            $modelKey,
+                            Config::modelHasRolesTable(),
+                            $registrar->pivotRole,
+                            $partition,
+                        ),
+                    ),
                 );
 
                 return;
             }
 
-            $contexts = static::deleteSubjectAssignments(
-                $model,
-                Config::modelHasPermissionsTable(),
-            );
+            $morphType = $model->getMorphClass();
 
-            if ($contexts === null) {
-                $registrar->forgetModelPermissionCache($model);
-            } else {
-                foreach ($contexts as $context) {
-                    $registrar->forgetModelPermissionCacheFor(
-                        $model,
-                        $context->partition,
-                        $context->team,
+            $registrar->runPermissionStorageMutationAfterSubjectCommit(
+                $model->getConnection(),
+                static function () use ($modelKey, $morphType, $registrar): void {
+                    $registrar->getPermissionConnection()->transaction(
+                        static function () use ($modelKey, $morphType, $registrar): void {
+                            $contexts = static::deleteSubjectAssignments(
+                                $morphType,
+                                $modelKey,
+                                Config::modelHasPermissionsTable(),
+                            );
+
+                            if ($contexts === null) {
+                                $registrar->invalidateModelPermissionCacheForIdentityAfterMutation(
+                                    $morphType,
+                                    (string) $modelKey,
+                                    null,
+                                    null,
+                                );
+
+                                return;
+                            }
+
+                            foreach ($contexts as $context) {
+                                $registrar->invalidateModelPermissionCacheForIdentityAfterMutation(
+                                    $morphType,
+                                    (string) $modelKey,
+                                    $context->partition,
+                                    $context->team,
+                                );
+                            }
+                        },
                     );
-                }
-            }
+                },
+            );
 
             $registrar->forgetLoadedRelationProvenance($model, 'permissions');
         });
 
         static::saved(function (Model $model): void {
             if (method_exists($model, 'flushQueuedPermissionAssignments')) {
-                $model->flushQueuedPermissionAssignments();
+                $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+                $registrar->runPermissionStorageMutationAfterSubjectCommit(
+                    $model->getConnection(),
+                    fn () => $model->flushQueuedPermissionAssignments(),
+                );
             }
         });
+    }
+
+    /**
+     * Delete the model and its permission assignments atomically.
+     */
+    public function delete(): int|bool|null
+    {
+        if (! $this->exists || ! static::shouldDeletePermissionAssignments($this)) {
+            return parent::delete();
+        }
+
+        return $this->getConnection()->transaction(
+            fn (): int|bool|null => parent::delete(),
+        );
+    }
+
+    /**
+     * Determine whether deleting the model removes permission assignments.
+     */
+    protected static function shouldDeletePermissionAssignments(Model $model): bool
+    {
+        return ! method_exists($model, 'isForceDeleting') || $model->isForceDeleting();
+    }
+
+    /**
+     * Get the model key required for permission assignment cleanup.
+     */
+    protected static function requireDeletionModelKey(Model $model): mixed
+    {
+        $modelKey = $model->getKey();
+
+        if ($modelKey === null) {
+            throw new MissingAttributeException($model, $model->getKeyName());
+        }
+
+        return $modelKey;
     }
 
     /**
@@ -123,18 +208,15 @@ trait HasPermissions
      *
      * @return null|array<int, PermissionRelationContext>
      */
-    protected static function deleteSubjectAssignments(Model $model, string $table): ?array
-    {
+    protected static function deleteSubjectAssignments(
+        string $morphType,
+        mixed $modelKey,
+        string $table,
+    ): ?array {
         $registrar = Container::getInstance()->make(PermissionRegistrar::class);
-        $connection = $model->getConnection();
+        $connection = $registrar->getPermissionConnection();
         $morphKey = Config::morphKey();
-        $morphType = $model->getMorphClass();
-        $modelKey = $model->getKey();
         $partitionColumn = PermissionRegistrar::partitionColumn();
-
-        if ($modelKey === null) {
-            throw new MissingAttributeException($model, $model->getKeyName());
-        }
 
         if ($partitionColumn === null && ! $registrar->teams) {
             $connection->table($table)
@@ -145,131 +227,121 @@ trait HasPermissions
             return null;
         }
 
-        return $connection->transaction(function () use (
-            $connection,
-            $modelKey,
-            $morphKey,
-            $morphType,
-            $partitionColumn,
-            $registrar,
-            $table,
-        ): array {
-            $columns = [];
+        $columns = [];
+
+        if ($partitionColumn !== null) {
+            $columns[] = $partitionColumn;
+        }
+
+        if ($registrar->teams) {
+            $columns[] = $registrar->teamsKey;
+        }
+
+        $scopes = $connection->table($table)
+            ->select($columns)
+            ->where($morphKey, $modelKey)
+            ->where(Config::MORPH_TYPE, $morphType)
+            ->distinct()
+            ->get();
+        $contexts = [];
+
+        foreach ($scopes as $scope) {
+            $partition = null;
 
             if ($partitionColumn !== null) {
-                $columns[] = $partitionColumn;
-            }
+                $partitionValue = $scope->{$partitionColumn};
 
-            if ($registrar->teams) {
-                $columns[] = $registrar->teamsKey;
-            }
-
-            $scopes = $connection->table($table)
-                ->select($columns)
-                ->where($morphKey, $modelKey)
-                ->where(Config::MORPH_TYPE, $morphType)
-                ->distinct()
-                ->get();
-            $contexts = [];
-
-            foreach ($scopes as $scope) {
-                $partition = null;
-
-                if ($partitionColumn !== null) {
-                    $partitionValue = $scope->{$partitionColumn};
-
-                    if (! is_int($partitionValue) && ! is_string($partitionValue)) {
-                        throw new UnexpectedValueException(sprintf(
-                            'Permission assignment partition column "%s" contained %s; expected int or string.',
-                            $partitionColumn,
-                            get_debug_type($partitionValue),
-                        ));
-                    }
-
-                    $partition = new PermissionPartition($partitionColumn, $partitionValue);
-                }
-
-                $team = $registrar->teams ? $scope->{$registrar->teamsKey} : null;
-
-                if ($team !== null && ! is_int($team) && ! is_string($team)) {
+                if (! is_int($partitionValue) && ! is_string($partitionValue)) {
                     throw new UnexpectedValueException(sprintf(
-                        'Permission assignment team column "%s" contained %s; expected int, string, or null.',
-                        $registrar->teamsKey,
-                        get_debug_type($team),
+                        'Permission assignment partition column "%s" contained %s; expected int or string.',
+                        $partitionColumn,
+                        get_debug_type($partitionValue),
                     ));
                 }
 
-                $contexts[] = new PermissionRelationContext(
-                    $partition,
-                    $registrar->teams,
-                    $team,
-                );
+                $partition = new PermissionPartition($partitionColumn, $partitionValue);
             }
 
-            $connection->table($table)
-                ->where($morphKey, $modelKey)
-                ->where(Config::MORPH_TYPE, $morphType)
-                ->delete();
+            $team = $registrar->teams ? $scope->{$registrar->teamsKey} : null;
 
-            return $contexts;
-        });
+            if ($team !== null && ! is_int($team) && ! is_string($team)) {
+                throw new UnexpectedValueException(sprintf(
+                    'Permission assignment team column "%s" contained %s; expected int, string, or null.',
+                    $registrar->teamsKey,
+                    get_debug_type($team),
+                ));
+            }
+
+            $contexts[] = new PermissionRelationContext(
+                $partition,
+                $registrar->teams,
+                $team,
+            );
+        }
+
+        $connection->table($table)
+            ->where($morphKey, $modelKey)
+            ->where(Config::MORPH_TYPE, $morphType)
+            ->delete();
+
+        return $contexts;
     }
 
     /**
      * Delete assignment pivots owned by a Role or Permission record.
      */
     protected static function deletePermissionRecordAssignments(
-        Model $model,
+        mixed $modelKey,
         string $modelAssignmentsTable,
         string $pivotKey,
+        ?PermissionPartition $partition,
     ): void {
-        $modelKey = $model->getKey();
+        $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+        $connection = $registrar->getPermissionConnection();
+        $modelAssignments = $connection
+            ->table($modelAssignmentsTable)
+            ->where($pivotKey, $modelKey);
+        $rolePermissions = $connection
+            ->table(Config::roleHasPermissionsTable())
+            ->where($pivotKey, $modelKey);
 
-        if ($modelKey === null) {
-            throw new MissingAttributeException($model, $model->getKeyName());
+        if ($partition) {
+            $modelAssignments->where($partition->column, $partition->value);
+            $rolePermissions->where($partition->column, $partition->value);
         }
 
-        $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+        $modelAssignments->delete();
+        $rolePermissions->delete();
+    }
+
+    /**
+     * Resolve and validate a permission record's deletion partition.
+     */
+    protected static function permissionRecordDeletionPartition(
+        Model $model,
+        PermissionRegistrar $registrar,
+    ): ?PermissionPartition {
         $partition = PermissionRegistrar::partitioningEnabled()
             ? $registrar->partitionFromRecord($model)
             : null;
 
-        if ($partition) {
-            /** @var PermissionPartition $current */
-            $current = $registrar->resolvePartition();
-
-            if ($current->column !== $partition->column
-                || ! $current->matches($partition->value)) {
-                throw PermissionPartitionViolation::forModel(
-                    $model,
-                    $current,
-                    $partition->value,
-                );
-            }
+        if (! $partition) {
+            return null;
         }
 
-        $model->getConnection()->transaction(function () use (
-            $model,
-            $modelKey,
-            $modelAssignmentsTable,
-            $partition,
-            $pivotKey,
-        ): void {
-            $modelAssignments = $model->getConnection()
-                ->table($modelAssignmentsTable)
-                ->where($pivotKey, $modelKey);
-            $rolePermissions = $model->getConnection()
-                ->table(Config::roleHasPermissionsTable())
-                ->where($pivotKey, $modelKey);
+        /** @var PermissionPartition $current */
+        $current = $registrar->resolvePartition();
 
-            if ($partition) {
-                $modelAssignments->where($partition->column, $partition->value);
-                $rolePermissions->where($partition->column, $partition->value);
-            }
+        if ($current->column !== $partition->column
+            || ! $current->matches($partition->value)) {
+            throw PermissionPartitionViolation::forModel(
+                $model,
+                $current,
+                $partition->value,
+            );
+        }
 
-            $modelAssignments->delete();
-            $rolePermissions->delete();
-        });
+        return $partition;
     }
 
     /**
@@ -369,95 +441,97 @@ trait HasPermissions
             return $this->relationCollection($this, 'permissions');
         }
 
-        $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
-        $assignments = $registrar->rememberModelPermissionAssignments(
-            $model,
-            fn (): array => $this->permissionAssignmentRelation($context)
-                ->get()
-                ->map(fn (Model $permission): array => [
-                    $permissionKey => $permission->getKey(),
-                    'is_denied' => $this->pivotIsDenied($permission),
-                ])
-                ->values()
-                ->all(),
-        );
+        return $registrar->rememberModelDirectPermissions($model, function () use ($context, $model, $registrar): Collection {
+            $permissionKey = Guard::getModelKeyName($this->getPermissionClass());
+            $assignments = $registrar->rememberModelPermissionAssignments(
+                $model,
+                fn (): array => $this->permissionAssignmentRelation($context)
+                    ->get()
+                    ->map(fn (Model $permission): array => [
+                        $permissionKey => $permission->getKey(),
+                        'is_denied' => $this->pivotIsDenied($permission),
+                    ])
+                    ->values()
+                    ->all(),
+            );
 
-        $permissions = $registrar->getPermissions(
-            [$permissionKey => array_column($assignments, $permissionKey)],
-            false,
-            $this->getPermissionClass(),
-        )->keyBy(fn (Model $permission): string => (string) $permission->getKey());
+            $permissions = $registrar->getPermissions(
+                [$permissionKey => array_column($assignments, $permissionKey)],
+                false,
+                $this->getPermissionClass(),
+            )->keyBy(fn (Model $permission): string => (string) $permission->getKey());
 
-        return Collection::make($assignments)
-            ->map(function (array $assignment) use ($permissions, $model, $permissionKey, $registrar, $context): ?Model {
-                $permission = $permissions->get((string) $assignment[$permissionKey]);
+            return Collection::make($assignments)
+                ->map(function (array $assignment) use ($permissions, $model, $permissionKey, $registrar, $context): ?Model {
+                    $permission = $permissions->get((string) $assignment[$permissionKey]);
 
-                if (! $permission instanceof Model) {
-                    return null;
-                }
-
-                $pivot = [
-                    $registrar->pivotPermission => $permission->getKey(),
-                    Config::morphKey() => $model->getKey(),
-                    Config::MORPH_TYPE => $model->getMorphClass(),
-                    'is_denied' => (bool) $assignment['is_denied'],
-                ];
-
-                if ($registrar->teams) {
-                    $pivot[$registrar->teamsKey] = $context->team;
-                }
-
-                if ($context->partition) {
-                    $pivot[$context->partition->column] = $context->partition->value;
-                }
-
-                $permission = clone $permission;
-                $morphPivot = MorphPivot::fromRawAttributes(
-                    $model,
-                    $pivot,
-                    Config::modelHasPermissionsTable(),
-                    true,
-                );
-                $morphPivot
-                    ->setPivotKeys(Config::morphKey(), $registrar->pivotPermission)
-                    ->setRelatedModel($permission)
-                    ->setMorphType(Config::MORPH_TYPE)
-                    ->setMorphClass($model->getMorphClass());
-
-                $pivotWheres = [];
-                $pivotWhereNulls = [];
-
-                if ($context->partition) {
-                    $pivotWheres[] = [
-                        $context->partition->column,
-                        '=',
-                        $context->partition->value,
-                    ];
-                }
-
-                if ($context->teamScoped) {
-                    if ($context->team === null) {
-                        $pivotWhereNulls[] = [$registrar->teamsKey];
-                    } else {
-                        $pivotWheres[] = [$registrar->teamsKey, '=', $context->team];
+                    if (! $permission instanceof Model) {
+                        return null;
                     }
-                }
 
-                if ($pivotWheres !== [] || $pivotWhereNulls !== []) {
-                    $morphPivot->setPivotConstraints(
-                        wheres: $pivotWheres,
-                        whereIns: [],
-                        whereNulls: $pivotWhereNulls,
-                        whereBetweens: [],
+                    $pivot = [
+                        $registrar->pivotPermission => $permission->getKey(),
+                        Config::morphKey() => $model->getKey(),
+                        Config::MORPH_TYPE => $model->getMorphClass(),
+                        'is_denied' => (bool) $assignment['is_denied'],
+                    ];
+
+                    if ($registrar->teams) {
+                        $pivot[$registrar->teamsKey] = $context->team;
+                    }
+
+                    if ($context->partition) {
+                        $pivot[$context->partition->column] = $context->partition->value;
+                    }
+
+                    $permission = clone $permission;
+                    $morphPivot = MorphPivot::fromRawAttributes(
+                        $model,
+                        $pivot,
+                        Config::modelHasPermissionsTable(),
+                        true,
                     );
-                }
+                    $morphPivot
+                        ->setPivotKeys(Config::morphKey(), $registrar->pivotPermission)
+                        ->setRelatedModel($permission)
+                        ->setMorphType(Config::MORPH_TYPE)
+                        ->setMorphClass($model->getMorphClass());
 
-                $permission->setRelation('pivot', $morphPivot);
+                    $pivotWheres = [];
+                    $pivotWhereNulls = [];
 
-                return $permission;
-            })
-            ->filter()
-            ->values();
+                    if ($context->partition) {
+                        $pivotWheres[] = [
+                            $context->partition->column,
+                            '=',
+                            $context->partition->value,
+                        ];
+                    }
+
+                    if ($context->teamScoped) {
+                        if ($context->team === null) {
+                            $pivotWhereNulls[] = [$registrar->teamsKey];
+                        } else {
+                            $pivotWheres[] = [$registrar->teamsKey, '=', $context->team];
+                        }
+                    }
+
+                    if ($pivotWheres !== [] || $pivotWhereNulls !== []) {
+                        $morphPivot->setPivotConstraints(
+                            wheres: $pivotWheres,
+                            whereIns: [],
+                            whereNulls: $pivotWhereNulls,
+                            whereBetweens: [],
+                        );
+                    }
+
+                    $permission->setRelation('pivot', $morphPivot);
+
+                    return $permission;
+                })
+                ->filter()
+                ->values();
+        });
     }
 
     /**
@@ -929,6 +1003,7 @@ trait HasPermissions
         $model = $this;
         $registrar = $this->permissionRegistrar();
         $context = $this->permissionAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $permissions = $this->collectPermissions($permissions, $context->partition);
 
         if ($permissions === []) {
@@ -970,9 +1045,9 @@ trait HasPermissions
         $model->unsetRelation('permissions');
 
         if ($this instanceof Role) {
-            $registrar->forgetCachedPermissionsFor($context->partition);
+            $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
         } else {
-            $registrar->forgetModelPermissionCacheFor(
+            $registrar->invalidateModelPermissionCacheAfterMutation(
                 $model,
                 $context->partition,
                 $context->team,
@@ -1093,7 +1168,7 @@ trait HasPermissions
             ];
         }
 
-        return $this->getConnection()->transaction(function () use ($context, $desired, $detaching, $relation): array {
+        return $this->permissionRegistrar()->getPermissionConnection()->transaction(function () use ($context, $desired, $detaching, $relation): array {
             $relatedPivotKey = $relation->getRelatedPivotKeyName();
             $pivots = $this->readCurrentAssignmentPivots(
                 $relation,
@@ -1335,7 +1410,10 @@ trait HasPermissions
             return;
         }
 
-        $this->getConnection()->transaction(
+        $registrar = $this->permissionRegistrar();
+        $this->ensureQueuedPermissionAssignmentTeamsSelected($assignments, $registrar);
+
+        $registrar->getPermissionConnection()->transaction(
             fn () => $this->attachQueuedPermissionAssignmentBatches($assignments),
         );
 
@@ -1358,6 +1436,20 @@ trait HasPermissions
                 $assignment['context'],
                 $assignment['pivotClass'],
             );
+        }
+    }
+
+    /**
+     * Ensure queued permission assignments have their required team context.
+     *
+     * @param array<int, array{permissions: array<int, int|string>, pivot: array<string, mixed>, context: PermissionRelationContext, pivotClass: class-string<Pivot>}> $assignments
+     */
+    protected function ensureQueuedPermissionAssignmentTeamsSelected(
+        array $assignments,
+        PermissionRegistrar $registrar,
+    ): void {
+        foreach ($assignments as $assignment) {
+            $registrar->ensureTeamIsSelectedForMutation($assignment['context']);
         }
     }
 
@@ -1385,9 +1477,9 @@ trait HasPermissions
 
         foreach ($contexts as $context) {
             if ($this instanceof Role) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelPermissionCacheFor(
+                $registrar->invalidateModelPermissionCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,
@@ -1483,6 +1575,7 @@ trait HasPermissions
     {
         $registrar = $this->permissionRegistrar();
         $context = $this->permissionAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $permissions = $this->collectPermissions($permissions, $context->partition);
 
         if (! $this->exists) {
@@ -1524,9 +1617,9 @@ trait HasPermissions
             $this->unsetRelation('permissions');
 
             if ($this instanceof Role) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelPermissionCacheFor(
+                $registrar->invalidateModelPermissionCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,
@@ -1557,6 +1650,7 @@ trait HasPermissions
     {
         $registrar = $this->permissionRegistrar();
         $context = $this->permissionAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
 
         $allowedIds = $this->collectPermissions($allowed, $context->partition);
         $deniedIds = $this->collectPermissions($denied, $context->partition);
@@ -1613,9 +1707,9 @@ trait HasPermissions
             $this->unsetRelation('permissions');
 
             if ($this instanceof Role) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelPermissionCacheFor(
+                $registrar->invalidateModelPermissionCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,
@@ -1641,6 +1735,7 @@ trait HasPermissions
     {
         $registrar = $this->permissionRegistrar();
         $context = $this->permissionAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $storedPermission = $this->getStoredPermission($permission, $context->partition);
         $permissions = $this->collectPermissions($storedPermission, $context->partition);
 
@@ -1665,9 +1760,9 @@ trait HasPermissions
 
         if ($detached > 0) {
             if ($this instanceof Role) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelPermissionCacheFor(
+                $registrar->invalidateModelPermissionCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,

--- a/src/permission/src/Traits/HasRoles.php
+++ b/src/permission/src/Traits/HasRoles.php
@@ -41,18 +41,27 @@ trait HasRoles
      */
     public static function bootHasRoles(): void
     {
-        static::deleting(function (Model $model): void {
-            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+        static::deleted(function (Model $model): void {
+            if (! static::shouldDeletePermissionAssignments($model)) {
                 return;
             }
 
             $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+            $modelKey = static::requireDeletionModelKey($model);
 
             if ($model instanceof Permission) {
-                static::deletePermissionRecordAssignments(
-                    $model,
-                    Config::modelHasPermissionsTable(),
-                    $registrar->pivotPermission,
+                $partition = static::permissionRecordDeletionPartition($model, $registrar);
+
+                $registrar->runPermissionStorageMutationAfterSubjectCommit(
+                    $model->getConnection(),
+                    static fn () => $registrar->getPermissionConnection()->transaction(
+                        static fn () => static::deletePermissionRecordAssignments(
+                            $modelKey,
+                            Config::modelHasPermissionsTable(),
+                            $registrar->pivotPermission,
+                            $partition,
+                        ),
+                    ),
                 );
 
                 return;
@@ -62,22 +71,42 @@ trait HasRoles
                 return;
             }
 
-            $contexts = static::deleteSubjectAssignments(
-                $model,
-                Config::modelHasRolesTable(),
-            );
+            $morphType = $model->getMorphClass();
 
-            if ($contexts === null) {
-                $registrar->forgetModelRoleCache($model);
-            } else {
-                foreach ($contexts as $context) {
-                    $registrar->forgetModelRoleCacheFor(
-                        $model,
-                        $context->partition,
-                        $context->team,
+            $registrar->runPermissionStorageMutationAfterSubjectCommit(
+                $model->getConnection(),
+                static function () use ($modelKey, $morphType, $registrar): void {
+                    $registrar->getPermissionConnection()->transaction(
+                        static function () use ($modelKey, $morphType, $registrar): void {
+                            $contexts = static::deleteSubjectAssignments(
+                                $morphType,
+                                $modelKey,
+                                Config::modelHasRolesTable(),
+                            );
+
+                            if ($contexts === null) {
+                                $registrar->invalidateModelRoleCacheForIdentityAfterMutation(
+                                    $morphType,
+                                    (string) $modelKey,
+                                    null,
+                                    null,
+                                );
+
+                                return;
+                            }
+
+                            foreach ($contexts as $context) {
+                                $registrar->invalidateModelRoleCacheForIdentityAfterMutation(
+                                    $morphType,
+                                    (string) $modelKey,
+                                    $context->partition,
+                                    $context->team,
+                                );
+                            }
+                        },
                     );
-                }
-            }
+                },
+            );
 
             $registrar->forgetLoadedRelationProvenance($model, 'roles');
         });
@@ -353,6 +382,7 @@ trait HasRoles
     {
         $registrar = $this->permissionRegistrar();
         $context = $this->roleAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $roles = $this->collectRoles($roles, $context->partition);
 
         if ($roles === []) {
@@ -400,9 +430,9 @@ trait HasRoles
         $this->unsetRelation('roles');
 
         if ($this instanceof Permission) {
-            $registrar->forgetCachedPermissionsFor($context->partition);
+            $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
         } else {
-            $registrar->forgetModelRoleCacheFor(
+            $registrar->invalidateModelRoleCacheAfterMutation(
                 $this,
                 $context->partition,
                 $context->team,
@@ -522,7 +552,15 @@ trait HasRoles
             return;
         }
 
-        $this->getConnection()->transaction(function () use ($roleAssignments, $permissionAssignments): void {
+        $registrar = $this->permissionRegistrar();
+
+        foreach ($roleAssignments as $assignment) {
+            $registrar->ensureTeamIsSelectedForMutation($assignment['context']);
+        }
+
+        $this->ensureQueuedPermissionAssignmentTeamsSelected($permissionAssignments, $registrar);
+
+        $registrar->getPermissionConnection()->transaction(function () use ($roleAssignments, $permissionAssignments): void {
             foreach ($roleAssignments as $assignment) {
                 $relation = $this->roleAssignmentRelation($assignment['context']);
 
@@ -553,13 +591,11 @@ trait HasRoles
             $contexts[$assignment['context']->identity()] = $assignment['context'];
         }
 
-        $registrar = $this->permissionRegistrar();
-
         foreach ($contexts as $context) {
             if ($this instanceof Permission) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelAssignmentCacheFor(
+                $registrar->invalidateModelAssignmentCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,
@@ -601,6 +637,7 @@ trait HasRoles
     {
         $registrar = $this->permissionRegistrar();
         $context = $this->roleAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $roles = $this->collectRoles($role, $context->partition);
 
         if ($roles === []) {
@@ -630,9 +667,9 @@ trait HasRoles
             $this->unsetRelation('roles');
 
             if ($this instanceof Permission) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelRoleCacheFor(
+                $registrar->invalidateModelRoleCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,
@@ -678,6 +715,7 @@ trait HasRoles
     {
         $registrar = $this->permissionRegistrar();
         $context = $this->roleAssignmentContext($registrar);
+        $registrar->ensureTeamIsSelectedForMutation($context);
         $roles = $this->collectRoles($roles, $context->partition);
 
         if (! $this->exists) {
@@ -712,7 +750,7 @@ trait HasRoles
         $detachedEventRoles = $this->roleDetachedEventIsListenedFor() ? $currentRoles : [];
 
         if ($rolesToDetach !== [] || $rolesToAttach !== []) {
-            $this->getConnection()->transaction(function () use ($context, $relation, $rolesToAttach, $rolesToDetach): void {
+            $registrar->getPermissionConnection()->transaction(function () use ($context, $relation, $rolesToAttach, $rolesToDetach): void {
                 if ($rolesToDetach !== []) {
                     $relation->detach($rolesToDetach, false);
                 }
@@ -727,9 +765,9 @@ trait HasRoles
             $this->unsetRelation('roles');
 
             if ($this instanceof Permission) {
-                $registrar->forgetCachedPermissionsFor($context->partition);
+                $registrar->invalidatePermissionCatalogAfterMutation($context->partition);
             } else {
-                $registrar->forgetModelRoleCacheFor(
+                $registrar->invalidateModelRoleCacheAfterMutation(
                     $this,
                     $context->partition,
                     $context->team,

--- a/src/permission/src/Traits/RefreshesPermissionCache.php
+++ b/src/permission/src/Traits/RefreshesPermissionCache.php
@@ -16,10 +16,29 @@ trait RefreshesPermissionCache
      */
     public static function bootRefreshesPermissionCache(): void
     {
+        static::saving(function (Model $model): void {
+            Container::getInstance()
+                ->make(PermissionRegistrar::class)
+                ->ensureModelUsesPermissionConnection($model);
+        });
+
+        static::deleting(function (Model $model): void {
+            $registrar = Container::getInstance()->make(PermissionRegistrar::class);
+            $registrar->ensureModelUsesPermissionConnection($model);
+            $partition = static::permissionPartitionForLifecycle($model, $registrar);
+
+            // Catalog invalidation includes transactional soft deletes; assignment rotation is hard-delete only.
+            $registrar->invalidatePermissionCatalogAfterMutation($partition);
+
+            if (static::shouldDeletePermissionAssignments($model)) {
+                $registrar->rotateModelAssignmentCacheTokenAfterMutation($partition);
+            }
+        });
+
         static::saved(function (Model $model): void {
             $registrar = Container::getInstance()->make(PermissionRegistrar::class);
 
-            $registrar->forgetCachedPermissionsFor(
+            $registrar->invalidatePermissionCatalogAfterMutation(
                 static::permissionPartitionForLifecycle($model, $registrar),
             );
         });
@@ -27,7 +46,7 @@ trait RefreshesPermissionCache
         static::deleted(function (Model $model): void {
             $registrar = Container::getInstance()->make(PermissionRegistrar::class);
 
-            $registrar->forgetCachedPermissionsFor(
+            $registrar->invalidatePermissionCatalogAfterMutation(
                 static::permissionPartitionForLifecycle($model, $registrar),
             );
         });

--- a/src/permission/src/Traits/RefreshesPermissionCache.php
+++ b/src/permission/src/Traits/RefreshesPermissionCache.php
@@ -31,6 +31,8 @@ trait RefreshesPermissionCache
             $registrar->invalidatePermissionCatalogAfterMutation($partition);
 
             if (static::shouldDeletePermissionAssignments($model)) {
+                // Rotate before the row disappears so deleted listeners cannot publish a false revocation;
+                // a later veto may waste one namespace but cannot make authorization state incorrect.
                 $registrar->rotateModelAssignmentCacheTokenAfterMutation($partition);
             }
         });

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Cache;
 use __PHP_Incomplete_Class;
 use Hypervel\Cache\ArrayStore;
 use Hypervel\Cache\CacheManager;
+use Hypervel\Cache\MemoizedStore;
 use Hypervel\Cache\NullStore;
 use Hypervel\Cache\RedisStore;
 use Hypervel\Cache\StorageStore;
@@ -498,6 +499,31 @@ class CacheManagerTest extends TestCase
         $this->assertSame('bar', $cacheManager->store('forget')->get('foo'));
         $cacheManager->forgetDriver('forget');
         $this->assertNull($cacheManager->store('forget')->get('foo'));
+    }
+
+    public function testForgetDriverForgetsTheCallingCoroutinesMemoizedRepository(): void
+    {
+        $app = $this->getApp([
+            'cache' => [
+                'stores' => [
+                    'array' => ['driver' => 'array'],
+                ],
+            ],
+        ]);
+        $cacheManager = new CacheManager($app);
+        $firstRepository = $cacheManager->memo('array');
+        $firstMemoizedStore = $firstRepository->getStore();
+
+        $this->assertInstanceOf(MemoizedStore::class, $firstMemoizedStore);
+
+        $cacheManager->forgetDriver('array');
+
+        $secondRepository = $cacheManager->memo('array');
+        $secondMemoizedStore = $secondRepository->getStore();
+
+        $this->assertInstanceOf(MemoizedStore::class, $secondMemoizedStore);
+        $this->assertNotSame($firstRepository, $secondRepository);
+        $this->assertNotSame($firstMemoizedStore->getInnerStore(), $secondMemoizedStore->getInnerStore());
     }
 
     public function testThrowExceptionWhenUnknownDriverIsUsed()

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -25,6 +25,14 @@ use stdClass;
 
 class CacheMemoizedStoreTest extends TestCase
 {
+    public function testExposesTheUnderlyingStore(): void
+    {
+        $innerStore = new ArrayStore;
+        $store = new MemoizedStore('test', new Repository($innerStore));
+
+        $this->assertSame($innerStore, $store->getInnerStore());
+    }
+
     public function testTouchExtendsTtl(): void
     {
         $store = new MemoizedStore('test', new Repository(new ArrayStore));

--- a/tests/Cache/ModelCacheCoordinatorTest.php
+++ b/tests/Cache/ModelCacheCoordinatorTest.php
@@ -8,9 +8,13 @@ use Carbon\CarbonInterval;
 use Closure;
 use Hypervel\Cache\ArrayLock;
 use Hypervel\Cache\ArrayStore;
+use Hypervel\Cache\Exceptions\UnsupportedModelCacheStoreException;
+use Hypervel\Cache\FailoverStore;
 use Hypervel\Cache\Lock;
+use Hypervel\Cache\MemoizedStore;
 use Hypervel\Cache\ModelCacheCoordinator;
 use Hypervel\Cache\Repository;
+use Hypervel\Cache\StackStore;
 use Hypervel\Cache\WorkerArrayStore;
 use Hypervel\Contracts\Cache\Lock as LockContract;
 use Hypervel\Contracts\Cache\LockProvider;
@@ -395,7 +399,7 @@ class ModelCacheCoordinatorTest extends TestCase
             300,
             fn (): string => 'uncached',
         ));
-        $coordinator->invalidate($repository, 'a-very-long-data-key');
+        $this->assertTrue($coordinator->invalidate($repository, 'a-very-long-data-key'));
 
         $this->assertSame($lockNames[0][0], $lockNames[1][0]);
         $this->assertSame(10, $lockNames[0][1]);
@@ -510,6 +514,46 @@ class ModelCacheCoordinatorTest extends TestCase
         $this->expectExceptionMessage('does not provide atomic locks');
 
         $coordinator->fill($missRepository, 'key', 300, fn (): string => 'database');
+    }
+
+    public function testStackAndFailoverTopologiesAreRejectedThroughDirectAndMemoizedStores(): void
+    {
+        $failoverStore = m::mock(FailoverStore::class);
+        $failoverStore->shouldReceive('getRaw')->twice()->with('key')->andReturnNull();
+        $failoverStore->shouldReceive('getPrefix')->once()->andReturn('');
+
+        $stores = [
+            'stack' => new StackStore([new ArrayStore]),
+            'failover' => $failoverStore,
+        ];
+
+        foreach ($stores as $name => $store) {
+            $repository = new Repository($store);
+
+            foreach ([
+                "direct {$name}" => $repository,
+                "memoized {$name}" => new Repository(new MemoizedStore($name, $repository)),
+            ] as $label => $candidate) {
+                try {
+                    (new ModelCacheCoordinator)->fill(
+                        $candidate,
+                        'key',
+                        300,
+                        fn (): string => 'database',
+                    );
+                } catch (UnsupportedModelCacheStoreException $exception) {
+                    $this->assertStringContainsString(
+                        'cannot guarantee that cached values and locks use the same backend',
+                        $exception->getMessage(),
+                        $label,
+                    );
+
+                    continue;
+                }
+
+                $this->fail("Expected {$label} to be rejected for coordinated model caching.");
+            }
+        }
     }
 
     public function testNonRefreshableLockIsRejectedOnlyAfterAMiss(): void

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -767,6 +767,9 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });
+        $connection->shouldReceive('table')->andReturnUsing(
+            fn ($table, $as = null) => $connection->query()->from($table, $as)
+        );
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
 

--- a/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyOrFailTest.php
@@ -12,6 +12,7 @@ use Hypervel\Database\Eloquent\Relations\Pivot;
 use Hypervel\Database\Schema\Builder;
 use Hypervel\Tests\TestCase;
 use RuntimeException;
+use UnitEnum;
 
 class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
 {
@@ -25,11 +26,20 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
             'driver' => 'sqlite',
             'database' => ':memory:',
         ]);
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'parent');
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'related');
 
         $db->bootEloquent();
         $db->setAsGlobal();
 
         $this->createSchema();
+        $this->createSplitSchema();
     }
 
     public function createSchema(): void
@@ -51,8 +61,35 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
         });
     }
 
+    public function createSplitSchema(): void
+    {
+        $this->schema('parent')->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+
+        $this->schema('parent')->create('role_user', function ($table) {
+            $table->integer('user_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+        });
+
+        $this->schema('related')->create('roles', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->schema('related')->create('role_user', function ($table) {
+            $table->integer('user_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+        });
+    }
+
     protected function tearDown(): void
     {
+        $this->schema('related')->drop('role_user');
+        $this->schema('related')->drop('roles');
+        $this->schema('parent')->drop('role_user');
+        $this->schema('parent')->drop('users');
         $this->schema()->drop('role_user');
         $this->schema()->drop('roles');
         $this->schema()->drop('users');
@@ -208,20 +245,48 @@ class DatabaseEloquentBelongsToManyOrFailTest extends TestCase
         $this->assertSame(0, DB::table('role_user')->count());
     }
 
+    public function testCustomPivotUsesThePivotQueryConnection(): void
+    {
+        OrFailSplitUser::create(['id' => 1, 'email' => 'taylor@hypervel.org']);
+        OrFailSplitRole::create(['id' => 1, 'name' => 'Admin']);
+
+        OrFailSplitUser::find(1)->rolesWithPivot()->attach(1);
+
+        $this->assertSame(0, $this->connection('parent')->table('role_user')->count());
+        $this->assertSame(1, $this->connection('related')->table('role_user')->count());
+    }
+
+    public function testOrFailMethodsTransactThePivotQueryConnection(): void
+    {
+        OrFailSplitUser::create(['id' => 1, 'email' => 'taylor@hypervel.org']);
+        OrFailSplitRole::create(['id' => 1, 'name' => 'Admin']);
+        $caught = null;
+
+        try {
+            OrFailSplitUser::find(1)->failingRoles()->attachOrFail(1);
+        } catch (RuntimeException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(RuntimeException::class, $caught);
+        $this->assertSame('Attach failed after writing the pivot.', $caught->getMessage());
+        $this->assertSame(0, $this->connection('related')->table('role_user')->count());
+    }
+
     /**
      * Get a database connection instance.
      */
-    protected function connection(): Connection
+    protected function connection(?string $name = null): Connection
     {
-        return Eloquent::getConnectionResolver()->connection();
+        return Eloquent::getConnectionResolver()->connection($name);
     }
 
     /**
      * Get a schema builder instance.
      */
-    protected function schema(): Builder
+    protected function schema(?string $name = null): Builder
     {
-        return $this->connection()->getSchemaBuilder();
+        return $this->connection($name)->getSchemaBuilder();
     }
 }
 
@@ -265,5 +330,62 @@ class OrFailFailingPivot extends Pivot
         parent::save($options);
 
         throw new RuntimeException('Pivot save failed.');
+    }
+}
+
+class OrFailSplitUser extends Eloquent
+{
+    protected UnitEnum|string|null $connection = 'parent';
+
+    protected ?string $table = 'users';
+
+    protected array $guarded = [];
+
+    public bool $timestamps = false;
+
+    public function rolesWithPivot(): BelongsToMany
+    {
+        return $this->belongsToMany(OrFailSplitRole::class, 'role_user', 'user_id', 'role_id')
+            ->using(OrFailSplitPivot::class);
+    }
+
+    public function failingRoles(): BelongsToMany
+    {
+        return new OrFailAfterAttachBelongsToMany(
+            (new OrFailSplitRole)->newQuery(),
+            $this,
+            'role_user',
+            'user_id',
+            'role_id',
+            $this->getKeyName(),
+            (new OrFailSplitRole)->getKeyName(),
+            'failingRoles',
+        );
+    }
+}
+
+class OrFailSplitRole extends Eloquent
+{
+    protected UnitEnum|string|null $connection = 'related';
+
+    protected ?string $table = 'roles';
+
+    protected array $guarded = [];
+
+    public bool $timestamps = false;
+}
+
+class OrFailSplitPivot extends Pivot
+{
+    public bool $timestamps = false;
+}
+
+class OrFailAfterAttachBelongsToMany extends BelongsToMany
+{
+    public function attach(mixed $ids, array $attributes = [], bool $touch = true): void
+    {
+        parent::attach($ids, $attributes, $touch);
+
+        throw new RuntimeException('Attach failed after writing the pivot.');
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database;
 
+use Hypervel\Database\ConnectionInterface;
 use Hypervel\Database\Eloquent\Builder;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\BelongsToMany;
@@ -56,6 +57,11 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 
         $builder->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(QueryBuilder::class));
         $mockQueryBuilder->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class, ['isExpression' => false]));
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('table')->andReturnUsing(
+            fn ($table) => $mockQueryBuilder->newQuery()->from($table)
+        );
+        $mockQueryBuilder->shouldReceive('getConnection')->andReturn($connection);
 
         return [$builder, $parent, 'club_user', 'club_id', 'user_id', 'id', 'id', null, false];
     }

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database\DatabaseEloquentMorphToManyTest;
 
+use Hypervel\Database\ConnectionInterface;
 use Hypervel\Database\Eloquent\Builder;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\MorphToMany;
@@ -135,6 +136,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $grammar->shouldReceive('isExpression')->with(m::type('string'))->andReturnFalse();
         $queryBuilder = m::mock(QueryBuilder::class);
         $queryBuilder->shouldReceive('getGrammar')->andReturn($grammar);
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('table')->andReturnUsing(
+            fn ($table) => $queryBuilder->newQuery()->from($table)
+        );
+        $queryBuilder->shouldReceive('getConnection')->andReturn($connection);
         $builder->shouldReceive('getQuery')->andReturn($queryBuilder);
 
         return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id', 'relation_name', false];

--- a/tests/Integration/Permission/Database/Postgres/PermissionCacheTransactionTest.php
+++ b/tests/Integration/Permission/Database/Postgres/PermissionCacheTransactionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Permission\Database\Postgres;
+
+use Hypervel\Contracts\Config\Repository;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Database\DatabaseManager;
+use Hypervel\Database\DatabaseTransactionsManager;
+use Hypervel\Database\QueryException;
+use Hypervel\Permission\Models\Permission;
+use Hypervel\Permission\Models\Role;
+use Hypervel\Permission\Traits\HasRoles;
+use Hypervel\Testbench\Attributes\RequiresDatabase;
+use Hypervel\Tests\Permission\Fixtures\Models\UserWithoutHasRoles;
+use Hypervel\Tests\Permission\TestCase as PermissionTestCase;
+use UnitEnum;
+
+use function Hypervel\Coroutine\parallel;
+
+#[RequiresDatabase('pgsql')]
+class PermissionCacheTransactionTest extends PermissionTestCase
+{
+    public const string SUBJECT_CONNECTION = 'permission_subject_postgres';
+
+    public const string STORAGE_CONNECTION = 'permission_storage_postgres';
+
+    protected array $connectionsToTransact = [];
+
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        /** @var Repository $config */
+        $config = $app->make('config');
+        $postgres = $config->array('database.connections.pgsql');
+
+        $config->set([
+            'database.default' => getenv('DB_CONNECTION') ?: 'testing',
+            'database.connections.' . self::SUBJECT_CONNECTION => $postgres,
+            'database.connections.' . self::STORAGE_CONNECTION => $postgres,
+            'permission.models.permission' => PostgresPermission::class,
+            'permission.models.role' => PostgresRole::class,
+            'permission.models.default_model' => PostgresUser::class,
+            'auth.providers.users.model' => PostgresUser::class,
+            'cache.stores.permission_shared' => ['driver' => 'worker-array'],
+            'permission.cache.store' => 'permission_shared',
+        ]);
+    }
+
+    protected function tearDownInCoroutine(): void
+    {
+        /** @var DatabaseManager $databaseManager */
+        $databaseManager = $this->app->make('db');
+        $databaseManager->purge(self::SUBJECT_CONNECTION);
+        $databaseManager->purge(self::STORAGE_CONNECTION);
+    }
+
+    public function testPostgresTransactionsKeepSharedAssignmentsCommittedAndRollbackSafe(): void
+    {
+        /** @var DatabaseManager $databaseManager */
+        $databaseManager = $this->app->make('db');
+        $subjectConnection = $databaseManager->connection(self::SUBJECT_CONNECTION);
+        $permissionConnection = $databaseManager->connection(self::STORAGE_CONNECTION);
+        $transactionManager = new DatabaseTransactionsManager;
+        $subjectConnection->setTransactionManager($transactionManager);
+        $permissionConnection->setTransactionManager($transactionManager);
+
+        $user = PostgresUser::create(['email' => 'postgres-transaction@example.com']);
+        $role = PostgresRole::create(['name' => 'postgres-editor']);
+
+        $this->assertFalse($user->hasRole($role));
+
+        $permissionConnection->beginTransaction();
+
+        try {
+            $user->assignRole($role);
+            $this->assertTrue($user->hasRole($role));
+        } finally {
+            $permissionConnection->rollBack();
+        }
+
+        [$hasRoleAfterRollback] = parallel([
+            fn (): bool => PostgresUser::findOrFail($user->getKey())->hasRole($role),
+        ]);
+
+        $this->assertFalse($hasRoleAfterRollback);
+
+        $permissionConnection->transaction(fn () => $user->assignRole($role));
+
+        [$hasRoleAfterCommit] = parallel([
+            fn (): bool => PostgresUser::findOrFail($user->getKey())->hasRole($role),
+        ]);
+
+        $this->assertTrue($hasRoleAfterCommit);
+    }
+
+    public function testCaughtCleanupFailureRollsBackTheDeleteSavepoint(): void
+    {
+        /** @var DatabaseManager $databaseManager */
+        $databaseManager = $this->app->make('db');
+        $permissionConnection = $databaseManager->connection(self::STORAGE_CONNECTION);
+        $permissionConnection->setTransactionManager(new DatabaseTransactionsManager);
+
+        $user = PostgresUser::create(['email' => 'postgres-delete@example.com']);
+        $role = PostgresRole::create(['name' => 'postgres-editor']);
+        $permission = PostgresPermission::create(['name' => 'postgres-publish']);
+        $user->assignRole($role);
+        $role->givePermissionTo($permission);
+
+        $permissionConnection->unprepared(<<<'SQL'
+CREATE FUNCTION fail_permission_role_cleanup() RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'forced PostgreSQL role permission cleanup failure';
+END;
+$$ LANGUAGE plpgsql
+SQL);
+        $permissionConnection->unprepared(<<<'SQL'
+CREATE TRIGGER fail_permission_role_cleanup
+BEFORE DELETE ON role_has_permissions
+FOR EACH ROW EXECUTE FUNCTION fail_permission_role_cleanup()
+SQL);
+
+        $caught = null;
+
+        try {
+            $permissionConnection->transaction(function () use ($permissionConnection, $role, &$caught): void {
+                try {
+                    $role->delete();
+                } catch (QueryException $exception) {
+                    $caught = $exception;
+                }
+
+                $permissionConnection->table('roles')
+                    ->where('id', $role->getKey())
+                    ->update(['name' => 'postgres-editor-after-recovery']);
+            });
+        } finally {
+            $permissionConnection->unprepared('DROP TRIGGER fail_permission_role_cleanup ON role_has_permissions');
+            $permissionConnection->unprepared('DROP FUNCTION fail_permission_role_cleanup()');
+        }
+
+        $this->assertInstanceOf(QueryException::class, $caught);
+        $this->assertSame(1, $permissionConnection->table('roles')->where('id', $role->getKey())->count());
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $this->assertSame(1, $permissionConnection->table('role_has_permissions')->count());
+        $this->assertSame(
+            'postgres-editor-after-recovery',
+            $permissionConnection->table('roles')->where('id', $role->getKey())->value('name'),
+        );
+    }
+}
+
+class PostgresUser extends UserWithoutHasRoles
+{
+    use HasRoles;
+
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::SUBJECT_CONNECTION;
+}
+
+class PostgresRole extends Role
+{
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::STORAGE_CONNECTION;
+}
+
+class PostgresPermission extends Permission
+{
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::STORAGE_CONNECTION;
+}

--- a/tests/Permission/CacheTest.php
+++ b/tests/Permission/CacheTest.php
@@ -78,7 +78,8 @@ class CacheTest extends TestCase
 
         $firstToken = $registrar->modelAssignmentCacheToken();
 
-        $registrar->forgetCachedPermissions();
+        $this->assertTrue($registrar->forgetCachedPermissions());
+        $this->assertFalse($registrar->forgetCachedPermissions());
 
         $this->assertMatchesRegularExpression('/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/', $firstToken);
         $this->assertNotSame($firstToken, $registrar->modelAssignmentCacheToken());

--- a/tests/Permission/CacheTest.php
+++ b/tests/Permission/CacheTest.php
@@ -24,9 +24,13 @@ class CacheTest extends TestCase
 
         $this->testUser->hasPermissionTo('edit-articles');
 
-        $payload = $registrar->getCacheRepository()->get($registrar->getCacheKey());
+        $entry = $registrar->getCacheRepository()->get($registrar->getCacheKey());
 
-        $this->assertIsArray($payload);
+        $this->assertIsArray($entry);
+        $this->assertSame('present', $entry['__hypervel_model_cache']);
+        $this->assertIsArray($entry['value']);
+
+        $payload = $entry['value'];
 
         $permission = collect($payload['permissions'])->first(
             fn (array $permission): bool => $permission['attributes']['name'] === 'edit-articles',
@@ -81,6 +85,23 @@ class CacheTest extends TestCase
         $this->assertTrue($this->testUser->hasRole('testRole'));
     }
 
+    public function testCatalogOnlyMutationsDoNotRotateTheAssignmentToken(): void
+    {
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $token = $registrar->modelAssignmentCacheToken();
+        $role = $this->app->make(RoleContract::class)::create(['name' => 'catalog-role']);
+        $permission = $this->app->make(PermissionContract::class)::create(['name' => 'catalog-permission']);
+
+        $role->name = 'renamed-catalog-role';
+        $role->save();
+        $permission->name = 'renamed-catalog-permission';
+        $permission->save();
+        $role->givePermissionTo($permission);
+        $role->revokePermissionTo($permission);
+
+        $this->assertSame($token, $registrar->modelAssignmentCacheToken());
+    }
+
     public function testRoleAssignmentMutationsInvalidateWarmModelRoleCache(): void
     {
         $this->assertFalse($this->testUser->hasRole('testRole'));
@@ -128,6 +149,30 @@ class CacheTest extends TestCase
 
         $this->testUser->revokePermissionTo('edit-articles');
         $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
+
+    public function testDirectPermissionHydrationIsMemoizedPerCoroutineAndClearedByMutation(): void
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $user = User::findOrFail($this->testUser->getKey());
+
+        $first = $user->getDirectPermissions()->sole();
+        $second = $user->getDirectPermissions()->sole();
+
+        $this->assertSame($first, $second);
+
+        $user->revokePermissionTo('edit-articles');
+        $user->givePermissionTo('edit-articles');
+
+        $afterMutation = $user->getDirectPermissions()->sole();
+        $this->assertNotSame($first, $afterMutation);
+
+        [$coroutineOne, $coroutineTwo] = parallel([
+            fn (): Model => User::findOrFail($user->getKey())->getDirectPermissions()->sole(),
+            fn (): Model => User::findOrFail($user->getKey())->getDirectPermissions()->sole(),
+        ]);
+
+        $this->assertNotSame($coroutineOne, $coroutineTwo);
     }
 
     public function testExplicitInvalidationClearsKeylessAssignmentCacheEntries(): void

--- a/tests/Permission/DeletionTest.php
+++ b/tests/Permission/DeletionTest.php
@@ -157,9 +157,9 @@ class DeletionTest extends TestCase
             'is_denied' => false,
         ]);
 
-        $cleanupObservedBeforeRecordDeletion = false;
+        $cleanupObservedAfterRecordDeletion = false;
 
-        StandaloneRole::deleting(function () use ($role, &$cleanupObservedBeforeRecordDeletion): void {
+        StandaloneRole::deleted(function () use ($role, &$cleanupObservedAfterRecordDeletion): void {
             $this->assertSame(0, DB::table(Config::modelHasRolesTable())
                 ->where(app('config')->get('permission.column_names.role_pivot_key'), $role->getKey())
                 ->count());
@@ -167,12 +167,12 @@ class DeletionTest extends TestCase
                 ->where(app('config')->get('permission.column_names.role_pivot_key'), $role->getKey())
                 ->count());
 
-            $cleanupObservedBeforeRecordDeletion = true;
+            $cleanupObservedAfterRecordDeletion = true;
         });
 
         $role->delete();
 
-        $this->assertTrue($cleanupObservedBeforeRecordDeletion);
+        $this->assertTrue($cleanupObservedAfterRecordDeletion);
     }
 
     public function testCustomPermissionCleanupDoesNotDependOnRefreshesPermissionCache(): void
@@ -194,9 +194,9 @@ class DeletionTest extends TestCase
             'is_denied' => false,
         ]);
 
-        $cleanupObservedBeforeRecordDeletion = false;
+        $cleanupObservedAfterRecordDeletion = false;
 
-        StandalonePermission::deleting(function () use ($permission, &$cleanupObservedBeforeRecordDeletion): void {
+        StandalonePermission::deleted(function () use ($permission, &$cleanupObservedAfterRecordDeletion): void {
             $this->assertSame(0, DB::table(Config::modelHasPermissionsTable())
                 ->where(app('config')->get('permission.column_names.permission_pivot_key'), $permission->getKey())
                 ->count());
@@ -204,12 +204,42 @@ class DeletionTest extends TestCase
                 ->where(app('config')->get('permission.column_names.permission_pivot_key'), $permission->getKey())
                 ->count());
 
-            $cleanupObservedBeforeRecordDeletion = true;
+            $cleanupObservedAfterRecordDeletion = true;
         });
 
         $permission->delete();
 
-        $this->assertTrue($cleanupObservedBeforeRecordDeletion);
+        $this->assertTrue($cleanupObservedAfterRecordDeletion);
+    }
+
+    public function testDeleteVetoInsideTransactionPreservesRoleAndAssignments(): void
+    {
+        $role = StandaloneRole::query()->create([
+            'name' => 'vetoed-role',
+            'guard_name' => 'web',
+        ]);
+
+        DB::table(Config::modelHasRolesTable())->insert([
+            app('config')->get('permission.column_names.role_pivot_key') => $role->getKey(),
+            Config::morphKey() => $this->testUser->getKey(),
+            'model_type' => $this->testUser->getMorphClass(),
+        ]);
+        DB::table(Config::roleHasPermissionsTable())->insert([
+            app('config')->get('permission.column_names.role_pivot_key') => $role->getKey(),
+            app('config')->get('permission.column_names.permission_pivot_key') => $this->testUserPermission->getKey(),
+            'is_denied' => false,
+        ]);
+
+        StandaloneRole::deleting(static fn (): bool => false);
+
+        $this->assertFalse(DB::transaction(fn (): int|bool|null => $role->delete()));
+        $this->assertDatabaseHas(Config::rolesTable(), [$role->getKeyName() => $role->getKey()]);
+        $this->assertSame(1, DB::table(Config::modelHasRolesTable())
+            ->where(app('config')->get('permission.column_names.role_pivot_key'), $role->getKey())
+            ->count());
+        $this->assertSame(1, DB::table(Config::roleHasPermissionsTable())
+            ->where(app('config')->get('permission.column_names.role_pivot_key'), $role->getKey())
+            ->count());
     }
 
     private function roleAssignmentCount(Model $model): int

--- a/tests/Permission/Integration/CacheTest.php
+++ b/tests/Permission/Integration/CacheTest.php
@@ -279,7 +279,11 @@ class CacheTest extends TestCase
             $roles[1]->pivot->getAttribute($this->registrar->pivotPermission),
         );
 
-        $payload = $this->registrar->getCacheRepository()->get($this->registrar->getCacheKey());
+        $cacheEntry = $this->registrar->getCacheRepository()->get($this->registrar->getCacheKey());
+
+        $this->assertSame('present', $cacheEntry['__hypervel_model_cache']);
+
+        $payload = $cacheEntry['value'];
 
         $matchingRoles = array_filter(
             $payload['roles'],

--- a/tests/Permission/PartitionCacheTest.php
+++ b/tests/Permission/PartitionCacheTest.php
@@ -6,6 +6,7 @@ namespace Hypervel\Tests\Permission;
 
 use Hypervel\Permission\PermissionRegistrar;
 use Hypervel\Permission\Support\PermissionPartition;
+use Hypervel\Support\Facades\DB;
 use Hypervel\Tests\Permission\Fixtures\Models\GlobalPartitionUser;
 use Hypervel\Tests\Permission\Fixtures\Models\PartitionedPermission;
 use Hypervel\Tests\Permission\Fixtures\Models\PartitionedRole;
@@ -30,8 +31,14 @@ class PartitionCacheTest extends PartitionTestCase
         $this->assertStringContainsString(self::PARTITION_A, $keyA);
         $this->assertStringContainsString(self::PARTITION_B, $keyB);
 
-        $payloadA = $registrar->getCacheRepository()->get($keyA);
-        $payloadB = $registrar->getCacheRepository()->get($keyB);
+        $entryA = $registrar->getCacheRepository()->get($keyA);
+        $entryB = $registrar->getCacheRepository()->get($keyB);
+
+        $this->assertSame('present', $entryA['__hypervel_model_cache']);
+        $this->assertSame('present', $entryB['__hypervel_model_cache']);
+
+        $payloadA = $entryA['value'];
+        $payloadB = $entryB['value'];
 
         $this->assertSame(['permission-a'], collect($payloadA['permissions'])->pluck('attributes.name')->all());
         $this->assertSame(['permission-b'], collect($payloadB['permissions'])->pluck('attributes.name')->all());
@@ -59,7 +66,7 @@ class PartitionCacheTest extends PartitionTestCase
 
         $this->assertFalse($registrar->getCacheRepository()->has($keyA));
         $this->assertTrue($registrar->getCacheRepository()->has($keyB));
-        $this->assertNotSame($tokenA, $registrar->modelAssignmentCacheToken());
+        $this->assertSame($tokenA, $registrar->modelAssignmentCacheToken());
 
         $this->setPartition(self::PARTITION_B);
 
@@ -85,21 +92,71 @@ class PartitionCacheTest extends PartitionTestCase
         $this->assertTrue($user->hasDirectPermission('articles.edit'));
     }
 
-    public function testReverseSyncBumpsOnlyTheCapturedPartitionToken(): void
+    public function testDirectPermissionHydrationMemoIsSeparatedByPartition(): void
     {
         $user = GlobalPartitionUser::create(['email' => 'global@example.com']);
+        $permissionA = PartitionedPermission::create(['name' => 'articles.edit']);
+        $user->givePermissionTo($permissionA);
+        $partitionA = $user->getDirectPermissions()->sole();
+        $this->assertSame($partitionA, $user->getDirectPermissions()->sole());
+
+        $this->setPartition(self::PARTITION_B);
+        $permissionB = PartitionedPermission::create(['name' => 'articles.edit']);
+        $user->givePermissionTo($permissionB);
+        $partitionB = $user->getDirectPermissions()->sole();
+        $this->assertNotSame($partitionA, $partitionB);
+
+        $this->setPartition(self::PARTITION_A);
+        $this->assertSame($partitionA, $user->getDirectPermissions()->sole());
+    }
+
+    public function testTargetedReverseMutationsDoNotRotateThePartitionToken(): void
+    {
+        $user = GlobalPartitionUser::create(['email' => 'global@example.com']);
+        $role = PartitionedRole::create(['name' => 'member']);
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $token = $registrar->modelAssignmentCacheToken();
+
+        $role->assignToModels($user);
+
+        $this->assertSame($token, $registrar->modelAssignmentCacheToken());
+        $this->assertTrue($user->hasRole('member'));
+
+        $role->removeFromModels($user);
+
+        $this->assertSame($token, $registrar->modelAssignmentCacheToken());
+        $this->assertFalse($user->hasRole('member'));
+    }
+
+    public function testReverseSyncRotatesOnlyTheAmbientPartitionToken(): void
+    {
+        $removedUser = GlobalPartitionUser::create(['email' => 'removed@example.com']);
+        $addedUser = GlobalPartitionUser::create(['email' => 'added@example.com']);
+        $unrelatedUser = GlobalPartitionUser::create(['email' => 'unrelated@example.com']);
         $roleA = PartitionedRole::create(['name' => 'member']);
+        $roleA->assignToModels($removedUser);
         $registrar = $this->app->make(PermissionRegistrar::class);
         $tokenA = $registrar->modelAssignmentCacheToken();
+
+        $this->assertTrue($removedUser->hasRole('member'));
+        $this->assertFalse($addedUser->hasRole('member'));
+        $this->assertFalse($unrelatedUser->hasRole('member'));
 
         $this->setPartition(self::PARTITION_B);
         PartitionedRole::create(['name' => 'member']);
         $tokenB = $registrar->modelAssignmentCacheToken();
 
         $this->setPartition(self::PARTITION_A);
-        $roleA->syncModels($user);
+        $roleA->syncModels($addedUser);
 
         $this->assertNotSame($tokenA, $registrar->modelAssignmentCacheToken());
+        $this->assertFalse($removedUser->hasRole('member'));
+        $this->assertTrue($addedUser->hasRole('member'));
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+        $this->assertFalse($unrelatedUser->hasRole('member'));
+        $this->assertNotSame([], DB::getQueryLog());
 
         $this->setPartition(self::PARTITION_B);
 

--- a/tests/Permission/PartitionDeletionTest.php
+++ b/tests/Permission/PartitionDeletionTest.php
@@ -191,6 +191,47 @@ SQL);
         $this->assertSame(1, DB::table('role_has_permissions')->count());
     }
 
+    public function testCaughtRoleCleanupFailureRollsBackOnlyTheDeleteOperation(): void
+    {
+        $user = GlobalPartitionUser::create(['email' => 'global@example.com']);
+        $role = PartitionedRole::create(['name' => 'member']);
+        $permission = PartitionedPermission::create(['name' => 'articles.edit']);
+        $user->assignRole($role);
+        $role->givePermissionTo($permission);
+
+        DB::unprepared(<<<'SQL'
+CREATE TRIGGER fail_nested_role_permission_cleanup
+BEFORE DELETE ON "role_has_permissions"
+BEGIN
+    SELECT RAISE(ABORT, 'forced nested role permission cleanup failure');
+END
+SQL);
+
+        $caught = null;
+
+        try {
+            DB::transaction(function () use ($role, &$caught): void {
+                try {
+                    $role->delete();
+                } catch (QueryException $exception) {
+                    $caught = $exception;
+                }
+
+                DB::table('roles')
+                    ->where('id', $role->getKey())
+                    ->update(['name' => 'member-after-recovery']);
+            });
+        } finally {
+            DB::unprepared('DROP TRIGGER fail_nested_role_permission_cleanup');
+        }
+
+        $this->assertInstanceOf(QueryException::class, $caught);
+        $this->assertDatabaseHas('roles', ['id' => $role->getKey()]);
+        $this->assertSame(1, DB::table('model_has_roles')->count());
+        $this->assertSame(1, DB::table('role_has_permissions')->count());
+        $this->assertDatabaseHas('roles', ['id' => $role->getKey(), 'name' => 'member-after-recovery']);
+    }
+
     public function testDeleteOrFailRollsBackPivotCleanupWithTheSubjectRow(): void
     {
         $user = GlobalPartitionUser::create(['email' => 'global@example.com']);

--- a/tests/Permission/PermissionCacheTransactionTest.php
+++ b/tests/Permission/PermissionCacheTransactionTest.php
@@ -1,0 +1,927 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Permission;
+
+use Hypervel\Cache\ModelCacheCoordinator;
+use Hypervel\Contracts\Cache\Repository as CacheRepository;
+use Hypervel\Database\Connection;
+use Hypervel\Database\DatabaseManager;
+use Hypervel\Database\DatabaseTransactionsManager;
+use Hypervel\Database\Eloquent\Relations\BelongsToMany;
+use Hypervel\Database\Eloquent\Relations\MorphPivot;
+use Hypervel\Database\Eloquent\Relations\MorphToMany;
+use Hypervel\Database\Eloquent\SoftDeletes;
+use Hypervel\Database\Schema\Blueprint;
+use Hypervel\Filesystem\Filesystem;
+use Hypervel\Permission\Exceptions\PermissionConnectionMismatch;
+use Hypervel\Permission\Models\Permission;
+use Hypervel\Permission\Models\Role;
+use Hypervel\Permission\PermissionRegistrar;
+use Hypervel\Permission\Support\PermissionPartition;
+use Hypervel\Permission\Support\PermissionRelationContext;
+use Hypervel\Permission\Traits\HasRoles;
+use Hypervel\Testing\ParallelTesting;
+use Hypervel\Tests\Permission\Fixtures\Models\User;
+use Hypervel\Tests\Permission\Fixtures\Models\UserWithoutHasRoles;
+use RuntimeException;
+use UnitEnum;
+
+use function Hypervel\Coroutine\parallel;
+
+class PermissionCacheTransactionTest extends TestCase
+{
+    public const string SUBJECT_CONNECTION = 'permission_subject';
+
+    public const string STORAGE_CONNECTION = 'permission_storage';
+
+    private Filesystem $filesystem;
+
+    private string $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+        $this->temporaryDirectory = ParallelTesting::tempDir('PermissionCacheTransactionTest');
+        $this->filesystem->deleteDirectory($this->temporaryDirectory);
+        $this->filesystem->ensureDirectoryExists($this->temporaryDirectory);
+    }
+
+    protected function tearDownInCoroutine(): void
+    {
+        $databaseManager = $this->app->make('db');
+        $databaseManager->purge(self::SUBJECT_CONNECTION);
+        $databaseManager->purge(self::STORAGE_CONNECTION);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->deleteDirectory($this->temporaryDirectory);
+
+        parent::tearDown();
+    }
+
+    public function testRolledBackAssignmentReadInsideTransactionIsNotPublishedToSharedCache(): void
+    {
+        $this->useSharedPermissionCache();
+
+        $connection = $this->testUser->getConnection();
+
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+
+        $connection->beginTransaction();
+
+        try {
+            $this->testUser->assignRole('testRole');
+
+            $this->assertTrue($this->testUser->hasRole('testRole'));
+        } finally {
+            $connection->rollBack();
+        }
+
+        $this->app->make(PermissionRegistrar::class)->clearPermissionsCollection();
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($this->testUser->getKey())->hasRole('testRole'),
+        ]);
+
+        $this->assertFalse($hasRole);
+    }
+
+    public function testCommittedAssignmentInvalidatesTheWarmSharedView(): void
+    {
+        $this->useSharedPermissionCache();
+        $connection = $this->testUser->getConnection();
+
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+
+        $connection->beginTransaction();
+        $this->testUser->assignRole('testRole');
+        $this->assertTrue($this->testUser->hasRole('testRole'));
+        $connection->commit();
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($this->testUser->getKey())->hasRole('testRole'),
+        ]);
+
+        $this->assertTrue($hasRole);
+    }
+
+    public function testNestedRollbackClearsOnlyTheNestedTransactionView(): void
+    {
+        $this->useSharedPermissionCache();
+        $connection = $this->testUser->getConnection();
+
+        $connection->beginTransaction();
+        $this->testUser->assignRole('testRole');
+        $this->assertTrue($this->testUser->hasRole('testRole'));
+
+        $connection->beginTransaction();
+        $this->testUser->removeRole('testRole');
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+        $connection->rollBack();
+
+        $this->assertTrue($this->testUser->hasRole('testRole'));
+
+        $connection->rollBack();
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($this->testUser->getKey())->hasRole('testRole'),
+        ]);
+
+        $this->assertFalse($hasRole);
+    }
+
+    public function testRolledBackCatalogReadDoesNotReplaceTheCommittedCatalog(): void
+    {
+        $this->useSharedPermissionCache();
+        $connection = $this->testUserRole->getConnection();
+
+        $this->assertSame($this->testUserRole->getKey(), Role::findByName('testRole')->getKey());
+
+        $connection->beginTransaction();
+        $this->testUserRole->name = 'renamed-role';
+        $this->testUserRole->save();
+        $this->assertSame($this->testUserRole->getKey(), Role::findByName('renamed-role')->getKey());
+        $connection->rollBack();
+
+        $this->assertSame($this->testUserRole->getKey(), Role::findByName('testRole')->getKey());
+    }
+
+    public function testRolledBackReverseSyncCannotPublishAssignmentsUnderTheCommittedToken(): void
+    {
+        $this->useSharedPermissionCache();
+        $retainedUser = User::create(['email' => 'retained-sync@example.com']);
+        $this->testUserRole->assignToModels([$this->testUser, $retainedUser]);
+        $connection = $this->testUserRole->getConnection();
+
+        $connection->beginTransaction();
+
+        try {
+            $this->testUserRole->syncModels($retainedUser);
+            $this->assertFalse($this->testUser->hasRole('testRole'));
+        } finally {
+            $connection->rollBack();
+        }
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($this->testUser->getKey())->hasRole('testRole'),
+        ]);
+
+        $this->assertTrue($hasRole);
+    }
+
+    public function testRolledBackRoleDeleteCannotPublishAssignmentsUnderTheCommittedToken(): void
+    {
+        $this->useSharedPermissionCache();
+        $secondRole = Role::create(['name' => 'second-role']);
+        $this->testUser->assignRole($this->testUserRole, $secondRole);
+        $connection = $secondRole->getConnection();
+
+        $connection->beginTransaction();
+
+        try {
+            $secondRole->delete();
+            $this->assertTrue($this->testUser->hasRole('testRole'));
+        } finally {
+            $connection->rollBack();
+        }
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($this->testUser->getKey())->hasRole('second-role'),
+        ]);
+
+        $this->assertTrue($hasRole);
+    }
+
+    public function testRepeatedReverseSyncPublishesAFreshCommittedToken(): void
+    {
+        $this->useSharedPermissionCache();
+        $secondUser = User::create(['email' => 'second-sync@example.com']);
+        $this->testUserRole->assignToModels([$this->testUser, $secondUser]);
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $sharedToken = $registrar->modelAssignmentCacheToken();
+        $connection = $this->testUserRole->getConnection();
+
+        $connection->beginTransaction();
+        $this->testUserRole->syncModels($secondUser);
+        $firstProvisionalToken = $registrar->modelAssignmentCacheToken();
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+
+        $this->testUserRole->syncModels($this->testUser);
+        $secondProvisionalToken = $registrar->modelAssignmentCacheToken();
+        $connection->commit();
+
+        $this->assertNotSame($sharedToken, $firstProvisionalToken);
+        $this->assertNotSame($firstProvisionalToken, $secondProvisionalToken);
+        $committedToken = $registrar->modelAssignmentCacheToken();
+        $this->assertNotSame($sharedToken, $committedToken);
+        $this->assertNotSame($firstProvisionalToken, $committedToken);
+        $this->assertNotSame($secondProvisionalToken, $committedToken);
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($this->testUser->getKey())->hasRole('testRole'),
+        ]);
+
+        $this->assertTrue($hasRole);
+    }
+
+    public function testNestedRotationRollbackInstallsAFreshOuterProvisionalToken(): void
+    {
+        $this->useSharedPermissionCache();
+        $secondUser = User::create(['email' => 'nested-sync@example.com']);
+        $this->testUserRole->assignToModels([$this->testUser, $secondUser]);
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $sharedToken = $registrar->modelAssignmentCacheToken();
+        $connection = $this->testUserRole->getConnection();
+
+        $connection->beginTransaction();
+        $this->testUserRole->syncModels($secondUser);
+        $outerProvisionalToken = $registrar->modelAssignmentCacheToken();
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+        $outerAssignmentCacheKey = $this->roleAssignmentCacheKey(
+            $this->testUser,
+            $outerProvisionalToken,
+        );
+        $this->assertTrue($registrar->getCacheRepository()->has($outerAssignmentCacheKey));
+
+        $connection->beginTransaction();
+        $this->testUserRole->syncModels($this->testUser);
+        $innerProvisionalToken = $registrar->modelAssignmentCacheToken();
+        $this->assertFalse($secondUser->hasRole('testRole'));
+        $connection->rollBack();
+
+        $afterRollbackToken = $registrar->modelAssignmentCacheToken();
+
+        $this->assertNotSame($sharedToken, $afterRollbackToken);
+        $this->assertNotSame($outerProvisionalToken, $afterRollbackToken);
+        $this->assertNotSame($innerProvisionalToken, $afterRollbackToken);
+        $afterRollbackCacheKey = $this->roleAssignmentCacheKey(
+            $this->testUser,
+            $afterRollbackToken,
+        );
+        $this->assertTrue($registrar->getCacheRepository()->has($outerAssignmentCacheKey));
+        $this->assertFalse($registrar->getCacheRepository()->has($afterRollbackCacheKey));
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+        $this->assertTrue($registrar->getCacheRepository()->has($afterRollbackCacheKey));
+        $this->assertTrue($secondUser->hasRole('testRole'));
+
+        $connection->commit();
+
+        $committedToken = $registrar->modelAssignmentCacheToken();
+        $this->assertNotSame($sharedToken, $committedToken);
+        $this->assertNotSame($outerProvisionalToken, $committedToken);
+        $this->assertNotSame($innerProvisionalToken, $committedToken);
+        $this->assertNotSame($afterRollbackToken, $committedToken);
+    }
+
+    public function testEarlyDeletedListenerCannotPublishARolledBackHardDeleteUnderTheCommittedToken(): void
+    {
+        $listenerHasRole = null;
+        $listenerToken = null;
+        $userId = $this->testUser->getKey();
+
+        EarlyDeletedListenerRole::deleted(static function () use (&$listenerHasRole, &$listenerToken, $userId): void {
+            $registrar = app(PermissionRegistrar::class);
+            $listenerToken = $registrar->modelAssignmentCacheToken();
+            $listenerHasRole = User::findOrFail($userId)->hasRole('early-listener-role');
+        });
+
+        config()->set('permission.models.role', EarlyDeletedListenerRole::class);
+        $this->flushPermissionState();
+
+        $role = EarlyDeletedListenerRole::create(['name' => 'early-listener-role']);
+        $this->testUser->assignRole($role);
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $committedToken = $registrar->modelAssignmentCacheToken();
+        $connection = $role->getConnection();
+
+        $connection->beginTransaction();
+
+        try {
+            $role->delete();
+        } finally {
+            $connection->rollBack();
+        }
+
+        $this->assertFalse($listenerHasRole);
+        $this->assertIsString($listenerToken);
+        $this->assertNotSame($committedToken, $listenerToken);
+        $this->assertSame($committedToken, $registrar->modelAssignmentCacheToken());
+
+        [$hasRole] = parallel([
+            fn (): bool => User::findOrFail($userId)->hasRole('early-listener-role'),
+        ]);
+
+        $this->assertTrue($hasRole);
+    }
+
+    public function testAssignmentTokenUsesOnlyTheCurrentConnectionSettlement(): void
+    {
+        [$subjectConnection] = $this->setUpAliasedPermissionStorage();
+        config()->set('permission.models.permission', DynamicAliasedPermission::class);
+        $this->flushPermissionState();
+
+        /** @var DatabaseManager $databaseManager */
+        $databaseManager = $this->app->make('db');
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $committedToken = $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            fn (): string => $registrar->modelAssignmentCacheToken(),
+        );
+
+        $provisionalToken = $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            function () use ($registrar, $subjectConnection): string {
+                $subjectConnection->beginTransaction();
+                $registrar->rotateModelAssignmentCacheTokenAfterMutation(null);
+
+                return $registrar->modelAssignmentCacheToken();
+            },
+        );
+        $storageToken = $databaseManager->usingConnection(
+            self::STORAGE_CONNECTION,
+            fn (): string => $registrar->modelAssignmentCacheToken(),
+        );
+
+        $this->assertNotSame($committedToken, $provisionalToken);
+        $this->assertSame($committedToken, $storageToken);
+
+        $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            fn () => $subjectConnection->rollBack(),
+        );
+    }
+
+    public function testAssignmentTokenSettlementsRemainIndependentAcrossConnectionAliases(): void
+    {
+        [$subjectConnection, $storageConnection] = $this->setUpAliasedPermissionStorage();
+        config()->set('permission.models.permission', DynamicAliasedPermission::class);
+        $this->flushPermissionState();
+
+        /** @var DatabaseManager $databaseManager */
+        $databaseManager = $this->app->make('db');
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $committedToken = $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            fn (): string => $registrar->modelAssignmentCacheToken(),
+        );
+        $subjectProvisionalToken = $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            function () use ($registrar, $subjectConnection): string {
+                $subjectConnection->beginTransaction();
+                $registrar->rotateModelAssignmentCacheTokenAfterMutation(null);
+
+                return $registrar->modelAssignmentCacheToken();
+            },
+        );
+        $storageProvisionalToken = $databaseManager->usingConnection(
+            self::STORAGE_CONNECTION,
+            function () use ($registrar, $storageConnection): string {
+                $storageConnection->beginTransaction();
+                $registrar->rotateModelAssignmentCacheTokenAfterMutation(null);
+
+                return $registrar->modelAssignmentCacheToken();
+            },
+        );
+
+        $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            fn () => $subjectConnection->commit(),
+        );
+
+        $subjectCommittedToken = $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            fn (): string => $registrar->modelAssignmentCacheToken(),
+        );
+        $storageStillProvisionalToken = $databaseManager->usingConnection(
+            self::STORAGE_CONNECTION,
+            fn (): string => $registrar->modelAssignmentCacheToken(),
+        );
+
+        $this->assertNotSame($committedToken, $subjectProvisionalToken);
+        $this->assertNotSame($subjectProvisionalToken, $storageProvisionalToken);
+        $this->assertNotSame($subjectProvisionalToken, $subjectCommittedToken);
+        $this->assertNotSame($storageProvisionalToken, $subjectCommittedToken);
+        $this->assertSame($storageProvisionalToken, $storageStillProvisionalToken);
+
+        $databaseManager->usingConnection(
+            self::STORAGE_CONNECTION,
+            fn () => $storageConnection->commit(),
+        );
+
+        $finalToken = $databaseManager->usingConnection(
+            self::SUBJECT_CONNECTION,
+            fn (): string => $registrar->modelAssignmentCacheToken(),
+        );
+        $this->assertNotSame($subjectProvisionalToken, $finalToken);
+        $this->assertNotSame($storageProvisionalToken, $finalToken);
+        $this->assertNotSame($subjectCommittedToken, $finalToken);
+    }
+
+    public function testReverseSyncRotatesBeforeItsFirstPivotMutation(): void
+    {
+        config()->set('permission.models.role', AssignmentTokenObservingRole::class);
+        $this->flushPermissionState();
+
+        $role = AssignmentTokenObservingRole::create(['name' => 'observed-sync-role']);
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $committedToken = $registrar->modelAssignmentCacheToken();
+        AssignmentTokenObservingPivot::$tokenAtCreation = null;
+
+        $role->syncModels($this->testUser);
+
+        $this->assertIsString(AssignmentTokenObservingPivot::$tokenAtCreation);
+        $this->assertNotSame($committedToken, AssignmentTokenObservingPivot::$tokenAtCreation);
+        $this->assertNotSame(
+            AssignmentTokenObservingPivot::$tokenAtCreation,
+            $registrar->modelAssignmentCacheToken(),
+        );
+    }
+
+    public function testTransactionalSoftDeleteCannotPublishARolledBackCatalog(): void
+    {
+        $listenerFoundRole = null;
+
+        EarlyDeletedListenerSoftRole::deleted(static function () use (&$listenerFoundRole): void {
+            $listenerFoundRole = app(PermissionRegistrar::class)
+                ->getRoles(['name' => 'soft-delete-role'])
+                ->isNotEmpty();
+        });
+
+        $this->setUpAliasedPermissionStorage();
+        config()->set('permission.models.role', EarlyDeletedListenerSoftRole::class);
+        $this->useSharedPermissionCache();
+        $role = EarlyDeletedListenerSoftRole::create(['name' => 'soft-delete-role']);
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $connection = $role->getConnection();
+
+        $connection->beginTransaction();
+
+        try {
+            $role->delete();
+        } finally {
+            $connection->rollBack();
+        }
+
+        $this->assertFalse($listenerFoundRole);
+
+        [$foundRoleId] = parallel([
+            fn (): mixed => EarlyDeletedListenerSoftRole::findByName('soft-delete-role')->getKey(),
+        ]);
+
+        $this->assertSame($role->getKey(), $foundRoleId);
+    }
+
+    public function testSameConnectionHardDeleteInvalidatesTheCatalogOnce(): void
+    {
+        $coordinator = new CountingPermissionCacheCoordinator;
+        $this->app->instance(ModelCacheCoordinator::class, $coordinator);
+        $this->app->forgetInstance(PermissionRegistrar::class);
+
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $coordinator->invalidationCount = 0;
+
+        $this->testUserRole->forceDelete();
+
+        $this->assertSame(1, $coordinator->invalidationCount);
+    }
+
+    public function testForwardAndReversePivotMutationsUsePermissionStorageConnection(): void
+    {
+        [$subjectConnection, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        [$user, $role] = $this->createAliasedPermissionFixtures();
+
+        $permissionConnection->beginTransaction();
+        $user->assignRole($role);
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $permissionConnection->rollBack();
+        $this->assertSame(0, $permissionConnection->table('model_has_roles')->count());
+
+        $permissionConnection->beginTransaction();
+        $role->users()->attach($user);
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $permissionConnection->rollBack();
+
+        $this->assertSame(0, $permissionConnection->table('model_has_roles')->count());
+        $this->assertSame(0, $subjectConnection->table('model_has_roles')->count());
+    }
+
+    public function testCustomPermissionPivotUsesPermissionStorageConnection(): void
+    {
+        $this->setUpAliasedPermissionStorage();
+        AliasedPermissionRolePivot::$createdOnConnection = null;
+        $user = AliasedCustomPivotPermissionUser::create(['email' => 'custom-pivot@example.com']);
+        $role = AliasedPermissionRole::create(['name' => 'custom-pivot-editor']);
+
+        $user->assignRole($role);
+
+        $this->assertSame(self::STORAGE_CONNECTION, AliasedPermissionRolePivot::$createdOnConnection);
+    }
+
+    public function testSubjectRollbackDoesNotDeleteCommittedPermissionAssignments(): void
+    {
+        [$subjectConnection, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        [$user, $role] = $this->createAliasedPermissionFixtures();
+        $user->assignRole($role);
+
+        $subjectConnection->beginTransaction();
+        $user->delete();
+
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+
+        $subjectConnection->rollBack();
+
+        $user = AliasedPermissionUser::findOrFail($user->getKey());
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+
+        $user->delete();
+
+        $this->assertSame(0, $permissionConnection->table('model_has_roles')->count());
+    }
+
+    public function testQueuedAssignmentsRemainAvailableAfterSubjectRollback(): void
+    {
+        [$subjectConnection, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        [, $role] = $this->createAliasedPermissionFixtures();
+        $user = new AliasedPermissionUser(['email' => 'queued@example.com']);
+        $user->assignRole($role);
+
+        $subjectConnection->beginTransaction();
+        $user->save();
+        $this->assertSame(0, $permissionConnection->table('model_has_roles')->count());
+        $subjectConnection->rollBack();
+
+        $this->assertSame(0, $permissionConnection->table('model_has_roles')->count());
+
+        $user->exists = false;
+        $user->setAttribute($user->getKeyName(), null);
+
+        $subjectConnection->transaction(fn (): bool => $user->save());
+
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $this->assertTrue($user->hasRole($role));
+    }
+
+    public function testVetoedStandaloneRoleDeletePreservesRecordAndAssignments(): void
+    {
+        [, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        [$user, $role] = $this->createAliasedPermissionFixtures();
+        $permission = AliasedPermission::create(['name' => 'publish']);
+        $user->assignRole($role);
+        $role->givePermissionTo($permission);
+
+        AliasedPermissionRole::deleting(static fn (): bool => false);
+
+        $this->assertFalse($role->delete());
+        $this->assertSame(0, $permissionConnection->transactionLevel());
+        $this->assertSame(1, $permissionConnection->table('roles')->where('id', $role->getKey())->count());
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $this->assertSame(1, $permissionConnection->table('role_has_permissions')->count());
+    }
+
+    public function testRoleAndPermissionModelWritesRequireTheSameConnectionName(): void
+    {
+        [, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        config()->set('permission.models.role', MismatchedConnectionRole::class);
+        $this->flushPermissionState();
+
+        $caught = null;
+
+        try {
+            MismatchedConnectionRole::create(['name' => 'editor']);
+        } catch (PermissionConnectionMismatch $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(PermissionConnectionMismatch::class, $caught);
+        $this->assertStringContainsString(self::SUBJECT_CONNECTION, $caught->getMessage());
+        $this->assertStringContainsString(self::STORAGE_CONNECTION, $caught->getMessage());
+        $this->assertSame(0, $permissionConnection->table('roles')->count());
+    }
+
+    public function testConnectionMismatchFailsBeforeDeleteSettlementRegistration(): void
+    {
+        [$subjectConnection, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        config()->set('permission.models.role', MismatchedConnectionRole::class);
+        $this->flushPermissionState();
+
+        $user = AliasedPermissionUser::create(['email' => 'subject@example.com']);
+        $roleId = $permissionConnection->table('roles')->insertGetId([
+            'name' => 'editor',
+            'guard_name' => 'web',
+        ]);
+        $role = MismatchedConnectionRole::findOrFail($roleId);
+        $user->assignRole($role);
+
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $catalogCacheKey = $registrar->getCacheKey();
+        $assignmentToken = $registrar->modelAssignmentCacheToken();
+        $caught = null;
+
+        $subjectConnection->transaction(function () use ($role, &$caught): void {
+            try {
+                $role->delete();
+            } catch (PermissionConnectionMismatch $exception) {
+                $caught = $exception;
+            }
+        });
+
+        $this->assertInstanceOf(PermissionConnectionMismatch::class, $caught);
+        $this->assertSame(1, $permissionConnection->table('roles')->where('id', $roleId)->count());
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $this->assertSame($assignmentToken, $registrar->modelAssignmentCacheToken());
+        $this->assertTrue($registrar->getCacheRepository()->has($catalogCacheKey));
+    }
+
+    public function testRolledBackDeleteSavepointDiscardsItsCacheSettlement(): void
+    {
+        [, $permissionConnection] = $this->setUpAliasedPermissionStorage();
+        [$user, $role] = $this->createAliasedPermissionFixtures();
+        $permission = AliasedPermission::create(['name' => 'publish']);
+        $user->assignRole($role);
+        $role->givePermissionTo($permission);
+
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $catalogCacheKey = $registrar->getCacheKey();
+        $assignmentToken = $registrar->modelAssignmentCacheToken();
+
+        $this->assertTrue($registrar->getCacheRepository()->has($catalogCacheKey));
+
+        $failure = new RuntimeException('Stop after permission cleanup.');
+        $caught = null;
+
+        AliasedPermissionRole::deleted(static function () use ($failure): never {
+            throw $failure;
+        });
+
+        $permissionConnection->transaction(function () use ($permissionConnection, $role, &$caught): void {
+            try {
+                $role->delete();
+            } catch (RuntimeException $exception) {
+                $caught = $exception;
+            }
+
+            $permissionConnection->table('roles')
+                ->where('id', $role->getKey())
+                ->update(['name' => 'editor-after-recovery']);
+        });
+
+        $this->assertSame($failure, $caught);
+        $this->assertSame(1, $permissionConnection->table('roles')->where('id', $role->getKey())->count());
+        $this->assertSame(1, $permissionConnection->table('model_has_roles')->count());
+        $this->assertSame(1, $permissionConnection->table('role_has_permissions')->count());
+        $this->assertSame($assignmentToken, $registrar->modelAssignmentCacheToken());
+        $this->assertTrue($registrar->getCacheRepository()->has($catalogCacheKey));
+    }
+
+    /**
+     * Set up two connection names backed by one permission database.
+     *
+     * @return array{Connection, Connection}
+     */
+    private function setUpAliasedPermissionStorage(): array
+    {
+        $databasePath = $this->temporaryDirectory . '/permissions.sqlite';
+        $this->filesystem->put($databasePath, '');
+        $connectionConfig = [
+            'driver' => 'sqlite',
+            'database' => $databasePath,
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ];
+
+        config()->set([
+            'database.connections.' . self::SUBJECT_CONNECTION => $connectionConfig,
+            'database.connections.' . self::STORAGE_CONNECTION => $connectionConfig,
+            'permission.models.permission' => AliasedPermission::class,
+            'permission.models.role' => AliasedPermissionRole::class,
+            'permission.models.default_model' => AliasedPermissionUser::class,
+            'auth.providers.users.model' => AliasedPermissionUser::class,
+            'cache.stores.permission_shared' => ['driver' => 'worker-array'],
+            'permission.cache.store' => 'permission_shared',
+        ]);
+
+        /** @var DatabaseManager $databaseManager */
+        $databaseManager = $this->app->make('db');
+        $subjectConnection = $databaseManager->connection(self::SUBJECT_CONNECTION);
+        $permissionConnection = $databaseManager->connection(self::STORAGE_CONNECTION);
+        $transactionManager = new DatabaseTransactionsManager;
+        $subjectConnection->setTransactionManager($transactionManager);
+        $permissionConnection->setTransactionManager($transactionManager);
+
+        $this->createAliasedPermissionSchema($permissionConnection);
+
+        $this->flushPermissionState();
+
+        return [$subjectConnection, $permissionConnection];
+    }
+
+    /**
+     * Configure a worker-shared cache for transaction visibility assertions.
+     */
+    private function useSharedPermissionCache(): void
+    {
+        config()->set([
+            'cache.stores.permission_shared' => ['driver' => 'worker-array'],
+            'permission.cache.store' => 'permission_shared',
+        ]);
+        $this->flushPermissionState();
+    }
+
+    /**
+     * Build an exact role-assignment cache key for an explicit token.
+     */
+    private function roleAssignmentCacheKey(
+        User $user,
+        string $token,
+    ): string {
+        return implode(':', [
+            config()->string('permission.cache.keys.model_roles'),
+            PermissionPartition::encodeCacheSegment($token),
+            PermissionPartition::encodeCacheSegment($user->getMorphClass()),
+            PermissionPartition::encodeCacheSegment((string) $user->getKey()),
+            PermissionPartition::encodeCacheSegment(null),
+        ]);
+    }
+
+    /**
+     * Create the permission schema through its authoritative connection.
+     */
+    private function createAliasedPermissionSchema(Connection $connection): void
+    {
+        $schema = $connection->getSchemaBuilder();
+
+        $schema->create('users', static function (Blueprint $table): void {
+            $table->id();
+            $table->string('email');
+        });
+        $schema->create('permissions', static function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+            $table->unique(['name', 'guard_name']);
+        });
+        $schema->create('roles', static function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+            $table->softDeletes();
+            $table->unique(['name', 'guard_name']);
+        });
+        $schema->create('model_has_permissions', static function (Blueprint $table): void {
+            $table->unsignedBigInteger('permission_test_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_test_id');
+            $table->boolean('is_denied')->default(false);
+            $table->primary(['permission_test_id', 'model_test_id', 'model_type']);
+        });
+        $schema->create('model_has_roles', static function (Blueprint $table): void {
+            $table->unsignedBigInteger('role_test_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_test_id');
+            $table->primary(['role_test_id', 'model_test_id', 'model_type']);
+        });
+        $schema->create('role_has_permissions', static function (Blueprint $table): void {
+            $table->unsignedBigInteger('permission_test_id');
+            $table->unsignedBigInteger('role_test_id');
+            $table->boolean('is_denied')->default(false);
+            $table->primary(['permission_test_id', 'role_test_id']);
+        });
+    }
+
+    /**
+     * Create one subject and role on the aliased permission database.
+     *
+     * @return array{AliasedPermissionUser, AliasedPermissionRole}
+     */
+    private function createAliasedPermissionFixtures(): array
+    {
+        return [
+            AliasedPermissionUser::create(['email' => 'subject@example.com']),
+            AliasedPermissionRole::create(['name' => 'editor']),
+        ];
+    }
+}
+
+class AliasedPermissionUser extends UserWithoutHasRoles
+{
+    use HasRoles;
+
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::SUBJECT_CONNECTION;
+}
+
+class AliasedPermissionRole extends Role
+{
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::STORAGE_CONNECTION;
+}
+
+class MismatchedConnectionRole extends Role
+{
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::SUBJECT_CONNECTION;
+}
+
+class EarlyDeletedListenerRole extends Role
+{
+}
+
+class EarlyDeletedListenerSoftRole extends Role
+{
+    use SoftDeletes;
+
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::STORAGE_CONNECTION;
+}
+
+class AliasedPermission extends Permission
+{
+    protected UnitEnum|string|null $connection = PermissionCacheTransactionTest::STORAGE_CONNECTION;
+}
+
+class DynamicAliasedPermission extends Permission
+{
+}
+
+class AssignmentTokenObservingRole extends Role
+{
+    /**
+     * Build a reverse assignment relation with an observing pivot.
+     */
+    protected function relationForModel(
+        string $modelClass,
+        ?PermissionRelationContext $context = null,
+    ): MorphToMany {
+        return parent::relationForModel($modelClass, $context)
+            ->using(AssignmentTokenObservingPivot::class);
+    }
+}
+
+class AssignmentTokenObservingPivot extends MorphPivot
+{
+    public static ?string $tokenAtCreation = null;
+
+    /**
+     * Boot the observing pivot model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::created(function (): void {
+            static::$tokenAtCreation = app(PermissionRegistrar::class)->modelAssignmentCacheToken();
+        });
+    }
+}
+
+class CountingPermissionCacheCoordinator extends ModelCacheCoordinator
+{
+    public int $invalidationCount = 0;
+
+    /**
+     * Count an exact cache invalidation.
+     */
+    public function invalidate(CacheRepository $cache, string $key): bool
+    {
+        ++$this->invalidationCount;
+
+        return parent::invalidate($cache, $key);
+    }
+}
+
+class AliasedCustomPivotPermissionUser extends AliasedPermissionUser
+{
+    protected string $guard_name = 'web';
+
+    /**
+     * Get the model's assigned roles.
+     */
+    public function roles(): BelongsToMany
+    {
+        return parent::roles()->using(AliasedPermissionRolePivot::class);
+    }
+}
+
+class AliasedPermissionRolePivot extends MorphPivot
+{
+    public static ?string $createdOnConnection = null;
+
+    /**
+     * Boot the custom pivot model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::created(function (self $pivot): void {
+            static::$createdOnConnection = $pivot->getConnectionName();
+        });
+    }
+}

--- a/tests/Permission/PermissionCacheTransactionTest.php
+++ b/tests/Permission/PermissionCacheTransactionTest.php
@@ -151,6 +151,113 @@ class PermissionCacheTransactionTest extends TestCase
         $this->assertSame($this->testUserRole->getKey(), Role::findByName('testRole')->getKey());
     }
 
+    public function testExplicitResetSettlesAfterCommit(): void
+    {
+        $this->useSharedPermissionCache();
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $cache = $registrar->getCacheRepository();
+        $catalogCacheKey = $registrar->getCacheKey();
+        $tokenCacheKey = config()->string('permission.cache.keys.model_token');
+        $catalogPayload = $cache->get($catalogCacheKey);
+        $assignmentToken = $registrar->modelAssignmentCacheToken();
+
+        $this->assertTrue($cache->has($catalogCacheKey));
+        $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+
+        $this->testUserRole->getConnection()->transaction(function () use (
+            $assignmentToken,
+            $cache,
+            $catalogCacheKey,
+            $catalogPayload,
+            $registrar,
+            $tokenCacheKey,
+        ): void {
+            $this->assertTrue($registrar->forgetCachedPermissions());
+            $this->assertSame($catalogPayload, $cache->get($catalogCacheKey));
+            $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+        });
+
+        $this->assertFalse($cache->has($catalogCacheKey));
+        $this->assertNotSame($assignmentToken, $cache->get($tokenCacheKey));
+    }
+
+    public function testExplicitResetIsDiscardedOnRollback(): void
+    {
+        $this->useSharedPermissionCache();
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $cache = $registrar->getCacheRepository();
+        $catalogCacheKey = $registrar->getCacheKey();
+        $tokenCacheKey = config()->string('permission.cache.keys.model_token');
+        $catalogPayload = $cache->get($catalogCacheKey);
+        $assignmentToken = $registrar->modelAssignmentCacheToken();
+        $connection = $this->testUserRole->getConnection();
+        $rolesTable = config()->string('permission.table_names.roles');
+
+        $this->assertTrue($cache->has($catalogCacheKey));
+        $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+
+        $connection->beginTransaction();
+
+        try {
+            $connection->table($rolesTable)->insert([
+                'name' => 'uncommitted-reset-role',
+                'guard_name' => 'web',
+            ]);
+            $this->assertTrue($registrar->forgetCachedPermissions());
+            $this->assertTrue($registrar->getRoles()->contains('name', 'uncommitted-reset-role'));
+            $this->assertSame($catalogPayload, $cache->get($catalogCacheKey));
+            $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+        } finally {
+            $connection->rollBack();
+        }
+
+        $this->assertSame(0, $connection->table($rolesTable)->where('name', 'uncommitted-reset-role')->count());
+        $this->assertSame($catalogPayload, $cache->get($catalogCacheKey));
+        $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+    }
+
+    public function testExplicitResetInRolledBackSavepointDoesNotSettleWithOuterCommit(): void
+    {
+        $this->useSharedPermissionCache();
+        $registrar = $this->app->make(PermissionRegistrar::class);
+        $registrar->getRoles();
+        $cache = $registrar->getCacheRepository();
+        $catalogCacheKey = $registrar->getCacheKey();
+        $tokenCacheKey = config()->string('permission.cache.keys.model_token');
+        $catalogPayload = $cache->get($catalogCacheKey);
+        $assignmentToken = $registrar->modelAssignmentCacheToken();
+        $connection = $this->testUserRole->getConnection();
+
+        $this->assertTrue($cache->has($catalogCacheKey));
+        $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+
+        $connection->transaction(function () use (
+            $assignmentToken,
+            $cache,
+            $catalogCacheKey,
+            $catalogPayload,
+            $connection,
+            $registrar,
+            $tokenCacheKey,
+        ): void {
+            $connection->beginTransaction();
+
+            try {
+                $this->assertTrue($registrar->forgetCachedPermissions());
+            } finally {
+                $connection->rollBack();
+            }
+
+            $this->assertSame($catalogPayload, $cache->get($catalogCacheKey));
+            $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+        });
+
+        $this->assertSame($catalogPayload, $cache->get($catalogCacheKey));
+        $this->assertSame($assignmentToken, $cache->get($tokenCacheKey));
+    }
+
     public function testRolledBackReverseSyncCannotPublishAssignmentsUnderTheCommittedToken(): void
     {
         $this->useSharedPermissionCache();

--- a/tests/Permission/TestCase.php
+++ b/tests/Permission/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Permission;
 
 use Hypervel\Auth\EloquentUserProvider;
+use Hypervel\Cache\CacheManager;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Schema\Blueprint;
@@ -353,8 +354,14 @@ abstract class TestCase extends TestbenchTestCase
     protected function flushPermissionState(): void
     {
         Guard::flushState();
-        $this->app->make('cache')->store('array')->clear();
+        $cacheStore = config()->string('permission.cache.store', 'default');
+
+        $this->app->make(CacheManager::class)
+            ->memo($cacheStore === 'default' ? null : $cacheStore)
+            ->clear();
         $this->app->forgetInstance(PermissionRegistrar::class);
+
+        // The store flush does not clear registrar runtime memos held in CoroutineContext.
         $this->app->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 

--- a/tests/Permission/Traits/HasPermissionsWithCustomModelsTest.php
+++ b/tests/Permission/Traits/HasPermissionsWithCustomModelsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Permission\Traits;
 
+use Hypervel\Permission\Models\Permission as BasePermission;
 use Hypervel\Permission\PermissionRegistrar;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Support\Facades\DB;
@@ -29,6 +30,31 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     public function testItCanUseCustomModelPermission(): void
     {
         $this->assertSame(Permission::class, $this->testUserPermission::class);
+    }
+
+    public function testBasePermissionRequestsReuseTheConfiguredCustomCatalogAndPrimaryKey(): void
+    {
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->getPermissions();
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $indexed = $registrar->getPermissions(
+            ['id' => $this->testUserPermission->getKey()],
+            true,
+            BasePermission::class,
+        )->sole();
+        $fallback = $registrar->getPermissions(
+            ['id' => $this->testUserPermission->getKey(), 'name' => $this->testUserPermission->name],
+            true,
+            BasePermission::class,
+        )->sole();
+        $found = BasePermission::findById($this->testUserPermission->getKey());
+
+        $this->assertInstanceOf(Permission::class, $indexed);
+        $this->assertTrue($indexed->is($fallback));
+        $this->assertTrue($indexed->is($found));
+        $this->assertSame([], DB::getQueryLog());
     }
 
     public function testFindOrCreateRestoresSoftDeletedPermission(): void
@@ -108,6 +134,8 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     public function testItDoesNotDetachUsersWhenSoftDeleting(): void
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
+        $registrar = app(PermissionRegistrar::class);
+        $token = $registrar->modelAssignmentCacheToken();
 
         DB::enableQueryLog();
         $this->testUserPermission->delete();
@@ -123,6 +151,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
                 ->where('permission_test_id', $permission->getKey())
                 ->count(),
         );
+        $this->assertSame($token, $registrar->modelAssignmentCacheToken());
     }
 
     public function testItDoesDetachRolesAndUsersWhenForceDeleting(): void
@@ -130,6 +159,8 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
         $permissionId = $this->testUserPermission->getKey();
         $this->testUserRole->givePermissionTo($permissionId);
         $this->testUser->givePermissionTo($permissionId);
+        $registrar = app(PermissionRegistrar::class);
+        $token = $registrar->modelAssignmentCacheToken();
 
         DB::enableQueryLog();
         $this->testUserPermission->forceDelete();
@@ -150,6 +181,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
                 ->where('permission_test_id', $permissionId)
                 ->count(),
         );
+        $this->assertNotSame($token, $registrar->modelAssignmentCacheToken());
     }
 
     public function testItTouchesWhenAssigningNewPermissions(): void

--- a/tests/Permission/Traits/HasRolesWithCustomModelsTest.php
+++ b/tests/Permission/Traits/HasRolesWithCustomModelsTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Permission\Traits;
 
+use Hypervel\Permission\Models\Role as BaseRole;
+use Hypervel\Permission\PermissionRegistrar;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Support\Facades\DB;
 use Hypervel\Tests\Permission\Fixtures\Models\Admin;
+use Hypervel\Tests\Permission\Fixtures\Models\Permission;
 use Hypervel\Tests\Permission\Fixtures\Models\Role;
 
 class HasRolesWithCustomModelsTest extends HasRolesTest
@@ -21,6 +24,58 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     public function testItCanUseCustomModelRole(): void
     {
         $this->assertSame(Role::class, $this->testUserRole::class);
+    }
+
+    public function testBaseRoleRequestsReuseTheConfiguredCustomCatalogAndPrimaryKey(): void
+    {
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->getRoles();
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $indexed = $registrar->getRoles(
+            ['id' => $this->testUserRole->getKey()],
+            true,
+            BaseRole::class,
+        )->sole();
+        $fallback = $registrar->getRoles(
+            ['id' => $this->testUserRole->getKey(), 'name' => $this->testUserRole->name],
+            true,
+            BaseRole::class,
+        )->sole();
+        $found = BaseRole::findById($this->testUserRole->getKey());
+
+        $this->assertInstanceOf(Role::class, $indexed);
+        $this->assertTrue($indexed->is($fallback));
+        $this->assertTrue($indexed->is($found));
+        $this->assertSame([], DB::getQueryLog());
+    }
+
+    public function testWarmRoleChecksDoNotConstructPermissionModelsForCacheIdentity(): void
+    {
+        config()->set('permission.models.permission', ConstructionCountingPermission::class);
+        $this->flushPermissionState();
+
+        $this->testUser->hasRole('testRole');
+        ConstructionCountingPermission::$constructionCount = 0;
+
+        $this->testUser->hasRole('testRole');
+        $this->testUser->hasRole('testRole');
+
+        $this->assertSame(0, ConstructionCountingPermission::$constructionCount);
+    }
+
+    public function testCleanAssignmentTokenReadsDoNotConstructPermissionModelsForCacheIdentity(): void
+    {
+        config()->set('permission.models.permission', ConstructionCountingPermission::class);
+        $this->flushPermissionState();
+        ConstructionCountingPermission::$constructionCount = 0;
+
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->modelAssignmentCacheToken();
+        $registrar->modelAssignmentCacheToken();
+
+        $this->assertSame(0, ConstructionCountingPermission::$constructionCount);
     }
 
     public function testFindOrCreateRestoresSoftDeletedRole(): void
@@ -65,6 +120,8 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     public function testItDoesNotDetachUsersWhenSoftDeleting(): void
     {
         $this->testUser->assignRole($this->testUserRole);
+        $registrar = app(PermissionRegistrar::class);
+        $token = $registrar->modelAssignmentCacheToken();
 
         DB::enableQueryLog();
         $this->testUserRole->delete();
@@ -80,6 +137,7 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
                 ->where('role_test_id', $role->getKey())
                 ->count(),
         );
+        $this->assertSame($token, $registrar->modelAssignmentCacheToken());
     }
 
     public function testItDoesDetachPermissionsAndUsersWhenForceDeleting(): void
@@ -87,6 +145,8 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
         $roleId = $this->testUserRole->getKey();
         $this->testUserPermission->assignRole($roleId);
         $this->testUser->assignRole($roleId);
+        $registrar = app(PermissionRegistrar::class);
+        $token = $registrar->modelAssignmentCacheToken();
 
         DB::enableQueryLog();
         $this->testUserRole->forceDelete();
@@ -107,6 +167,7 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
                 ->where('role_test_id', $roleId)
                 ->count(),
         );
+        $this->assertNotSame($token, $registrar->modelAssignmentCacheToken());
     }
 
     public function testItTouchesWhenAssigningNewRoles(): void
@@ -126,5 +187,17 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
 
         $this->assertSame('2021-07-20 19:13:14', $role1->refresh()->updated_at->format('Y-m-d H:i:s'));
         $this->assertSame('2021-07-20 19:13:14', $role2->refresh()->updated_at->format('Y-m-d H:i:s'));
+    }
+}
+
+class ConstructionCountingPermission extends Permission
+{
+    public static int $constructionCount = 0;
+
+    public function __construct(array $attributes = [])
+    {
+        ++static::$constructionCount;
+
+        parent::__construct($attributes);
     }
 }

--- a/tests/Permission/Traits/TeamHasAssignedModelsTest.php
+++ b/tests/Permission/Traits/TeamHasAssignedModelsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Permission\Traits;
 
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Permission\Exceptions\TeamNotSelected;
 use Hypervel\Permission\PermissionRegistrar;
 use Hypervel\Permission\Support\Config;
 use Hypervel\Support\Facades\DB;
@@ -134,6 +135,20 @@ class TeamHasAssignedModelsTest extends HasAssignedModelsTest
 
         setPermissionsTeamId(2);
         $this->assertTrue($user->fresh()->hasRole($this->testUserRole));
+    }
+
+    public function testReverseModelMutationsRequireASelectedTeam(): void
+    {
+        setPermissionsTeamId(null);
+
+        foreach (['assignToModels', 'removeFromModels', 'syncModels'] as $method) {
+            try {
+                $this->testUserRole->{$method}([]);
+                $this->fail('Expected the teamless reverse mutation to be rejected.');
+            } catch (TeamNotSelected $exception) {
+                $this->assertStringContainsString('current team', $exception->getMessage());
+            }
+        }
     }
 
     private function roleAssignmentsFor(User $user): int

--- a/tests/Permission/Traits/TeamHasPermissionsTest.php
+++ b/tests/Permission/Traits/TeamHasPermissionsTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Permission\Traits;
 
+use Closure;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\MorphPivot;
 use Hypervel\Permission\Events\PermissionAttachedEvent;
 use Hypervel\Permission\Events\PermissionDetachedEvent;
+use Hypervel\Permission\Exceptions\TeamNotSelected;
 use Hypervel\Permission\PermissionRegistrar;
 use Hypervel\Permission\Support\Config;
 use Hypervel\Support\ClassInvoker;
@@ -108,6 +110,22 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         $this->assertTrue($this->testUser->hasPermissionTo($this->testUserPermission));
         $this->testUser->getAllPermissions();
         $this->assertSame([], DB::getQueryLog());
+    }
+
+    public function testDirectPermissionHydrationMemoIsSeparatedByTeam(): void
+    {
+        setPermissionsTeamId(1);
+        $this->testUser->givePermissionTo($this->testUserPermission);
+        $teamOne = $this->testUser->getDirectPermissions()->sole();
+        $this->assertSame($teamOne, $this->testUser->getDirectPermissions()->sole());
+
+        setPermissionsTeamId(2);
+        $this->testUser->givePermissionTo($this->testUserPermission);
+        $teamTwo = $this->testUser->getDirectPermissions()->sole();
+        $this->assertNotSame($teamOne, $teamTwo);
+
+        setPermissionsTeamId(1);
+        $this->assertSame($teamOne, $this->testUser->getDirectPermissions()->sole());
     }
 
     public function testItCanSyncOrRemovePermissionsWithoutDetachingDifferentTeams(): void
@@ -389,6 +407,45 @@ class TeamHasPermissionsTest extends HasPermissionsTest
             $this->testUser,
             $this->testUserPermission,
         );
+    }
+
+    public function testPermissionMutationsRequireASelectedTeam(): void
+    {
+        setPermissionsTeamId(null);
+        $unsavedUser = new User(['email' => 'teamless-queued-permission@example.com']);
+
+        $this->assertTeamNotSelected(fn () => $this->testUser->givePermissionTo('edit-articles'));
+        $this->assertTeamNotSelected(fn () => $this->testUser->denyPermissionTo('edit-articles'));
+        $this->assertTeamNotSelected(fn () => $this->testUser->revokePermissionTo('edit-articles'));
+        $this->assertTeamNotSelected(fn () => $this->testUser->syncPermissions());
+        $this->assertTeamNotSelected(fn () => $this->testUser->syncPermissionEffects());
+        $this->assertTeamNotSelected(fn () => $unsavedUser->givePermissionTo('edit-articles'));
+    }
+
+    public function testDirectPermissionRelationWritesRequireASelectedTeam(): void
+    {
+        setPermissionsTeamId(null);
+        $relation = $this->testUser->permissions();
+        $permissionId = $this->testUserPermission->getKey();
+
+        $this->assertTeamNotSelected(fn () => $relation->attach($permissionId));
+        $this->assertTeamNotSelected(fn () => $relation->detach($permissionId));
+        $this->assertTeamNotSelected(fn () => $relation->toggle($permissionId));
+        $this->assertTeamNotSelected(fn () => $relation->sync([$permissionId]));
+        $this->assertTeamNotSelected(fn () => $relation->updateExistingPivot($permissionId, []));
+    }
+
+    /**
+     * Assert a team-scoped mutation rejects missing team context.
+     */
+    private function assertTeamNotSelected(Closure $mutation): void
+    {
+        try {
+            $mutation();
+            $this->fail('Expected the teamless mutation to be rejected.');
+        } catch (TeamNotSelected $exception) {
+            $this->assertStringContainsString('current team', $exception->getMessage());
+        }
     }
 
     /**

--- a/tests/Permission/Traits/TeamHasRolesTest.php
+++ b/tests/Permission/Traits/TeamHasRolesTest.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Permission\Traits;
 
+use BadMethodCallException;
+use Closure;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Database\Eloquent\Model;
 use Hypervel\Permission\Contracts\Role;
 use Hypervel\Permission\Exceptions\RoleDoesNotExist;
+use Hypervel\Permission\Exceptions\TeamNotSelected;
 use Hypervel\Permission\PermissionRegistrar;
 use Hypervel\Permission\Support\Config;
+use Hypervel\Permission\Traits\HasPermissions;
 use Hypervel\Support\Facades\DB;
 use Hypervel\Tests\Permission\Fixtures\Models\User;
+use UnitEnum;
 
 class TeamHasRolesTest extends HasRolesTest
 {
@@ -149,6 +155,76 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertTrue($matches->first()->is(app(Role::class)::findByName('shared-role')));
     }
 
+    public function testFallbackRoleLookupFiltersTeamsBeforeSelectingOneResult(): void
+    {
+        DB::table(Config::rolesTable())->insert([
+            [
+                'name' => 'fallback-role',
+                'guard_name' => 'web',
+                'team_test_id' => 2,
+            ],
+            [
+                'name' => 'fallback-role',
+                'guard_name' => 'web',
+                'team_test_id' => 1,
+            ],
+            [
+                'name' => 'fallback-role',
+                'guard_name' => 'web',
+                'team_test_id' => null,
+            ],
+        ]);
+        $registrar = app(PermissionRegistrar::class);
+
+        setPermissionsTeamId(1);
+        $teamRole = $registrar->getRoles([
+            'name' => 'fallback-role',
+            'guard_name' => 'web',
+            'team_test_id' => [2, 1],
+        ], true)->sole();
+        $this->assertSame(1, $teamRole->team_test_id);
+
+        setPermissionsTeamId(null);
+        $globalRole = $registrar->getRoles([
+            'name' => 'fallback-role',
+            'guard_name' => 'web',
+            'team_test_id' => [2, null],
+        ], true)->sole();
+        $this->assertNull($globalRole->team_test_id);
+    }
+
+    public function testIncompatibleRoleCatalogIsTeamFilteredAndLoadedOncePerCoroutine(): void
+    {
+        DB::table(Config::rolesTable())->insert([
+            [
+                'name' => 'standalone-role',
+                'guard_name' => 'web',
+                'team_test_id' => 2,
+            ],
+            [
+                'name' => 'standalone-role',
+                'guard_name' => 'web',
+                'team_test_id' => 1,
+            ],
+        ]);
+        setPermissionsTeamId(1);
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $registrar = app(PermissionRegistrar::class);
+        $parameters = [
+            'name' => 'standalone-role',
+            'guard_name' => 'web',
+            'team_test_id' => [2, 1],
+        ];
+        $first = $registrar->getRoles($parameters, true, TeamFallbackRole::class)->sole();
+        $second = $registrar->getRoles($parameters, true, TeamFallbackRole::class)->sole();
+
+        $this->assertSame(1, $first->team_test_id);
+        $this->assertTrue($first->is($second));
+        $this->assertCount(1, DB::getQueryLog());
+    }
+
     public function testRoleFindOrCreateCreatesCurrentTeamRoleWhenOnlyAnotherTeamHasSameName(): void
     {
         app(Role::class)->create(['name' => 'team-find-or-create', 'team_test_id' => 2]);
@@ -229,5 +305,66 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertCount(1, User::role($this->testUserRole)->get());
         $this->assertCount(0, User::role('testRole2')->get());
         $this->assertCount(1, User::withoutRole('testRole')->get());
+    }
+
+    public function testRoleMutationsRequireASelectedTeam(): void
+    {
+        setPermissionsTeamId(null);
+        $unsavedUser = new User(['email' => 'teamless-queued-role@example.com']);
+
+        $this->assertTeamNotSelected(fn () => $this->testUser->assignRole('testRole'));
+        $this->assertTeamNotSelected(fn () => $this->testUser->removeRole('testRole'));
+        $this->assertTeamNotSelected(fn () => $this->testUser->syncRoles());
+        $this->assertTeamNotSelected(fn () => $unsavedUser->assignRole('testRole'));
+    }
+
+    public function testDirectRoleRelationWritesRequireASelectedTeam(): void
+    {
+        setPermissionsTeamId(null);
+        $relation = $this->testUser->roles();
+        $roleId = $this->testUserRole->getKey();
+
+        $this->assertTeamNotSelected(fn () => $relation->attach($roleId));
+        $this->assertTeamNotSelected(fn () => $relation->detach($roleId));
+        $this->assertTeamNotSelected(fn () => $relation->toggle($roleId));
+        $this->assertTeamNotSelected(fn () => $relation->sync([$roleId]));
+        $this->assertTeamNotSelected(fn () => $relation->updateExistingPivot($roleId, []));
+    }
+
+    /**
+     * Assert a team-scoped mutation rejects missing team context.
+     */
+    private function assertTeamNotSelected(Closure $mutation): void
+    {
+        try {
+            $mutation();
+            $this->fail('Expected the teamless mutation to be rejected.');
+        } catch (TeamNotSelected $exception) {
+            $this->assertStringContainsString('current team', $exception->getMessage());
+        }
+    }
+}
+
+class TeamFallbackRole extends Model implements Role
+{
+    use HasPermissions;
+
+    protected array $guarded = [];
+
+    protected ?string $table = 'roles';
+
+    public static function findByName(UnitEnum|string $name, ?string $guardName): self
+    {
+        throw new BadMethodCallException;
+    }
+
+    public static function findById(int|string $id, ?string $guardName): self
+    {
+        throw new BadMethodCallException;
+    }
+
+    public static function findOrCreate(UnitEnum|string $name, ?string $guardName): self
+    {
+        throw new BadMethodCallException;
     }
 }

--- a/tests/Permission/WildcardPermissionTest.php
+++ b/tests/Permission/WildcardPermissionTest.php
@@ -95,7 +95,7 @@ class WildcardPermissionTest extends TestCase
             ->where(Config::morphKey(), $this->testUser->getKey())
             ->where('model_type', $this->testUser->getMorphClass())
             ->delete();
-        $registrar->bumpModelAssignmentCacheToken();
+        $registrar->rotateModelAssignmentCacheTokenAfterMutation(null);
 
         $this->assertFalse($this->testUser->hasPermissionTo('posts.create'));
     }


### PR DESCRIPTION
## Summary

This PR fixes permission cache publication and invalidation around database transactions. It also makes pivot writes use their real connection owner, narrows invalidation, and removes repeated permission hydration.

The existing cache invalidation path forgot shared entries as soon as a mutation started. A read inside the transaction could then publish uncommitted grants or revocations. If the transaction rolled back, that value remained shared until its TTL expired. A concurrent cold fill could also publish stale committed state after a newer mutation committed.

## What changed

### Transaction-safe permission caching

- Coordinate cold fills and committed invalidation with the same exact-key lock.
- Keep cache hits lock-free. Store topology and lock capability are checked only on a cold fill or invalidation.
- Keep uncommitted catalog and assignment values in coroutine-local state instead of publishing them.
- Invalidate shared entries after commit. Rollback only discards the transaction-local view.
- Use provisional assignment namespaces for bulk replacement and hard deletion, where exact invalidation cannot safely cover every affected subject or restore a value omitted by a rolled-back read.
- Ensure every committed assignment token points at a fresh namespace, so cache completion order cannot restore older data.

### Connection ownership

- Make pivot statements, pivot models, and transactional relation wrappers use the connection that owns the pivot write.
- Route permission tables, pivots, package transactions, and cache settlement through the configured Permission model connection.
- Require configured Role and Permission models to resolve to the same connection name. Subject models may still use another connection.
- Defer subject cleanup until its transaction commits when subject and permission storage use different connections.

### Narrower and faster invalidation

- Keep catalog-only changes from rotating the partition-wide assignment token.
- Invalidate exact subject keys for targeted assignment mutations.
- Rotate the assignment namespace only for bulk `syncModels()`, hard or force deletion, and explicit full cache resets.
- Memoize hydrated direct permissions for one coroutine and reuse the configured catalog for compatible custom model classes.
- Keep indexed team lookups on their existing constant-time path while applying the same team boundary to fallback paths.

### Write validation

- Fail before database work when a team-scoped write has no selected team.
- Fail before Role or Permission persistence when their configured connection names do not match.
- Preserve null-team read behavior and global roles.

The existing Spatie-style method signatures, named arguments, and relation APIs remain intact. The new failures replace invalid configurations or writes that previously produced database errors, cross-team ambiguity, or incorrect cache settlement.

## Cache store requirements

Coordinated permission caching requires one backend that owns both values and refreshable locks. Memoized repositories are unwrapped for this validation. Stack and failover stores are rejected because their value and lock operations do not share one reliable coherence boundary.

## Tests

Coverage includes:

- commit, rollback, nested savepoints, repeated mutations, and concurrent stale fills;
- provisional assignment namespaces across bulk synchronization and deletion;
- independent connection settlement and PostgreSQL transaction behavior;
- default and custom pivot connection ownership;
- exact versus partition-wide invalidation;
- custom Role and Permission models and primary keys;
- team filtering and every supported team-scoped mutation family;
- deletion vetoes, cleanup failures, queued assignments, and cross-connection subjects;
- lock-free cache hits and invalid cache-store topologies.

`composer fix` is green, including formatting, static analysis, the parallel test suite, and Testbench checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction-aware permission and role caching across commits, rollbacks, teams, and concurrent operations.
  * Added support for dedicated permission database connections and custom catalogs.
  * Added validation requiring a selected team before team-scoped changes.
  * Improved compatibility with custom role, permission, and pivot models.

* **Bug Fixes**
  * Corrected pivot operations and cleanup across separate database connections.
  * Improved cache invalidation after assignments, deletions, and permission updates.

* **Documentation**
  * Expanded guidance for connections, teams, caching, deletion behavior, performance, and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->