### PR TITLE
Add portable sparse ordinary indexes

### DIFF
--- a/docs/plans/2026-08-30-1515-database-sparse-index-schema-api.md
+++ b/docs/plans/2026-08-30-1515-database-sparse-index-schema-api.md
@@ -1,0 +1,188 @@
+# Database sparse-index schema API implementation plan
+
+## Status and authority
+
+This plan owns the approved database schema-builder enhancement for sparse ordinary indexes. Implementation and verification are complete. The Components capability must be made available to the aggregate package before implementing the separate Workflow sparse-index adoption plan.
+
+The first consumer is the Workflow sparse-index adoption plan at `packages/hypervel/docs/plans/workflow/2026-08-30-2112-workflow-sparse-index-adoption.md`. Components owns the public API, SQL compilation, schema introspection, SQLite rebuild behavior, framework documentation, and framework tests. Workflow owns its index choices and performance gates.
+
+## Goal and design boundary
+
+Add one Laravel-style modifier for the common portable case where an ordinary index should contain only rows whose chosen column is not null:
+
+```php
+$table->index(
+    ['status', 'admission_reconcile_at', 'id'],
+    'workflow_executions_admission_index',
+)->whereNotNull('admission_reconcile_at');
+```
+
+PostgreSQL and SQLite compile this as a partial index with `WHERE <column> IS NOT NULL`. MySQL and MariaDB compile the existing full ordinary index because they do not support partial indexes. The migration therefore keeps one portable definition and a safe full-index fallback.
+
+Keep the surface deliberately narrow:
+
+- support one `whereNotNull(string $column)` predicate on ordinary `index()` and `rawIndex()` definitions;
+- reject the modifier immediately on primary, unique, full-text, spatial, and vector indexes with an actionable `LogicException`;
+- let a repeated call replace the prior column, matching `Fluent` modifier behavior;
+- do not validate table or column existence before the database compiles the migration;
+- do not require the predicate column to be part of the index; and
+- do not add arbitrary SQL predicates, closures, predicate lists, an expression tree, engine strategy objects, or a second schema abstraction.
+
+Partial unique indexes are useful in other domains, but they carry different correctness semantics and have no approved consumer here. Rejecting them keeps this enhancement an ordinary-index storage optimization rather than a portable constraint API.
+
+The supported floors already include partial indexes: PostgreSQL 10+ and SQLite 3.26+. No server-version branch or compatibility shim is needed.
+
+## Public schema API
+
+### Index definitions
+
+Narrow the native return type of these `Blueprint` methods from `Fluent` to `IndexDefinition`:
+
+- `primary()`
+- `unique()`
+- `index()`
+- `fullText()`
+- `spatialIndex()`
+- `vectorIndex()`
+- `rawIndex()`
+
+These methods already return index commands in practice. The concrete type makes existing fluent index modifiers and the new method visible to IDEs and PHPStan without changing runtime call shape. `foreign()` continues to return `ForeignKeyDefinition`, and non-index commands continue to use `Fluent`.
+
+Add a subtype-preserving `addCommandDefinition(Fluent $definition)` helper, including the same template PHPDoc shape as the existing `addColumnDefinition()`. The generic `addCommand()` sends its created `Fluent` through that helper, while `indexCommand()` constructs an `IndexDefinition`, sends it through the same append path, and returns the concrete subtype. Keep the existing command attributes and order unchanged.
+
+`foreign()` also reuses `indexCommand()` for conventional name generation and attribute assembly, then immediately replaces the appended definition with a `ForeignKeyDefinition`. Preserve that behavior and add one short comment at the call site explaining the temporary index definition; do not split or duplicate index-name generation merely to avoid the intermediate subtype.
+
+Add a concrete method to `IndexDefinition`:
+
+```php
+public function whereNotNull(string $column): static
+{
+    if ($this->get('name') !== 'index') {
+        throw new LogicException(
+            'The [whereNotNull] modifier is only available for ordinary indexes.',
+        );
+    }
+
+    return $this->set('whereNotNull', $column);
+}
+```
+
+Use a concrete method rather than an `@method` annotation because the index-kind guard is part of the public contract. Keep the existing magic modifier annotations for their existing behavior.
+
+`rawIndex()` delegates to `index()`, so it receives the ordinary command name `index` and passes the same guard without a separate branch.
+
+### SQL compilation
+
+Add one protected grammar helper beside the base grammar's other SQL-fragment helpers. It returns either an empty string or the wrapped ` where <column> is not null` suffix. PostgreSQL and SQLite `compileIndex()` append it to their existing SQL. This keeps quoting identical in both engines without introducing a dialect object.
+
+Preserve every existing composition rule:
+
+- PostgreSQL `online()` still emits `CONCURRENTLY` and `algorithm()` still emits `USING ...` before the predicate;
+- raw index expressions remain the index key expression while the predicate column is wrapped as an identifier;
+- SQLite schema-qualified index names and target tables remain unchanged; and
+- MySQL and MariaDB do not inspect the modifier and emit the same SQL as a normal full index.
+
+### Public index introspection
+
+Extend every `Schema::getIndexes()` record with `partial: bool`:
+
+```php
+array{
+    name: string,
+    columns: list<string>,
+    type: null|string,
+    unique: bool,
+    primary: bool,
+    partial: bool,
+}
+```
+
+Populate it at the lowest owning layer:
+
+| Engine | Source |
+|---|---|
+| PostgreSQL | `pg_index.indpred IS NOT NULL` |
+| SQLite | `pragma_index_list.partial` |
+| MySQL / MariaDB | literal `false` in `MySqlProcessor` |
+
+Update the `Builder` and base `Processor` array-shape PHPDocs. Do not expose raw predicate SQL; callers need the stable capability fact, not an engine-specific expression parser.
+
+### SQLite schema-state preservation
+
+SQLite already treats a partial index as non-reconstructible and replays its exact `sqlite_master.sql` during a table rebuild. Preserve that design rather than creating a partial-index parser.
+
+Extend SQLite's internal index record with `partial: bool`. Both arms of `SQLiteGrammar::compileIndexes()` must project it: the synthetic primary-key row reports `false`, while ordinary rows retain `pragma_index_list.partial`. Keep the flag in the processor record for the public projection, but do not duplicate it onto `BlueprintState` index definitions: existing partial indexes are already identified by `reconstructible = false` and stored SQL, while new definitions retain `whereNotNull` directly.
+
+Keep `reconstructible = false` for an introspected partial index because its stored predicate may be arbitrary SQL and must be replayed exactly. Document this invariant beside the SQLite introspection expression because both rebuild and rename depend on it. A newly declared simple `whereNotNull()` index remains reconstructible because the command retains the complete supported predicate; a newly declared raw index still follows the existing raw-expression rules. Existing partial indexes continue through the stored-SQL rebuild and index-rename paths without a predicate parser.
+
+Narrow `BlueprintState`'s primary-key property and accessor to `?IndexDefinition`: both introspected and newly declared primary keys now have that exact type. Because `update(Fluent $command)` prevents static narrowing, the `primary`, `index`, and `foreign` cases narrow the command with checked `@var` annotations. Do not use `assign.propertyType` suppressions there because they would hide a later genuine mismatch on the assignment line.
+
+## Source and documentation changes
+
+Implement one file at a time in this order:
+
+1. `src/database/src/Schema/IndexDefinition.php` — public modifier and index-kind validation.
+2. `src/database/src/Schema/Blueprint.php` — concrete return types and `IndexDefinition` command construction.
+3. `src/database/src/Schema/Grammars/Grammar.php` — shared predicate suffix compiler.
+4. `src/database/src/Schema/Grammars/PostgresGrammar.php` — partial DDL and `indpred` introspection.
+5. `src/database/src/Schema/Grammars/SQLiteGrammar.php` — partial DDL and public/internal `partial` metadata.
+6. `src/database/src/Schema/BlueprintState.php` — narrow primary-key state to `?IndexDefinition` and replace assignment suppressions with checked case-local `@var` narrowing.
+7. `src/database/src/Query/Processors/PostgresProcessor.php` — normalize PostgreSQL partial state.
+8. `src/database/src/Query/Processors/SQLiteProcessor.php` — expose the public flag and retain it internally.
+9. `src/database/src/Query/Processors/MySqlProcessor.php` — normalize the unsupported-engine fallback as `false`; MariaDB inherits it.
+10. `src/database/src/Query/Processors/Processor.php`, `src/database/src/Schema/Builder.php`, and `src/database/src/Schema/SQLiteBuilder.php` — complete public and internal record types.
+11. `src/database/src/Console/TableCommand.php` — include `partial` in the index attributes rendered by `db:table`.
+12. `src/docs/migrations.md` — add an anchored Partial Indexes subsection with a concise example and explain PostgreSQL/SQLite partial behavior, MySQL/MariaDB full fallback, and ordinary-index-only validation. Do not add a porting-guide entry because the change is additive and requires no Laravel porter action.
+
+## Test plan
+
+Update each test file and run it immediately before moving to the next.
+
+### Public API and grammar
+
+- `tests/Database/DatabaseSchemaBlueprintTest.php`
+  - prove all seven index methods return `IndexDefinition`;
+  - prove `index()` and `rawIndex()` retain `whereNotNull`;
+  - prove primary, unique, full-text, spatial, and vector definitions reject the modifier with the exact useful error in named data-provider cases;
+  - prove `foreign()` still returns and leaves only the replacement `ForeignKeyDefinition` command.
+- `tests/Database/DatabasePostgresSchemaGrammarTest.php`
+  - assert exact partial-index SQL;
+  - assert composition with algorithm, `online()`, and a raw index expression;
+  - pin the index-introspection query's partial projection.
+- `tests/Database/DatabaseSQLiteSchemaGrammarTest.php`
+  - assert exact ordinary, raw, and schema-qualified partial-index SQL;
+  - pin the public/internal introspection query shape.
+- `tests/Database/DatabaseMySqlSchemaGrammarTest.php` and `DatabaseMariaDbSchemaGrammarTest.php`
+  - assert that the same definition compiles to the unchanged full-index SQL.
+
+### Normalization, real engines, and rebuilds
+
+- `tests/Database/DatabasePostgresProcessorTest.php`, `DatabaseSQLiteProcessorTest.php`, and `DatabaseMySqlProcessorTest.php`
+  - assert the exact six-field public record;
+  - for SQLite, assert the internal record also preserves `partial`, stored SQL, and `reconstructible = false`.
+- `tests/Database/DatabaseConsoleJsonTest.php`
+  - prove `db:table` identifies partial indexes in its rendered attribute set.
+- `tests/Integration/Database/SchemaBuilderTest.php`
+  - create the index through the real schema builder on all configured engines;
+  - assert `partial === true` on PostgreSQL/SQLite and `false` on MySQL/MariaDB;
+  - assert a plain unique index reports `partial === false` on every engine so the projection is proven to discriminate;
+  - assert every introspected index, including primary and unique records, reports the complete public shape.
+- `tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php`
+  - create a partial index through the public API;
+  - trigger a table rebuild and then rename that index;
+  - prove the stored predicate, public `partial` flag, and physical index definition survive both paths exactly.
+- add `types/Database/Schema.php` to pin the concrete `IndexDefinition` return type and the fluent `static` return from `whereNotNull()`.
+
+Audit existing exact `getIndexes()` array assertions across `tests/` and update each for the new required `partial` member. Do not weaken them to subset assertions merely to accommodate the new field.
+
+## Verification
+
+After the focused files are green:
+
+1. run the complete database unit-test group affected by schema grammars and processors;
+2. run the real SQLite schema tests and each configured MySQL, MariaDB, and PostgreSQL schema-builder test group;
+3. run `composer fix` once at the meaningful completed checkpoint;
+4. inspect the diff for stale `Fluent` return docs, five-field index record shapes, unused imports, obsolete suppressions, duplicate predicate compilation, and documentation drift; and
+5. obtain adversarial code review and repeat targeted verification until signed off.
+
+The completed change must add no runtime query cost, worker state, cache, registry, or application configuration. Its only production effect is migration-time DDL and one boolean in explicit schema-introspection results.

