### PR TITLE
Fix framework lifecycle and result handling

### DIFF
--- a/docs/plans/2026-08-29-0533-components-framework-correctness-fixes.md
+++ b/docs/plans/2026-08-29-0533-components-framework-correctness-fixes.md
@@ -125,7 +125,7 @@ Add a no-throw `Call::__destruct()` that invokes this resource-only path. It mus
 - Abandoning an incomplete state releases buffers and the native resource once without publishing a terminal result.
 - Dropping an unfinished call invokes abandonment once.
 - Dropping a completed call performs no abandonment work.
-- Real client-streaming and bidirectional integration tests prove that dropping an unfinished call releases the connection for subsequent work.
+- Real client-streaming and bidirectional tests against the grpc-go interoperability server prove that dropping an unfinished call releases the connection for subsequent work. Hypervel's server exposes only unary and server-streaming routes.
 
 ## Support error fidelity
 

--- a/docs/plans/2026-08-29-0533-components-framework-correctness-fixes.md
+++ b/docs/plans/2026-08-29-0533-components-framework-correctness-fixes.md
@@ -1,0 +1,186 @@
+# Framework Correctness Fixes
+
+## Goal
+
+Fix a set of verified framework defects in cache, queue, console, gRPC, Sentry, and support code. Each correction stands on its own, preserves Laravel-shaped public APIs where they remain correct, and uses the smallest owning boundary. The changes must not add general observer machinery, compatibility shims, or unrelated coroutine-cancellation handling.
+
+## Design rules
+
+- Preserve existing Laravel APIs unless the verified defect is in the API contract itself.
+- Fix each defect at the lowest framework boundary that owns the behavior.
+- Keep hot paths unchanged except for the direct branch or return-value handling needed by the fix.
+- Preserve exact `Swoole\Coroutine\CanceledException` only where a new exhaustive catch would otherwise turn cancellation into ordinary cleanup work. Do not widen this into a framework-wide cancellation audit.
+- Preserve the first ordinary failure when cleanup must continue, while attempting all independently required cleanup.
+- Add focused regression tests for every changed behavior. Do not add test-only production APIs or speculative edge-case machinery.
+- Document only public behavior developers need to know.
+
+## Cache tag flush results
+
+`TagSet::reset()` and `flush()` return `bool` so tagged repositories can report the backing store's real outcome instead of unconditional success. Update `VersionedTagSet`, Redis `AllTagSet` and `AnyTagSet`, and `StackTagSet` accordingly.
+
+The multi-item tag sets must:
+
+- attempt every remaining tag or stack layer after a `false` result;
+- return `false` when any operation returns `false`;
+- retain the first ordinary exception, continue the independent remaining operations, then rethrow it;
+- stop immediately and preserve the exact cancellation instance.
+
+Keep this shared iteration rule on `TagSet`; it has several real consumers and avoids divergent implementations. Bulk flushes continue to dispatch through the per-tag `flushTag()` extension point, and Redis all-mode reset dispatches through `resetTag()`. These methods keep their Laravel-shaped string results; a missing delete target is an idempotent success, while backend failures throw. `VersionedTagSet::resetTag()` still returns the generated identifier even when a null store rejects persistence, matching its existing public contract, so bulk reset uses the protected `writeTagId()` extension point instead.
+
+`TaggedCache::flush()` returns the tag-set result, emits `CacheFlushed` only for success, and emits the existing `CacheFlushFailed` event for a false result. A thrown tag-set failure continues to escape normally.
+
+Update cache documentation for truthful tagged-flush results, including the null driver. Add one concise porting note because Laravel subclasses that retain `void` return types are not signature-compatible with Hypervel.
+
+### Tests
+
+- Every tag-set family reports its backing operation's result correctly.
+- Empty and repeated tagged flushes succeed and emit success events.
+- Multi-tag and stack implementations attempt later entries after false and ordinary failure, preserve the first ordinary exception, and stop on exact cancellation.
+- Tagged cache emits the matching success or failure event and returns the exact boolean.
+- Null-store tagged flush returns false while tagged reads remain misses.
+
+## Cache failover history
+
+`FailoverStore` currently replaces its consecutive-failure snapshot in `finally`, even when a `CacheFailedOver` listener interrupts an attempt. That can falsely mark unattempted stores as recovered and cause duplicate failure events on the next request.
+
+When listener dispatch interrupts either failover loop, retain:
+
+- failures observed during the current attempt; and
+- previous failures for stores the current attempt did not reach.
+
+Do not claim recovery for an unattempted store and do not duplicate a failure just observed. A normally completed operation still replaces the history with its fresh snapshot. Preserve the exact listener exception and keep normal failover ordering unchanged.
+
+Normalize configured store names to a positional list once in the constructor. Sparse configuration keys must not be confused with iteration positions when retaining unattempted failure history.
+
+### Tests
+
+- An interrupting listener does not erase unattempted failure history.
+- The next operation emits only genuinely new failure transitions.
+- Both first-success and every-store attempt paths retain their existing ordinary success/failure behavior.
+
+## Cache dispatcher refresh and Sentry configuration
+
+`CacheManager::refreshEventDispatcher()` updates only resolved concrete `Hypervel\Cache\Repository` instances whose current dispatcher is non-null. This preserves stores configured with events disabled and avoids calling implementation-specific methods on custom repositories that implement only the cache contract. It remains a boot-or-tests worker-wide mutator.
+
+Sentry cache tracing and breadcrumbs must honor each store's `events` setting. Remove the Sentry boot-time loop that force-enables events on every configured store. Do not add a second event source or mutate application cache configuration.
+
+### Tests and docs
+
+- Dispatcher refresh replaces dispatchers on enabled resolved repositories.
+- Disabled repositories remain disabled after refresh and `Event::fake()` restoration.
+- Contract-only custom repositories are left untouched.
+- Sentry records no cache span or breadcrumb from a store whose events are disabled.
+- Sentry documentation states that cache telemetry honors the store setting.
+
+## Queue pop waiting
+
+`Worker::daemon()` currently creates a `Waiter` with its ten-second default timeout. This contradicts the documented Redis `block_for=0` behavior and terminates idle workers when a configured blocking pop exceeds ten seconds.
+
+Create the pop waiter through one protected `createPopWaiter(): Waiter` method returning `new Waiter(-1)`. Keep the per-pop child coroutine because it owns and releases coroutine-scoped pooled queue connections. Do not add polling, a second timeout setting, or new worker state.
+
+### Tests
+
+- The default pop waiter is unbounded.
+- The protected factory remains overridable for focused worker tests.
+- Existing timeout monitoring and queue-pop behavior remain unchanged.
+
+## Deferred callback ownership
+
+Deferred callbacks must drain at the execution boundary that owns them:
+
+- The `JobAttempted` listener skips only connections whose event runs inline in another owner's frame. That is the `sync` connection. A `deferred` job runs from its coroutine-exit callback after the enclosing lifecycle has drained, while a `background` job runs in a fresh coroutine; both own their callback collections.
+- A `Command` that creates its own coroutine drains that coroutine's collection after `AfterExecute` observers and isolation-mutex cleanup. Commands already running in a request, job, or command coroutine leave ownership with that enclosing lifecycle.
+- `Console\Application::doRunCommand()` drains the non-coroutine frame for CLI execution. This also covers plain Symfony commands and callbacks registered in the application frame around a Hypervel command.
+- The application owner is gated by `runningInConsole()`, absence of a coroutine, and one internal coroutine-context marker held through the drain. Nested non-coroutine command calls therefore leave the shared collection to the outer application frame. Do not expose this marker through a public API.
+- Remove the `CommandFinished` drain listener. Its event fires in the wrong frame for coroutine commands and can recursively drain the same collection during nested programmatic calls.
+- Resolve the scoped collection only when the owning frame already created it, so lifecycles that do not call `defer()` allocate nothing.
+- A drain is one bounded pass. A callback registered while deferred callbacks are running is not executed by that lifecycle. In the non-coroutine console frame it remains on the shared collection for the next owning call; in a coroutine it disappears with that coroutine's scoped collection. Do not add a repeated drain or re-entrancy state: no supported framework path re-enters the same collection, while an unbounded drain can never terminate when callbacks register themselves.
+
+When an owned command fails, run only callbacks whose `always` setting permits it. Preserve the first ordinary command or lifecycle failure. Exact cancellation remains terminal and skips arbitrary deferred callbacks, while fixed marker restoration and mutex cleanup still run. Keep this logic at the two existing console execution boundaries; do not introduce a callback runner or another lifecycle abstraction.
+
+Immediate dispatch on the `deferred` queue connection naturally requires an active coroutine because it delegates to `Coroutine::defer()`. Keep the native failure rather than adding a redundant guard or fallback. Delayed dispatch remains valid because the timer invokes it from a coroutine.
+
+### Tests
+
+- Deferred and background queue jobs drain their own callbacks while sync jobs retain their existing behavior; jobs without callbacks do not resolve an empty collection.
+- Default Hypervel commands drain their coroutine collection after fixed command cleanup, including when the event dispatcher is disabled.
+- Non-coroutine Hypervel commands, plain Symfony commands, and the root CLI execution path drain the application-frame collection with correct success and `always` filtering.
+- Non-console application frames do not claim or drain the non-coroutine callback collection, and leave no ownership marker behind.
+- Commands that do not call `defer()` do not resolve or allocate the scoped collection.
+- Nested programmatic calls do not drain the outer application collection; a real nested `Artisan::call()` from a deferred callback terminates and invokes each callback once.
+- HTTP requests and queued jobs that invoke commands retain ownership of their collections.
+- A callback registered during a non-coroutine drain remains for the next top-level call; one registered during a coroutine drain is not run and does not survive that coroutine.
+- First ordinary failure precedence is preserved at both new ownership boundaries; exact cancellation skips deferred callbacks and preserves identity.
+
+## gRPC abandoned-call cleanup
+
+Dropping an unfinished client or bidirectional gRPC call before `writesDone()` can retain its `StreamState`, receiver coroutine, and pooled connection indefinitely when no deadline is configured.
+
+Add `StreamState::abandonIfIncomplete(): void`. It is idempotent, releases buffered messages, and invokes the existing abandonment path only while no terminal status or failure exists.
+
+Add a no-throw `Call::__destruct()` that invokes this resource-only path. It must not publish a status, create an application-level cancellation result, or run completion observers. Completed calls are naturally ignored by `abandonIfIncomplete()`. Destructors suppress cleanup failures because they may run during process shutdown.
+
+### Tests
+
+- Abandoning an incomplete state releases buffers and the native resource once without publishing a terminal result.
+- Dropping an unfinished call invokes abandonment once.
+- Dropping a completed call performs no abandonment work.
+- Real client-streaming and bidirectional integration tests prove that dropping an unfinished call releases the connection for subsequent work.
+
+## Support error fidelity
+
+Remove broad catches from `SystemInfo::getCpuCores()`, `getTotalMemory()`, and `detectVirtualization()`. Their OS probes already represent unavailability through false or null results; dependency and runtime failures must remain visible. Reword the class contract to promise null only when the OS probe is unavailable. This also makes `getTotalMemory()` consistent with the existing uncaught `getMemoryLimitFormatted()` path when `ext-intl` is missing.
+
+When `FileinfoMimeTypeGuesser` converts a finfo-construction failure to `RuntimeException`, retain the exact original throwable as `previous`.
+
+### Tests
+
+- Unavailable system probes still return null.
+- A missing formatting dependency remains visible on both SystemInfo memory-formatting paths.
+- Fileinfo construction failure preserves the exact previous exception.
+
+## Documentation
+
+Update only these public surfaces:
+
+- `src/docs/cache.md`: truthful tagged-flush results, including null-store behavior.
+- `src/docs/grpc.md`: dropping an unfinished call retires its pooled connection.
+- `src/docs/helpers.md`: callbacks registered during deferred execution are not guaranteed to run.
+- `src/docs/porting-from-laravel.md`: concise tag-set return-type and per-tag extension-point differences.
+- `src/docs/queues.md`: immediate deferred dispatch requires an active coroutine; delayed dispatch supplies one through its timer.
+- `src/docs/sentry.md`: cache telemetry honors each store's `events` option.
+
+The remaining fixes preserve existing public behavior or repair internal lifecycle ownership and need regression tests rather than narrative documentation.
+
+## Implementation sequence
+
+1. Cache tag result contracts, implementations, tests, and docs.
+2. Cache failover history and dispatcher refresh, with focused tests.
+3. Sentry cache configuration behavior, integration test, and docs.
+4. Queue pop waiter and focused worker test.
+5. Deferred callback ownership across Console and Foundation, with focused lifecycle tests.
+6. gRPC abandoned-call cleanup with unit and real integration tests.
+7. SystemInfo and Fileinfo exception fidelity with focused tests.
+8. Review the complete diff against `0.4`, run all changed test files, then run the full repository checks.
+
+## Validation
+
+Run each changed test file immediately after editing it. After every coherent package slice, run its focused suite. Final validation is:
+
+```bash
+composer fix
+git diff --check
+```
+
+Review the final diff and commit series to confirm that every file belongs to one of the fixes above and that no observer hooks, broad cancellation audit, compatibility code, stale comments, or unrelated changes were included.
+
+## Completion criteria
+
+- Tagged cache flushes report the backing operation's real result.
+- Failover history remains truthful when a listener interrupts an attempt.
+- Cache dispatcher refresh and Sentry preserve explicit event-disable configuration.
+- Queue workers honor indefinite and long blocking-pop settings.
+- Deferred callbacks drain exactly once at the owning queue or console lifecycle.
+- Abandoned unfinished gRPC calls release native resources without inventing a terminal result.
+- SystemInfo and Fileinfo no longer hide the original supported failure.
+- Focused and full checks pass, with no dead code, unnecessary machinery, or public API drift beyond the documented `TagSet` return type.