--- a/docs/plans/2026-08-30-1515-database-sparse-index-schema-api.md
+++ b/docs/plans/2026-08-30-1515-database-sparse-index-schema-api.md
@@ -115,6 +115,8 @@ Extend SQLite's internal index record with `partial: bool`. Both arms of `SQLite
 
 Keep `reconstructible = false` for an introspected partial index because its stored predicate may be arbitrary SQL and must be replayed exactly. Document this invariant beside the SQLite introspection expression because both rebuild and rename depend on it. A newly declared simple `whereNotNull()` index remains reconstructible because the command retains the complete supported predicate; a newly declared raw index still follows the existing raw-expression rules. Existing partial indexes continue through the stored-SQL rebuild and index-rename paths without a predicate parser.
 
+When a same-blueprint column rename updates a newly declared index, rewrite both its indexed columns and its optional `whereNotNull` predicate column. During a legacy table rebuild, treat the optional predicate column as an index reference alongside the indexed columns so dropping a predicate-only column fails before any mutation instead of replaying a semantically degraded index.
+
 Narrow `BlueprintState`'s primary-key property and accessor to `?IndexDefinition`: both introspected and newly declared primary keys now have that exact type. Because `update(Fluent $command)` prevents static narrowing, the `primary`, `index`, and `foreign` cases narrow the command with checked `@var` annotations. Do not use `assign.propertyType` suppressions there because they would hide a later genuine mismatch on the assignment line.
 
 ## Source and documentation changes
@@ -125,8 +127,8 @@ Implement one file at a time in this order:
 2. `src/database/src/Schema/Blueprint.php` — concrete return types and `IndexDefinition` command construction.
 3. `src/database/src/Schema/Grammars/Grammar.php` — shared predicate suffix compiler.
 4. `src/database/src/Schema/Grammars/PostgresGrammar.php` — partial DDL and `indpred` introspection.
-5. `src/database/src/Schema/Grammars/SQLiteGrammar.php` — partial DDL and public/internal `partial` metadata.
-6. `src/database/src/Schema/BlueprintState.php` — narrow primary-key state to `?IndexDefinition` and replace assignment suppressions with checked case-local `@var` narrowing.
+5. `src/database/src/Schema/Grammars/SQLiteGrammar.php` — partial DDL, public/internal `partial` metadata, and complete legacy-rebuild validation for indexed and predicate-only column references.
+6. `src/database/src/Schema/BlueprintState.php` — narrow primary-key state to `?IndexDefinition`, replace assignment suppressions with checked case-local `@var` narrowing, and carry simple predicate columns through same-blueprint renames.
 7. `src/database/src/Query/Processors/PostgresProcessor.php` — normalize PostgreSQL partial state.
 8. `src/database/src/Query/Processors/SQLiteProcessor.php` — expose the public flag and retain it internally.
 9. `src/database/src/Query/Processors/MySqlProcessor.php` — normalize the unsupported-engine fallback as `false`; MariaDB inherits it.
@@ -170,7 +172,9 @@ Update each test file and run it immediately before moving to the next.
 - `tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php`
   - create a partial index through the public API;
   - trigger a table rebuild and then rename that index;
-  - prove the stored predicate, public `partial` flag, and physical index definition survive both paths exactly.
+  - prove the stored predicate, public `partial` flag, and physical index definition survive both paths exactly;
+  - prove a newly declared predicate follows a same-blueprint predicate-column rename through a rebuild even when that column is not an index key; and
+  - force the pre-3.35 rebuild path and prove dropping a newly declared index's predicate-only column fails with the existing actionable dropped-column error.
 - add `types/Database/Schema.php` to pin the concrete `IndexDefinition` return type and the fluent `static` return from `whereNotNull()`.
 
 Audit existing exact `getIndexes()` array assertions across `tests/` and update each for the new required `partial` member. Do not weaken them to subset assertions merely to accommodate the new field.

--- a/src/database/src/Console/TableCommand.php
+++ b/src/database/src/Console/TableCommand.php
@@ -147,6 +147,7 @@ class TableCommand extends DatabaseInspectionCommand
             count($index['columns']) > 1 ? 'compound' : null,
             $index['unique'] && ! $index['primary'] ? 'unique' : null,
             $index['primary'] ? 'primary' : null,
+            $index['partial'] ? 'partial' : null,
         ]))->filter();
     }
 

--- a/src/database/src/Query/Processors/MySqlProcessor.php
+++ b/src/database/src/Query/Processors/MySqlProcessor.php
@@ -65,6 +65,7 @@ class MySqlProcessor extends Processor
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => $name === 'primary',
+                'partial' => false,
             ];
         }, $results);
     }

--- a/src/database/src/Query/Processors/PostgresProcessor.php
+++ b/src/database/src/Query/Processors/PostgresProcessor.php
@@ -113,6 +113,7 @@ class PostgresProcessor extends Processor
                 'type' => strtolower($result->type),
                 'unique' => (bool) $result->unique,
                 'primary' => (bool) $result->primary,
+                'partial' => (bool) $result->partial,
             ];
         }, $results);
     }

--- a/src/database/src/Query/Processors/Processor.php
+++ b/src/database/src/Query/Processors/Processor.php
@@ -123,7 +123,7 @@ class Processor
      * Process the results of an indexes query.
      *
      * @param list<array<string, mixed>> $results