--- a/src/cache/src/CacheManager.php
+++ b/src/cache/src/CacheManager.php
@@ -390,16 +390,21 @@ class CacheManager implements FactoryContract
     }
 
     /**
-     * Re-set the event dispatcher on all resolved cache repositories.
+     * Re-set the event dispatcher on resolved event-emitting cache repositories.
      *
-     * Boot or tests only. Replaces the dispatcher on every cached repository
-     * for the worker lifetime; per-request use races across coroutines.
-     * Reached by Event::fake() / Event::fakeFor() to point cached repositories
-     * at the fake dispatcher and to restore them afterwards.
+     * Boot or tests only. Replaces the dispatcher on cached concrete repositories
+     * that already emit events, preserving disabled stores and custom repository
+     * implementations. Per-request use races across coroutines. Reached by
+     * Event::fake() / Event::fakeFor() to install and restore fake dispatchers.
      */
     public function refreshEventDispatcher(): void
     {
-        array_map($this->setEventDispatcher(...), $this->stores);
+        foreach ($this->stores as $repository) {
+            // The current dispatcher records whether this repository emits events.
+            if ($repository instanceof Repository && $repository->getEventDispatcher() !== null) {
+                $this->setEventDispatcher($repository);
+            }
+        }
     }
 
     /**

--- a/src/cache/src/FailoverStore.php
+++ b/src/cache/src/FailoverStore.php
@@ -34,6 +34,13 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
     protected const string FAILING_CACHES_CONTEXT_PREFIX = '__cache.failover.failing_caches.';
 
     /**
+     * The cache stores in failover order.
+     *
+     * @var list<string>
+     */
+    protected array $stores;
+
+    /**
      * Create a new failover store.
      *
      * @param array<int, string> $stores
@@ -41,8 +48,9 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
     public function __construct(
         protected CacheManager $cache,
         protected Dispatcher $events,
-        protected array $stores
+        array $stores
     ) {
+        $this->stores = array_values($stores);
     }
 
     /**
@@ -307,7 +315,7 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
         [$lastException, $failedCaches] = [null, []];
 
         try {
-            foreach ($this->stores as $store) {
+            foreach ($this->stores as $position => $store) {
                 try {
                     return $this->store($store)->{$method}(...$arguments);
                 } catch (Throwable $exception) {
@@ -315,7 +323,17 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
 
                     $failedCaches[] = $store;
 
-                    $this->recordStoreFailure($store, $exception, $failingCaches);
+                    try {
+                        $this->recordStoreFailure($store, $exception, $failingCaches);
+                    } catch (Throwable $listenerException) {
+                        $failedCaches = $this->failureHistoryAfterInterruption(
+                            $failingCaches,
+                            $failedCaches,
+                            $position + 1,
+                        );
+
+                        throw $listenerException;
+                    }
                 }
             }
         } finally {
@@ -339,14 +357,24 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
         $failedCaches = [];
 
         try {
-            foreach ($this->stores as $store) {
+            foreach ($this->stores as $position => $store) {
                 try {
                     $results[] = $this->store($store)->{$method}(...$arguments);
                 } catch (Throwable $exception) {
                     $lastException = $exception;
                     $failedCaches[] = $store;
 
-                    $this->recordStoreFailure($store, $exception, $failingCaches);
+                    try {
+                        $this->recordStoreFailure($store, $exception, $failingCaches);
+                    } catch (Throwable $listenerException) {
+                        $failedCaches = $this->failureHistoryAfterInterruption(
+                            $failingCaches,
+                            $failedCaches,
+                            $position + 1,
+                        );
+
+                        throw $listenerException;
+                    }
                 }
             }
         } finally {
@@ -354,6 +382,26 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
         }
 
         return [$results, $lastException];
+    }
+
+    /**
+     * Build failure history after an interrupted failover attempt.
+     *
+     * @param list<string> $previousFailures
+     * @param list<string> $observedFailures
+     *
+     * @return list<string>
+     */
+    protected function failureHistoryAfterInterruption(
+        array $previousFailures,
+        array $observedFailures,
+        int $unattemptedFromPosition,
+    ): array {
+        // An interrupted attempt cannot establish recovery for stores it never reached.
+        return array_values(array_unique([
+            ...$observedFailures,
+            ...array_intersect($previousFailures, array_slice($this->stores, $unattemptedFromPosition)),
+        ]));
     }
 
     /**

--- a/src/cache/src/Redis/AllTagSet.php
+++ b/src/cache/src/Redis/AllTagSet.php
@@ -41,9 +41,16 @@ class AllTagSet extends NamespacedTagSet
     /**
      * Reset all tags in the set.
      */
-    public function reset(): void
+    public function reset(): bool
     {
-        array_walk($this->names, [$this, 'resetTag']);
+        return $this->attemptEach(
+            $this->names,
+            function (string $name): bool {
+                $this->resetTag($name);
+
+                return true;
+            },
+        );
     }
 
     /**
@@ -59,9 +66,16 @@ class AllTagSet extends NamespacedTagSet
     /**
      * Flush all the tags in the set.
      */
-    public function flush(): void
+    public function flush(): bool
     {
-        array_walk($this->names, [$this, 'flushTag']);
+        return $this->attemptEach(
+            $this->names,
+            function (string $name): bool {
+                $this->flushTag($name);
+
+                return true;
+            },
+        );
     }
 
     /**

--- a/src/cache/src/Redis/AnyTagSet.php
+++ b/src/cache/src/Redis/AnyTagSet.php
@@ -70,9 +70,9 @@ class AnyTagSet extends TagSet
      * In any mode, this deletes the cached items themselves, unlike
      * namespaced tag sets where reset only invalidates tag tracking.
      */
-    public function reset(): void
+    public function reset(): bool
     {
-        $this->flush();
+        return $this->flush();
     }
 
     /**
@@ -81,9 +81,9 @@ class AnyTagSet extends TagSet
      * Deletes all cache items that have any of the specified tags
      * (union semantics), along with their reverse indexes and tag hashes.
      */
-    public function flush(): void
+    public function flush(): bool
     {
-        $this->getRedisStore()->anyTagOps()->flush()->execute($this->names);
+        return $this->getRedisStore()->anyTagOps()->flush()->execute($this->names);
     }
 
     /**

--- a/src/cache/src/StackTagSet.php
+++ b/src/cache/src/StackTagSet.php
@@ -33,19 +33,22 @@ class StackTagSet extends TagSet
     /**
      * Reset all tags in the set.
      */
-    public function reset(): void
+    public function reset(): bool
     {
-        $this->flush();
+        return $this->flush();
     }
 
     /**
      * Flush all the tags in the set.
      */
-    public function flush(): void
+    public function flush(): bool
     {
-        foreach ($this->store->taggableLayers() as $layer) {
-            // Flush via tag sets so the stack-level tagged cache emits events once.
-            $layer->tags($this->names)->getTags()->flush();
-        }
+        return $this->attemptEach(
+            $this->store->taggableLayers(),
+            function (TaggableStore $layer): bool {
+                // Flush via tag sets so the stack-level tagged cache emits events once.
+                return $layer->tags($this->names)->getTags()->flush();
+            },
+        );
     }
 }

--- a/src/cache/src/TagSet.php
+++ b/src/cache/src/TagSet.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Hypervel\Cache;
 
+use Closure;
 use Hypervel\Contracts\Cache\Store;
+use Swoole\Coroutine\CanceledException;
+use Throwable;
 
 abstract class TagSet
 {
@@ -30,12 +33,44 @@ abstract class TagSet
     /**
      * Reset all tags in the set.
      */
-    abstract public function reset(): void;
+    abstract public function reset(): bool;
 
     /**
      * Flush all the tags in the set.
      */
-    abstract public function flush(): void;
+    abstract public function flush(): bool;
+
+    /**
+     * Attempt an operation for every item.
+     *
+     * @template TItem
+     *
+     * @param iterable<TItem> $items
+     * @param Closure(TItem): bool $operation
+     */
+    protected function attemptEach(iterable $items, Closure $operation): bool
+    {
+        $result = true;
+        $exception = null;
+
+        foreach ($items as $item) {
+            try {
+                if (! $operation($item)) {
+                    $result = false;
+                }
+            } catch (CanceledException $throwable) {
+                throw $throwable;
+            } catch (Throwable $throwable) {
+                $exception ??= $throwable;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+
+        return $result;
+    }
 
     /**
      * Get all of the tag names in the set.

--- a/src/cache/src/TaggedCache.php
+++ b/src/cache/src/TaggedCache.php
@@ -8,6 +8,7 @@ use Closure;
 use DateInterval;
 use DateTimeInterface;
 use Hypervel\Cache\Events\CacheFlushed;
+use Hypervel\Cache\Events\CacheFlushFailed;
 use Hypervel\Cache\Events\CacheFlushing;
 use Hypervel\Contracts\Cache\Store;
 use UnitEnum;
@@ -76,11 +77,15 @@ abstract class TaggedCache extends Repository
     {
         $this->event(CacheFlushing::class, fn (): CacheFlushing => new CacheFlushing($this->getName()));
 
-        $this->tags->reset();
+        $result = $this->tags->reset();
 
-        $this->event(CacheFlushed::class, fn (): CacheFlushed => new CacheFlushed($this->getName()));
+        if ($result) {
+            $this->event(CacheFlushed::class, fn (): CacheFlushed => new CacheFlushed($this->getName()));
+        } else {
+            $this->event(CacheFlushFailed::class, fn (): CacheFlushFailed => new CacheFlushFailed($this->getName()));
+        }
 
-        return true;
+        return $result;
     }
 
     /**

--- a/src/cache/src/VersionedTagSet.php
+++ b/src/cache/src/VersionedTagSet.php
@@ -16,9 +16,12 @@ class VersionedTagSet extends NamespacedTagSet
     /**
      * Reset all tags in the set.
      */
-    public function reset(): void
+    public function reset(): bool
     {
-        array_walk($this->names, [$this, 'resetTag']);
+        return $this->attemptEach(
+            $this->names,
+            fn (string $name): bool => $this->writeTagId($name, $this->newTagId()),
+        );
     }
 
     /**
@@ -26,7 +29,9 @@ class VersionedTagSet extends NamespacedTagSet
      */
     public function resetTag(string $name): string
     {
-        $this->store->forever($this->tagKey($name), $id = str_replace('.', '', uniqid('', true)));
+        $id = $this->newTagId();
+
+        $this->writeTagId($name, $id);
 
         return $id;
     }
@@ -34,9 +39,16 @@ class VersionedTagSet extends NamespacedTagSet
     /**
      * Flush all the tags in the set.
      */
-    public function flush(): void
+    public function flush(): bool
     {
-        array_walk($this->names, [$this, 'flushTag']);
+        return $this->attemptEach(
+            $this->names,
+            function (string $name): bool {
+                $this->flushTag($name);
+
+                return true;
+            },
+        );
     }
 
     /**
@@ -63,5 +75,21 @@ class VersionedTagSet extends NamespacedTagSet
     public function tagKey(string $name): string
     {
         return 'tag:' . $name . ':key';
+    }
+
+    /**
+     * Generate a new tag identifier.
+     */
+    protected function newTagId(): string
+    {
+        return str_replace('.', '', uniqid('', true));
+    }
+
+    /**
+     * Persist a tag identifier.
+     */
+    protected function writeTagId(string $name, string $id): bool
+    {
+        return $this->store->forever($this->tagKey($name), $id);
     }
 }

--- a/src/console/src/Application.php
+++ b/src/console/src/Application.php
@@ -8,13 +8,18 @@ use Closure;
 use Hypervel\Console\Attributes\Aliases;
 use Hypervel\Console\Attributes\Signature;
 use Hypervel\Console\Events\ArtisanStarting;
+use Hypervel\Container\Container;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Console\Application as ConsoleApplicationContract;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Support\Defer\DeferredCallback;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Support\ProcessUtils;
 use Override;
 use ReflectionClass;
+use Swoole\Coroutine\CanceledException;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -30,6 +35,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Process\PhpExecutableFinder;
+use Throwable;
 
 class Application extends SymfonyApplication implements ConsoleApplicationContract
 {
@@ -37,6 +43,11 @@ class Application extends SymfonyApplication implements ConsoleApplicationContra
      * The CoroutineContext key holding the output from the previous command.
      */
     protected const string LAST_OUTPUT_CONTEXT_KEY = '__console.last_output';
+
+    /**
+     * The CoroutineContext key marking the owner of non-coroutine deferred callbacks.
+     */
+    private const string DEFERRED_CALLBACK_OWNER_CONTEXT_KEY = '__console.deferred_callback_owner';
 
     /**
      * The console application bootstrappers.
@@ -344,11 +355,49 @@ class Application extends SymfonyApplication implements ConsoleApplicationContra
     #[Override]
     protected function doRunCommand(SymfonyCommand $command, InputInterface $input, OutputInterface $output): int
     {
-        return parent::doRunCommand(
-            $this->freshCommandForRun($command),
-            $input,
-            $output
-        );
+        $command = $this->freshCommandForRun($command);
+        $ownsDeferredCallbacks = $this->container->runningInConsole()
+            && ! Coroutine::inCoroutine()
+            && ! CoroutineContext::has(self::DEFERRED_CALLBACK_OWNER_CONTEXT_KEY);
+
+        if (! $ownsDeferredCallbacks) {
+            return parent::doRunCommand($command, $input, $output);
+        }
+
+        $container = Container::getInstance();
+        $exitCode = SymfonyCommand::FAILURE;
+        $exception = null;
+
+        CoroutineContext::set(self::DEFERRED_CALLBACK_OWNER_CONTEXT_KEY, true);
+
+        try {
+            try {
+                $exitCode = parent::doRunCommand($command, $input, $output);
+            } catch (Throwable $throwable) {
+                $exception = $throwable;
+            }
+
+            if (! $exception instanceof CanceledException
+                && $container->resolvedScoped(DeferredCallbackCollection::class)
+            ) {
+                try {
+                    $container->make(DeferredCallbackCollection::class)
+                        ->invokeWhen(fn (DeferredCallback $callback) => ($exception === null && $exitCode === SymfonyCommand::SUCCESS) || $callback->always);
+                } catch (CanceledException $cancellation) {
+                    $exception = $cancellation;
+                } catch (Throwable $throwable) {
+                    $exception ??= $throwable;
+                }
+            }
+        } finally {
+            CoroutineContext::forget(self::DEFERRED_CALLBACK_OWNER_CONTEXT_KEY);
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+
+        return $exitCode;
     }
 
     /**

--- a/src/console/src/Application.php
+++ b/src/console/src/Application.php
@@ -382,7 +382,7 @@ class Application extends SymfonyApplication implements ConsoleApplicationContra
             ) {
                 try {
                     $container->make(DeferredCallbackCollection::class)
-                        ->invokeWhen(fn (DeferredCallback $callback) => ($exception === null && $exitCode === SymfonyCommand::SUCCESS) || $callback->always);
+                        ->invokeWhen(fn (DeferredCallback $callback): bool => ($exception === null && $exitCode === SymfonyCommand::SUCCESS) || $callback->always);
                 } catch (CanceledException $cancellation) {
                     $exception = $cancellation;
                 } catch (Throwable $throwable) {

--- a/src/console/src/Command.php
+++ b/src/console/src/Command.php
@@ -14,13 +14,17 @@ use Hypervel\Console\Events\AfterExecute;
 use Hypervel\Console\Events\AfterHandle;
 use Hypervel\Console\Events\BeforeHandle;
 use Hypervel\Console\View\Components\Factory;
+use Hypervel\Container\Container;
 use Hypervel\Contracts\Console\Isolatable;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Coroutine\Coroutine;
+use Hypervel\Support\Defer\DeferredCallback;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Support\Traits\Macroable;
 use ReflectionClass;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 use Swoole\ExitException;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -294,8 +298,9 @@ class Command extends SymfonyCommand
         }
 
         $exception = null;
+        $runsInOwnCoroutine = $this->coroutine && ! Coroutine::inCoroutine();
 
-        $callback = function () use ($input, $output, $commandMutex, &$exception): int {
+        $callback = function () use ($input, $output, $commandMutex, $runsInOwnCoroutine, &$exception): int {
             try {
                 $this->exitCode = $this->executeCommand($input, $output);
             } catch (Throwable $throwable) {
@@ -322,12 +327,27 @@ class Command extends SymfonyCommand
                         $exception ??= $throwable;
                     }
                 }
+
+                if ($runsInOwnCoroutine && ! $exception instanceof CanceledException) {
+                    $container = Container::getInstance();
+
+                    if ($container->resolvedScoped(DeferredCallbackCollection::class)) {
+                        try {
+                            $container->make(DeferredCallbackCollection::class)
+                                ->invokeWhen(fn (DeferredCallback $callback) => ($exception === null && $this->normalizeExitCode($this->exitCode) === self::SUCCESS) || $callback->always);
+                        } catch (CanceledException $cancellation) {
+                            $exception = $cancellation;
+                        } catch (Throwable $throwable) {
+                            $exception ??= $throwable;
+                        }
+                    }
+                }
             }
 
             return $this->exitCode;
         };
 
-        if ($this->coroutine && ! Coroutine::inCoroutine()) {
+        if ($runsInOwnCoroutine) {
             run($callback, $this->hookFlags);
         } else {
             $callback();

--- a/src/console/src/Command.php
+++ b/src/console/src/Command.php
@@ -334,7 +334,7 @@ class Command extends SymfonyCommand
                     if ($container->resolvedScoped(DeferredCallbackCollection::class)) {
                         try {
                             $container->make(DeferredCallbackCollection::class)
-                                ->invokeWhen(fn (DeferredCallback $callback) => ($exception === null && $this->normalizeExitCode($this->exitCode) === self::SUCCESS) || $callback->always);
+                                ->invokeWhen(fn (DeferredCallback $callback): bool => ($exception === null && $this->normalizeExitCode($this->exitCode) === self::SUCCESS) || $callback->always);
                         } catch (CanceledException $cancellation) {
                             $exception = $cancellation;
                         } catch (Throwable $throwable) {

--- a/src/docs/cache.md
+++ b/src/docs/cache.md
@@ -625,6 +625,8 @@ cache()->remember('users', $seconds, function () {
 > [!WARNING]
 > Cache tags are supported by the `redis`, `array`, `failover`, `null`, and `stack` cache drivers. Stack tags require an any-mode composition; see [Tagged Cache Stacks](#tagged-cache-stacks). Cache tags are not supported by the `file`, `storage`, `database`, `swoole`, `session`, or `memo` drivers.
 
+The `flush` method returns `true` only when every tag or taggable stack layer accepts the flush. The null cache driver rejects tag identifier writes, so tagged flushes on that driver return `false` even though tagged reads continue to behave as cache misses.
+
 <a name="redis-tag-modes"></a>
 ### Redis Tag Modes
 

--- a/src/docs/grpc.md
+++ b/src/docs/grpc.md
@@ -522,6 +522,8 @@ $client = new GreeterClient('grpc.example.com:50051', [
 
 Connections are opened when first needed and reused by later calls. In most applications, you should register clients as singletons so each worker can reuse its connections. If you create a short-lived client, call its `close` method when you have finished using it. Calling `close` more than once is safe, but a closed client cannot start another call.
 
+Dropping an unfinished call abandons its native stream and retires the connection so the pool can replace it safely. Finish calls normally when possible so their connections remain reusable.
+
 The client's `target` method returns the target string passed to its constructor.
 
 <a name="generated-style-clients"></a>

--- a/src/docs/helpers.md
+++ b/src/docs/helpers.md
@@ -3520,6 +3520,8 @@ By default, deferred functions will only be executed if the HTTP response, Artis
 defer(fn () => Metrics::reportOrder($order))->always();
 ```
 
+A deferred function registered while deferred functions are being executed is not run during the same lifecycle and is not guaranteed to run at all.
+
 > [!WARNING]
 > Hypervel runs on Swoole, which exposes its own global `defer` function that conflicts with Hypervel's `defer` helper. Always call Hypervel's `defer` helper explicitly by namespace: `use function Hypervel\Support\defer;`
 

--- a/src/docs/porting-from-laravel.md
+++ b/src/docs/porting-from-laravel.md
@@ -562,6 +562,8 @@ For local in-memory caching, use the [Swoole table cache](/docs/{{version}}/cach
 
 The Redis cache store supports two tag modes. The default `all` mode follows Laravel's classic tagged-cache behavior. In `any` mode, tags are invalidation indexes: retrieve values by their plain keys, and flushing any one assigned tag removes the value. Review the [Redis tag mode documentation](/docs/{{version}}/cache#redis-tag-modes) before changing `REDIS_CACHE_TAG_MODE`.
 
+Custom cache tag sets must declare `TagSet::reset(): bool` and `TagSet::flush(): bool`. Hypervel uses these results to report a rejected tagged flush instead of returning unconditional success. Custom `VersionedTagSet` subclasses should override `writeTagId()` for bulk reset persistence; `resetTag()` keeps returning the generated identifier.
+
 <a name="sessions"></a>
 ### Sessions
 

--- a/src/docs/queues.md
+++ b/src/docs/queues.md
@@ -1257,6 +1257,8 @@ RecordDelivery::dispatch($order)->onConnection('deferred');
 
 The `deferred` connection executes jobs using `Coroutine::defer`, so the job runs when the current coroutine is ending. This is useful for small follow-up work that should not delay the response.
 
+Immediate dispatch to this connection requires an active coroutine. A console command that opts out of coroutine execution should use `sync` for inline work or `background` to create a coroutine instead. Delayed dispatch remains available because the timer executes its callback inside a coroutine.
+
 Similarly, the `background` connection processes jobs in another coroutine within the current worker process:
 
 ```php

--- a/src/docs/sentry.md
+++ b/src/docs/sentry.md
@@ -158,7 +158,7 @@ SENTRY_TRACES_SAMPLE_RATE=0.1
 
 The default configuration traces requests, database queries, HTTP client requests, cache operations, queued jobs, notifications, and views. The conventional `/up` health route path is ignored by default.
 
-Enabling cache spans or breadcrumbs also enables repository events for every configured cache store while Sentry has an active DSN or Spotlight endpoint. This applies even when a store's own `events` option is `false`, because those events are required to record cache telemetry. Disable both `SENTRY_TRACE_CACHE_ENABLED` and `SENTRY_BREADCRUMBS_CACHE_ENABLED` when cache repository events must remain disabled.
+Cache spans and breadcrumbs follow cache repository events. Configured stores honor their `events` option, but the `failover` store defaults this option to `false`; enable it explicitly when failover operations should produce telemetry. `Cache::memo()` does not emit a second event for its memoization layer, while operations that reach the wrapped repository follow that store's setting.
 
 Incoming trace headers are still propagated when local trace recording is disabled. This allows a Hypervel service to remain part of a distributed trace without recording its own transaction.
 

--- a/src/foundation/src/Providers/FoundationServiceProvider.php
+++ b/src/foundation/src/Providers/FoundationServiceProvider.php
@@ -7,8 +7,8 @@ namespace Hypervel\Foundation\Providers;
 use Carbon\FactoryImmutable;
 use Hypervel\Concurrency\Console\InvokeSerializedClosureCommand;
 use Hypervel\Config\Repository;
-use Hypervel\Console\Events\CommandFinished;
 use Hypervel\Console\Scheduling\Schedule;
+use Hypervel\Container\Container as BaseContainer;
 use Hypervel\Contracts\Console\Kernel as ConsoleKernelContract;
 use Hypervel\Contracts\Container\Container;
 use Hypervel\Contracts\Events\Dispatcher;
@@ -255,13 +255,10 @@ class FoundationServiceProvider extends ServiceProvider
         $this->app->scoped(DeferredCallbackCollection::class);
         $events = $this->app->make('events');
 
-        $events->listen(function (CommandFinished $event) {
-            $this->app->make(DeferredCallbackCollection::class)
-                ->invokeWhen(fn (DeferredCallback $callback) => $this->app->runningInConsole() && ($event->exitCode === 0 || $callback->always));
-        });
-
         $events->listen(function (JobAttempted $event) {
-            if (in_array($event->connectionName, ['sync', 'deferred'], true)) {
+            if ($event->connectionName === 'sync'
+                || ! BaseContainer::getInstance()->resolvedScoped(DeferredCallbackCollection::class)
+            ) {
                 return;
             }
 

--- a/src/grpc/src/Client/Call.php
+++ b/src/grpc/src/Client/Call.php
@@ -738,4 +738,16 @@ abstract class Call
         $this->writeSemaphoreClosed = true;
         $this->writeSemaphore->close();
     }
+
+    /**
+     * Release unfinished native call resources.
+     */
+    public function __destruct()
+    {
+        try {
+            $this->state->abandonIfIncomplete();
+        } catch (Throwable) {
+            // Destructors cannot safely surface cleanup failures during process shutdown.
+        }
+    }
 }

--- a/src/grpc/src/Client/StreamState.php
+++ b/src/grpc/src/Client/StreamState.php
@@ -354,6 +354,19 @@ final class StreamState
     }
 
     /**
+     * Release an incomplete native stream without publishing a result.
+     */
+    public function abandonIfIncomplete(): void
+    {
+        if ($this->isComplete()) {
+            return;
+        }
+
+        $this->releaseBuffers();
+        $this->abandon();
+    }
+
+    /**
      * Determine whether retry pushback was present.
      */
     public function hasRetryPushback(): bool

--- a/src/queue/src/Worker.php
+++ b/src/queue/src/Worker.php
@@ -226,7 +226,7 @@ class Worker
 
         $this->raiseWorkerStartingEvent($connectionName, $queue, $options);
 
-        $waiter = new Waiter;
+        $waiter = $this->createPopWaiter();
         $concurrent = new Concurrent($options->concurrency);
 
         $this->monitorTimeoutJobs($options);
@@ -342,6 +342,14 @@ class Worker
                 $this->monitorId = null;
             }
         }