-     * @return list<array{name: string, columns: list<string>, type: null|string, unique: bool, primary: bool}>
+     * @return list<array{name: string, columns: list<string>, type: null|string, unique: bool, primary: bool, partial: bool}>
      */
     public function processIndexes(array $results): array
     {

--- a/src/database/src/Query/Processors/SQLiteProcessor.php
+++ b/src/database/src/Query/Processors/SQLiteProcessor.php
@@ -63,7 +63,7 @@ class SQLiteProcessor extends Processor
         return array_map(
             static fn (array $index): array => Arr::only(
                 $index,
-                ['name', 'columns', 'type', 'unique', 'primary'],
+                ['name', 'columns', 'type', 'unique', 'primary', 'partial'],
             ),
             $this->processIndexesForSchemaState($results),
         );
@@ -73,7 +73,7 @@ class SQLiteProcessor extends Processor
      * Process indexes with the metadata required to reconstruct SQLite schema state.
      *
      * @internal
-     * @return list<array{name: string, physical_name: string, columns: list<string>, type: null|string, unique: bool, primary: bool, sql: null|string, origin: null|string, reconstructible: bool, collations: null|list<string>, descending: null|list<bool>}>
+     * @return list<array{name: string, physical_name: string, columns: list<string>, type: null|string, unique: bool, primary: bool, partial: bool, sql: null|string, origin: null|string, reconstructible: bool, collations: null|list<string>, descending: null|list<bool>}>
      */
     public function processIndexesForSchemaState(array $results): array
     {
@@ -93,6 +93,7 @@ class SQLiteProcessor extends Processor
                 'type' => null,
                 'unique' => (bool) $result->unique,
                 'primary' => $isPrimary,
+                'partial' => (bool) $result->partial,
                 'sql' => $result->sql,
                 'origin' => $result->origin,
                 'reconstructible' => (bool) $result->reconstructible,

--- a/src/database/src/Schema/Blueprint.php
+++ b/src/database/src/Schema/Blueprint.php
@@ -205,7 +205,7 @@ class Blueprint
                         ? 'vectorIndex'
                         : $index;
 
-                    /** @var Fluent $command */
+                    /** @var IndexDefinition $command */
                     $command = $this->{$indexMethod}($column->name);
 
                     if ($placeGeneratedIndexes && in_array($command->name, self::FOREIGN_KEY_TARGET_COMMANDS, true)) {
@@ -240,7 +240,7 @@ class Blueprint
                         ? 'vectorIndex'
                         : $index;
 
-                    /** @var Fluent $command */
+                    /** @var IndexDefinition $command */
                     $command = $this->{$indexMethod}($column->name, $column->{$index});
 
                     if ($placeGeneratedIndexes && in_array($command->name, self::FOREIGN_KEY_TARGET_COMMANDS, true)) {
@@ -632,7 +632,7 @@ class Blueprint
     /**
      * Specify the primary key(s) for the table.
      */
-    public function primary(array|string $columns, ?string $name = null, ?string $algorithm = null): Fluent
+    public function primary(array|string $columns, ?string $name = null, ?string $algorithm = null): IndexDefinition
     {
         return $this->indexCommand('primary', $columns, $name, $algorithm);
     }
@@ -640,7 +640,7 @@ class Blueprint
     /**
      * Specify a unique index for the table.
      */
-    public function unique(array|string $columns, ?string $name = null, ?string $algorithm = null): Fluent
+    public function unique(array|string $columns, ?string $name = null, ?string $algorithm = null): IndexDefinition
     {
         return $this->indexCommand('unique', $columns, $name, $algorithm);
     }
@@ -648,7 +648,7 @@ class Blueprint
     /**
      * Specify an index for the table.
      */
-    public function index(array|string $columns, ?string $name = null, ?string $algorithm = null): Fluent
+    public function index(array|string $columns, ?string $name = null, ?string $algorithm = null): IndexDefinition
     {
         return $this->indexCommand('index', $columns, $name, $algorithm);
     }
@@ -656,7 +656,7 @@ class Blueprint
     /**
      * Specify a fulltext index for the table.
      */
-    public function fullText(array|string $columns, ?string $name = null, ?string $algorithm = null): Fluent
+    public function fullText(array|string $columns, ?string $name = null, ?string $algorithm = null): IndexDefinition
     {
         return $this->indexCommand('fulltext', $columns, $name, $algorithm);
     }
@@ -664,7 +664,7 @@ class Blueprint
     /**
      * Specify a spatial index for the table.
      */
-    public function spatialIndex(array|string $columns, ?string $name = null, ?string $operatorClass = null): Fluent
+    public function spatialIndex(array|string $columns, ?string $name = null, ?string $operatorClass = null): IndexDefinition
     {
         return $this->indexCommand('spatialIndex', $columns, $name, null, $operatorClass);
     }
@@ -672,7 +672,7 @@ class Blueprint
     /**
      * Specify a vector index for the table.
      */
-    public function vectorIndex(string $column, ?string $name = null): Fluent
+    public function vectorIndex(string $column, ?string $name = null): IndexDefinition
     {
         [$algorithm, $operatorClass] = $this->grammar instanceof MariaDbGrammar
             ? [null, 'M=6 DISTANCE=cosine']
@@ -684,7 +684,7 @@ class Blueprint
     /**
      * Specify a raw index for the table.
      */
-    public function rawIndex(string $expression, string $name): Fluent
+    public function rawIndex(string $expression, string $name): IndexDefinition
     {
         return $this->index([new Expression($expression)], $name);
     }
@@ -694,6 +694,8 @@ class Blueprint
      */
     public function foreign(array|string $columns, ?string $name = null): ForeignKeyDefinition
     {
+        // Reuse the index command to assemble the conventional name and attributes
+        // before replacing it with the foreign-key definition.
         $command = new ForeignKeyDefinition(
             $this->indexCommand('foreign', $columns, $name)->getAttributes()
         );
@@ -1432,7 +1434,7 @@ class Blueprint
     /**
      * Create a new index command on the blueprint.
      */
-    protected function indexCommand(string $type, array|string $columns, ?string $index, ?string $algorithm = null, ?string $operatorClass = null): Fluent
+    protected function indexCommand(string $type, array|string $columns, ?string $index, ?string $algorithm = null, ?string $operatorClass = null): IndexDefinition
     {
         $columns = (array) $columns;
 
@@ -1443,10 +1445,10 @@ class Blueprint
             ? $this->createIndexName($type, $columns)
             : $index;
 
-        return $this->addCommand(
-            $type,
-            compact('index', 'columns', 'algorithm', 'operatorClass')
-        );
+        return $this->addCommandDefinition(new IndexDefinition(array_merge(
+            ['name' => $type],
+            compact('index', 'columns', 'algorithm', 'operatorClass'),
+        )));
     }
 
     /**
@@ -1555,9 +1557,22 @@ class Blueprint
      */
     protected function addCommand(string $name, array $parameters = []): Fluent
     {
-        $this->commands[] = $command = $this->createCommand($name, $parameters);
+        return $this->addCommandDefinition($this->createCommand($name, $parameters));
+    }
 
-        return $command;
+    /**
+     * Add a new command definition to the blueprint.
+     *
+     * @template TCommandDefinition of \Hypervel\Support\Fluent
+     *
+     * @param TCommandDefinition $definition
+     * @return TCommandDefinition
+     */
+    protected function addCommandDefinition(Fluent $definition): Fluent
+    {
+        $this->commands[] = $definition;
+
+        return $definition;
     }
 
     /**

--- a/src/database/src/Schema/BlueprintState.php
+++ b/src/database/src/Schema/BlueprintState.php
@@ -37,7 +37,7 @@ class BlueprintState
     /**
      * The primary key.
      */
-    private Fluent|IndexDefinition|null $primaryKey;
+    private ?IndexDefinition $primaryKey;
 
     /**
      * The indexes.
@@ -135,7 +135,7 @@ class BlueprintState
     /**
      * Get the primary key.
      */
-    public function getPrimaryKey(): Fluent|IndexDefinition|null
+    public function getPrimaryKey(): ?IndexDefinition
     {
         return $this->primaryKey;
     }
@@ -240,6 +240,7 @@ class BlueprintState
 
                 break;
             case 'primary':
+                /** @var IndexDefinition $command */
                 $this->primaryKey = $command;
                 break;
             case 'unique':
@@ -258,7 +259,7 @@ class BlueprintState
                 $command->columnRenamed = false;
                 $command->columnDropped = false;
 
-                // @phpstan-ignore assign.propertyType (Blueprint commands are Fluent, stored as IndexDefinition)
+                /** @var IndexDefinition $command */
                 $this->indexes[] = $command;
                 break;
             case 'renameIndex':
@@ -272,7 +273,7 @@ class BlueprintState
 
                 break;
             case 'foreign':
-                // @phpstan-ignore assign.propertyType (Blueprint commands are Fluent, stored as ForeignKeyDefinition)
+                /** @var ForeignKeyDefinition $command */
                 $this->foreignKeys[] = $command;
                 break;
             case 'dropPrimary':

--- a/src/database/src/Schema/BlueprintState.php
+++ b/src/database/src/Schema/BlueprintState.php
@@ -218,6 +218,10 @@ class BlueprintState
                 foreach ($this->indexes as $index) {
                     $index->columnRenamed = true;
                     $index->columns = $this->replaceColumn($index->columns, $command->from, $command->to);
+
+                    if ($index->whereNotNull === $command->from) {
+                        $index->whereNotNull = $command->to;
+                    }
                 }
 
                 foreach ($this->foreignKeys as $foreignKey) {

--- a/src/database/src/Schema/Builder.php
+++ b/src/database/src/Schema/Builder.php
@@ -367,7 +367,7 @@ class Builder
     /**
      * Get the indexes for a given table.
      *
-     * @return list<array{name: string, columns: list<string>, type: null|string, unique: bool, primary: bool}>
+     * @return list<array{name: string, columns: list<string>, type: null|string, unique: bool, primary: bool, partial: bool}>
      */
     public function getIndexes(string $table): array
     {

--- a/src/database/src/Schema/Grammars/Grammar.php
+++ b/src/database/src/Schema/Grammars/Grammar.php
@@ -326,6 +326,17 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the not-null predicate for a sparse index.
+     */
+    protected function compileWhereNotNull(Fluent $command): string
+    {
+        /** @var null|string $column */
+        $column = $command->whereNotNull;
+
+        return is_null($column) ? '' : ' where ' . $this->wrap($column) . ' is not null';
+    }
+
+    /**
      * Get the command with a given name if it exists on the blueprint.
      */
     protected function getCommandByName(Blueprint $blueprint, string $name): ?Fluent

--- a/src/database/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/database/src/Schema/Grammars/PostgresGrammar.php
@@ -159,7 +159,8 @@ class PostgresGrammar extends Grammar
     {
         return sprintf(
             "select ic.relname as name, string_agg(a.attname, ',' order by indseq.ord) as columns, "
-            . 'am.amname as "type", i.indisunique as "unique", i.indisprimary as "primary" '
+            . 'am.amname as "type", i.indisunique as "unique", i.indisprimary as "primary", '
+            . 'i.indpred is not null as "partial" '
             . 'from pg_index i '
             . 'join pg_class tc on tc.oid = i.indrelid '
             . 'join pg_namespace tn on tn.oid = tc.relnamespace '
@@ -168,7 +169,7 @@ class PostgresGrammar extends Grammar
             . 'join lateral unnest(i.indkey) with ordinality as indseq(num, ord) on true '
             . 'left join pg_attribute a on a.attrelid = i.indrelid and a.attnum = indseq.num '
             . 'where tc.relname = %s and tn.nspname = %s '
-            . 'group by ic.relname, am.amname, i.indisunique, i.indisprimary',
+            . 'group by ic.relname, am.amname, i.indisunique, i.indisprimary, i.indpred is not null',
             $this->quoteString($table),
             $schema ? $this->quoteString($schema) : 'current_schema()'
         );
@@ -337,12 +338,13 @@ class PostgresGrammar extends Grammar
     public function compileIndex(Blueprint $blueprint, Fluent $command): string
     {
         return sprintf(
-            'create index %s%s on %s%s (%s)',
+            'create index %s%s on %s%s (%s)%s',
             $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using ' . $command->algorithm : '',
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $this->compileWhereNotNull($command),
         );
     }
 

--- a/src/database/src/Schema/Grammars/SQLiteGrammar.php
+++ b/src/database/src/Schema/Grammars/SQLiteGrammar.php
@@ -347,12 +347,16 @@ class SQLiteGrammar extends Grammar
 
         $indexes = (new Collection($blueprint->getState()->getIndexes()))
             ->map(function (Fluent $index) use ($blueprint, $definedColumnNames, &$inlineUniqueConstraints) {
-                $projectedColumns = array_filter(
+                $referencedColumns = array_filter(
                     $index->columns,
                     static fn (mixed $column): bool => is_string($column),
                 );
 
-                if (! empty(array_diff($projectedColumns, $definedColumnNames))) {
+                if (is_string($index->whereNotNull)) {
+                    $referencedColumns[] = $index->whereNotNull;
+                }
+
+                if (! empty(array_diff($referencedColumns, $definedColumnNames))) {
                     throw new RuntimeException(
                         "Cannot rebuild table [{$blueprint->getTable()}] because index [{$index->index}] references a dropped column."
                     );

--- a/src/database/src/Schema/Grammars/SQLiteGrammar.php
+++ b/src/database/src/Schema/Grammars/SQLiteGrammar.php
@@ -166,10 +166,12 @@ class SQLiteGrammar extends Grammar
         $quotedTable = $this->quoteString($table);
         $quotedSchema = $this->quoteString($schema);
 
+        // Partial indexes must remain non-reconstructible so rebuilds and renames
+        // replay their stored predicate SQL instead of silently creating a full index.
         return sprintf(
-            'select \'primary\' as name, group_concat(hex(col)) as columns, 1 as "unique", 1 as "primary", null as sql, \'pk\' as origin, 1 as reconstructible, null as collations, null as "descending" '
+            'select \'primary\' as name, group_concat(hex(col)) as columns, 1 as "unique", 1 as "primary", null as sql, \'pk\' as origin, 1 as reconstructible, 0 as partial, null as collations, null as "descending" '
             . 'from (select name as col from pragma_table_xinfo(%s, %s) where pk > 0 order by pk, cid) group by name '
-            . 'union all select name, case when count(*) = count(col) then group_concat(col) end as columns, "unique", origin = \'pk\' as "primary", sql, origin, not partial and min(simple) as reconstructible, '
+            . 'union all select name, case when count(*) = count(col) then group_concat(col) end as columns, "unique", origin = \'pk\' as "primary", sql, origin, not partial and min(simple) as reconstructible, partial, '
             . 'case when count(*) = count(col) then group_concat(collation) end as collations, '
             . 'case when count(*) = count(col) then group_concat("descending") end as "descending" '
             . 'from (select il.*, case when ii.name is not null then hex(ii.name) end as col, hex(ii.coll) as collation, ii."desc" as "descending", '
@@ -567,11 +569,12 @@ class SQLiteGrammar extends Grammar
         [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
 
         return sprintf(
-            'create index %s%s on %s (%s)',
+            'create index %s%s on %s (%s)%s',
             $schema ? $this->wrapValue($schema) . '.' : '',
             $this->wrap($command->index),
             $this->wrapTable($table),
-            $this->columnizeIndexedColumns($command)
+            $this->columnizeIndexedColumns($command),
+            $this->compileWhereNotNull($command),
         );
     }
 

--- a/src/database/src/Schema/IndexDefinition.php
+++ b/src/database/src/Schema/IndexDefinition.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Database\Schema;
 
 use Hypervel\Support\Fluent;
+use LogicException;
 
 /**
  * @method $this algorithm(string $algorithm) Specify an algorithm for the index (MySQL/PostgreSQL)
@@ -17,4 +18,18 @@ use Hypervel\Support\Fluent;
  */
 class IndexDefinition extends Fluent
 {
+    /**
+     * Limit the index to rows where the given column is not null.
+     */
+    public function whereNotNull(string $column): static
+    {
+        // Fluent stores the command type under name and the physical index name under index.
+        if ($this->get('name') !== 'index') {
+            throw new LogicException(
+                'The [whereNotNull] modifier is only available for ordinary indexes.',
+            );
+        }
+
+        return $this->set('whereNotNull', $column);
+    }
 }

--- a/src/database/src/Schema/SQLiteBuilder.php
+++ b/src/database/src/Schema/SQLiteBuilder.php
@@ -189,7 +189,7 @@ class SQLiteBuilder extends Builder
      * Get the indexes used to reconstruct SQLite schema state.
      *
      * @internal
-     * @return list<array{name: string, physical_name: string, columns: list<string>, type: null|string, unique: bool, primary: bool, sql: null|string, origin: null|string, reconstructible: bool, collations: null|list<string>, descending: null|list<bool>}>
+     * @return list<array{name: string, physical_name: string, columns: list<string>, type: null|string, unique: bool, primary: bool, partial: bool, sql: null|string, origin: null|string, reconstructible: bool, collations: null|list<string>, descending: null|list<bool>}>
      */
     public function getIndexesForSchemaState(string $table): array
     {

--- a/src/docs/migrations.md
+++ b/src/docs/migrations.md
@@ -1547,6 +1547,22 @@ $table->unique('email')->online();
 
 When using PostgreSQL, this adds the `CONCURRENTLY` option to the index creation statement.
 
+<a name="partial-indexes"></a>
+#### Partial Indexes
+
+To create an index that contains only rows where a column is not null, you may chain the `whereNotNull` method onto an ordinary index definition:
+
+```php
+$table->index(
+    ['account_id', 'archived_at'],
+    'records_archived_index',
+)->whereNotNull('archived_at');
+```
+
+PostgreSQL and SQLite create a partial index for this definition. MySQL and MariaDB do not support partial indexes, so they create the same ordinary index over every row. This allows the same migration to run on each supported database.
+
+The `whereNotNull` modifier is available on indexes created with `index` and `rawIndex`. Using it with a primary, unique, full text, spatial, or vector index throws a `LogicException`.
+
 <a name="renaming-indexes"></a>
 ### Renaming Indexes
 

--- a/tests/Database/DatabaseConsoleJsonTest.php
+++ b/tests/Database/DatabaseConsoleJsonTest.php
@@ -32,6 +32,20 @@ class DatabaseConsoleJsonTest extends TestCase
         $command->renderJson(['value' => NAN]);
     }
 
+    public function testTableCommandIncludesPartialIndexAttribute(): void
+    {
+        [$command] = $this->tableCommand();
+
+        $this->assertSame(['btree', 'compound', 'partial'], $command->indexAttributes([
+            'name' => 'records_active_index',
+            'columns' => ['account_id', 'archived_at'],
+            'type' => 'btree',
+            'unique' => false,
+            'primary' => false,
+            'partial' => true,
+        ]));
+    }
+
     public function testShowCommandRendersValidJson(): void
     {
         [$command, $output] = $this->showCommand();
@@ -80,6 +94,11 @@ class TableCommandProbe extends TableCommand
     public function renderJson(array $data): void
     {
         $this->displayJson($data);
+    }
+
+    public function indexAttributes(array $index): array
+    {
+        return $this->getAttributesForIndex($index)->values()->all();
     }
 }
 

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -389,6 +389,18 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
     }
 
+    public function testWhereNotNullIndexUsesTheFullIndexFallback(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['account_id', 'archived_at'], 'users_active_index')
+            ->whereNotNull('archived_at');
+
+        $this->assertSame(
+            ['alter table `users` add index `users_active_index`(`account_id`, `archived_at`)'],
+            $blueprint->toSql(),
+        );
+    }
+
     public function testAddingIndexWithAlgorithm()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabaseMySqlProcessorTest.php
+++ b/tests/Database/DatabaseMySqlProcessorTest.php
@@ -31,4 +31,31 @@ class DatabaseMySqlProcessorTest extends TestCase
 
         $this->assertEquals($expected, $processor->processColumns($listing));
     }
+
+    public function testProcessIndexesReportsFullIndexes(): void
+    {
+        $processor = new MySqlProcessor;
+
+        $this->assertSame([
+            [
+                'name' => 'users_active_index',
+                'columns' => ['account_id', 'archived_at'],
+                'type' => 'btree',
+                'unique' => false,
+                'primary' => false,
+                'partial' => false,
+            ],
+            [
+                'name' => 'primary',
+                'columns' => ['id'],
+                'type' => 'btree',
+                'unique' => true,
+                'primary' => true,
+                'partial' => false,
+            ],
+        ], $processor->processIndexes([
+            ['name' => 'Users_Active_Index', 'columns' => 'account_id,archived_at', 'type' => 'BTREE', 'unique' => false],
+            ['name' => 'PRIMARY', 'columns' => 'id', 'type' => 'BTREE', 'unique' => true],
+        ]));
+    }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -388,6 +388,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
     }
 
+    public function testWhereNotNullIndexUsesTheFullIndexFallback(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['account_id', 'archived_at'], 'users_active_index')
+            ->whereNotNull('archived_at');
+
+        $this->assertSame(
+            ['alter table `users` add index `users_active_index`(`account_id`, `archived_at`)'],
+            $blueprint->toSql(),
+        );
+    }
+
     public function testAddingIndexWithAlgorithm()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -35,4 +35,31 @@ class DatabasePostgresProcessorTest extends TestCase
 
         $this->assertEquals($expected, $processor->processColumns($listing));
     }
+
+    public function testProcessIndexesIncludesPartialMetadata(): void
+    {
+        $processor = new PostgresProcessor;
+
+        $this->assertSame([
+            [
+                'name' => 'users_active_index',
+                'columns' => ['account_id', 'archived_at'],
+                'type' => 'btree',
+                'unique' => false,
+                'primary' => false,
+                'partial' => true,
+            ],
+            [
+                'name' => 'users_pkey',
+                'columns' => ['id'],
+                'type' => 'btree',
+                'unique' => true,
+                'primary' => true,
+                'partial' => false,
+            ],
+        ], $processor->processIndexes([
+            ['name' => 'Users_Active_Index', 'columns' => 'account_id,archived_at', 'type' => 'BTREE', 'unique' => false, 'primary' => false, 'partial' => true],
+            ['name' => 'Users_PKey', 'columns' => 'id', 'type' => 'BTREE', 'unique' => true, 'primary' => true, 'partial' => false],
+        ]));
+    }
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -393,6 +393,51 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create index concurrently "baz" on "users" ("foo")', $statements[0]);
     }
 
+    public function testAddingPartialIndex(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['account_id', 'archived_at'], 'users_active_index')
+            ->whereNotNull('archived_at');
+
+        $this->assertSame(
+            ['create index "users_active_index" on "users" ("account_id", "archived_at") where "archived_at" is not null'],
+            $blueprint->toSql(),
+        );
+    }
+
+    public function testPartialRawIndexComposesWithAlgorithmAndOnlineCreation(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->rawIndex('(lower(email))', 'users_email_lower_index')
+            ->algorithm('hash')
+            ->online()
+            ->whereNotNull('email');
+
+        $this->assertSame(
+            ['create index concurrently "users_email_lower_index" on "users" using hash ((lower(email))) where "email" is not null'],
+            $blueprint->toSql(),
+        );
+    }
+
+    public function testCompileIndexesIncludesPartialMetadata(): void
+    {
+        $this->assertSame(
+            'select ic.relname as name, string_agg(a.attname, \',\' order by indseq.ord) as columns, '
+            . 'am.amname as "type", i.indisunique as "unique", i.indisprimary as "primary", '
+            . 'i.indpred is not null as "partial" '
+            . 'from pg_index i '
+            . 'join pg_class tc on tc.oid = i.indrelid '
+            . 'join pg_namespace tn on tn.oid = tc.relnamespace '
+            . 'join pg_class ic on ic.oid = i.indexrelid '
+            . 'join pg_am am on am.oid = ic.relam '
+            . 'join lateral unnest(i.indkey) with ordinality as indseq(num, ord) on true '
+            . 'left join pg_attribute a on a.attrelid = i.indrelid and a.attnum = indseq.num '
+            . 'where tc.relname = \'users\' and tn.nspname = \'public\' '
+            . 'group by ic.relname, am.amname, i.indisunique, i.indisprimary, i.indpred is not null',
+            $this->getGrammar()->compileIndexes('public', 'users'),
+        );
+    }
+
     public function testAddingFulltextIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -37,7 +37,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
         $this->assertEquals($expected, $processor->processColumns($listing));
     }
 
-    public function testProcessIndexesKeepsPublicShapeAndPreservesSchemaStateMetadata(): void
+    public function testProcessIndexesIncludesPartialFlagAndPreservesSchemaStateMetadata(): void
     {
         $processor = new SQLiteProcessor;
         $results = [
@@ -46,9 +46,10 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'columns' => '656D61696C',
                 'unique' => 1,
                 'primary' => 0,
-                'sql' => 'CREATE UNIQUE INDEX "MixedCase_Index" ON "users" ("email")',
+                'partial' => 1,
+                'sql' => 'CREATE UNIQUE INDEX "MixedCase_Index" ON "users" ("email") WHERE "email" IS NOT NULL',
                 'origin' => 'c',
-                'reconstructible' => 1,
+                'reconstructible' => 0,
                 'collations' => '42494E415259',
                 'descending' => '0',
             ],
@@ -57,6 +58,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'columns' => null,
                 'unique' => 1,
                 'primary' => 0,
+                'partial' => 0,
                 'sql' => null,
                 'origin' => 'u',
                 'reconstructible' => 0,
@@ -72,6 +74,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'type' => null,
                 'unique' => true,
                 'primary' => false,
+                'partial' => true,
             ],
             [
                 'name' => 'sqlite_autoindex_users_1',
@@ -79,6 +82,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'type' => null,
                 'unique' => true,
                 'primary' => false,
+                'partial' => false,
             ],
         ], $processor->processIndexes($results));
 
@@ -90,9 +94,10 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'type' => null,
                 'unique' => true,
                 'primary' => false,
-                'sql' => 'CREATE UNIQUE INDEX "MixedCase_Index" ON "users" ("email")',
+                'partial' => true,
+                'sql' => 'CREATE UNIQUE INDEX "MixedCase_Index" ON "users" ("email") WHERE "email" IS NOT NULL',
                 'origin' => 'c',
-                'reconstructible' => true,
+                'reconstructible' => false,
                 'collations' => ['BINARY'],
                 'descending' => [false],
             ],
@@ -103,6 +108,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'type' => null,
                 'unique' => true,
                 'primary' => false,
+                'partial' => false,
                 'sql' => null,
                 'origin' => 'u',
                 'reconstructible' => false,
@@ -120,6 +126,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
             'columns' => '656D61696C2C61646472657373',
             'unique' => 1,
             'primary' => 0,
+            'partial' => 0,
             'sql' => null,
             'origin' => 'u',
             'reconstructible' => 0,
@@ -134,6 +141,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
             'type' => null,
             'unique' => true,
             'primary' => false,
+            'partial' => false,
             'sql' => null,
             'origin' => 'u',
             'reconstructible' => false,
@@ -156,6 +164,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
             'columns' => 'not-hexadecimal',
             'unique' => 0,
             'primary' => 0,
+            'partial' => 0,
             'sql' => 'CREATE INDEX contacts_index ON contacts (email)',
             'origin' => 'c',
             'reconstructible' => 1,
@@ -176,6 +185,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'columns' => '656D61696C',
                 'unique' => 0,
                 'primary' => 0,
+                'partial' => 0,
                 'sql' => 'CREATE INDEX "users_email_index" ON "users" ("email")',
                 'origin' => 'c',
                 'reconstructible' => 1,
@@ -187,6 +197,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'columns' => '74656E616E745F6964,6964',
                 'unique' => 1,
                 'primary' => 1,
+                'partial' => 0,
                 'sql' => null,
                 'origin' => 'pk',
                 'reconstructible' => 1,
@@ -198,6 +209,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
                 'columns' => '74656E616E745F6964,6964',
                 'unique' => 1,
                 'primary' => 1,
+                'partial' => 0,
                 'sql' => null,
                 'origin' => 'pk',
                 'reconstructible' => 1,

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -272,6 +272,18 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingPartialIndex(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['account_id', 'archived_at'], 'users_active_index')
+            ->whereNotNull('archived_at');
+
+        $this->assertSame(
+            ['create index "users_active_index" on "users" ("account_id", "archived_at") where "archived_at" is not null'],
+            $blueprint->toSql(),
+        );
+    }
+
     public function testAddingUniqueKeyWithSchema()
     {
         $blueprint = new Blueprint($this->getConnection(), 'foo.users');
@@ -286,6 +298,18 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->index(['foo', 'bar'], 'baz');
 
         $this->assertSame(['create index "foo"."baz" on "users" ("foo", "bar")'], $blueprint->toSql());
+    }
+
+    public function testAddingPartialIndexWithSchema(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'foo.users');
+        $blueprint->index(['account_id', 'archived_at'], 'users_active_index')
+            ->whereNotNull('archived_at');
+
+        $this->assertSame(
+            ['create index "foo"."users_active_index" on "users" ("account_id", "archived_at") where "archived_at" is not null'],
+            $blueprint->toSql(),
+        );
     }
 
     public function testAddingSpatialIndex()
@@ -316,6 +340,35 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
+    }
+
+    public function testAddingPartialRawIndex(): void
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->rawIndex('(lower(email))', 'users_email_lower_index')
+            ->whereNotNull('email');
+
+        $this->assertSame(
+            ['create index "users_email_lower_index" on "users" ((lower(email))) where "email" is not null'],
+            $blueprint->toSql(),
+        );
+    }
+
+    public function testCompileIndexesIncludesPartialMetadata(): void
+    {
+        $this->assertSame(
+            'select \'primary\' as name, group_concat(hex(col)) as columns, 1 as "unique", 1 as "primary", null as sql, \'pk\' as origin, 1 as reconstructible, 0 as partial, null as collations, null as "descending" '
+            . 'from (select name as col from pragma_table_xinfo(\'users\', \'main\') where pk > 0 order by pk, cid) group by name '
+            . 'union all select name, case when count(*) = count(col) then group_concat(col) end as columns, "unique", origin = \'pk\' as "primary", sql, origin, not partial and min(simple) as reconstructible, partial, '
+            . 'case when count(*) = count(col) then group_concat(collation) end as collations, '
+            . 'case when count(*) = count(col) then group_concat("descending") end as "descending" '
+            . 'from (select il.*, case when ii.name is not null then hex(ii.name) end as col, hex(ii.coll) as collation, ii."desc" as "descending", '
+            . 'ii.name is not null and ii."desc" = 0 and lower(ii.coll) = \'binary\' as simple, '
+            . '(select sql from "main".sqlite_master where type = \'index\' and name = il.name) as sql '
+            . 'from pragma_index_list(\'users\', \'main\') il left join pragma_index_xinfo(il.name, \'main\') ii on ii.key = 1 order by il.seq, ii.seqno) '
+            . 'group by name, "unique", "primary", sql, origin, partial',
+            $this->getGrammar()->compileIndexes('main', 'users'),
+        );
     }
 
     public function testAddingIncrementingID()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -8,12 +8,16 @@ use Closure;
 use Hypervel\Database\Connection;
 use Hypervel\Database\Schema\Blueprint;
 use Hypervel\Database\Schema\Builder;
+use Hypervel\Database\Schema\ForeignKeyDefinition;
 use Hypervel\Database\Schema\Grammars\MySqlGrammar;
+use Hypervel\Database\Schema\IndexDefinition;
 use Hypervel\Support\Fluent;
 use Hypervel\Tests\Database\Fixtures\Models\User;
 use Hypervel\Tests\TestCase;
 use InvalidArgumentException;
+use LogicException;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DatabaseSchemaBlueprintTest extends TestCase
 {
@@ -53,6 +57,69 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->spatialIndex('coordinates');
         $commands = $blueprint->getCommands();
         $this->assertSame('geo_coordinates_spatialindex', $commands[0]->index);
+    }
+
+    public function testIndexMethodsReturnIndexDefinitions(): void
+    {
+        $blueprint = $this->getBlueprint(table: 'users');
+
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->primary('id'));
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->unique('email'));
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->index('name'));
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->fullText('bio'));
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->spatialIndex('location'));
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->vectorIndex('embedding'));
+        $this->assertInstanceOf(IndexDefinition::class, $blueprint->rawIndex('(lower(email))', 'users_email_lower_index'));
+    }
+
+    public function testOrdinaryIndexesRetainTheWhereNotNullModifier(): void
+    {
+        $blueprint = $this->getBlueprint(table: 'users');
+
+        $index = $blueprint->index('email')->whereNotNull('email');
+        $rawIndex = $blueprint->rawIndex('(lower(email))', 'users_email_lower_index')
+            ->whereNotNull('email');
+
+        $this->assertSame('email', $index->get('whereNotNull'));
+        $this->assertSame('email', $rawIndex->get('whereNotNull'));
+
+        $index->whereNotNull('verified_at');
+
+        $this->assertSame('verified_at', $index->get('whereNotNull'));
+    }
+
+    #[DataProvider('nonOrdinaryIndexProvider')]
+    public function testWhereNotNullRejectsNonOrdinaryIndexes(string $method, string $column): void
+    {
+        $blueprint = $this->getBlueprint(table: 'users');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'The [whereNotNull] modifier is only available for ordinary indexes.',
+        );
+
+        $blueprint->{$method}($column)->whereNotNull('email');
+    }
+
+    public static function nonOrdinaryIndexProvider(): array
+    {
+        return [
+            'primary' => ['primary', 'id'],
+            'unique' => ['unique', 'email'],
+            'full text' => ['fullText', 'bio'],
+            'spatial' => ['spatialIndex', 'location'],
+            'vector' => ['vectorIndex', 'embedding'],
+        ];
+    }
+
+    public function testForeignReplacesTheTemporaryIndexDefinition(): void
+    {
+        $blueprint = $this->getBlueprint(table: 'users');
+
+        $foreign = $blueprint->foreign('team_id');
+
+        $this->assertInstanceOf(ForeignKeyDefinition::class, $foreign);
+        $this->assertSame([$foreign], $blueprint->getCommands());
     }
 
     public function testIndexDefaultNamesWhenPrefixSupplied()