+    }
+
+    /**
+     * Create the waiter used to pop jobs.
+     */
+    protected function createPopWaiter(): Waiter
+    {
+        return new Waiter(-1);
     }
 
     /**

--- a/src/sentry/src/Features/CacheFeature.php
+++ b/src/sentry/src/Features/CacheFeature.php
@@ -55,13 +55,6 @@ class CacheFeature extends Feature
 
     public function onBoot(): void
     {
-        $config = $this->container->make('config');
-        $stores = array_keys($config->array('cache.stores'));
-        // This method runs only for an active endpoint with cache telemetry enabled,
-        // which requires repository events even when a store explicitly disabled them.
-        foreach ($stores as $store) {
-            $config->set("cache.stores.{$store}.events", true);
-        }
         /** @var Dispatcher $dispatcher */
         $dispatcher = $this->container->make('events');
         if ($this->isBreadcrumbFeatureEnabled(self::FEATURE_KEY)) {

--- a/src/support/src/FileinfoMimeTypeGuesser.php
+++ b/src/support/src/FileinfoMimeTypeGuesser.php
@@ -59,7 +59,7 @@ class FileinfoMimeTypeGuesser
                 fn () => new finfo(FILEINFO_MIME_TYPE, $this->magicFile)
             );
         } catch (Exception $e) {
-            throw new RuntimeException($e->getMessage());
+            throw new RuntimeException($e->getMessage(), previous: $e);
         }
         try {
             $mimeType = $finfo->file($path) ?: null;

--- a/src/support/src/SystemInfo.php
+++ b/src/support/src/SystemInfo.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Hypervel\Support;
 
-use Exception;
-
 /**
  * System information utilities for benchmarking and diagnostics.
  *
  * Provides cross-platform detection of CPU cores, memory, and virtualization.
- * All methods fail gracefully and return null when information is unavailable.
+ * Operating-system probes return null when their information is unavailable.
  */
 class SystemInfo
 {
@@ -21,30 +19,26 @@ class SystemInfo
      */
     public function getCpuCores(): ?int
     {
-        try {
-            if (PHP_OS_FAMILY === 'Linux') {
-                $cpuinfo = @file_get_contents('/proc/cpuinfo');
+        if (PHP_OS_FAMILY === 'Linux') {
+            $cpuinfo = @file_get_contents('/proc/cpuinfo');
 
-                if ($cpuinfo) {
-                    $count = substr_count($cpuinfo, 'processor');
+            if ($cpuinfo) {
+                $count = substr_count($cpuinfo, 'processor');
 
-                    return $count > 0 ? $count : null;
-                }
-            } elseif (PHP_OS_FAMILY === 'Darwin') {
-                $output = @shell_exec('sysctl -n hw.ncpu 2>/dev/null');
-
-                if ($output) {
-                    return (int) trim($output);
-                }
-            } elseif (PHP_OS_FAMILY === 'Windows') {
-                $cores = getenv('NUMBER_OF_PROCESSORS');
-
-                if ($cores) {
-                    return (int) $cores;
-                }
+                return $count > 0 ? $count : null;
             }
-        } catch (Exception) {
-            // Silently fail
+        } elseif (PHP_OS_FAMILY === 'Darwin') {
+            $output = @shell_exec('sysctl -n hw.ncpu 2>/dev/null');
+
+            if ($output) {
+                return (int) trim($output);
+            }
+        } elseif (PHP_OS_FAMILY === 'Windows') {
+            $cores = getenv('NUMBER_OF_PROCESSORS');
+
+            if ($cores) {
+                return (int) $cores;
+            }
         }
 
         return null;
@@ -57,30 +51,26 @@ class SystemInfo
      */
     public function getTotalMemory(): ?string
     {
-        try {
-            if (PHP_OS_FAMILY === 'Linux') {
-                $meminfo = @file_get_contents('/proc/meminfo');
+        if (PHP_OS_FAMILY === 'Linux') {
+            $meminfo = @file_get_contents('/proc/meminfo');
 
-                if ($meminfo && preg_match('/MemTotal:\s+(\d+)\s+kB/i', $meminfo, $matches)) {
-                    $kb = (int) $matches[1];
+            if ($meminfo && preg_match('/MemTotal:\s+(\d+)\s+kB/i', $meminfo, $matches)) {
+                $kb = (int) $matches[1];
 
-                    return Number::fileSize($kb * 1024, precision: 1);
-                }
-            } elseif (PHP_OS_FAMILY === 'Darwin') {
-                $output = @shell_exec('sysctl -n hw.memsize 2>/dev/null');
-
-                if ($output) {
-                    return Number::fileSize((int) trim($output), precision: 1);
-                }
-            } elseif (PHP_OS_FAMILY === 'Windows') {
-                $output = @shell_exec('wmic computersystem get totalphysicalmemory 2>nul');
-
-                if ($output && preg_match('/\d+/', $output, $matches)) {
-                    return Number::fileSize((int) $matches[0], precision: 1);
-                }
+                return Number::fileSize($kb * 1024, precision: 1);
             }
-        } catch (Exception) {
-            // Silently fail
+        } elseif (PHP_OS_FAMILY === 'Darwin') {
+            $output = @shell_exec('sysctl -n hw.memsize 2>/dev/null');
+
+            if ($output) {
+                return Number::fileSize((int) trim($output), precision: 1);
+            }
+        } elseif (PHP_OS_FAMILY === 'Windows') {
+            $output = @shell_exec('wmic computersystem get totalphysicalmemory 2>nul');
+
+            if ($output && preg_match('/\d+/', $output, $matches)) {
+                return Number::fileSize((int) $matches[0], precision: 1);
+            }
         }
 
         return null;
@@ -93,48 +83,44 @@ class SystemInfo
      */
     public function detectVirtualization(): ?string
     {
-        try {
-            if (PHP_OS_FAMILY === 'Linux') {
-                // Check for common virtualization indicators
-                $dmiDecodeOutput = @shell_exec('cat /sys/class/dmi/id/product_name 2>/dev/null');
+        if (PHP_OS_FAMILY === 'Linux') {
+            // Check for common virtualization indicators
+            $dmiDecodeOutput = @shell_exec('cat /sys/class/dmi/id/product_name 2>/dev/null');
 
-                if ($dmiDecodeOutput) {
-                    $product = strtolower(trim($dmiDecodeOutput));
+            if ($dmiDecodeOutput) {
+                $product = strtolower(trim($dmiDecodeOutput));
 
-                    if (str_contains($product, 'virtualbox')) {
-                        return 'VirtualBox';
-                    }
-
-                    if (str_contains($product, 'vmware')) {
-                        return 'VMware';
-                    }
-
-                    if (str_contains($product, 'kvm')) {
-                        return 'KVM';
-                    }
-
-                    if (str_contains($product, 'qemu')) {
-                        return 'QEMU';
-                    }
-
-                    if (str_contains($product, 'bochs')) {
-                        return 'Bochs';
-                    }
+                if (str_contains($product, 'virtualbox')) {
+                    return 'VirtualBox';
                 }
 
-                // Check for container
-                if (file_exists('/.dockerenv')) {
-                    return 'Docker';
+                if (str_contains($product, 'vmware')) {
+                    return 'VMware';
                 }
 
-                $cgroupContent = @file_get_contents('/proc/1/cgroup');
+                if (str_contains($product, 'kvm')) {
+                    return 'KVM';
+                }
 
-                if ($cgroupContent && (str_contains($cgroupContent, 'docker') || str_contains($cgroupContent, 'lxc'))) {
-                    return 'Container';
+                if (str_contains($product, 'qemu')) {
+                    return 'QEMU';
+                }
+
+                if (str_contains($product, 'bochs')) {
+                    return 'Bochs';
                 }
             }
-        } catch (Exception) {
-            // Silently fail
+
+            // Check for container
+            if (file_exists('/.dockerenv')) {
+                return 'Docker';
+            }
+
+            $cgroupContent = @file_get_contents('/proc/1/cgroup');
+
+            if ($cgroupContent && (str_contains($cgroupContent, 'docker') || str_contains($cgroupContent, 'lxc'))) {
+                return 'Container';
+            }
         }
 
         return null;

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -413,6 +413,22 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->clear());
     }
 
+    public function testEmptyTaggedFlushIsIdempotentAndDispatchesSuccessEvents(): void
+    {
+        $events = [];
+        $repository = new Repository(new ArrayStore, ['store' => 'array']);
+        $repository->setEventDispatcher($this->getCapturingDispatcher($events));
+
+        $this->assertTrue($repository->tags('missing')->flush());
+        $this->assertTrue($repository->tags('missing')->flush());
+        $this->assertSame([
+            CacheFlushing::class,
+            CacheFlushed::class,
+            CacheFlushing::class,
+            CacheFlushed::class,
+        ], array_map(get_class(...), $events));
+    }
+
     public function testFlushLocksTriggersEvents()
     {
         $dispatcher = $this->getDispatcher();

--- a/tests/Cache/CacheFailoverStoreTest.php
+++ b/tests/Cache/CacheFailoverStoreTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Cache;
 use BadMethodCallException;
 use Hypervel\Cache\ArrayStore;
 use Hypervel\Cache\CacheManager;
+use Hypervel\Cache\Events\CacheFailedOver;
 use Hypervel\Cache\FailoverStore;
 use Hypervel\Cache\Repository;
 use Hypervel\Contracts\Cache\CanFlushLocks;
@@ -166,6 +167,159 @@ class CacheFailoverStoreTest extends TestCase
         $store->flushLocks();
     }
 
+    public function testFirstSuccessListenerFailurePreservesObservedAndUnattemptedFailures(): void
+    {
+        $listenerFailure = new RuntimeException('listener failure');
+        $first = m::mock(Store::class);
+        $first->shouldReceive('forget')->once()->with('key')->andReturnTrue();
+        $first->shouldReceive('get')->twice()->with('key')->andThrow(new RuntimeException('first failure'));
+        $second = m::mock(Store::class);
+        $second->shouldReceive('forget')->once()->with('key')->andThrow(new RuntimeException('second failure'));
+        $second->shouldReceive('get')->once()->with('key')->andThrow(new RuntimeException('second failure'));
+        $third = m::mock(Store::class);
+        $third->shouldReceive('forget')->once()->with('key')->andReturnTrue();
+        $third->shouldReceive('get')->once()->with('key')->andReturn('value');
+        $failedStores = [];
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('hasListeners')->with(CacheFailedOver::class)->andReturnTrue();
+        $events->shouldReceive('dispatch')->andReturnUsing(
+            function (CacheFailedOver $event) use (&$failedStores, $listenerFailure): void {
+                $failedStores[] = $event->storeName;
+
+                if ($event->storeName === 'first') {
+                    throw $listenerFailure;
+                }
+            }
+        );
+        $store = $this->makeFailoverStore(
+            ['first' => $first, 'second' => $second, 'third' => $third],
+            $events,
+        );
+
+        $this->assertFalse($store->forget('key'));
+
+        try {
+            $store->get('key');
+            $this->fail('Expected the failover listener failure to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($listenerFailure, $exception);
+        }
+
+        $this->assertSame('value', $store->get('key'));
+        $this->assertSame(['second', 'first'], $failedStores);
+    }
+
+    public function testEveryStoreListenerFailurePreservesObservedAndUnattemptedFailures(): void
+    {
+        $listenerFailure = new RuntimeException('listener failure');
+        $firstCall = 0;
+        $first = m::mock(Store::class);
+        $first->shouldReceive('forget')->times(3)->with('key')->andReturnUsing(
+            function () use (&$firstCall): bool {
+                ++$firstCall;
+
+                return $firstCall === 1
+                    ? true
+                    : throw new RuntimeException('first failure');
+            }
+        );
+        $second = m::mock(Store::class);
+        $second->shouldReceive('forget')->twice()->with('key')->andThrow(new RuntimeException('second failure'));
+        $third = m::mock(Store::class);
+        $third->shouldReceive('forget')->twice()->with('key')->andReturnTrue();
+        $failedStores = [];
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('hasListeners')->with(CacheFailedOver::class)->andReturnTrue();
+        $events->shouldReceive('dispatch')->andReturnUsing(
+            function (CacheFailedOver $event) use (&$failedStores, $listenerFailure): void {
+                $failedStores[] = $event->storeName;
+
+                if ($event->storeName === 'first') {
+                    throw $listenerFailure;
+                }
+            }
+        );
+        $store = $this->makeFailoverStore(
+            ['first' => $first, 'second' => $second, 'third' => $third],
+            $events,
+        );
+
+        $this->assertFalse($store->forget('key'));
+
+        try {
+            $store->forget('key');
+            $this->fail('Expected the failover listener failure to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($listenerFailure, $exception);
+        }
+
+        $this->assertFalse($store->forget('key'));
+        $this->assertSame(['second', 'first'], $failedStores);
+    }
+
+    public function testListenerInterruptionPreservesUnattemptedFailureHistoryWithSparseStoreKeys(): void
+    {
+        $listenerFailure = new RuntimeException('listener failure');
+        $firstFailure = new RuntimeException('first failure');
+        $secondFailure = new RuntimeException('second failure');
+        $thirdFailure = new RuntimeException('third failure');
+        $firstCall = 0;
+        $secondCall = 0;
+        $first = m::mock(Store::class);
+        $first->shouldReceive('forget')->times(3)->with('key')->andReturnUsing(
+            function () use (&$firstCall, $firstFailure): bool {
+                ++$firstCall;
+
+                return $firstCall === 1 ? true : throw $firstFailure;
+            }
+        );
+        $second = m::mock(Store::class);
+        $second->shouldReceive('forget')->times(3)->with('key')->andReturnUsing(
+            function () use (&$secondCall, $secondFailure): bool {
+                ++$secondCall;
+
+                return $secondCall === 1 ? true : throw $secondFailure;
+            }
+        );
+        $third = m::mock(Store::class);
+        $third->shouldReceive('forget')->twice()->with('key')->andThrow($thirdFailure);
+        $failedStores = [];
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('hasListeners')->with(CacheFailedOver::class)->andReturnTrue();
+        $events->shouldReceive('dispatch')->andReturnUsing(
+            function (CacheFailedOver $event) use (&$failedStores, $listenerFailure): void {
+                $failedStores[] = $event->storeName;
+
+                if ($event->storeName === 'second') {
+                    throw $listenerFailure;
+                }
+            }
+        );
+        $store = $this->makeFailoverStore(
+            ['first' => $first, 'second' => $second, 'third' => $third],
+            $events,
+            [0 => 'first', 2 => 'second', 5 => 'third'],
+        );
+
+        $this->assertFalse($store->forget('key'));
+
+        try {
+            $store->forget('key');
+            $this->fail('Expected the failover listener failure to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($listenerFailure, $exception);
+        }
+
+        try {
+            $store->forget('key');
+            $this->fail('Expected every backing store to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($thirdFailure, $exception);
+        }
+
+        $this->assertSame(['third', 'first', 'second'], $failedStores);
+    }
+
     public function testSeparateLockStoreReportingRequiresEveryLockProviderToBeSeparate(): void
     {
         $separate = $this->lockStore();
@@ -204,9 +358,13 @@ class CacheFailoverStoreTest extends TestCase
      * Create a failover store with the given named backing stores.
      *
      * @param array<string, Store> $stores
+     * @param null|array<int, string> $storeNames
      */
-    protected function makeFailoverStore(array $stores): FailoverStore
-    {
+    protected function makeFailoverStore(
+        array $stores,
+        ?Dispatcher $events = null,
+        ?array $storeNames = null,
+    ): FailoverStore {
         $cache = m::mock(CacheManager::class);
 
         foreach ($stores as $name => $store) {
@@ -215,7 +373,11 @@ class CacheFailoverStoreTest extends TestCase
                 ->andReturn(new Repository($store));
         }
 
-        return new FailoverStore($cache, m::mock(Dispatcher::class), array_keys($stores));
+        return new FailoverStore(
+            $cache,
+            $events ?? m::mock(Dispatcher::class),
+            $storeNames ?? array_keys($stores),
+        );
     }
 
     /**

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -336,7 +336,7 @@ class CacheManagerTest extends TestCase
         $this->assertSame($eventDispatcher, $repo->getEventDispatcher());
     }
 
-    public function testItRefreshesDispatcherOnAllStores()
+    public function testItRefreshesDispatcherOnAllStores(): void
     {
         $userConfig = [
             'cache' => [
@@ -355,21 +355,47 @@ class CacheManagerTest extends TestCase
 
         $app = $this->getApp($userConfig);
 
+        $originalDispatcher = m::mock(Dispatcher::class);
+        $app->instance(Dispatcher::class, $originalDispatcher);
+
         $cacheManager = new CacheManager($app);
         $repo1 = $cacheManager->store('store_1');
         $repo2 = $cacheManager->store('store_2');
 
-        $this->assertNull($repo1->getEventDispatcher());
-        $this->assertNull($repo2->getEventDispatcher());
+        $this->assertSame($originalDispatcher, $repo1->getEventDispatcher());
+        $this->assertSame($originalDispatcher, $repo2->getEventDispatcher());
 
-        $eventDispatcher = m::mock(Dispatcher::class);
-        $app->instance(Dispatcher::class, $eventDispatcher);
+        $replacementDispatcher = m::mock(Dispatcher::class);
+        $app->instance(Dispatcher::class, $replacementDispatcher);
 
         $cacheManager->refreshEventDispatcher();
 
         $this->assertNotSame($repo1, $repo2);
-        $this->assertSame($eventDispatcher, $repo1->getEventDispatcher());
-        $this->assertSame($eventDispatcher, $repo2->getEventDispatcher());
+        $this->assertSame($replacementDispatcher, $repo1->getEventDispatcher());
+        $this->assertSame($replacementDispatcher, $repo2->getEventDispatcher());
+    }
+
+    public function testRefreshEventDispatcherSkipsCustomRepositoryImplementations(): void
+    {
+        $app = $this->getApp([
+            'cache' => [
+                'stores' => [
+                    'custom' => ['driver' => 'custom'],
+                ],
+            ],
+        ]);
+        $app->instance(Dispatcher::class, m::mock(Dispatcher::class));
+
+        $cacheManager = new CacheManager($app);
+        $repository = m::mock(CacheRepository::class);
+        $repository->shouldNotReceive('setEventDispatcher');
+        $cacheManager->extend('custom', fn () => $repository);
+
+        $this->assertSame($repository, $cacheManager->store('custom'));
+
+        $cacheManager->refreshEventDispatcher();
+
+        $this->assertSame($repository, $cacheManager->store('custom'));
     }
 
     public function testItSetsDefaultDriverChangesGlobalConfig()
@@ -691,7 +717,7 @@ class CacheManagerTest extends TestCase
         $cacheManager->store('session');
     }
 
-    public function testMakesRepositoryWithoutDispatcherWhenEventsDisabled()
+    public function testMakesRepositoryWithoutDispatcherWhenEventsDisabled(): void
     {
         $userConfig = [
             'cache' => [
@@ -708,16 +734,25 @@ class CacheManagerTest extends TestCase
         ];
 
         $app = $this->getApp($userConfig);
-        $app->bind(Dispatcher::class, fn () => new Event);
+        $originalDispatcher = new Event;
+        $app->instance(Dispatcher::class, $originalDispatcher);
 
         $cacheManager = new CacheManager($app);
 
         // The repository will have an event dispatcher
         $repo = $cacheManager->store('my_store');
-        $this->assertNotNull($repo->getEventDispatcher());
+        $this->assertSame($originalDispatcher, $repo->getEventDispatcher());
 
         // This repository will not have an event dispatcher as 'events' is false
         $repoWithoutEvents = $cacheManager->store('my_store_without_events');
+        $this->assertNull($repoWithoutEvents->getEventDispatcher());
+
+        $replacementDispatcher = new Event;
+        $app->instance(Dispatcher::class, $replacementDispatcher);
+
+        $cacheManager->refreshEventDispatcher();
+
+        $this->assertSame($replacementDispatcher, $repo->getEventDispatcher());
         $this->assertNull($repoWithoutEvents->getEventDispatcher());
     }
 

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Cache;
 
+use Hypervel\Cache\Events\CacheFlushFailed;
+use Hypervel\Cache\Events\CacheFlushing;
 use Hypervel\Cache\NullStore;
 use Hypervel\Cache\Repository;
 use Hypervel\Contracts\Cache\CanFlushLocks;
+use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Tests\TestCase;
+use Mockery as m;
 
 class CacheNullStoreTest extends TestCase
 {
@@ -58,6 +62,24 @@ class CacheNullStoreTest extends TestCase
         });
 
         $this->assertSame(2, $count);
+    }
+
+    public function testTaggedFlushReportsRejectedTagIdentifierWrites(): void
+    {
+        $captured = [];
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('hasListeners')->withAnyArgs()->andReturnTrue();
+        $events->shouldReceive('dispatch')->andReturnUsing(function (object $event) use (&$captured): void {
+            $captured[] = $event;
+        });
+
+        $cache = (new Repository(new NullStore, ['store' => 'null']))->tags(['users', 'posts']);
+        $cache->setEventDispatcher($events);
+
+        $this->assertFalse($cache->flush());
+        $this->assertSame([CacheFlushing::class, CacheFlushFailed::class], array_map(get_class(...), $captured));
+        $this->assertSame('null', $captured[1]->storeName);
+        $this->assertSame(['users', 'posts'], $captured[1]->tags);
     }
 
     public function testLocksCanBeFlushed(): void

--- a/tests/Cache/CacheStackStoreTagsTest.php
+++ b/tests/Cache/CacheStackStoreTagsTest.php
@@ -31,6 +31,7 @@ use Hypervel\Tests\TestCase;
 use Mockery as m;
 use RuntimeException;
 use stdClass;
+use Swoole\Coroutine\CanceledException;
 
 class CacheStackStoreTagsTest extends TestCase
 {
@@ -512,11 +513,78 @@ class CacheStackStoreTagsTest extends TestCase
 
         $taggable->shouldReceive('tags')->once()->with(['tag'])->andReturn($taggedCache);
         $taggedCache->shouldReceive('getTags')->once()->andReturn($tagSet);
-        $tagSet->shouldReceive('flush')->once();
+        $tagSet->shouldReceive('flush')->once()->andReturnTrue();
 
         $stack = new StackStore([$this->nonTaggableStore(), $taggable]);
 
         $this->assertTrue($stack->tags(['tag'])->clear());
+    }
+
+    public function testClearFlushesEveryTaggableLayerAndAggregatesFalseResults(): void
+    {
+        $firstTaggable = $this->anyModeTaggableStore();
+        $secondTaggable = $this->anyModeTaggableStore();
+        $firstTaggedCache = m::mock(TaggedCache::class);
+        $secondTaggedCache = m::mock(TaggedCache::class);
+        $firstTagSet = m::mock(TagSet::class);
+        $secondTagSet = m::mock(TagSet::class);
+
+        $firstTaggable->shouldReceive('tags')->once()->with(['tag'])->andReturn($firstTaggedCache);
+        $secondTaggable->shouldReceive('tags')->once()->with(['tag'])->andReturn($secondTaggedCache);
+        $firstTaggedCache->shouldReceive('getTags')->once()->andReturn($firstTagSet);
+        $secondTaggedCache->shouldReceive('getTags')->once()->andReturn($secondTagSet);
+        $firstTagSet->shouldReceive('flush')->once()->andReturnFalse();
+        $secondTagSet->shouldReceive('flush')->once()->andReturnTrue();
+
+        $stack = new StackStore([$firstTaggable, $secondTaggable]);
+
+        $this->assertFalse($stack->tags(['tag'])->clear());
+    }
+
+    public function testTagSetFlushAttemptsEveryLayerAndPreservesTheFirstException(): void
+    {
+        $firstException = new RuntimeException('first tag flush failed');
+        $firstTaggable = $this->anyModeTaggableStore();
+        $secondTaggable = $this->anyModeTaggableStore();
+        $firstTaggedCache = m::mock(TaggedCache::class);
+        $secondTaggedCache = m::mock(TaggedCache::class);
+        $firstTagSet = m::mock(TagSet::class);
+        $secondTagSet = m::mock(TagSet::class);
+
+        $firstTaggable->shouldReceive('tags')->once()->with(['tag'])->andReturn($firstTaggedCache);
+        $secondTaggable->shouldReceive('tags')->once()->with(['tag'])->andReturn($secondTaggedCache);
+        $firstTaggedCache->shouldReceive('getTags')->once()->andReturn($firstTagSet);
+        $secondTaggedCache->shouldReceive('getTags')->once()->andReturn($secondTagSet);
+        $firstTagSet->shouldReceive('flush')->once()->andThrow($firstException);
+        $secondTagSet->shouldReceive('flush')->once()->andThrow(new RuntimeException('second tag flush failed'));
+
+        try {
+            (new StackStore([$firstTaggable, $secondTaggable]))->tags(['tag'])->getTags()->flush();
+            $this->fail('Expected the first tag flush exception to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($firstException, $exception);
+        }
+    }
+
+    public function testTagSetFlushStopsImmediatelyOnCancellation(): void
+    {
+        $cancellation = new CanceledException;
+        $firstTaggable = $this->anyModeTaggableStore();
+        $secondTaggable = $this->anyModeTaggableStore();
+        $firstTaggedCache = m::mock(TaggedCache::class);
+        $firstTagSet = m::mock(TagSet::class);
+
+        $firstTaggable->shouldReceive('tags')->once()->with(['tag'])->andReturn($firstTaggedCache);
+        $firstTaggedCache->shouldReceive('getTags')->once()->andReturn($firstTagSet);
+        $firstTagSet->shouldReceive('flush')->once()->andThrow($cancellation);
+        $secondTaggable->shouldNotReceive('tags');
+
+        try {
+            (new StackStore([$firstTaggable, $secondTaggable]))->tags(['tag'])->getTags()->flush();
+            $this->fail('Expected the tag flush cancellation to be rethrown.');
+        } catch (CanceledException $exception) {
+            $this->assertSame($cancellation, $exception);
+        }
     }
 
     private function anyModeTaggableStore(): TaggableStore|m\MockInterface

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -8,9 +8,15 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use Hypervel\Cache\ArrayStore;
+use Hypervel\Cache\NullStore;
 use Hypervel\Cache\Repository;
 use Hypervel\Cache\TaggedCache;
+use Hypervel\Cache\VersionedTagSet;
+use Hypervel\Contracts\Cache\Store;
 use Hypervel\Tests\TestCase;
+use Mockery as m;
+use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 
 enum TaggedCacheTestKeyStringEnum: string
 {
@@ -94,6 +100,156 @@ class CacheTaggedCacheTest extends TestCase
         $store->tags('zap')->flush();
         $this->assertNull($store->tags($tags1)->get('foo'));
         $this->assertSame('bar', $store->tags($tags2)->get('foo'));
+    }
+
+    public function testVersionedTagResetAttemptsEveryTagAndAggregatesFalseResults(): void
+    {
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forever')
+            ->once()
+            ->with('tag:users:key', m::type('string'))
+            ->andReturnFalse();
+        $store->shouldReceive('forever')
+            ->once()
+            ->with('tag:posts:key', m::type('string'))
+            ->andReturnTrue();
+
+        $this->assertFalse((new VersionedTagSet($store, ['users', 'posts']))->reset());
+    }
+
+    public function testVersionedTagFlushAttemptsEveryTagAndTreatsMissingTagKeysAsSuccess(): void
+    {
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forget')->once()->with('tag:users:key')->andReturnFalse();
+        $store->shouldReceive('forget')->once()->with('tag:posts:key')->andReturnTrue();
+
+        $this->assertTrue((new VersionedTagSet($store, ['users', 'posts']))->flush());
+    }
+
+    public function testVersionedTagFlushUsesThePerTagExtensionPoint(): void
+    {
+        $tagSet = new class(m::mock(Store::class), ['users', 'posts']) extends VersionedTagSet {
+            public array $flushed = [];
+
+            public function flushTag(string $name): string
+            {
+                $this->flushed[] = $name;
+
+                return $name;
+            }
+        };
+
+        $this->assertTrue($tagSet->flush());
+        $this->assertSame(['users', 'posts'], $tagSet->flushed);
+    }
+
+    public function testVersionedFlushTagReturnsItsKeyWhenTheTagDoesNotExist(): void
+    {
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forget')->once()->with('tag:users:key')->andReturnFalse();
+
+        $this->assertSame('tag:users:key', (new VersionedTagSet($store))->flushTag('users'));
+    }
+
+    public function testVersionedTagResetUsesTheWriteExtensionPoint(): void
+    {
+        $tagSet = new class(m::mock(Store::class), ['users', 'posts']) extends VersionedTagSet {
+            public array $written = [];
+
+            protected function writeTagId(string $name, string $id): bool
+            {
+                $this->written[] = $name;
+
+                return $name !== 'users';
+            }
+        };
+
+        $this->assertFalse($tagSet->reset());
+        $this->assertSame(['users', 'posts'], $tagSet->written);
+    }
+
+    public function testVersionedTagResetAttemptsLaterTagsAndRethrowsTheFirstException(): void
+    {
+        $firstException = new RuntimeException('users failed');
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forever')
+            ->once()
+            ->with('tag:users:key', m::type('string'))
+            ->andThrow($firstException);
+        $store->shouldReceive('forever')
+            ->once()
+            ->with('tag:posts:key', m::type('string'))
+            ->andThrow(new RuntimeException('posts failed'));
+        $store->shouldReceive('forever')
+            ->once()
+            ->with('tag:comments:key', m::type('string'))
+            ->andReturnTrue();
+
+        try {
+            (new VersionedTagSet($store, ['users', 'posts', 'comments']))->reset();
+            $this->fail('Expected the first tag reset exception to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($firstException, $exception);
+        }
+    }
+
+    public function testVersionedTagFlushAttemptsLaterTagsAndRethrowsTheFirstException(): void
+    {
+        $firstException = new RuntimeException('users failed');
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forget')->once()->with('tag:users:key')->andThrow($firstException);
+        $store->shouldReceive('forget')
+            ->once()
+            ->with('tag:posts:key')
+            ->andThrow(new RuntimeException('posts failed'));
+        $store->shouldReceive('forget')->once()->with('tag:comments:key')->andReturnTrue();
+
+        try {
+            (new VersionedTagSet($store, ['users', 'posts', 'comments']))->flush();
+            $this->fail('Expected the first tag flush exception to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($firstException, $exception);
+        }
+    }
+
+    public function testVersionedTagResetStopsImmediatelyOnCancellation(): void
+    {
+        $cancellation = new CanceledException;
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forever')
+            ->once()
+            ->with('tag:users:key', m::type('string'))
+            ->andThrow($cancellation);
+        $store->shouldNotReceive('forever')->with('tag:posts:key', m::type('string'));
+
+        try {
+            (new VersionedTagSet($store, ['users', 'posts']))->reset();
+            $this->fail('Expected the tag reset cancellation to be rethrown.');
+        } catch (CanceledException $exception) {
+            $this->assertSame($cancellation, $exception);
+        }
+    }
+
+    public function testVersionedTagFlushStopsImmediatelyOnCancellation(): void
+    {
+        $cancellation = new CanceledException;
+        $store = m::mock(Store::class);
+        $store->shouldReceive('forget')->once()->with('tag:users:key')->andThrow($cancellation);
+        $store->shouldNotReceive('forget')->with('tag:posts:key');
+
+        try {
+            (new VersionedTagSet($store, ['users', 'posts']))->flush();
+            $this->fail('Expected the tag flush cancellation to be rethrown.');
+        } catch (CanceledException $exception) {
+            $this->assertSame($cancellation, $exception);
+        }
+    }
+
+    public function testResetTagReturnsGeneratedIdentifierWhenTheStoreRejectsTheWrite(): void
+    {
+        $identifier = (new VersionedTagSet(new NullStore, ['users']))->resetTag('users');
+
+        $this->assertNotSame('', $identifier);
     }
 
     public function testClearFlushesOnlyTaggedNamespace(): void

--- a/tests/Cache/Redis/AllTagSetTest.php
+++ b/tests/Cache/Redis/AllTagSetTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Cache\Redis;
 
 use Hypervel\Cache\Redis\AllTagSet;
+use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 
 /**
  * Tests for AllTagSet class.
@@ -16,10 +18,7 @@ use Hypervel\Cache\Redis\AllTagSet;
  */
 class AllTagSetTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
-    public function testResetWalksAllTags(): void
+    public function testResetAttemptsEveryTag(): void
     {
         $connection = $this->mockConnection();
         $store = $this->createStore($connection);
@@ -34,15 +33,10 @@ class AllTagSetTest extends RedisCacheTestCase
             ->with('prefix:_all:tag:posts:entries')
             ->andReturn(1);
 
-        $tagSet->reset();
-
-        $this->assertTrue(true);
+        $this->assertTrue($tagSet->reset());
     }
 
-    /**
-     * @test
-     */
-    public function testFlushWalksAllTags(): void
+    public function testFlushAttemptsEveryTag(): void
     {
         $connection = $this->mockConnection();
         $store = $this->createStore($connection);
@@ -57,14 +51,103 @@ class AllTagSetTest extends RedisCacheTestCase
             ->with('prefix:_all:tag:posts:entries')
             ->andReturn(1);
 
-        $tagSet->flush();
-
-        $this->assertTrue(true);
+        $this->assertTrue($tagSet->flush());
     }
 
-    /**
-     * @test
-     */
+    public function testResetAndFlushAttemptEveryTagAndTreatMissingTagsAsSuccess(): void
+    {
+        $connection = $this->mockConnection();
+        $store = $this->createStore($connection);
+        $tagSet = new AllTagSet($store, ['users', 'posts']);
+
+        $connection->shouldReceive('del')
+            ->twice()
+            ->with('prefix:_all:tag:users:entries')
+            ->andReturn(0);
+        $connection->shouldReceive('del')
+            ->twice()
+            ->with('prefix:_all:tag:posts:entries')
+            ->andReturn(1);
+
+        $this->assertTrue($tagSet->reset());
+        $this->assertTrue($tagSet->flush());
+    }
+
+    public function testResetAndFlushUseTheirPerTagExtensionPoints(): void
+    {
+        $tagSet = new class($this->createStore($this->mockConnection()), ['users', 'posts']) extends AllTagSet {
+            public array $flushed = [];
+
+            public array $reset = [];
+
+            public function resetTag(string $name): string
+            {
+                $this->reset[] = $name;
+
+                return $name;
+            }
+
+            public function flushTag(string $name): string
+            {
+                $this->flushed[] = $name;
+
+                return $name;
+            }
+        };
+
+        $this->assertTrue($tagSet->reset());
+        $this->assertTrue($tagSet->flush());
+        $this->assertSame(['users', 'posts'], $tagSet->reset);
+        $this->assertSame(['users', 'posts'], $tagSet->flushed);
+    }
+
+    public function testResetAttemptsLaterTagsAndRethrowsTheFirstException(): void
+    {
+        $firstException = new RuntimeException('users failed');
+        $connection = $this->mockConnection();
+        $tagSet = new AllTagSet($this->createStore($connection), ['users', 'posts', 'comments']);
+
+        $connection->shouldReceive('del')
+            ->once()
+            ->with('prefix:_all:tag:users:entries')
+            ->andThrow($firstException);
+        $connection->shouldReceive('del')
+            ->once()
+            ->with('prefix:_all:tag:posts:entries')
+            ->andThrow(new RuntimeException('posts failed'));
+        $connection->shouldReceive('del')
+            ->once()
+            ->with('prefix:_all:tag:comments:entries')
+            ->andReturn(1);
+
+        try {
+            $tagSet->reset();
+            $this->fail('Expected the first tag reset exception to be rethrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($firstException, $exception);
+        }
+    }
+
+    public function testResetStopsImmediatelyOnCancellation(): void
+    {
+        $cancellation = new CanceledException;
+        $connection = $this->mockConnection();
+        $tagSet = new AllTagSet($this->createStore($connection), ['users', 'posts']);
+
+        $connection->shouldReceive('del')
+            ->once()
+            ->with('prefix:_all:tag:users:entries')
+            ->andThrow($cancellation);
+        $connection->shouldNotReceive('del')->with('prefix:_all:tag:posts:entries');
+
+        try {
+            $tagSet->reset();
+            $this->fail('Expected the tag reset cancellation to be rethrown.');
+        } catch (CanceledException $exception) {
+            $this->assertSame($cancellation, $exception);
+        }
+    }
+
     public function testFlushTagCallsResetTag(): void
     {
         $connection = $this->mockConnection();
@@ -83,9 +166,20 @@ class AllTagSetTest extends RedisCacheTestCase
         $this->assertSame('_all:tag:users:entries', $result);
     }
 
-    /**
-     * @test
-     */
+    public function testPerTagOperationsReturnTheIdentifierWhenTheTagDoesNotExist(): void
+    {
+        $connection = $this->mockConnection();
+        $tagSet = new AllTagSet($this->createStore($connection), ['users']);
+
+        $connection->shouldReceive('del')
+            ->twice()
+            ->with('prefix:_all:tag:users:entries')
+            ->andReturn(0);
+
+        $this->assertSame('_all:tag:users:entries', $tagSet->resetTag('users'));
+        $this->assertSame('_all:tag:users:entries', $tagSet->flushTag('users'));
+    }
+
     public function testResetTagDeletesTagAndReturnsId(): void
     {
         $connection = $this->mockConnection();
@@ -102,9 +196,6 @@ class AllTagSetTest extends RedisCacheTestCase
         $this->assertSame('_all:tag:users:entries', $result);
     }
 
-    /**
-     * @test
-     */
     public function testTagIdReturnsCorrectFormat(): void
     {
         $connection = $this->mockConnection();
@@ -115,9 +206,6 @@ class AllTagSetTest extends RedisCacheTestCase
         $this->assertSame('_all:tag:posts:entries', $tagSet->tagId('posts'));
     }
 
-    /**
-     * @test
-     */
     public function testTagKeyReturnsCorrectFormat(): void
     {
         $connection = $this->mockConnection();
@@ -128,9 +216,6 @@ class AllTagSetTest extends RedisCacheTestCase
         $this->assertSame('_all:tag:users:entries', $tagSet->tagKey('users'));
     }
 
-    /**
-     * @test
-     */
     public function testTagIdsReturnsArrayOfTagIdentifiers(): void
     {
         $connection = $this->mockConnection();
@@ -146,9 +231,6 @@ class AllTagSetTest extends RedisCacheTestCase
         ], $tagIds);
     }
 
-    /**
-     * @test
-     */
     public function testGetNamesReturnsOriginalTagNames(): void
     {
         $connection = $this->mockConnection();

--- a/tests/Cache/Redis/AnyTagSetTest.php
+++ b/tests/Cache/Redis/AnyTagSetTest.php
@@ -181,10 +181,7 @@ class AnyTagSetTest extends RedisCacheTestCase
         $this->pipeline->shouldReceive('zrem')->andReturnSelf();
         $this->pipeline->shouldReceive('exec')->andReturn([]);
 
-        $tagSet->flush();
-
-        // If we get here without exception, the flush executed through the full chain
-        $this->assertTrue(true);
+        $this->assertTrue($tagSet->flush());
     }
 
     /**
@@ -249,10 +246,7 @@ class AnyTagSetTest extends RedisCacheTestCase
         $this->pipeline->shouldReceive('zrem')->andReturnSelf();
         $this->pipeline->shouldReceive('exec')->andReturn([]);
 
-        $tagSet->reset();
-
-        // If we get here without exception, reset executed flush correctly
-        $this->assertTrue(true);
+        $this->assertTrue($tagSet->reset());
     }
 
     /**

--- a/tests/Console/ConsoleApplicationDeferredCallbacksTest.php
+++ b/tests/Console/ConsoleApplicationDeferredCallbacksTest.php
@@ -1,0 +1,464 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Console;
+
+use Closure;
+use Hypervel\Console\Application as ConsoleApplication;
+use Hypervel\Console\Command;
+use Hypervel\Console\CommandMutex;
+use Hypervel\Console\Events\AfterExecute;
+use Hypervel\Container\Container;
+use Hypervel\Contracts\Console\Isolatable;
+use Hypervel\Contracts\Events\Dispatcher;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
+use Hypervel\Testbench\TestCase;
+use Mockery as m;
+use RuntimeException;
+use Swoole\Coroutine\CanceledException;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConsoleApplicationDeferredCallbacksTest extends TestCase
+{
+    protected bool $runTestsInCoroutine = false;
+
+    public function testCoroutineCommandDrainsAfterObserversAndMutexCleanup(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+        $mutex = m::mock(CommandMutex::class);
+        $mutex->shouldReceive('create')->once()->andReturnUsing(function () use (&$calls): bool {
+            $calls[] = 'mutex-created';
+
+            return true;
+        });
+        $mutex->shouldReceive('forget')->once()->andReturnUsing(function () use (&$calls): bool {
+            $calls[] = 'mutex-released';
+
+            return true;
+        });
+        $this->app->instance(CommandMutex::class, $mutex);
+        $this->app->make(Dispatcher::class)->listen(AfterExecute::class, function () use (&$calls): void {
+            $calls[] = 'after-execute';
+        });
+
+        $application->addCommand(new IsolatableDeferredCommand('test:coroutine-order', function () use (&$calls): int {
+            $calls[] = 'handle';
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred';
+            });
+
+            return Command::SUCCESS;
+        }));
+
+        $application->call('test:coroutine-order', ['--isolated' => true]);
+
+        $this->assertSame([
+            'mutex-created',
+            'handle',
+            'after-execute',
+            'mutex-released',
+            'deferred',
+        ], $calls);
+    }
+
+    public function testCoroutineCommandDrainsWhenItsEventDispatcherIsDisabled(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:coroutine-disabled-events', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred';
+            });
+
+            return Command::SUCCESS;
+        }));
+
+        $application->call('test:coroutine-disabled-events', ['--disable-event-dispatcher' => true]);
+
+        $this->assertSame(['deferred'], $calls);
+    }
+
+    public function testCommandsWithoutDeferredCallbacksDoNotResolveTheCollection(): void
+    {
+        $application = $this->createConsoleApplication();
+        $application->addCommand(new DeferredCommand(
+            'test:no-defer-coroutine',
+            fn () => Command::SUCCESS,
+        ));
+        $application->addCommand(new DeferredCommand(
+            'test:no-defer-non-coroutine',
+            fn () => Command::SUCCESS,
+            coroutine: false,
+        ));
+
+        $application->call('test:no-defer-coroutine');
+        $application->call('test:no-defer-non-coroutine');
+
+        $this->assertFalse(Container::getInstance()->resolvedScoped(DeferredCallbackCollection::class));
+    }
+
+    public function testApplicationFrameDoesNotOwnCallbacksOutsideConsoleExecution(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+        $this->app->setRunningInConsole(false);
+        $application->addCommand(new DeferredCommand('test:not-console', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred';
+            });
+
+            return Command::SUCCESS;
+        }, coroutine: false));
+
+        $application->call('test:not-console');
+
+        $this->assertSame([], $calls);
+
+        $this->app->setRunningInConsole(true);
+        $application->addCommand(new DeferredCommand(
+            'test:next-console-owner',
+            fn () => Command::SUCCESS,
+            coroutine: false,
+        ));
+        $application->call('test:next-console-owner');
+
+        $this->assertSame(['deferred'], $calls);
+    }
+
+    public function testNonCoroutineCommandDrainsWithSuccessAndAlwaysFiltering(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:non-coroutine-success', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'success';
+            });
+
+            return Command::SUCCESS;
+        }, coroutine: false));
+        $application->addCommand(new DeferredCommand('test:non-coroutine-failure', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'skipped';
+            });
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            }, always: true);
+
+            return Command::FAILURE;
+        }, coroutine: false));
+
+        $this->assertSame(Command::SUCCESS, $application->call('test:non-coroutine-success'));
+        $this->assertSame(Command::FAILURE, $application->call('test:non-coroutine-failure'));
+
+        $this->assertSame(['success', 'always'], $calls);
+    }
+
+    public function testPlainSymfonyCommandsDrainThroughProgrammaticAndRootExecution(): void
+    {
+        $programmaticApplication = $this->createConsoleApplication();
+        $rootApplication = $this->createConsoleApplication();
+        $calls = [];
+        $programmaticApplication->addCommand(new PlainDeferredCommand('test:plain-programmatic', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'programmatic';
+            });
+
+            return SymfonyCommand::SUCCESS;
+        }));
+        $rootApplication->addCommand(new PlainDeferredCommand('test:plain-root', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'root';
+            });
+
+            return SymfonyCommand::SUCCESS;
+        }));
+
+        $this->assertSame(SymfonyCommand::SUCCESS, $programmaticApplication->call('test:plain-programmatic'));
+        $this->assertSame(SymfonyCommand::SUCCESS, $rootApplication->run(
+            new ArrayInput(['command' => 'test:plain-root']),
+            new BufferedOutput,
+        ));
+
+        $this->assertSame(['programmatic', 'root'], $calls);
+    }
+
+    public function testNestedProgrammaticCallFromDeferredCallbackDoesNotReenterTheDrain(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:nested-inner', function () use (&$calls): int {
+            $calls[] = 'inner-handle';
+
+            return Command::SUCCESS;
+        }, coroutine: false));
+        $application->addCommand(new DeferredCommand('test:nested-outer', function () use ($application, &$calls): int {
+            defer(function () use ($application, &$calls): void {
+                $calls[] = 'first-deferred';
+                $application->call('test:nested-inner');
+            });
+            defer(function () use (&$calls): void {
+                $calls[] = 'second-deferred';
+            });
+
+            return Command::SUCCESS;
+        }, coroutine: false));
+
+        $application->call('test:nested-outer');
+
+        $this->assertSame(['first-deferred', 'inner-handle', 'second-deferred'], $calls);
+    }
+
+    public function testCallbackAddedDuringNonCoroutineDrainRunsAtNextOwningCall(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:one-pass-register', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'first';
+                defer(function () use (&$calls): void {
+                    $calls[] = 'second';
+                });
+            });
+
+            return Command::SUCCESS;
+        }, coroutine: false));
+        $application->addCommand(new DeferredCommand(
+            'test:one-pass-next',
+            fn () => Command::SUCCESS,
+            coroutine: false,
+        ));
+
+        $application->call('test:one-pass-register');
+        $this->assertSame(['first'], $calls);
+        $this->assertCount(1, $this->app->make(DeferredCallbackCollection::class));
+
+        $application->call('test:one-pass-next');
+        $this->assertSame(['first', 'second'], $calls);
+        $this->assertCount(0, $this->app->make(DeferredCallbackCollection::class));
+    }
+
+    public function testCallbackAddedDuringCoroutineDrainDoesNotSurviveTheCoroutine(): void
+    {
+        $application = $this->createConsoleApplication();
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:coroutine-one-pass', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'first';
+                defer(function () use (&$calls): void {
+                    $calls[] = 'second';
+                });
+            });
+
+            return Command::SUCCESS;
+        }));
+        $application->addCommand(new DeferredCommand(
+            'test:coroutine-next',
+            fn () => Command::SUCCESS,
+            coroutine: false,
+        ));
+
+        $application->call('test:coroutine-one-pass');
+        $application->call('test:coroutine-next');
+
+        $this->assertSame(['first'], $calls);
+    }
+
+    public function testApplicationOwnerRunsAlwaysCallbacksAndPreservesCommandFailure(): void
+    {
+        $application = $this->createConsoleApplication();
+        $failure = new RuntimeException('command failed');
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:application-failure', function () use (&$calls, $failure): never {
+            defer(function () use (&$calls): void {
+                $calls[] = 'skipped';
+            });
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            }, always: true);
+
+            throw $failure;
+        }, coroutine: false));
+
+        try {
+            $application->call('test:application-failure');
+            $this->fail('Expected the command to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($failure, $exception);
+        }
+
+        $application->addCommand(new DeferredCommand('test:application-recovery', function () use (&$calls): int {
+            defer(function () use (&$calls): void {
+                $calls[] = 'recovery';
+            });
+
+            return Command::SUCCESS;
+        }, coroutine: false));
+        $application->call('test:application-recovery');
+
+        $this->assertSame(['always', 'recovery'], $calls);
+    }
+
+    public function testApplicationOwnerCancellationSkipsDeferredCallbacks(): void
+    {
+        $application = $this->createConsoleApplication();
+        $cancellation = new CanceledException;
+        $calls = [];
+
+        $application->addCommand(new PlainDeferredCommand('test:application-cancellation', function () use (&$calls, $cancellation): never {
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            }, always: true);
+
+            throw $cancellation;
+        }));
+
+        try {
+            $application->call('test:application-cancellation');
+            $this->fail('Expected the command to be cancelled.');
+        } catch (CanceledException $exception) {
+            $this->assertSame($cancellation, $exception);
+        }
+
+        $this->assertSame([], $calls);
+    }
+
+    public function testCommandOwnerCancellationSkipsDeferredCallbacks(): void
+    {
+        $application = $this->createConsoleApplication();
+        $cancellation = new CanceledException;
+        $calls = [];
+
+        $application->addCommand(new DeferredCommand('test:command-cancellation', function () use (&$calls, $cancellation): never {
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            }, always: true);
+
+            throw $cancellation;
+        }));
+
+        try {
+            $application->call('test:command-cancellation');
+            $this->fail('Expected the command to be cancelled.');
+        } catch (CanceledException $exception) {
+            $this->assertSame($cancellation, $exception);
+        }
+
+        $this->assertSame([], $calls);
+    }
+
+    public function testApplicationOwnerPreservesEarlierFailureWhenDrainAlsoFails(): void
+    {
+        $application = $this->createConsoleApplication();
+        $commandFailure = new RuntimeException('command failed');
+        $drainFailure = new RuntimeException('drain failed');
+        $this->app->scoped(
+            DeferredCallbackCollection::class,
+            fn () => new ThrowingDeferredCallbackCollection($drainFailure),
+        );
+
+        $application->addCommand(new DeferredCommand('test:application-drain-failure', function () use ($commandFailure): never {
+            defer(fn () => null);
+
+            throw $commandFailure;
+        }, coroutine: false));
+
+        try {
+            $application->call('test:application-drain-failure');
+            $this->fail('Expected the command to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($commandFailure, $exception);
+        }
+    }
+
+    public function testCommandOwnerPreservesEarlierFailureWhenDrainAlsoFails(): void
+    {
+        $application = $this->createConsoleApplication();
+        $commandFailure = new RuntimeException('command failed');
+        $drainFailure = new RuntimeException('drain failed');
+        $this->app->scoped(
+            DeferredCallbackCollection::class,
+            fn () => new ThrowingDeferredCallbackCollection($drainFailure),
+        );
+
+        $application->addCommand(new DeferredCommand('test:command-drain-failure', function () use ($commandFailure): never {
+            defer(fn () => null);
+
+            throw $commandFailure;
+        }));
+
+        try {
+            $application->call('test:command-drain-failure');
+            $this->fail('Expected the command to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($commandFailure, $exception);
+        }
+    }
+
+    private function createConsoleApplication(): ConsoleApplication
+    {
+        return new ConsoleApplication(
+            $this->app,
+            $this->app->make('events'),
+            '1.0',
+        );
+    }
+}
+
+class DeferredCommand extends Command
+{
+    public function __construct(
+        string $name,
+        private readonly Closure $callback,
+        bool $coroutine = true,
+    ) {
+        $this->coroutine = $coroutine;
+
+        parent::__construct($name);
+    }
+
+    public function handle(): int
+    {
+        return ($this->callback)();
+    }
+}
+
+class IsolatableDeferredCommand extends DeferredCommand implements Isolatable
+{
+}
+
+class PlainDeferredCommand extends SymfonyCommand
+{
+    public function __construct(string $name, private readonly Closure $callback)
+    {
+        parent::__construct($name);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return ($this->callback)();
+    }
+}
+
+class ThrowingDeferredCallbackCollection extends DeferredCallbackCollection
+{
+    public function __construct(private readonly RuntimeException $exception)
+    {
+    }
+
+    public function invokeWhen(?Closure $when = null): void
+    {
+        throw $this->exception;
+    }
+}

--- a/tests/Console/ConsoleApplicationResolveTest.php
+++ b/tests/Console/ConsoleApplicationResolveTest.php
@@ -370,7 +370,7 @@ class ConsoleApplicationResolveTest extends TestCase
     // Application::call()
     // ---------------------------------------------------------------
 
-    public function testCallStringAndArrayInputProduceSameResult()
+    public function testCallStringAndArrayInputProduceSameResult(): void
     {
         $app = $this->createApp(
             m::mock(Application::class, [

--- a/tests/Console/ConsoleApplicationResolveTest.php
+++ b/tests/Console/ConsoleApplicationResolveTest.php
@@ -373,7 +373,10 @@ class ConsoleApplicationResolveTest extends TestCase
     public function testCallStringAndArrayInputProduceSameResult()
     {
         $app = $this->createApp(
-            m::mock(Application::class, ['version' => '1.0']),
+            m::mock(Application::class, [
+                'version' => '1.0',
+                'runningInConsole' => false,
+            ]),
         );
 
         $codeOfCallingArrayInput = $app->call('help', [

--- a/tests/Foundation/CoroutineQueueDeferredCallbacksTest.php
+++ b/tests/Foundation/CoroutineQueueDeferredCallbacksTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Foundation\CoroutineQueueDeferredCallbacksTest;
+
+use Hypervel\Queue\BackgroundQueue;
+use Hypervel\Queue\DeferredQueue;
+use Hypervel\Queue\Jobs\SyncJob;
+use Hypervel\Testbench\TestCase;
+use RuntimeException;
+use Throwable;
+
+use function Hypervel\Coroutine\run;
+
+class CoroutineQueueDeferredCallbacksTest extends TestCase
+{
+    protected bool $runTestsInCoroutine = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CoroutineQueueDeferredCallbacksState::$calls = [];
+    }
+
+    public function testImmediateJobDrainsItsDeferredCallbacks(): void
+    {
+        $queue = $this->configureQueue(new DeferredQueue, 'deferred');
+
+        run(fn () => $queue->push(CoroutineQueueSuccessfulHandler::class));
+
+        $this->assertSame(['normal', 'always'], CoroutineQueueDeferredCallbacksState::$calls);
+    }
+
+    public function testFailedJobDrainsOnlyAlwaysDeferredCallbacks(): void
+    {
+        $failure = null;
+        $queue = $this->configureQueue(new DeferredQueue, 'deferred');
+        $queue->setExceptionCallback(function (Throwable $exception) use (&$failure): void {
+            $failure = $exception;
+        });
+
+        run(fn () => $queue->push(CoroutineQueueFailingHandler::class));
+
+        $this->assertInstanceOf(RuntimeException::class, $failure);
+        $this->assertSame('Deferred queue job failed.', $failure->getMessage());
+        $this->assertSame(['always'], CoroutineQueueDeferredCallbacksState::$calls);
+    }
+
+    public function testDelayedJobDrainsCallbacksInItsTimerCoroutine(): void
+    {
+        $queue = $this->configureQueue(new DeferredQueue, 'deferred');
+
+        run(fn () => $queue->later(0, CoroutineQueueSuccessfulHandler::class));
+
+        $this->assertSame(['normal', 'always'], CoroutineQueueDeferredCallbacksState::$calls);
+    }
+
+    public function testBackgroundJobDrainsCallbacksInItsOwnCoroutine(): void
+    {
+        $queue = $this->configureQueue(new BackgroundQueue, 'background');
+
+        run(fn () => $queue->push(CoroutineQueueSuccessfulHandler::class));
+
+        $this->assertSame(['normal', 'always'], CoroutineQueueDeferredCallbacksState::$calls);
+    }
+
+    private function configureQueue(BackgroundQueue|DeferredQueue $queue, string $connectionName): BackgroundQueue|DeferredQueue
+    {
+        $queue->setConnectionName($connectionName);
+        $queue->setContainer($this->app);
+
+        return $queue;
+    }
+}
+
+class CoroutineQueueSuccessfulHandler
+{
+    public function fire(SyncJob $job, mixed $data): void
+    {
+        defer(fn () => CoroutineQueueDeferredCallbacksState::$calls[] = 'normal');
+        defer(fn () => CoroutineQueueDeferredCallbacksState::$calls[] = 'always', always: true);
+    }
+}
+
+class CoroutineQueueFailingHandler extends CoroutineQueueSuccessfulHandler
+{
+    public function fire(SyncJob $job, mixed $data): void
+    {
+        parent::fire($job, $data);
+
+        throw new RuntimeException('Deferred queue job failed.');
+    }
+
+    public function failed(): void
+    {
+    }
+}
+
+class CoroutineQueueDeferredCallbacksState
+{
+    /**
+     * @var list<string>
+     */
+    public static array $calls = [];
+}

--- a/tests/Foundation/DeferredCallbacksTest.php
+++ b/tests/Foundation/DeferredCallbacksTest.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Foundation\DeferredCallbacksTest;
 
-use Hypervel\Console\Events\CommandFinished;
+use Hypervel\Console\Application as ConsoleApplication;
+use Hypervel\Console\Command;
+use Hypervel\Container\Container;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Contracts\Queue\Job;
+use Hypervel\Queue\Events\JobAttempted;
 use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Support\Facades\Route;
 use Hypervel\Testbench\TestCase;
 use Mockery as m;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\NullOutput;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DeferredCallbacksTest extends TestCase
 {
@@ -23,7 +25,7 @@ class DeferredCallbacksTest extends TestCase
         DeferredCallbacksTestState::reset();
     }
 
-    public function testHttpTerminateRunsDeferredCallbacksForSuccessfulResponses()
+    public function testHttpTerminateRunsDeferredCallbacksForSuccessfulResponses(): void
     {
         Route::get('/deferred-callbacks/success', function () {
             defer(function () {
@@ -39,7 +41,7 @@ class DeferredCallbacksTest extends TestCase
         $this->assertCount(0, $this->app->make(DeferredCallbackCollection::class));
     }
 
-    public function testHttpTerminateSkipsFailedResponsesUnlessAlwaysTrue()
+    public function testHttpTerminateSkipsFailedResponsesUnlessAlwaysTrue(): void
     {
         Route::get('/deferred-callbacks/failure', function () {
             defer(function () {
@@ -59,43 +61,57 @@ class DeferredCallbacksTest extends TestCase
         $this->assertCount(0, $this->app->make(DeferredCallbackCollection::class));
     }
 
-    public function testCommandFinishedRunsDeferredCallbacksForSuccessfulExitCodes()
+    public function testHttpRequestOwnsCallbacksRegisteredByNestedCommand(): void
     {
-        defer(function () {
-            DeferredCallbacksTestState::record('normal');
+        $application = $this->createConsoleApplication();
+        $application->addCommand(new NestedDeferredCommand);
+
+        Route::get('/deferred-callbacks/command', function () use ($application) {
+            $application->call('deferred-callbacks:nested');
+            DeferredCallbacksTestState::record('after-command');
+
+            return response('ok');
         });
 
-        defer(function () {
-            DeferredCallbacksTestState::record('always');
-        }, always: true);
+        $this->get('/deferred-callbacks/command')->assertOk();
 
-        $this->app->make(Dispatcher::class)->dispatch(
-            new CommandFinished('deferred-callbacks:test', new StringInput(''), new NullOutput, 0)
-        );
-
-        $this->assertSame(['normal', 'always'], DeferredCallbacksTestState::$calls);
+        $this->assertSame(['after-command', 'deferred'], DeferredCallbacksTestState::$calls);
         $this->assertCount(0, $this->app->make(DeferredCallbackCollection::class));
     }
 
-    public function testCommandFinishedSkipsFailedExitCodesUnlessAlwaysTrue()
+    public function testJobLifecycleOwnsCallbacksRegisteredByNestedCommand(): void
     {
-        defer(function () {
-            DeferredCallbacksTestState::record('normal');
-        });
+        $application = $this->createConsoleApplication();
+        $application->addCommand(new NestedDeferredCommand);
+        $application->call('deferred-callbacks:nested');
 
-        defer(function () {
-            DeferredCallbacksTestState::record('always');
-        }, always: true);
+        $this->assertSame([], DeferredCallbacksTestState::$calls);
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('hasFailed')->andReturnFalse();
 
         $this->app->make(Dispatcher::class)->dispatch(
-            new CommandFinished('deferred-callbacks:test', new StringInput(''), new NullOutput, 1)
+            new JobAttempted('database', $job, null)
         );
 
-        $this->assertSame(['always'], DeferredCallbacksTestState::$calls);
+        $this->assertSame(['deferred'], DeferredCallbacksTestState::$calls);
         $this->assertCount(0, $this->app->make(DeferredCallbackCollection::class));
     }
 
-    public function testJobAttemptedRunsDeferredCallbacksForSuccessfulJobs()
+    public function testJobWithoutDeferredCallbacksDoesNotResolveTheCollection(): void
+    {
+        $job = m::mock(Job::class);
+        $job->shouldNotReceive('hasFailed');
+
+        $this->app->make(Dispatcher::class)->dispatch(
+            new JobAttempted('database', $job, null)
+        );
+
+        $this->assertFalse(Container::getInstance()->resolvedScoped(DeferredCallbackCollection::class));
+    }
+
+    #[DataProvider('owningQueueConnections')]
+    public function testJobAttemptedRunsDeferredCallbacksForSuccessfulJobs(string $connection): void
     {
         defer(function () {
             DeferredCallbacksTestState::record('job');
@@ -105,14 +121,23 @@ class DeferredCallbacksTest extends TestCase
         $job->shouldReceive('hasFailed')->andReturnFalse();
 
         $this->app->make(Dispatcher::class)->dispatch(
-            new \Hypervel\Queue\Events\JobAttempted('database', $job, null)
+            new JobAttempted($connection, $job, null)
         );
 
         $this->assertSame(['job'], DeferredCallbacksTestState::$calls);
         $this->assertCount(0, $this->app->make(DeferredCallbackCollection::class));
     }
 
-    public function testJobAttemptedSkipsFailedJobsAndSyncConnectionsUnlessAlwaysTrue()
+    public static function owningQueueConnections(): array
+    {
+        return [
+            'persistent' => ['database'],
+            'deferred' => ['deferred'],
+            'background' => ['background'],
+        ];
+    }
+
+    public function testJobAttemptedSkipsFailedJobsAndSyncConnectionsUnlessAlwaysTrue(): void
     {
         defer(function () {
             DeferredCallbacksTestState::record('normal');
@@ -126,7 +151,7 @@ class DeferredCallbacksTest extends TestCase
         $failedJob->shouldReceive('hasFailed')->andReturnTrue();
 
         $this->app->make(Dispatcher::class)->dispatch(
-            new \Hypervel\Queue\Events\JobAttempted('database', $failedJob, null)
+            new JobAttempted('database', $failedJob, null)
         );
 
         $this->assertSame(['always'], DeferredCallbacksTestState::$calls);
@@ -141,11 +166,34 @@ class DeferredCallbacksTest extends TestCase
         $syncJob->shouldReceive('hasFailed')->never();
 
         $this->app->make(Dispatcher::class)->dispatch(
-            new \Hypervel\Queue\Events\JobAttempted('sync', $syncJob, null)
+            new JobAttempted('sync', $syncJob, null)
         );
 
         $this->assertSame([], DeferredCallbacksTestState::$calls);
         $this->assertCount(1, $this->app->make(DeferredCallbackCollection::class));
+    }
+
+    private function createConsoleApplication(): ConsoleApplication
+    {
+        return new ConsoleApplication(
+            $this->app,
+            $this->app->make('events'),
+            '1.0',
+        );
+    }
+}
+
+class NestedDeferredCommand extends Command
+{
+    protected ?string $name = 'deferred-callbacks:nested';
+
+    public function handle(): int
+    {
+        defer(function (): void {
+            DeferredCallbacksTestState::record('deferred');
+        });
+
+        return self::SUCCESS;
     }
 }
 

--- a/tests/Grpc/BaseClientTest.php
+++ b/tests/Grpc/BaseClientTest.php
@@ -699,20 +699,22 @@ class BaseClientTest extends TestCase
         $this->bindFactory(new ClientCallClientFactory(...$engineClients));
         $first = $this->newClient(options: ['connections' => 2]);
         $second = $this->newClient(options: ['connections' => 2]);
+        $calls = [];
 
         for ($index = 0; $index < 3; ++$index) {
-            $first->unary(
+            $calls[] = $first->unary(
                 '/testing.Service/Unary',
                 new StringValue,
                 [StringValue::class, 'decode'],
             );
-            $second->unary(
+            $calls[] = $second->unary(
                 '/testing.Service/Unary',
                 new StringValue,
                 [StringValue::class, 'decode'],
             );
         }
 
+        $this->assertCount(6, $calls);
         $this->assertSame(
             [2, 2, 1, 1],
             array_map(static fn (ClientCallClient $client): int => count($client->sentRequests), $engineClients),

--- a/tests/Grpc/ClientStreamingCallTest.php
+++ b/tests/Grpc/ClientStreamingCallTest.php
@@ -145,6 +145,31 @@ class ClientStreamingCallTest extends TestCase
         $call->write(new StringValue);
     }
 
+    public function testDroppingAnIncompleteCallAbandonsItsNativeStream(): void
+    {
+        [$call, , $state, $connection] = $this->call();
+
+        unset($call);
+
+        // Abandoned calls must release immediately, without waiting for cycle collection.
+        $this->assertTrue($state->isAbandoned());
+        $this->assertFalse($state->isComplete());
+        $this->assertFalse($connection->isAccepting());
+    }
+
+    public function testDroppingACompletedCallDoesNotAbandonItsNativeStream(): void
+    {
+        [$call, $client, $state, $connection] = $this->call();
+        $this->respondSuccessfully($client, 'reply');
+        $this->assertSame(StatusCode::Ok, $state->status()->code());
+
+        unset($call);
+
+        $this->assertFalse($state->isAbandoned());
+        $this->assertTrue($state->isComplete());
+        $this->assertTrue($connection->isAccepting());
+    }
+
     public function testWaitHalfClosesAndCachesOneUnaryResponse(): void
     {
         $deserializations = 0;

--- a/tests/Grpc/StreamStateTest.php
+++ b/tests/Grpc/StreamStateTest.php
@@ -490,6 +490,8 @@ class StreamStateTest extends TestCase
         $invocations = 0;
         $callbackOwner = $this->trackAbandonmentCallback($state, $invocations);
 
+        $this->assertNotNull($callbackOwner->get());
+
         $state->fail(new ConnectionException('example.test:443', 'connection lost'));
 
         $this->assertSame(0, $invocations);
@@ -506,10 +508,38 @@ class StreamStateTest extends TestCase
             'The gRPC deadline was exceeded.',
         );
 
+        $this->assertNotNull($callbackOwner->get());
+
         $state->failWithStatus($status);
         $state->failWithStatus($status);
 
         $this->assertSame(1, $invocations);
+        $this->assertNull($callbackOwner->get());
+    }
+
+    public function testAbandonsAnIncompleteStreamWithoutPublishingAResult(): void
+    {
+        $state = $this->state();
+        $invocations = 0;
+        $callbackOwner = $this->trackAbandonmentCallback($state, $invocations);
+        $state->handle(new Response(
+            1,
+            200,
+            ['content-type' => 'application/grpc+proto'],
+            (new FrameEncoder(1024))->encode('buffered'),
+            true,
+        ));
+
+        $this->assertNotNull($callbackOwner->get());
+
+        $state->abandonIfIncomplete();
+        $state->abandonIfIncomplete();
+
+        $this->assertSame(1, $invocations);
+        $this->assertTrue($state->isAbandoned());
+        $this->assertFalse($state->isComplete());
+        $this->assertSame(0, $state->bufferedMessageCount());
+        $this->assertSame(0, $state->bufferedBytes());
         $this->assertNull($callbackOwner->get());
     }
 
@@ -601,7 +631,9 @@ class StreamStateTest extends TestCase
     {
         $owner = new stdClass;
         $reference = WeakReference::create($owner);
-        $state->onAbandon(function () use (&$invocations): void {
+        $state->onAbandon(function () use (&$invocations, $owner): void {
+            // Retain the owner until StreamState releases this callback.
+            $owner->invoked = true;
             ++$invocations;
         });
 

--- a/tests/Integration/Grpc/GoServerTest.php
+++ b/tests/Integration/Grpc/GoServerTest.php
@@ -158,6 +158,39 @@ class GoServerTest extends GrpcIntegrationTestCase
         );
     }
 
+    public function testDroppingAnUnfinishedClientStreamReleasesTheConnection(): void
+    {
+        $client = $this->newTestClient([
+            'connections' => 1,
+            'timeout' => 2.0,
+        ]);
+        $call = $client->clientStream();
+        $call->write((new TestRequest)->setValue('unfinished'));
+
+        unset($call);
+
+        $reply = $client->unary((new TestRequest)->setValue('after-client-stream'))->wait();
+
+        $this->assertSame('unary:after-client-stream', $reply->getValue());
+    }
+
+    public function testDroppingAnUnfinishedBidirectionalStreamReleasesTheConnection(): void
+    {
+        $client = $this->newTestClient([
+            'connections' => 1,
+            'timeout' => 2.0,
+        ]);
+        $call = $client->bidiStream();
+        $call->write((new TestRequest)->setValue('unfinished'));
+        $this->assertSame('bidi:unfinished', $call->read()?->getValue());
+
+        unset($call);
+
+        $reply = $client->unary((new TestRequest)->setValue('after-bidi-stream'))->wait();
+
+        $this->assertSame('unary:after-bidi-stream', $reply->getValue());
+    }
+
     public function testMergedHeaderOnlyRetryBehaviorMatchesTheDocumentedSwooleBoundary(): void
     {
         $client = $this->newTestClient(['timeout' => 2.0]);

--- a/tests/Integration/Grpc/HypervelServerTest.php
+++ b/tests/Integration/Grpc/HypervelServerTest.php
@@ -194,39 +194,6 @@ class HypervelServerTest extends GrpcIntegrationTestCase
         $this->assertSame('unary:recovered', $reply->getValue());
     }
 
-    public function testDroppingAnUnfinishedClientStreamReleasesTheConnection(): void
-    {
-        $client = $this->newTestClient([
-            'connections' => 1,
-            'timeout' => 2.0,
-        ]);
-        $call = $client->clientStream();
-        $call->write((new TestRequest)->setValue('unfinished'));
-
-        unset($call);
-
-        $reply = $client->unary((new TestRequest)->setValue('after-client-stream'))->wait();
-
-        $this->assertSame('unary:after-client-stream', $reply->getValue());
-    }
-
-    public function testDroppingAnUnfinishedBidirectionalStreamReleasesTheConnection(): void
-    {
-        $client = $this->newTestClient([
-            'connections' => 1,
-            'timeout' => 2.0,
-        ]);
-        $call = $client->bidiStream();
-        $call->write((new TestRequest)->setValue('unfinished'));
-        $this->assertSame('bidi:unfinished', $call->read()?->getValue());
-
-        unset($call);
-
-        $reply = $client->unary((new TestRequest)->setValue('after-bidi-stream'))->wait();
-
-        $this->assertSame('unary:after-bidi-stream', $reply->getValue());
-    }
-
     public function testServerSendLimitReturnsResourceExhausted(): void
     {
         $client = $this->newTestClient(['timeout' => 2.0]);

--- a/tests/Integration/Grpc/HypervelServerTest.php
+++ b/tests/Integration/Grpc/HypervelServerTest.php
@@ -194,6 +194,39 @@ class HypervelServerTest extends GrpcIntegrationTestCase
         $this->assertSame('unary:recovered', $reply->getValue());
     }
 
+    public function testDroppingAnUnfinishedClientStreamReleasesTheConnection(): void
+    {
+        $client = $this->newTestClient([
+            'connections' => 1,
+            'timeout' => 2.0,
+        ]);
+        $call = $client->clientStream();
+        $call->write((new TestRequest)->setValue('unfinished'));
+
+        unset($call);
+
+        $reply = $client->unary((new TestRequest)->setValue('after-client-stream'))->wait();
+
+        $this->assertSame('unary:after-client-stream', $reply->getValue());
+    }
+
+    public function testDroppingAnUnfinishedBidirectionalStreamReleasesTheConnection(): void
+    {
+        $client = $this->newTestClient([
+            'connections' => 1,
+            'timeout' => 2.0,
+        ]);
+        $call = $client->bidiStream();
+        $call->write((new TestRequest)->setValue('unfinished'));
+        $this->assertSame('bidi:unfinished', $call->read()?->getValue());
+
+        unset($call);
+
+        $reply = $client->unary((new TestRequest)->setValue('after-bidi-stream'))->wait();
+
+        $this->assertSame('unary:after-bidi-stream', $reply->getValue());
+    }
+
     public function testServerSendLimitReturnsResourceExhausted(): void
     {
         $client = $this->newTestClient(['timeout' => 2.0]);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -20,6 +20,7 @@ use Hypervel\Contracts\Queue\Queue;
 use Hypervel\Coordinator\Constants;
 use Hypervel\Coordinator\Timer;
 use Hypervel\Coroutine\Coroutine;
+use Hypervel\Coroutine\Waiter;
 use Hypervel\Http\Request;
 use Hypervel\Queue\CallQueuedHandler;
 use Hypervel\Queue\Events\JobAttempted;
@@ -45,6 +46,7 @@ use Hypervel\Queue\WorkerStopReason;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
+use ReflectionProperty;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -288,6 +290,14 @@ class QueueWorkerTest extends TestCase
         $this->assertSame(0, $status);
 
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessing::class))->once();
+    }
+
+    public function testDefaultPopWaiterIsUnbounded(): void
+    {
+        $waiter = $this->getWorker()->createPopWaiterForTest();
+        $popTimeout = new ReflectionProperty(Waiter::class, 'popTimeout');
+
+        $this->assertSame(-1.0, $popTimeout->getValue($waiter));
     }
 
     public function testTimeoutZeroDoesNotCreateADeadline(): void
@@ -1377,6 +1387,11 @@ class InsomniacWorker extends Worker
     public function registerCoroutineJobForTest(Job $job, WorkerOptions $options): string
     {
         return parent::registerCoroutineJob($job, $options);
+    }
+
+    public function createPopWaiterForTest(): Waiter
+    {
+        return parent::createPopWaiter();
     }
 
     public function runningJobExpiryForTest(string $jobId): ?float

--- a/tests/Sentry/Features/CacheIntegrationTest.php
+++ b/tests/Sentry/Features/CacheIntegrationTest.php
@@ -73,6 +73,22 @@ class CacheIntegrationTest extends SentryTestCase
         $this->assertEmpty($this->getCurrentSentryBreadcrumbs());
     }
 
+    public function testCacheTelemetryHonorsEventsDisabledStoreConfiguration(): void
+    {
+        $this->resetApplicationWithConfig([
+            'cache.stores.array.events' => false,
+        ]);
+
+        $transaction = $this->startTransaction();
+
+        Cache::put('foo', 'bar');
+
+        $this->assertFalse(config()->boolean('cache.stores.array.events'));
+        $this->assertNull(Cache::store('array')->getEventDispatcher());
+        $this->assertCount(1, $transaction->getSpanRecorder()->getSpans());
+        $this->assertEmpty($this->getCurrentSentryBreadcrumbs());
+    }
+
     public function testCacheBreadcrumbReplacesSessionKeyWithPlaceholder(): void
     {
         $this->startSession();

--- a/tests/Support/FileinfoMimeTypeGuesserTest.php
+++ b/tests/Support/FileinfoMimeTypeGuesserTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Support;
 
+use Exception;
 use finfo;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Support\FileinfoMimeTypeGuesser;
 use Hypervel\Tests\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use RuntimeException;
 
 use function Hypervel\Coroutine\parallel;
 
@@ -30,6 +32,19 @@ class FileinfoMimeTypeGuesserTest extends TestCase
             ->guessMimeType(__DIR__ . '/Fixtures/test.gif');
 
         $this->assertEquals('image/gif', $mimeType);
+    }
+
+    public function testFinfoConstructionFailureRetainsItsCause(): void
+    {
+        try {
+            (new FileinfoMimeTypeGuesser(__DIR__ . '/Fixtures/missing.magic'))
+                ->guessMimeType(__DIR__ . '/Fixtures/test.gif');
+
+            $this->fail('The invalid magic database did not fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertInstanceOf(Exception::class, $exception->getPrevious());
+            $this->assertSame($exception->getMessage(), $exception->getPrevious()->getMessage());
+        }
     }
 
     public function testGuessMimeTypeIsCoroutineScoped(): void

--- a/tests/Support/SystemInfoTest.php
+++ b/tests/Support/SystemInfoTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Support;
+
+use Hypervel\Tests\TestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use Symfony\Component\Process\Process;
+
+#[RequiresOperatingSystem('Linux|Darwin')]
+class SystemInfoTest extends TestCase
+{
+    public function testMemoryFormattingMethodsExposeMissingIntlExtension(): void
+    {
+        $script = <<<'PHP'
+require $argv[1];
+
+if (extension_loaded('intl')) {
+    exit(77);
+}
+
+$systemInfo = new Hypervel\Support\SystemInfo;
+
+foreach (['getTotalMemory', 'getMemoryLimitFormatted'] as $method) {
+    try {
+        $systemInfo->{$method}();
+        fwrite(STDERR, "The [{$method}] dependency failure was hidden.\n");
+        exit(1);
+    } catch (RuntimeException $exception) {
+        if (! str_contains($exception->getMessage(), 'The "intl" PHP extension is required')) {
+            throw $exception;
+        }
+    }
+}
+PHP;
+        $process = new Process([
+            PHP_BINARY,
+            '-n',
+            '-d',
+            'memory_limit=128M',
+            '-r',
+            $script,
+            dirname(__DIR__, 2) . '/vendor/autoload.php',
+        ]);
+        $process->run();
+
+        if ($process->getExitCode() === 77) {
+            $this->markTestSkipped('The intl extension is compiled into this PHP binary.');
+        }
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+    }
+}


### PR DESCRIPTION
## Problem

This PR fixes several independent framework correctness issues found while tracing cache, queue, console, gRPC, and support lifecycles.

The common failures were incorrect result reporting, state being updated before an operation had actually completed, work being drained by the wrong execution frame, and native resources surviving after their public owner had been dropped.

## Cache

Tagged cache flushes previously returned success even when a backing operation returned `false`. This made the null store and other rejecting stores look successful and caused the success event to be emitted for failed flushes.

This changes `TagSet::reset()` and `TagSet::flush()` to return the aggregate boolean result. Multi-tag and stack implementations still attempt independent remaining operations after a `false` result or ordinary exception, then return `false` or rethrow the first exception. Coroutine cancellation remains terminal. The protected per-tag `resetTag()` and `flushTag()` extension points keep their Laravel-shaped string results, and deleting an already-missing tag remains an idempotent success.

`TaggedCache::flush()` now returns the real result and emits either `CacheFlushed` or `CacheFlushFailed` to match it.

`FailoverStore` also retained an incorrect failure snapshot when a `CacheFailedOver` listener interrupted iteration. Stores that were never attempted could be marked as recovered, producing duplicate transition events later. Interrupted operations now combine failures observed during the current attempt with the previous state of stores that were not reached. Store names are normalized to positional values once so sparse configuration keys cannot affect that calculation.

Finally, cache event dispatcher refresh now touches only resolved concrete repositories that already have events enabled. Custom contract-only repositories and stores configured with `events: false` remain untouched. The Sentry cache integration no longer force-enables events during boot, so tracing and breadcrumbs follow the store configuration.

## Queue and deferred callbacks

The queue worker created its pop waiter with a ten-second default timeout. That contradicted long and indefinite blocking-pop configuration and could stop an otherwise healthy idle worker. Pop waiting is now unbounded by default through a small protected factory, while the existing child coroutine continues to own and release pooled queue connections.

Deferred callbacks now drain from the execution frame that owns their collection:

- Deferred and background queue jobs drain their own callback collections. Sync jobs leave the collection with their enclosing request, job, or command lifecycle.
- Hypervel commands that create a coroutine drain after command observers and isolation-mutex cleanup.
- Top-level non-coroutine console execution drains the application-frame collection.
- Nested programmatic command calls leave the shared collection to the outer owner instead of re-entering the same drain.

The collection is resolved only when that frame created one, so commands and jobs that do not call `defer()` do not allocate it. Draining is one bounded pass. Ordinary failures preserve the first failure while still running eligible `always` callbacks; coroutine cancellation skips arbitrary deferred work while fixed cleanup still runs.

## gRPC

Dropping an unfinished client-streaming or bidirectional call before `writesDone()` could retain its `StreamState`, receiver coroutine, buffered messages, and pooled connection indefinitely when no deadline existed.

`StreamState::abandonIfIncomplete()` now provides an idempotent resource cleanup path. `Call::__destruct()` uses that path when an unfinished call is dropped. This does not publish a terminal status, synthesize application cancellation, or invoke completion observers. Completed calls remain unchanged, and destructor cleanup cannot throw during shutdown.

## Support diagnostics

`SystemInfo` used broad catches around operating-system probes. Those catches also hid dependency and runtime failures that callers need to see. The probes still return `null` when the operating system does not provide a value, but failures from required dependencies and runtime execution now remain visible.

`FileinfoMimeTypeGuesser` still converts finfo construction failures to its public `RuntimeException`, but now retains the original throwable as the previous exception.

## Public API and documentation

The public compatibility change is the `bool` return type on `TagSet::reset()` and `TagSet::flush()`. The porting guide documents the required subclass update and the unchanged per-tag extension points.

The cache, queue, deferred callback, gRPC, and Sentry documentation is updated where application-visible behavior changed.

## Testing

Focused regression coverage was added for each failure path, including false results, listener interruption, disabled event stores, nested console execution, deferred and background queues, abandoned gRPC streams, and preserved exception causes.

The full repository checks pass with `composer fix`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cache tag flushes now accurately report success or failure and preserve relevant failure details.
  - Cache telemetry respects per-store event settings.
  - Deferred callbacks now run reliably across console commands and queue jobs.
  - Incomplete gRPC calls are cleaned up safely, allowing connections to be reused.
  - Queue workers now wait indefinitely for available jobs by default.
  - MIME type errors retain their original cause.

- **Documentation**
  - Clarified tagged-cache results, deferred dispatch behavior, gRPC cleanup, deferred callback timing, and migration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->