@@ -890,7 +957,7 @@ enum ApostropheBackedEnum: string
 
 class DatabaseSchemaBlueprintOrderingTestBlueprint extends Blueprint
 {
-    public ?Fluent $generatedUniqueCommand = null;
+    public ?IndexDefinition $generatedUniqueCommand = null;
 
     /**
      * Add a custom schema command.
@@ -903,7 +970,7 @@ class DatabaseSchemaBlueprintOrderingTestBlueprint extends Blueprint
     /**
      * Specify a unique index for the table.
      */
-    public function unique(array|string $columns, ?string $name = null, ?string $algorithm = null): Fluent
+    public function unique(array|string $columns, ?string $name = null, ?string $algorithm = null): IndexDefinition
     {
         $command = parent::unique($columns, $name, $algorithm);
         $command->testMetadata = 'preserved';

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -406,6 +406,50 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertFalse(Schema::hasIndex('foo', ['bar'], 'unique'));
     }
 
+    public function testGetPartialIndexMetadata(): void
+    {
+        Schema::create('partial_index_records', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->unsignedBigInteger('account_id');
+            $table->dateTime('archived_at')->nullable();
+            $table->index(
+                ['account_id', 'archived_at'],
+                'partial_index_records_active_index',
+            )->whereNotNull('archived_at');
+        });
+
+        $indexes = Schema::getIndexes('partial_index_records');
+        $driver = DB::connection()->getDriverName();
+
+        $this->assertCount(3, $indexes);
+
+        foreach ($indexes as $index) {
+            $this->assertSame(
+                ['name', 'columns', 'type', 'unique', 'primary', 'partial'],
+                array_keys($index),
+            );
+        }
+
+        $this->assertSame([
+            'name' => 'partial_index_records_active_index',
+            'columns' => ['account_id', 'archived_at'],
+            'type' => $driver === 'sqlite' ? null : 'btree',
+            'unique' => false,
+            'primary' => false,
+            'partial' => in_array($driver, ['pgsql', 'sqlite'], true),
+        ], collect($indexes)->firstWhere('name', 'partial_index_records_active_index'));
+
+        $this->assertSame([
+            'name' => 'partial_index_records_email_unique',
+            'columns' => ['email'],
+            'type' => $driver === 'sqlite' ? null : 'btree',
+            'unique' => true,
+            'primary' => false,
+            'partial' => false,
+        ], collect($indexes)->firstWhere('name', 'partial_index_records_email_unique'));
+    }
+
     public function testGetUniqueIndexes()
     {
         Schema::create('foo', function (Blueprint $table) {

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -9,9 +9,12 @@ use Exception;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Database\QueryException;
 use Hypervel\Database\Schema\Blueprint;
+use Hypervel\Database\SQLiteConnection;
 use Hypervel\Support\Facades\DB;
 use Hypervel\Support\Facades\Schema;
 use Hypervel\Testbench\Attributes\RequiresDatabase;
+use Override;
+use PDO;
 use RuntimeException;
 
 class DatabaseSchemaBlueprintTest extends SqliteTestCase
@@ -367,6 +370,56 @@ class DatabaseSchemaBlueprintTest extends SqliteTestCase
             collect($schema->getIndexes('items'))
                 ->firstWhere('name', 'items_renamed_active_index')['partial'],
         );
+    }
+
+    public function testPublicPartialIndexPredicateFollowsSameBlueprintColumnRename(): void
+    {
+        $schema = DB::connection()->getSchemaBuilder();
+        $schema->create('items', function (Blueprint $table) {
+            $table->integer('account_id');
+            $table->dateTime('archived_at')->nullable();
+            $table->string('description');
+        });
+
+        $schema->table('items', function (Blueprint $table) {
+            $table->index('account_id', 'items_active_index')
+                ->whereNotNull('archived_at');
+            $table->renameColumn('archived_at', 'archived');
+            $table->text('description')->change();
+        });
+
+        $this->assertSame(
+            'CREATE INDEX "items_active_index" on "items" ("account_id") where "archived" is not null',
+            $this->indexSql('items_active_index'),
+        );
+    }
+
+    public function testLegacyRebuildRejectsNewPartialIndexReferencingDroppedPredicateColumn(): void
+    {
+        // SQLite versions before 3.35 rebuild tables to drop columns, so force that path on the current runtime.
+        $connection = new class(new PDO('sqlite::memory:'), ':memory:', '', ['driver' => 'sqlite', 'database' => ':memory:']) extends SQLiteConnection {
+            #[Override]
+            public function getServerVersion(): string
+            {
+                return '3.34.0';
+            }
+        };
+        $schema = $connection->getSchemaBuilder();
+        $schema->create('items', function (Blueprint $table) {
+            $table->integer('account_id');
+            $table->dateTime('archived_at')->nullable();
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Cannot rebuild table [items] because index [items_active_index] references a dropped column.',
+        );
+
+        $schema->table('items', function (Blueprint $table) {
+            $table->index('account_id', 'items_active_index')
+                ->whereNotNull('archived_at');
+            $table->dropColumn('archived_at');
+        });
     }
 
     public function testRebuildQualifiesReplayedIndexesForAnAttachedSchema(): void

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -327,6 +327,48 @@ class DatabaseSchemaBlueprintTest extends SqliteTestCase
         $this->assertSame($indexSql, $this->indexSql('MixedCase_Index'));
     }
 
+    public function testPublicPartialIndexSurvivesRebuildAndRename(): void
+    {
+        $schema = DB::connection()->getSchemaBuilder();
+        $schema->create('items', function (Blueprint $table) {
+            $table->integer('account_id');
+            $table->dateTime('archived_at')->nullable();
+            $table->string('description');
+        });
+
+        $schema->table('items', function (Blueprint $table) {
+            $table->index(['account_id', 'archived_at'], 'items_active_index')
+                ->whereNotNull('archived_at');
+            $table->text('description')->change();
+        });
+
+        $indexSql = 'CREATE INDEX "items_active_index" on "items" ("account_id", "archived_at") where "archived_at" is not null';
+
+        $this->assertSame($indexSql, $this->indexSql('items_active_index'));
+        $this->assertSame([
+            'name' => 'items_active_index',
+            'columns' => ['account_id', 'archived_at'],
+            'type' => null,
+            'unique' => false,
+            'primary' => false,
+            'partial' => true,
+        ], collect($schema->getIndexes('items'))->firstWhere('name', 'items_active_index'));
+
+        $schema->table('items', function (Blueprint $table) {
+            $table->renameIndex('items_active_index', 'items_renamed_active_index');
+        });
+
+        $this->assertNull($this->indexSql('items_active_index'));
+        $this->assertSame(
+            'CREATE INDEX "items_renamed_active_index" on "items" ("account_id", "archived_at") where "archived_at" is not null',
+            $this->indexSql('items_renamed_active_index'),
+        );
+        $this->assertTrue(
+            collect($schema->getIndexes('items'))
+                ->firstWhere('name', 'items_renamed_active_index')['partial'],
+        );
+    }
+
     public function testRebuildQualifiesReplayedIndexesForAnAttachedSchema(): void
     {
         $connection = DB::connection();

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -105,7 +105,7 @@ SQL);
         $this->assertSame([], collect($indexes)->firstWhere('name', 'table_mixed_raw_index')['columns']);
     }
 
-    public function testSchemaStateIndexMetadataDoesNotChangeThePublicIndexShape(): void
+    public function testSchemaStateIndexMetadataDoesNotLeakIntoThePublicIndexShape(): void
     {
         $connection = DB::connection('conn1');
         $schema = $connection->getSchemaBuilder();
@@ -118,6 +118,7 @@ SQL);
             'type' => null,
             'unique' => false,
             'primary' => false,
+            'partial' => false,
         ], collect($schema->getIndexes('users'))->firstWhere('name', 'mixedcase_index'));
 
         $this->assertSame([
@@ -127,6 +128,7 @@ SQL);
             'type' => null,
             'unique' => false,
             'primary' => false,
+            'partial' => false,
             'sql' => $indexSql,
             'origin' => 'c',
             'reconstructible' => false,

--- a/types/Database/Schema.php
+++ b/types/Database/Schema.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Types\Database\Schema;
+
+use Hypervel\Database\Schema\Blueprint;
+
+use function PHPStan\Testing\assertType;
+
+function testIndexDefinitionsUseConcreteTypes(Blueprint $table): void
+{
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->primary('id'));
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->unique('email'));
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->index('name'));
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->fullText('body'));
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->spatialIndex('location'));
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->vectorIndex('embedding'));
+    assertType('Hypervel\Database\Schema\IndexDefinition', $table->rawIndex('(lower(email))', 'users_email_lower_index'));
+    assertType(
+        'Hypervel\Database\Schema\IndexDefinition',
+        $table->index('archived_at')->whereNotNull('archived_at'),
+    );
+}


### PR DESCRIPTION
## Motivation

PostgreSQL and SQLite can reduce index size and write maintenance by excluding rows where a selected column is null. The schema builder did not expose that capability, so portable migrations had to choose between raw engine-specific SQL and full indexes on every database.

This adds one narrow schema modifier for the common not-null case while keeping the same migration valid on all supported engines.

## Public API

Ordinary and raw index definitions now return a concrete `IndexDefinition` and accept `whereNotNull`:

```php
$table->index(
    ["account_id", "archived_at"],
    "records_archived_index",
)->whereNotNull("archived_at");
```

The modifier is limited to ordinary indexes. Primary, unique, full-text, spatial, and vector definitions reject it immediately because partial constraint semantics are a different API contract.

The existing Blueprint index methods now expose their real `IndexDefinition` return type to PHP and static analysis. Foreign-key command construction keeps its existing replacement behavior.

## Database behavior

- PostgreSQL and SQLite compile `WHERE <column> IS NOT NULL` with the predicate column quoted through the existing grammar.
- MySQL and MariaDB keep the existing full ordinary index as a portable fallback.
- PostgreSQL online and algorithm modifiers continue to compose with the predicate.
- Raw index expressions remain raw index keys; only the predicate column is identifier-wrapped.

There is no new backend layer, predicate parser, configuration, registry, cache, or runtime query path.

## Introspection and SQLite schema changes

`Schema::getIndexes()` now includes a required `partial` boolean on every supported database. PostgreSQL derives it from `pg_index.indpred`, SQLite uses `pragma_index_list.partial`, and MySQL-family processors report `false`.

SQLite keeps arbitrary existing partial predicates safe during table rebuilds and index renames. Introspected partial indexes remain non-reconstructible and replay their stored SQL. Newly declared `whereNotNull` indexes keep the complete supported predicate on their `IndexDefinition` and can be reconstructed normally.

The `db:table` command also identifies partial indexes in its index attributes.

## Documentation

The migrations documentation includes the new API, supported engine behavior, MySQL and MariaDB fallback, and the ordinary-index restriction.

## Validation

- Exact grammar and processor tests cover PostgreSQL, SQLite, MySQL, and MariaDB.
- Integration tests execute the schema definition on all four database engines and verify positive and negative partial metadata.
- SQLite integration coverage exercises table rebuild and index rename preservation.
- Static type fixtures pin the concrete index-definition and fluent return types.
- Formatting, static analysis, the full parallel suite, Testbench, and package dogfood checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for defining partial indexes with `whereNotNull()`.
  - PostgreSQL and SQLite create filtered indexes; MySQL and MariaDB use standard indexes.
  - Unsupported index types reject the modifier with a clear exception.
  - Index metadata and table inspection now report whether an index is partial.
  - Partial indexes remain available through SQLite table rebuilds and column renames.

- **Documentation**
  - Added partial-index usage guidance and database-specific behavior to the migrations documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->