### PR TITLE
Fix Redis cleanup, tagged cache consistency, and Horizon execution

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -311,4 +311,5 @@ jobs:
           QUEUE_CONNECTION=redis vendor/bin/phpunit --no-progress tests/Integration/Queue/JobDispatchingTest.php
           vendor/bin/paratest --max-processes=15 tests/Integration/RateLimiter/Redis
           vendor/bin/paratest --max-processes=15 tests/Integration/Redis
+          vendor/bin/phpunit --no-progress tests/Integration/Reverb/ClearStateCommandTest.php
           vendor/bin/paratest --max-processes=15 tests/Integration/Session/Redis

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -708,7 +708,8 @@ Each integration group has its own workflow file in `.github/workflows/`:
 |----------|------|-----------|
 | `engine.yml` | HTTP test servers | `tests/Integration/Engine`, `tests/Integration/HttpServer` |
 | `databases.yml` | MySQL, MariaDB, PostgreSQL, SQLite | `tests/Integration/Database`, `tests/Integration/*/Database/*` |
-| `redis.yml` | Redis, Redis Cluster, Valkey | `tests/Integration/Auth/Redis`, `tests/Integration/Broadcasting/Redis`, `tests/Integration/Cache/Redis`, `tests/Integration/Horizon`, `tests/Integration/Http/Redis`, `tests/Integration/Queue/Redis`, `tests/Integration/RateLimiter/Redis`, `tests/Integration/Redis`, `tests/Integration/Session/Redis`; it also reruns the driver-neutral queue chaining and dispatching tests with Redis, while the Cluster job runs the topology-neutral Redis files and Redis-backed Reverb state tests listed in the workflow |
+| `redis.yml` | Redis, Redis Cluster, Valkey | `tests/Integration/Auth/Redis`, `tests/Integration/Broadcasting/Redis`, `tests/Integration/Cache/Redis`, `tests/Integration/Horizon`, `tests/Integration/Http/Redis`, `tests/Integration/Queue/Redis`, `tests/Integration/RateLimiter/Redis`, `tests/Integration/Redis`, `tests/Integration/Session/Redis`; it also reruns the driver-neutral queue chaining and dispatching tests with Redis, the listed topology-neutral Reverb state tests with Cluster, and Reverb state recovery with Valkey |
+| `reverb.yml` | Redis-backed Reverb servers and state | `tests/Integration/Reverb` |
 | `scout.yml` | Meilisearch, Typesense | `tests/Integration/Scout/*` |
 
 When adding integration tests that need a new service, either add them to an existing workflow or create a new one. The workflow must start the service and set the appropriate env vars.

--- a/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
@@ -12,7 +12,7 @@ Resolve every genuine issue retained in this master plan against the current 0.4
 - Finding 123 was valid but is already fixed on the current branch.
 - Findings 4, 9, 14, 93, 119, 129, and 153 require no change: some are false positives, while the rest propose churn or machinery for deliberate behavior that is already correct.
 - Finding 88 is an exact duplicate of finding 32 and must not become a second patch.
-- Findings 6, 26, and 154 are only partially correct as written. Their valid portions remain in this plan; their invalid portions are explicitly rejected below.
+- Findings 6 and 26 are only partially correct as written. Their valid portions remain in this plan; their invalid portions are explicitly rejected below.
 - Some audit statements about Laravel were stale or incorrect. A defect shared with current Laravel remains a defect, but the plan does not cite false upstream parity as evidence.
 
 ## Rejected, duplicate, resolved, and narrowed claims
@@ -31,7 +31,6 @@ Resolve every genuine issue retained in this master plan against the current 0.4
 | 123 | Valid, already resolved | RedisConnection::callGet is mixed on the current branch. Retain or extend the serializer regression test, but do not schedule another production change. |
 | 129 | Rejected | Framework reset methods are no-throw lifecycle boundaries by design, and the subscriber already preserves the first error across its explicit outer cleanup stages. Wrapping roughly two hundred static resets in per-call fault-isolation machinery optimizes for unsupported throwing reset implementations and weakens the simple at-most-once cleanup contract. |
 | 153 | Rejected | Immediate hard termination is deliberate, documented, and pinned by testKillDoesNotWaitForUnrelatedActiveJobs. The timed-out coroutine is not cancellable, so the worker is poisoned; draining siblings delays the hard timeout while the stuck job can continue side effects. |
-| 154 | Partially confirmed | Remove the never-supported SQL Server branch and document the Redis script argument. Keep raw usleep: Swoole hooks make it coroutine-friendly, queue tests already override Worker::sleep, and Support\\Sleep adds avoidable allocation/global-fake machinery to polling paths. The 1ms shutdown-only empty check does not justify a new Concurrent notification API. |
 
 ## Cross-cutting design decisions
 
@@ -46,7 +45,7 @@ Resolve every genuine issue retained in this master plan against the current 0.4
 - Apply that rule consistently: Horizon uses `vonage`, never upstream Horizon's stale `nexmo` name.
 - Hypervel worker singletons retain only boot-time immutable/baseline state. Request, job, command, and test overrides belong in CoroutineContext and are cleaned at execution boundaries. This is an architectural adaptation, not a port of Laravel's process-per-request mutable-static assumptions.
 - Most fixes remove work, bound memory by correct lifetime, preserve a fast path, or add only constant-time state checks.
-- Reverb recovery is an operator command with zero steady-state cost. Queue timeout behavior remains unchanged because the proposed drain would weaken its safety contract.
+- Queue timeout behavior remains unchanged because the proposed drain would weaken its safety contract.
 - No fix may add periodic polling, arbitrary eviction thresholds, a distributed lock on every request/cache hit, metadata shortcuts with delayed correctness, or a new abstraction whose only purpose is an unsupported failure mode.
 - Performance and scalability claims must be measured during implementation for the affected hot paths. A fix does not land if its package benchmark/load test shows a material regression that is not inherent to the required correctness guarantee; revise the design instead.
 - Load tests must cover high-cardinality input and long worker lifetimes, not only request latency: retained memory must converge to the natural live/configured keyspace, and temporary request/job state must disappear at execution teardown.
@@ -101,12 +100,11 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 | 92 | Remove pagination's hard runtime requirements on database and http. Keep them in require-dev and add Composer suggests only if the optional model/resource transformations need explanation. | Standalone pagination Composer install/autoload; metadata has no cycle; model/pivot/resource instanceof paths still work when optional packages are installed. |
 | 93 | No change; see disposition above. | Preserve nullable-path and state-flush behavior. |
 
-### Reverb, Wayfinder, and Tinker
+### Wayfinder and Tinker
 
 | ID | Proposed implementation | Required tests |
 |---:|---|---|
 | 104 | Resolve the root seeder with Container::build, matching Seeder::resolve and its fresh-instance convention. | Two programmatic db:seed runs receive distinct root objects; nested seeder remains fresh; container dependencies inject correctly. |
-| 112 | Add a manual-only `reverb:clear-state` command for crash recovery. Require all Reverb nodes using the selected Redis connection/prefix to be stopped, scan only RedisSharedState's `reverb:{*}:*` namespace across the selected connection's cluster nodes, and delete in bounded UNLINK batches (DEL fallback where unavailable). Provide `--dry-run`; otherwise require interactive confirmation or `--force`. Document the stop/clear/start runbook and explicitly exclude webhook buffer keys. Never schedule it, invoke it at boot, or wire it into automatic recovery; do not add leases, heartbeats, per-node aggregation, or hot-path Redis work without operational evidence. | Dry-run reports without deletion; confirmation/force behavior; only shared-state counters/locks/smoothing keys are removed; webhook and unrelated Redis data survive; multi-batch and cluster-wide scanning; stopped-nodes safety warning; command registration does not add scheduled/boot execution; docs runbook. |
 | 113 | Render Wayfinder @see with docblock_method when explicitly supplied, otherwise original_method, never the allocated TypeScript identifier. | Reserved PHP method renamed in TS; collision suffix; invokable; named and controller files; IDE target string. |
 | 114 | Strip the :parameters suffix from gathered middleware before class reflection for URL::defaults extraction. | Parameterized class middleware, alias-resolved middleware, unparameterized middleware, and absent class. |
 | 115 | Detect duplicate route names before generation and fail with a generator exception listing both conflicting routes. Do not emit ambiguous overloads because Laravel route caching also treats duplicate names as invalid. | Two different URIs with one name; identical duplicate; error identifies methods/URIs; ordinary grouped namespaces compile. |
@@ -123,17 +121,12 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 | ID | Proposed implementation | Required tests |
 |---:|---|---|
 | 123 | No production change; retain the resolved disposition above. | Serializer-enabled get returns array, object, int, float, string, and null mapping without TypeError. |
-| 124 | Pass the original Throwable as previous when wrapping Sentinel and Redis Cluster connection creation, and correct message punctuation. | Previous exception identity/type/trace for both paths; message; successful creation. |
-| 125 | Widen RedisStore increment/decrement and their operation execute methods to bool\|int, matching Store. Pass false through without a TypeError. | Native false response; positive/negative integer result; repository/stack/tagged callers; exceptions still propagate. |
-| 126 | Make TagMode::fromConfig throw InvalidArgumentException for any value other than all or any. Include the accepted values in the message. | Both valid modes; typo, case error, and empty value fail while resolving the store; benchmark command path. |
 | 129 | No change; see disposition above. | Preserve reset/subscriber lifecycle tests. |
 | 131 | Add per-run memoization for class imports by source file/namespace, parsed docblocks by exact string, facade method-name sets by class, and ReflectionMethodDecorator source ReflectionClass. Hoist immutable PHPDoc parser objects. Do not add production counters or test-only observability seams. | Generated output remains byte-identical; cache keys separate namespaces/files/docblocks and cannot cross-contaminate results; a focused before/after benchmark outside timing-sensitive CI demonstrates the repeated-input speedup. |
 | 132 | Recursively walk traits-of-traits and parent traits when matching a method's source file for import resolution. Guard cycles/duplicates by trait name. | Public method declared in a nested trait resolves that trait's imports; parent trait chain; class import with same short name does not win. |
 | 133 | Map supported PHPStan scalar refinements to runtime base types and preserve generic values: list<T>/non-empty-list<T> becomes array<int,T>, non-empty-array<K,V> preserves K,V, string refinements become string, signed integer refinements become int. Keep template resolution before unknown fallback. | Each listed pseudo-type; nested union/intersection/generic; template named like a class; generated facade PHPDoc contains no unintended mixed. |
 | 134 | Catch only ReflectionException around getPrototype, reject unknown CLI flags with nonzero exit, send warnings/exceptions to STDERR, and add ext-tokenizer to facade-documenter's package requirements. | Malformed prototype docblock surfaces; typoed flag fails without writing; stdout remains generated output only; metadata assertion and standalone script smoke test. |
 | 153 | No change; see disposition above. | Preserve immediate-kill, non-drain, timeout event, and idempotency documentation coverage. |
-| 154 | Remove only the dead SQL Server lock branch and document ARGV[2] as the Redis migration batch limit. Keep coroutine-hooked usleep and the shutdown-only 1ms poll; do not add Support\\Sleep or a Concurrent completion primitive. | Database grammar set excludes sqlsrv; Lua argument documentation/review; existing Worker sleep override and shutdown drain tests remain green. |
-| 159 | Use raw PHP_BINARY in HorizonRestartStrategy's array-form Symfony Process command. Keep PhpBinary::path only for shell command-string substitution. | Real array command starts a child executable; path containing spaces; environment argument; existing shell command strings remain correctly quoted; remove the mock-only blind spot. |
 | 160 | Port the current laravel/vonage-notification-channel package into a Hypervel split package, then make Horizon's existing routeSmsNotificationsTo API effective by adding the missing route in SendNotification and channel selection in LongWaitDetected::via, adapted to the current `vonage` channel, `toVonage`, and VonageMessage. Do not copy Horizon upstream's obsolete `nexmo` name or introduce a second/deprecated driver. `Vonage\Client` caches service objects whose `APIResource` mutates `lastRequest`/`lastResponse` around yielding HTTP calls, so framework-created channels build a fresh SDK Client per send while sharing only normalized immutable configuration and Hypervel's coroutine-safe PSR-18 transport. Add per-execution memoization only later if measurement proves construction material. Keep the Vonage facade non-caching and preserve direct construction with a supplied Client and per-message `usingClient` overrides. Add the package README, canonical notification docs, Horizon docs, `HorizonServiceProvider.stub`, and Horizon Boost notification reference using `vonage` only. | Ported package provider/config, route resolution, message construction, channel send/failure, facade, direct constructor, and per-message override; deterministic concurrent sends cannot exchange SDK request/response state; repeated sends get distinct SDK clients but reuse the safe HTTP transport; Horizon's two consumers use `vonage`; absent number adds no channel; mail/Slack composition; public routeSmsNotificationsTo remains unchanged; all docs/stubs/Boost references contain no `nexmo` surface. |
 
 ## Commit and dependency structure
@@ -141,10 +134,8 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 Use package-sized commits that remain reviewable and bisectable. The following order avoids building fixes on obsolete primitives:
 
 1. Mail and data representation: 21, 30-32, 34-35, 82.
-2. Reverb recovery command and runbook: 112, with no runtime state-model change.
-3. Queue cleanup: only the two valid parts of 154; 153 deliberately stays unchanged.
-4. Vonage notification channel port followed by Horizon wiring: 160.
-5. Remaining package-local correctness work by package, followed by performance/docs/cleanup.
+2. Vonage notification channel port followed by Horizon wiring: 160.
+3. Remaining package-local correctness work by package, followed by performance/docs/cleanup.
 
 Do not combine unrelated packages merely because their findings have the same severity.
 
@@ -155,7 +146,7 @@ For every changed test file:
 1. From the components repository root, run that exact test file immediately with `./vendor/bin/phpunit --no-progress path/to/Test.php`.
 2. For deterministic concurrency tests, run the exact file repeatedly and under the parallel runner where supported.
 3. Run the complete affected package test directory after its individual files pass.
-4. Run integration suites for every affected external system: MySQL/MariaDB and PostgreSQL for database semantics, and Redis for Reverb/cache.
+4. Run integration suites for every affected external system: MySQL/MariaDB and PostgreSQL for database semantics, and Redis for cache.
 
 Additional required checks:
 

--- a/docs/plans/2026-08-30-1350-components-operational-infrastructure-remediation-plan.md
+++ b/docs/plans/2026-08-30-1350-components-operational-infrastructure-remediation-plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation, verification, and review for audit findings 112, 124–126, 154, and 159 are complete against the current `0.4` branch, including the follow-up cache cleanup and test-timing corrections.
+Implementation, verification, and review for audit findings 112, 124–126, 154, and 159 are complete against the current `0.4` branch, including the follow-up cache cleanup, prune correctness, test assertion, and timing corrections.
 
 ## Outcome
 
@@ -102,6 +102,8 @@ The cache benchmark's emergency cleanup output must not recommend the blocking `
 ```text
 redis-cli --scan --pattern '<cachePrefix><KEY_PREFIX>*' | xargs -r -n 1000 redis-cli UNLINK
 ```
+
+`BenchmarkContext::cleanup()` must remove benchmark-owned keys and tag storage from both modes regardless of the store's mode when cleanup begins. It must also sweep benchmark tag names from the explicit any-mode registry derived with `TagKeyBuilder(TagMode::Any, $context->prefix())`. A comparison interrupted after switching modes can otherwise leave registry members that no physical-key pattern matches. Preserve unrelated registry members.
 
 ### 3. Redis and Valkey support policy
 
@@ -227,11 +229,16 @@ For standalone Redis, keep each scan page bounded and execute the existence chec
 
 Redis Cluster cannot make the cross-slot value and metadata operations atomic. Collect orphan candidates, remove them with one variadic `HDEL` or `ZREM` per scan page, then recheck each candidate and conditionally repair it:
 
-- Any mode restores a removed hash field with `HSETNX` only when both the value and reverse-index membership now exist. If an empty hash was removed from the registry but revived, restore only a missing registry member with `ZADD NX MAX_EXPIRY`, preserving a writer's real score.
+- Any mode restores a removed hash field with `HSETNX` only when both the value and reverse-index membership now exist. Run this repair after every integer `HDEL` result, including zero: fields can expire between `HSCAN` and `HDEL`, and zero cannot distinguish that harmless case from a concurrent remover followed by an interrupted writer. If an empty hash was removed from the registry but revived, restore only a missing registry member with `ZADD NX MAX_EXPIRY`, preserving a writer's real score.
 - All mode restores a removed member with `ZADD NX -1` when its value appears after removal. The conservative forever score cannot cause premature expiry and preserves any score a writer already published.
+- Treat every integer Cluster removal reply, including zero, as a completed removal attempt that requires the repair check. Another actor can remove the candidate before this prune's `ZREM` and a writer can publish the value before the repair read. Only a non-integer reply skips repair; the removal count remains statistics only.
 - Subtract repaired candidates from the batch removal count and clamp the result at zero. Statistics remain exact without a concurrent writer and may conservatively undercount during the repair race because a batch result cannot identify which candidate it removed; that rare imprecision avoids one Redis removal round trip per orphan. Keep the existing `empty_hashes_deleted` and `empty_sets_deleted` statistic names, documenting that they include structures Redis removed with their final entry. Add `orphaned_tags_removed` for any-mode registry cleanup.
 
-All-mode writers must publish the cache value before its memberships. Reorder `Put`, `Forever`, `Add`, `PutMany`, and the standalone `Increment` / `Decrement` pipelines without adding commands or round trips. Preserve `Add`'s unconditional membership behavior when `SET NX` reports an existing value. In Cluster `PutMany`, collect only successful `SETEX` keys, publish memberships only for those keys, skip `ZADD` when all writes fail, and still return `false` when any write fails. The standalone pipeline cannot branch on queued `SETEX` results before `exec()` without another round trip; keep its single-round-trip behavior and rely on prune to reclaim metadata after a failed value command.
+All-mode writers must publish the cache value before its memberships. Reorder `Put`, `Forever`, `Add`, `PutMany`, and the standalone `Increment` / `Decrement` pipelines without adding commands. For non-empty standalone `Add`, queue `SET NX` before the membership writes in the same pipeline; keep the direct `SET` path for empty tags. This removes its former second round trip while preserving unconditional membership publication when the key already exists.
+
+The idempotent boolean writers `Put`, `Forever`, `Add`, `PutMany`, and Cluster `Touch` must report a membership write that returns strict `false`. Inspect results already returned by the pipeline or sequential commands; integer zero is a successful idempotent `ZADD`. Do not stop the remaining Cluster membership writes, add rollback, or retry. `Add` returns false when the key exists or any write fails, so its docblock must not claim that false proves the key existed. In Cluster `PutMany`, collect only successful `SETEX` keys, publish memberships only for those keys, skip `ZADD` when all writes fail, and still return false when any value or membership write fails. The standalone pipeline cannot filter memberships after failed value writes without another round trip; keep its single-round-trip behavior and rely on prune to reclaim metadata.
+
+Do not apply membership-result reporting to `Increment` or `Decrement`. Once their counter command succeeds, returning false for a later metadata failure would falsely report that the mutation did not happen and could cause a retry to apply it twice. Keep their existing return ownership while prune repairs stale metadata.
 
 ### 10. Queue cleanup finding (154)
 
@@ -274,6 +281,8 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `src/cache/src/RedisStore.php`
 - `src/cache/src/FailoverStore.php`
 - `src/cache/src/NullStore.php`
+- `src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php`
+- `src/cache/src/Redis/Console/BenchmarkCommand.php`
 - `src/cache/src/Redis/Operations/Increment.php`
 - `src/cache/src/Redis/Operations/Decrement.php`
 - `src/cache/src/Redis/Operations/AnyTag/Increment.php`
@@ -285,8 +294,8 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `src/cache/src/Redis/Operations/AllTag/Put.php`
 - `src/cache/src/Redis/Operations/AllTag/PutMany.php`
 - `src/cache/src/Redis/Operations/AllTag/Prune.php`
+- `src/cache/src/Redis/Operations/AllTag/Touch.php`
 - `src/cache/src/Redis/Operations/AnyTag/Prune.php`
-- `src/cache/src/Redis/Console/BenchmarkCommand.php`
 - `src/queue/src/Worker.php`
 - `src/queue/src/LuaScripts.php`
 - `src/horizon/src/Console/HorizonRestartStrategy.php`
@@ -316,7 +325,9 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `tests/Cache/Redis/Operations/AllTag/PutTest.php`
 - `tests/Cache/Redis/Operations/AllTag/PutManyTest.php`
 - `tests/Cache/Redis/Operations/AllTag/PruneTest.php`
+- `tests/Cache/Redis/Operations/AllTag/TouchTest.php`
 - `tests/Cache/Redis/Operations/AnyTag/PruneTest.php`
+- `tests/Integration/Cache/Redis/BenchmarkContextTest.php`
 - `tests/Integration/Cache/Redis/PruneIntegrationTest.php`
 - `tests/Cache/CacheFailoverStoreTest.php`
 - `tests/Cache/CacheNullStoreTest.php`
@@ -325,6 +336,7 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `tests/Coordinator/TimerTest.php`
 - `tests/Queue/QueueWorkerTest.php`
 - `tests/Horizon/Console/HorizonRestartStrategyTest.php`
+- `tests/Testing/TestResponseTest.php`
 
 ### Documentation and workflow ownership
 
@@ -381,12 +393,18 @@ No root README or Laravel porting-guide entry is needed: the source fixes preser
 
 ### Tagged-cache pruning
 
+- With the store configured for all mode, seed benchmark and unrelated members in the any-mode registry, run benchmark cleanup, and prove only the benchmark member is removed. Retain the existing physical-key and unrelated-key coverage in both modes.
 - Assert standalone prune uses one bounded Lua call per scan page and atomically removes empty any-mode registry entries.
 - Assert a custom scan count reaches the standalone `HSCAN` and bounds each Lua page.
 - Assert Cluster prune batches same-metadata-key removals into one variadic command per page, permanently removes durable orphans, and repairs value/hash, value/member, and hash/registry races with `HSETNX` or `ZADD NX` without overwriting writer metadata.
+- Assert Cluster prune still performs its repair reads and conditional `HSETNX` or `ZADD NX` when the batched any-mode `HDEL` or all-mode `ZREM` returns integer zero.
 - Strengthen the real Redis integration coverage to prove any-mode prune removes both empty tag hashes and registry members; the same integration suite runs against the real Cluster service in its CI job.
-- Assert every changed all-mode writer queues or issues the value command before memberships while preserving its return contract.
+- Assert every changed all-mode writer queues or issues the value command before memberships. For idempotent boolean writers, assert a strict-false membership reply returns false, while integer zero remains success on both pipeline and Cluster paths. Cover a whole pipeline failure separately. Preserve counter return ownership after a successful mutation.
 - For Cluster `PutMany`, assert partial failure tags only successful values and total failure issues no `ZADD`. Keep the standalone pipeline single-round-trip failure coverage.
+
+### PHPUnit assertion ownership
+
+- Add explicit fluent-return assertions to the three successful `TestResponse` paths that otherwise perform no PHPUnit assertion. Both PHP runtimes execute those paths without assertions; why only the PHP 8.4 CI run reported them as risky is not established. The explicit assertions make the tests independent of that reporting difference without changing production assertion counting.
 
 ### Full-suite timing regression
 

--- a/docs/plans/2026-08-30-1350-components-operational-infrastructure-remediation-plan.md
+++ b/docs/plans/2026-08-30-1350-components-operational-infrastructure-remediation-plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation for audit findings 112, 124–126, 154, and 159 is complete against the current `0.4` branch. Targeted tests, full repository verification, self-review, and code review are complete.
+Implementation, verification, and review for audit findings 112, 124–126, 154, and 159 are complete against the current `0.4` branch, including the follow-up cache cleanup and test-timing corrections.
 
 ## Outcome
 
@@ -15,9 +15,12 @@ This slice will:
 - preserve underlying Sentinel and Cluster connection failures;
 - align cache increment/decrement implementations with the existing `Store` contract;
 - reject invalid cache tag modes at configuration boundaries;
+- make tagged-cache pruning remove orphaned metadata without racing concurrent writers;
+- publish all-mode cache values before their tag memberships and omit memberships for failed Cluster batch writes;
 - make the queue worker tolerate a cache counter failure without treating booleans as counts;
-- document the Redis queue migration batch argument; and
-- start Horizon through an array-form process command that uses executable paths, the application working directory, and useful failure diagnostics.
+- document the Redis queue migration batch argument;
+- start Horizon through an array-form process command that uses executable paths, the application working directory, and useful failure diagnostics; and
+- make recurring-timer continuation and stopping tests wait for the behavior they assert instead of relying on fixed scheduling delays.
 
 The implementation must preserve Laravel's public contracts. It must not add automatic Reverb recovery, distributed liveness machinery, runtime version probes, blocking bulk deletion fallbacks, or steady-state Redis work.
 
@@ -216,13 +219,27 @@ Use `TagMode::All` as `CacheManager`'s default rather than the magic string `'al
 
 The benchmark command must parse `--tag-mode` once with `TagMode::tryFrom()`, use `TagMode::supportedValues()` for its accepted-values message, and carry the enum through `runComparison()`, `runSuiteWithRuns()`, and `runSuite()`. Convert back to `$tagMode->value` only at the existing `ResultsFormatter::displayResultsTable()` string boundary and for console output. Comparison mode uses `TagMode::All` and `TagMode::Any` directly.
 
-### 9. Queue cleanup finding (154)
+### 9. Tagged-cache prune ownership and writer ordering
+
+Any-mode prune currently leaves an empty tag in the registry, while both tag modes use separate existence checks and metadata removals that can delete metadata published by a concurrent writer. Redis automatically deletes a hash or sorted set when its final field or member is removed, so the explicit final-key deletion is redundant and widens that race.
+
+For standalone Redis, keep each scan page bounded and execute the existence checks plus conditional `HDEL` or `ZREM` in one Lua call. Finalize an any-mode tag with one Lua call that checks `HLEN` and removes the empty tag from its registry atomically. Do not add an unbounded script or move the full prune into Lua.
+
+Redis Cluster cannot make the cross-slot value and metadata operations atomic. Collect orphan candidates, remove them with one variadic `HDEL` or `ZREM` per scan page, then recheck each candidate and conditionally repair it:
+
+- Any mode restores a removed hash field with `HSETNX` only when both the value and reverse-index membership now exist. If an empty hash was removed from the registry but revived, restore only a missing registry member with `ZADD NX MAX_EXPIRY`, preserving a writer's real score.
+- All mode restores a removed member with `ZADD NX -1` when its value appears after removal. The conservative forever score cannot cause premature expiry and preserves any score a writer already published.
+- Subtract repaired candidates from the batch removal count and clamp the result at zero. Statistics remain exact without a concurrent writer and may conservatively undercount during the repair race because a batch result cannot identify which candidate it removed; that rare imprecision avoids one Redis removal round trip per orphan. Keep the existing `empty_hashes_deleted` and `empty_sets_deleted` statistic names, documenting that they include structures Redis removed with their final entry. Add `orphaned_tags_removed` for any-mode registry cleanup.
+
+All-mode writers must publish the cache value before its memberships. Reorder `Put`, `Forever`, `Add`, `PutMany`, and the standalone `Increment` / `Decrement` pipelines without adding commands or round trips. Preserve `Add`'s unconditional membership behavior when `SET NX` reports an existing value. In Cluster `PutMany`, collect only successful `SETEX` keys, publish memberships only for those keys, skip `ZADD` when all writes fail, and still return `false` when any write fails. The standalone pipeline cannot branch on queued `SETEX` results before `exec()` without another round trip; keep its single-round-trip behavior and rely on prune to reclaim metadata after a failed value command.
+
+### 10. Queue cleanup finding (154)
 
 The driver-neutral database refactor already removed the never-supported SQL Server lock branch. Do not reintroduce a database-specific branch or add replacement runtime machinery.
 
 The remaining source change is to document `ARGV[2]` as the migration batch size in `LuaScripts::migrateExpiredJobs()`. Preserve raw `usleep()` calls, the queue worker's existing overridable `sleep()` method, and the shutdown-only 1 ms poll; Swoole hooks the relevant sleep calls and the existing seams already make tests deterministic.
 
-### 10. Horizon child process execution (finding 159)
+### 11. Horizon child process execution (finding 159)
 
 `HorizonRestartStrategy` passes `PhpBinary::path()` to Symfony's array-form `Process`. `PhpBinary::path()` is shell-escaped text for command strings, not an executable path. Keep it in `SupervisorCommandString` and `WorkerCommandString`, but use Hypervel's executable helpers for the array command:
 
@@ -263,6 +280,12 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `src/cache/src/Redis/Operations/AnyTag/Decrement.php`
 - `src/cache/src/Redis/Operations/AllTag/Increment.php`
 - `src/cache/src/Redis/Operations/AllTag/Decrement.php`
+- `src/cache/src/Redis/Operations/AllTag/Add.php`
+- `src/cache/src/Redis/Operations/AllTag/Forever.php`
+- `src/cache/src/Redis/Operations/AllTag/Put.php`
+- `src/cache/src/Redis/Operations/AllTag/PutMany.php`
+- `src/cache/src/Redis/Operations/AllTag/Prune.php`
+- `src/cache/src/Redis/Operations/AnyTag/Prune.php`
 - `src/cache/src/Redis/Console/BenchmarkCommand.php`
 - `src/queue/src/Worker.php`
 - `src/queue/src/LuaScripts.php`
@@ -280,6 +303,7 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `tests/Redis/PhpRedisClusterConnectionTest.php`
 - `tests/Cache/TagModeTest.php`
 - `tests/Cache/CacheManagerTest.php`
+- `tests/Cache/Redis/AllTaggedCacheTest.php`
 - `tests/Cache/Redis/RedisStoreTest.php`
 - `tests/Cache/Redis/Operations/IncrementTest.php`
 - `tests/Cache/Redis/Operations/DecrementTest.php`
@@ -287,10 +311,18 @@ If the child has already terminated after startup, throw a `RuntimeException` th
 - `tests/Cache/Redis/Operations/AnyTag/DecrementTest.php`
 - `tests/Cache/Redis/Operations/AllTag/IncrementTest.php`
 - `tests/Cache/Redis/Operations/AllTag/DecrementTest.php`
+- `tests/Cache/Redis/Operations/AllTag/AddTest.php`
+- `tests/Cache/Redis/Operations/AllTag/ForeverTest.php`
+- `tests/Cache/Redis/Operations/AllTag/PutTest.php`
+- `tests/Cache/Redis/Operations/AllTag/PutManyTest.php`
+- `tests/Cache/Redis/Operations/AllTag/PruneTest.php`
+- `tests/Cache/Redis/Operations/AnyTag/PruneTest.php`
+- `tests/Integration/Cache/Redis/PruneIntegrationTest.php`
 - `tests/Cache/CacheFailoverStoreTest.php`
 - `tests/Cache/CacheNullStoreTest.php`
 - `tests/Cache/CacheRepositoryTest.php`
 - `tests/Cache/Redis/Console/BenchmarkCommandTest.php`
+- `tests/Coordinator/TimerTest.php`
 - `tests/Queue/QueueWorkerTest.php`
 - `tests/Horizon/Console/HorizonRestartStrategyTest.php`
 
@@ -346,6 +378,19 @@ No root README or Laravel porting-guide entry is needed: the source fixes preser
 - In a separate-process test, use `ParallelTesting::tempDir()` to create an application directory containing spaces and a temporary PHP `artisan` script. Start the real Horizon process, record its working directory and arguments, and verify ordinary and zero-named environments without leaking the strategy's signal handlers or application base path to other tests.
 - Use a controlled `Process` test double for terminated startup failures and assert the exception includes the exit code and trimmed stderr. Also cover empty stderr without appending empty noise; do not race a real child against the production startup grace period.
 - Preserve shell-string tests for `SupervisorCommandString` and `WorkerCommandString`.
+
+### Tagged-cache pruning
+
+- Assert standalone prune uses one bounded Lua call per scan page and atomically removes empty any-mode registry entries.
+- Assert a custom scan count reaches the standalone `HSCAN` and bounds each Lua page.
+- Assert Cluster prune batches same-metadata-key removals into one variadic command per page, permanently removes durable orphans, and repairs value/hash, value/member, and hash/registry races with `HSETNX` or `ZADD NX` without overwriting writer metadata.
+- Strengthen the real Redis integration coverage to prove any-mode prune removes both empty tag hashes and registry members; the same integration suite runs against the real Cluster service in its CI job.
+- Assert every changed all-mode writer queues or issues the value command before memberships while preserving its return contract.
+- For Cluster `PutMany`, assert partial failure tags only successful values and total failure issues no `ZADD`. Keep the standalone pipeline single-round-trip failure coverage.
+
+### Full-suite timing regression
+
+- In both recurring-timer error-reporting tests, signal a `Channel` from the second callback and wait on that signal with a bounded timeout. Apply the same pattern to the stop-after-ten-ticks test. This preserves the exact continuation and stopping assertions without assuming the scheduler completes a fixed number of ticks within a short sleep.
 
 ## Verification
 

--- a/docs/plans/2026-08-30-1350-components-operational-infrastructure-remediation-plan.md
+++ b/docs/plans/2026-08-30-1350-components-operational-infrastructure-remediation-plan.md
@@ -1,0 +1,382 @@
+# Operational Infrastructure Remediation
+
+## Status
+
+Implementation for audit findings 112, 124–126, 154, and 159 is complete against the current `0.4` branch. Targeted tests, full repository verification, self-review, and code review are complete.
+
+## Outcome
+
+This slice will:
+
+- provide an explicit recovery command for stale Redis-backed Reverb shared state after an abnormal shutdown;
+- make bounded Redis pattern deletion fail visibly instead of reporting a false zero count;
+- document the Redis and Valkey server versions Hypervel supports;
+- apply PhpRedis's numeric packing exception consistently to standalone and Cluster connections;
+- preserve underlying Sentinel and Cluster connection failures;
+- align cache increment/decrement implementations with the existing `Store` contract;
+- reject invalid cache tag modes at configuration boundaries;
+- make the queue worker tolerate a cache counter failure without treating booleans as counts;
+- document the Redis queue migration batch argument; and
+- start Horizon through an array-form process command that uses executable paths, the application working directory, and useful failure diagnostics.
+
+The implementation must preserve Laravel's public contracts. It must not add automatic Reverb recovery, distributed liveness machinery, runtime version probes, blocking bulk deletion fallbacks, or steady-state Redis work.
+
+## Scope and decisions
+
+### 1. Reverb crash recovery (finding 112)
+
+Redis-backed `RedisSharedState` stores global connection, subscription, presence, webhook-lock, and smoothing state under keys shaped as `reverb:{hash}:...`. Normal worker shutdown drains this state, but a hard crash cannot run that cleanup. Stale counters can therefore survive indefinitely and affect connection limits and channel state.
+
+Add `reverb:clear-state` as a manual recovery command:
+
+```php
+#[AsCommand(name: 'reverb:clear-state')]
+class ClearStateCommand extends Command
+{
+    protected ?string $signature = 'reverb:clear-state
+        {--dry-run : Count matching Reverb shared-state keys without deleting them}
+        {--force : Skip the confirmation prompt}';
+
+    protected string $description = 'Clear Redis-backed Reverb shared state';
+}
+```
+
+Match the neighbouring `InstallCommand`: import Symfony's `AsCommand` attribute and declare the attribute, signature, and description together so the command participates in the lazy command map without instantiation.
+
+The command has these invariants:
+
+- It selects `reverb.servers.reverb.scaling.connection`; it does not resolve `SharedState`, whose implementation depends on live server topology.
+- `RedisSharedState` owns one public logical scan pattern, `reverb:{*}:*`, so the recovery boundary cannot drift from its key format.
+- The pattern excludes webhook buffer keys shaped as `reverb:webhook:{tag}:...`, `reverb:message:*` keys, and unrelated Redis data without additional filtering machinery.
+- A dry run counts matching keys and does not ask for confirmation.
+- A destructive run always asks for confirmation unless `--force` is supplied, regardless of the application environment. Cancellation returns failure; a completed clear returns success.
+- The warning requires every Reverb node sharing the selected Redis endpoint, logical database, and prefix to be stopped before deletion. The documented runbook is stop all nodes, dry-run or clear, then start all nodes. Explain that the clear removes short-lived webhook throttle and deduplication locks stored through `RedisSharedState`, which regenerate, but never buffered webhook payloads.
+- The command is registered for console use before `reverb.enabled` can short-circuit `ReverbServiceProvider::boot()`. It is never scheduled or invoked during boot, worker startup, or ordinary shutdown.
+- Reverb scaling continues to reject Redis Cluster. Do not add Reverb-specific Cluster behavior or tests.
+
+Dry-run scanning must consume the generator while its pooled connection is still checked out:
+
+```php
+$count = $redis->withConnection(
+    fn (RedisConnection $connection): int => iterator_count(
+        $connection->safeScan(RedisSharedState::KEY_PATTERN),
+    ),
+    transform: false,
+);
+```
+
+Do not expose `safeScan()` on `RedisProxy`: returning that generator would release the connection before iteration. Destructive deletion uses `$redis->flushByPattern(...)`, whose proxy method already owns the connection for the complete scan/delete operation.
+
+### 2. Bounded Redis pattern deletion
+
+`FlushByPattern` already scans without `KEYS`, strips `OPT_PREFIX`, buffers at most 1,000 logical keys, and deletes each batch with `UNLINK`. Preserve that design.
+
+The existing docblock promises a `DEL` fallback that does not exist. Delete that false sentence; do not add the fallback. Hypervel will support Redis 6.2+ and Valkey 7.2+, both of which provide `UNLINK`; falling back to synchronous `DEL` could block Redis's main thread while arbitrary values are freed. Remove the inline Redis-4 availability comment as well: once the documented floor is Redis 6.2, it no longer explains a supported-runtime decision.
+
+Before each `UNLINK` batch, clear the native PhpRedis last-error slot. If `UNLINK` returns an integer, add it to the deleted count. If it returns `false`, read the last error exactly once and throw `RedisException` with that message, or a stable `UNLINK` failure message when PhpRedis provides none:
+
+```php
+$this->connection->clearLastError();
+$result = $this->connection->unlink(...$keys);
+
+if (is_int($result)) {
+    return $result;
+}
+
+throw new RedisException(
+    $this->connection->getLastError() ?? 'Redis UNLINK failed while deleting keys by pattern.',
+);
+```
+
+This adds no network request to successful deletion. `clearLastError()` and `getLastError()` access extension-local error state; the latter is used only after failure.
+
+Remove `deleteKeys()`'s empty-array guard. Both callers already prove that the batch is non-empty, so retaining it would preserve dead control flow in a method being rewritten. Document beside `flushByPattern()` that a failed batch deletion raises `RedisException` rather than returning an under-count.
+
+`FakeRedisClient` does not run the native `Redis` constructor. Give it a local nullable last-error value plus correctly typed `clearLastError()`, `getLastError()`, and a test setter so error behavior can be exercised without touching uninitialized extension state.
+
+The cache benchmark's emergency cleanup output must not recommend the blocking `KEYS | DEL` pattern. Replace it with this cursor-based, non-blocking, bounded-batch command and update the existing output assertion:
+
+```text
+redis-cli --scan --pattern '<cachePrefix><KEY_PREFIX>*' | xargs -r -n 1000 redis-cli UNLINK
+```
+
+### 3. Redis and Valkey support policy
+
+Add a compact supported-server list to the Redis guide's Introduction, before the PhpRedis extension paragraph:
+
+```markdown
+<div class="content-list" markdown="1">
+
+- Redis server 6.2+ ([Version Policy](https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/))
+- Valkey 7.2+ ([Version Policy](https://valkey.io/topics/releases/))
+
+</div>
+```
+
+The word `server` distinguishes the Redis release from the separately documented PhpRedis extension. Redis 6.2 is the compatibility floor; currently maintained Redis or Valkey releases remain preferable. Optional features retain their stricter Redis 8 / Valkey 9 requirements. Do not duplicate this list in the root README, add runtime probes, or add minimum-version CI in this slice.
+
+### 4. PhpRedis numeric packing and Redis-backed counters
+
+With a PhpRedis serializer enabled, numeric values may be stored as serialized bytes and rejected by Redis atomic increment/decrement commands. PhpRedis 6.2 added `OPT_PACK_IGNORE_NUMBERS` so numeric values remain raw while other values retain configured serialization.
+
+`RedisConnection::setOptions()` currently discards named `pack_ignore_numbers` configuration on `RedisCluster`. That is incorrect: PhpRedis 6.2+ handles this option in the shared `Redis`/`RedisCluster` option path, and Cluster packing uses the same client flags.
+
+Apply the named option to both standalone and Cluster clients:
+
+```php
+if ($name === 'pack_ignore_numbers'
+    && ! defined(Redis::class . '::OPT_PACK_IGNORE_NUMBERS')) {
+    throw new InvalidRedisOptionException(
+        'The redis option `pack_ignore_numbers` requires PhpRedis 6.2 or later.',
+    );
+}
+```
+
+Then resolve and call `setOption()` normally. Update the PHPStan suppression to explain that the guard runs before constant resolution. Do not add a numeric-option guard: a numeric key cannot identify the missing named constant. Do not throw for every `setOption() === false`; shared option records may legitimately include the Cluster-only `failover` option for a standalone connection.
+
+Document one solution in each owning place without repeating the full explanation:
+
+- `redis.md`: correct the current standalone-only statement and explain under serialization that Redis atomic counters need `SERIALIZER_NONE` or PhpRedis 6.2+ `pack_ignore_numbers`, on standalone and Cluster connections.
+- `cache.md`: add the actionable counter requirement beside `increment` / `decrement`.
+- `queues.md`: state that `MaxExceptions` uses an atomic counter on the default cache store and link to the cache guidance.
+
+Do not add an integration test that merely freezes a third-party serializer limitation.
+
+### 5. Redis connection exception chains (finding 124)
+
+Both Sentinel master resolution and Redis Cluster construction currently discard the original non-cancellation exception and omit punctuation. The merged cancellation work now detects a nested `CanceledException` with `RedisCancellation::cancellationFrom()` and rethrows it unchanged. Preserve that guard and improve only the ordinary failure branch:
+
+```php
+throw new ConnectionException(
+    'Connection reconnect failed: ' . $exception->getMessage(),
+    previous: $exception,
+);
+```
+
+Apply this only to the existing non-cancellation branch in `PhpRedisConnection::createRedisSentinel()` and `PhpRedisClusterConnection::createRedisCluster()`. Do not catch, wrap, or otherwise alter the cancellation returned by `RedisCancellation::cancellationFrom()`. Successful construction is unchanged.
+
+### 6. Cache increment/decrement contracts (finding 125)
+
+`Hypervel\Contracts\Cache\Store` already declares `bool|int`. PhpRedis legitimately returns `false` from `INCRBY` / `DECRBY`, but `RedisStore` and its base operations narrow this to `int`, causing a `TypeError` instead of returning the contract value.
+
+Use these precise internal types:
+
+- `RedisStore::increment()` / `decrement()`: `int|false`.
+- Base Redis `Increment::execute()` / `Decrement::execute()`: `int|false`.
+- All six AnyTag operation boundaries (`execute`, Cluster helper, Lua helper for increment and decrement): `int|false`, matching their existing docblocks and AllTag operations.
+- `FailoverStore::increment()` / `decrement()`: `bool|int`, because it delegates to arbitrary `Store` implementations and `true` is contract-valid.
+- `NullStore::decrement()` value parameter: `int`, matching `Store`; its `bool` return remains correct.
+
+Keep `Repository`, `TaggedCache`, `StackStore`, and the public contract at `bool|int`. Exceptions still propagate.
+
+The AnyTag Cluster helpers have a second correctness obligation. Their native `MULTI` result can be `false`, or an array whose counter entry is `false`, while the TTL entry remains `-1`. The current code continues by destroying and rebuilding reverse indexes, tag hashes, and registry membership even though the counter did not change. Validate the result before destructuring or publishing metadata:
+
+```php
+$results = $multi->exec();
+
+if (! is_array($results) || ! is_int($results[0] ?? null)) {
+    return false;
+}
+
+[$newValue, $ttl] = $results;
+```
+
+The scripted standalone path aborts before metadata writes and `evalWithShaCache()` raises `LuaScriptException` with Redis's error. Do not force topology symmetry by swallowing that exception or manufacturing one for Cluster. Clarify on both AnyTag operation docblocks that Cluster can return `false`, while Redis errors from the scripted path raise.
+
+AllTag's Cluster helpers currently publish sorted-set memberships before issuing the counter command. Reverse this sequential order: run `incrBy` / `decrBy`, return `false` unless the result is an integer, then publish memberships. This is side-effect free for a reported counter failure and adds no command or round trip. Do not split the standalone pipeline: gaining the same check there would add a real hot-path round trip to eliminate a recoverable stale membership.
+
+### 7. Queue `MaxExceptions` counter
+
+`Worker::markJobAsFailedIfWillExceedMaxExceptions()` compares the configured limit directly with the cache result. Besides the Redis `TypeError`, PHP's mixed-type comparison treats `true` as satisfying every non-negative threshold, while `false` satisfies only a zero threshold:
+
+```text
+maxExceptions=0 <= true  => true    maxExceptions=0 <= false => true
+maxExceptions=1 <= true  => true    maxExceptions=1 <= false => false
+maxExceptions=3 <= true  => true    maxExceptions=3 <= false => false
+```
+
+Capture the result once and act only on an integer:
+
+```php
+$exceptions = $this->cache->increment('job-exceptions:' . $uuid);
+
+if (is_int($exceptions) && $maxExceptions <= $exceptions) {
+    $this->cache->forget('job-exceptions:' . $uuid);
+    $this->failJob($job, $e);
+}
+```
+
+`false` and `true` are not counts and must not fail the job. This adds one local type check to an exception/retry path and no I/O.
+
+### 8. Cache tag-mode validation (finding 126)
+
+`TagMode::fromConfig()` currently maps every invalid value to `all`, silently changing invalid `any` configuration into different cache semantics. Throw `InvalidArgumentException` unless the value is exactly `all` or `any`; the message must name the rejected value and list both accepted values. Derive the accepted values once in `TagMode::supportedValues()` so configuration and command errors cannot drift.
+
+Use `TagMode::All` as `CacheManager`'s default rather than the magic string `'all'`. Invalid explicit configuration must fail while the Redis store resolves.
+
+The benchmark command must parse `--tag-mode` once with `TagMode::tryFrom()`, use `TagMode::supportedValues()` for its accepted-values message, and carry the enum through `runComparison()`, `runSuiteWithRuns()`, and `runSuite()`. Convert back to `$tagMode->value` only at the existing `ResultsFormatter::displayResultsTable()` string boundary and for console output. Comparison mode uses `TagMode::All` and `TagMode::Any` directly.
+
+### 9. Queue cleanup finding (154)
+
+The driver-neutral database refactor already removed the never-supported SQL Server lock branch. Do not reintroduce a database-specific branch or add replacement runtime machinery.
+
+The remaining source change is to document `ARGV[2]` as the migration batch size in `LuaScripts::migrateExpiredJobs()`. Preserve raw `usleep()` calls, the queue worker's existing overridable `sleep()` method, and the shutdown-only 1 ms poll; Swoole hooks the relevant sleep calls and the existing seams already make tests deterministic.
+
+### 10. Horizon child process execution (finding 159)
+
+`HorizonRestartStrategy` passes `PhpBinary::path()` to Symfony's array-form `Process`. `PhpBinary::path()` is shell-escaped text for command strings, not an executable path. Keep it in `SupervisorCommandString` and `WorkerCommandString`, but use Hypervel's executable helpers for the array command:
+
+```php
+$command = [php_binary(), artisan_binary(), 'horizon'];
+
+if ($this->environment !== null && $this->environment !== '') {
+    $command[] = '--environment=' . $this->environment;
+}
+
+return (new Process($command, $this->application->basePath()))->setTimeout(null);
+```
+
+`php_binary()` uses Symfony's executable finder, `artisan_binary()` preserves the framework's Artisan override, and the already-injected application contract supplies the deterministic working directory without reaching through a global helper.
+
+If the child has already terminated after startup, throw a `RuntimeException` that always includes its exit code and appends trimmed stderr only when stderr is non-empty. Do not add an injectable binary-path seam.
+
+## Files to change
+
+### Source
+
+- `src/reverb/src/Console/Commands/ClearStateCommand.php` (new)
+- `src/reverb/src/ReverbServiceProvider.php`
+- `src/reverb/src/Servers/Hypervel/Scaling/RedisSharedState.php`
+- `src/redis/src/Operations/FlushByPattern.php`
+- `src/redis/src/RedisProxy.php`
+- `src/redis/src/RedisConnection.php`
+- `src/redis/src/PhpRedisConnection.php`
+- `src/redis/src/PhpRedisClusterConnection.php`
+- `src/cache/src/TagMode.php`
+- `src/cache/src/CacheManager.php`
+- `src/cache/src/RedisStore.php`
+- `src/cache/src/FailoverStore.php`
+- `src/cache/src/NullStore.php`
+- `src/cache/src/Redis/Operations/Increment.php`
+- `src/cache/src/Redis/Operations/Decrement.php`
+- `src/cache/src/Redis/Operations/AnyTag/Increment.php`
+- `src/cache/src/Redis/Operations/AnyTag/Decrement.php`
+- `src/cache/src/Redis/Operations/AllTag/Increment.php`
+- `src/cache/src/Redis/Operations/AllTag/Decrement.php`
+- `src/cache/src/Redis/Console/BenchmarkCommand.php`
+- `src/queue/src/Worker.php`
+- `src/queue/src/LuaScripts.php`
+- `src/horizon/src/Console/HorizonRestartStrategy.php`
+
+### Tests and fixtures
+
+- `tests/Reverb/Console/Commands/ClearStateCommandTest.php` (new)
+- `tests/Reverb/DisabledReverbServiceProviderTest.php` (new)
+- `tests/Reverb/Servers/Hypervel/Scaling/RedisSharedStateTest.php`
+- `tests/Integration/Reverb/ClearStateCommandTest.php` (new)
+- `tests/Redis/Fixtures/FakeRedisClient.php`
+- `tests/Redis/Operations/FlushByPatternTest.php`
+- `tests/Redis/RedisConnectionTest.php`
+- `tests/Redis/PhpRedisClusterConnectionTest.php`
+- `tests/Cache/TagModeTest.php`
+- `tests/Cache/CacheManagerTest.php`
+- `tests/Cache/Redis/RedisStoreTest.php`
+- `tests/Cache/Redis/Operations/IncrementTest.php`
+- `tests/Cache/Redis/Operations/DecrementTest.php`
+- `tests/Cache/Redis/Operations/AnyTag/IncrementTest.php`
+- `tests/Cache/Redis/Operations/AnyTag/DecrementTest.php`
+- `tests/Cache/Redis/Operations/AllTag/IncrementTest.php`
+- `tests/Cache/Redis/Operations/AllTag/DecrementTest.php`
+- `tests/Cache/CacheFailoverStoreTest.php`
+- `tests/Cache/CacheNullStoreTest.php`
+- `tests/Cache/CacheRepositoryTest.php`
+- `tests/Cache/Redis/Console/BenchmarkCommandTest.php`
+- `tests/Queue/QueueWorkerTest.php`
+- `tests/Horizon/Console/HorizonRestartStrategyTest.php`
+
+### Documentation and workflow ownership
+
+- `src/docs/reverb.md`
+- `src/docs/redis.md`
+- `src/docs/cache.md`
+- `src/docs/queues.md`
+- `.github/workflows/redis.yml`: run the standalone-only Reverb recovery integration test in the Valkey job, not the Redis or Cluster jobs. The existing `reverb.yml` workflow already runs the complete Reverb integration directory against Redis 8.
+- `AGENTS.md`: once the owner approves implementing this plan, add the missing `reverb.yml` workflow row for `tests/Integration/Reverb`, and update the existing `redis.yml` row to name the standalone Valkey recovery test as well as the already-listed Cluster Reverb tests. Do not imply that `redis.yml` runs every Reverb integration test, and do not add unrelated gRPC documentation.
+- `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`: after implementation and verification, remove findings 112, 124–126, 154, and 159 plus summary/grouping prose that only describes those completed items. This active master plan is the exception to the historical-plan rule; this focused plan becomes the owning implementation record.
+
+No root README or Laravel porting-guide entry is needed: the source fixes preserve public APIs, and the Reverb command is a Hypervel operational feature documented in its owning guide.
+
+## Test plan
+
+### Reverb command
+
+- Assert the command name, `--dry-run`, and `--force` options.
+- In the unconditional unit `RedisSharedStateTest`, create a small anonymous `RedisSharedState` subclass that exposes the real key builders for the connection counter and the existing six channel/member shapes. Assert with `fnmatch()` that `RedisSharedState::KEY_PATTERN` matches every generated key while rejecting webhook buffer keys, `reverb:message:*`, and unrelated keys. Do not use hand-written positive literals: this unit test must fail during the ordinary suite if the key builder and recovery pattern drift apart, even when Redis is unavailable.
+- Assert dry-run uses the configured scaling connection, consumes the scan while the raw connection is held, reports the total, performs no deletion, and asks no question.
+- Assert destructive execution uses the configured connection and exact logical pattern.
+- Assert confirmation is required in every environment; rejection returns failure without deleting; confirmation and `--force` delete and return success.
+- Assert the command remains registered when `reverb.enabled` is false.
+- With standalone Redis and `InteractsWithRedis`, configure scaling to the per-worker default connection and seed all seven shared-state shapes through `RedisSharedState`'s public operations, including `acquireConnectionSlot()` for the app-scoped connection counter. Seed webhook buffer keys, a `reverb:message:*` key, and unrelated keys directly, then prove dry-run preserves everything while the destructive command removes only shared state. Do not extend the existing integration `keysForTest()` array with the connection key: that helper is intentionally channel-scoped and its Cluster-slot assertion would be invalid for an app-scoped key.
+
+### Redis primitives and options
+
+- Preserve existing transformed-connection rejection, prefix handling, scan iteration, and 1,000-key batching tests.
+- Replace the false-to-zero `UNLINK` test with separate native-error and no-native-error exception tests. Assert the error slot is cleared before deletion and read only after failure.
+- Assert named `pack_ignore_numbers` is applied to standalone and Cluster clients when the constant exists.
+- When the constant is unavailable, assert named configuration throws the PhpRedis 6.2 requirement instead of being skipped.
+- Preserve numeric option configuration and the legitimate mixed-topology `setOption(false)` behavior.
+- For ordinary Sentinel and Cluster construction failures, assert wrapper message punctuation and exact previous exception identity, type, and message. Preserve the newly merged tests proving that nested cancellation escapes both boundaries as the same `CanceledException` instance.
+
+### Cache and queue contracts
+
+- Assert base Redis increment/decrement return positive, negative, and `false` results without coercion or `TypeError`.
+- Assert `RedisStore` and `Repository` preserve `false`; keep existing exception propagation tests.
+- Assert AnyTag Cluster success, non-array transaction failure, and a failed counter entry. Both failure shapes return `false` without reading or changing reverse indexes, tag hashes, or the registry. Preserve the standalone Lua exception and integer behavior.
+- Assert AllTag Cluster success still uses sequential commands in counter-first order, while a failed counter returns `false` without any `zadd`. Preserve the single-round-trip pipeline behavior and its existing failure test.
+- Assert Failover accepts any contract-valid boolean/integer result and NullStore's signature remains contract-compatible.
+- Assert exact `all` and `any` parse successfully; typo, case mismatch, and empty values throw with both accepted values in the message.
+- Assert invalid store configuration fails during `CacheManager` resolution while omitted configuration defaults to `TagMode::All`.
+- Assert benchmark valid modes run unchanged, invalid CLI input returns failure, and enum values reach the existing formatter boundary.
+- Assert `MaxExceptions` fails at an integer threshold, but `false` and `true` results do not fail or forget the counter, including the zero-limit boolean edge.
+- Remove redundant `@test` annotations from already `test*`-named methods in the four touched tagged-counter test files; do not replace them with attributes.
+
+### Queue and Horizon
+
+- Keep queue migration behavior tests unchanged; verify the Lua argument documentation against the call order in `RedisQueue::migrateExpiredJobs()`.
+- In a separate-process test, use `ParallelTesting::tempDir()` to create an application directory containing spaces and a temporary PHP `artisan` script. Start the real Horizon process, record its working directory and arguments, and verify ordinary and zero-named environments without leaking the strategy's signal handlers or application base path to other tests.
+- Use a controlled `Process` test double for terminated startup failures and assert the exception includes the exit code and trimmed stderr. Also cover empty stderr without appending empty noise; do not race a real child against the production startup grace period.
+- Preserve shell-string tests for `SupervisorCommandString` and `WorkerCommandString`.
+
+## Verification
+
+During implementation, run targeted tests after each coherent slice, then run:
+
+```bash
+composer fix
+```
+
+This is the required final gate and runs code style, PHPStan, and the parallel test suite. Run the real Redis integration test explicitly when local Redis is configured. In CI, `reverb.yml` owns the Redis run for the complete Reverb integration directory, while `redis.yml` adds only the distinct Valkey run for the recovery test. After all checks pass, trace every changed caller/callee and review the complete diff for stale comments, redundant branches, needless abstractions, public API drift, and hot-path overhead before requesting code review.
+
+## Design boundaries
+
+- automatic Reverb state recovery, TTLs, leases, heartbeats, or per-node state aggregation;
+- Redis Cluster support for Reverb scaling;
+- `DEL` fallback or runtime Redis/Valkey version detection;
+- a general backend capability registry;
+- changing Horizon's exact-key `DEL` calls, which remove small known keys rather than arbitrary bulk values;
+- Redis `INCREX`, a Horizon notification-channel port, queue sleep rewrites, or a new concurrency primitive;
+- unrelated changes from `docs/todo.md`;
+- new package porting or an upstream PR.
+
+## References
+
+- Current audit scope: `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`
+- Reverb key owner: `src/reverb/src/Servers/Hypervel/Scaling/RedisSharedState.php`
+- Redis pooled-operation boundaries: `src/redis/src/RedisProxy.php`, `src/redis/src/RedisConnection.php`
+- Laravel cache contract and Redis behavior: `examples/laravel/framework/src/Illuminate/Contracts/Cache/Store.php`, `examples/laravel/framework/src/Illuminate/Cache/RedisStore.php`
+- Laravel queue comparison: `examples/laravel/framework/src/Illuminate/Queue/Worker.php`, `examples/laravel/framework/src/Illuminate/Queue/LuaScripts.php`
+- Laravel Redis numeric packing option: `examples/laravel/framework/src/Illuminate/Redis/Connectors/PhpRedisConnector.php`
+- Redis [`UNLINK`](https://redis.io/docs/latest/commands/unlink/) and [large-deletion latency guidance](https://redis.io/faq/doc/16mfqr9c6n/how-to-troubleshoot-latency-issues-and-sporadic-failures-using-del/)
+- Redis [version management](https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/)
+- Valkey [release policy](https://valkey.io/topics/releases/)
+- PhpRedis 6.2/6.3 source: [`redis.c`](https://github.com/phpredis/phpredis/blob/6.3.0/redis.c), [`redis_commands.c`](https://github.com/phpredis/phpredis/blob/6.3.0/redis_commands.c), [`redis_cluster.c`](https://github.com/phpredis/phpredis/blob/6.3.0/redis_cluster.c), [`cluster_library.c`](https://github.com/phpredis/phpredis/blob/6.3.0/cluster_library.c), and [`common.h`](https://github.com/phpredis/phpredis/blob/6.2.0/common.h)

--- a/src/cache/src/CacheManager.php
+++ b/src/cache/src/CacheManager.php
@@ -291,7 +291,7 @@ class CacheManager implements FactoryContract
             $connection,
             serializableClassPolicy: $this->serializableClassPolicy,
         );
-        $store->setTagMode($config['tag_mode'] ?? 'all');
+        $store->setTagMode($config['tag_mode'] ?? TagMode::All);
 
         return $this->repository(
             $store->setLockConnection($config['lock_connection'] ?? $connection),

--- a/src/cache/src/FailoverStore.php
+++ b/src/cache/src/FailoverStore.php
@@ -117,7 +117,7 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Increment the value of an item in the cache.
      */
-    public function increment(string $key, int $value = 1): int|false
+    public function increment(string $key, int $value = 1): bool|int
     {
         return $this->attemptOnAllStores(__FUNCTION__, func_get_args());
     }
@@ -125,7 +125,7 @@ class FailoverStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Decrement the value of an item in the cache.
      */
-    public function decrement(string $key, int $value = 1): int|false
+    public function decrement(string $key, int $value = 1): bool|int
     {
         return $this->attemptOnAllStores(__FUNCTION__, func_get_args());
     }

--- a/src/cache/src/NullStore.php
+++ b/src/cache/src/NullStore.php
@@ -38,7 +38,7 @@ class NullStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Decrement the value of an item in the cache.
      */
-    public function decrement(string $key, mixed $value = 1): bool
+    public function decrement(string $key, int $value = 1): bool
     {
         return false;
     }

--- a/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
+++ b/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
@@ -164,6 +164,23 @@ class BenchmarkContext
     }
 
     /**
+     * Get every pattern needed to remove benchmark-owned keys.
+     *
+     * The all-mode value pattern overlaps tag storage today. The explicit tag
+     * patterns keep each key family covered if that value pattern narrows;
+     * deleting the overlap is idempotent.
+     *
+     * @return array<string>
+     */
+    public function getCleanupPatterns(): array
+    {
+        return [
+            ...$this->getCacheValuePatterns(self::KEY_PREFIX),
+            ...$this->getTagStoragePatterns(self::KEY_PREFIX),
+        ];
+    }
+
+    /**
      * Get a value prefixed with the benchmark prefix.
      *
      * Used for both cache keys and tag names to ensure complete isolation
@@ -232,9 +249,8 @@ class BenchmarkContext
      *
      * This method uses mode-aware patterns to ensure complete cleanup:
      * 1. Flush all tagged items via $store->tags()->flush()
-     * 2. Clean non-tagged benchmark keys
-     * 3. Clean any remaining tag storage structures (matching _bench: prefix)
-     * 4. Run prune command to clean up orphans
+     * 2. Clean remaining benchmark values and tag storage across both modes
+     * 3. Remove benchmark entries from the any-mode tag registry
      */
     public function cleanup(): void
     {
@@ -252,32 +268,23 @@ class BenchmarkContext
             $this->prefixed('cleanup:shared:3'),
         ];
 
-        // Standard tags (max 10)
-        for ($i = 0; $i < 10; ++$i) {
+        for ($i = 0; $i < $this->tagsPerItem; ++$i) {
             $tags[] = $this->prefixed("tag:{$i}");
         }
 
-        // Heavy tags (max 60 to cover extreme scale)
-        for ($i = 0; $i < 60; ++$i) {
+        for ($i = 0; $i < $this->heavyTags; ++$i) {
             $tags[] = $this->prefixed("heavy:tag:{$i}");
         }
 
-        // 1. Flush tagged items - this handles cache values, tag hashes/zsets, and registry
+        // 1. This is a fast pass through the public tag API; the physical patterns and registry sweep below guarantee cleanup.
         $store->tags($tags)->flush();
 
-        // 2. Clean up non-tagged benchmark keys using mode-aware patterns
-        // In all mode, tagged keys are at {prefix}{xxh128}:{key}, so we need multiple patterns
-        foreach ($this->getCacheValuePatterns(self::KEY_PREFIX) as $pattern) {
+        // 2. Clean up remaining keys from both modes, including all-mode namespaced values.
+        foreach ($this->getCleanupPatterns() as $pattern) {
             $this->flushKeysByPattern($storeInstance, $pattern);
         }
 
-        // 3. Clean up any remaining tag storage structures matching benchmark prefix
-        // Uses patterns for both modes to ensure complete cleanup after --compare-tag-modes
-        foreach ($this->getTagStoragePatterns(self::KEY_PREFIX) as $pattern) {
-            $this->flushKeysByPattern($storeInstance, $pattern);
-        }
-
-        // 4. Any mode: clean up benchmark entries from the tag registry
+        // 3. Any mode: clean up benchmark entries from the tag registry
         if ($this->isAnyMode()) {
             $context = $storeInstance->getContext();
             $context->withConnection(function (RedisConnection $connection) use ($context): void {

--- a/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
+++ b/src/cache/src/Redis/Console/Benchmark/BenchmarkContext.php
@@ -94,30 +94,6 @@ class BenchmarkContext
     }
 
     /**
-     * Get the current tag mode.
-     */
-    public function getTagMode(): TagMode
-    {
-        return $this->getStoreInstance()->getTagMode();
-    }
-
-    /**
-     * Check if the store is configured for 'any' tag mode.
-     */
-    public function isAnyMode(): bool
-    {
-        return $this->getTagMode() === TagMode::Any;
-    }
-
-    /**
-     * Check if the store is configured for 'all' tag mode.
-     */
-    public function isAllMode(): bool
-    {
-        return $this->getTagMode() === TagMode::All;
-    }
-
-    /**
      * Get patterns to match all tag storage structures with a given tag name prefix.
      *
      * Returns patterns for both tag modes to ensure complete cleanup
@@ -284,21 +260,20 @@ class BenchmarkContext
             $this->flushKeysByPattern($storeInstance, $pattern);
         }
 
-        // 3. Any mode: clean up benchmark entries from the tag registry
-        if ($this->isAnyMode()) {
-            $context = $storeInstance->getContext();
-            $context->withConnection(function (RedisConnection $connection) use ($context): void {
-                $registryKey = $context->registryKey();
-                $members = $connection->zRange($registryKey, 0, -1);
-                $benchmarkMembers = array_filter(
-                    $members,
-                    fn (string $member): bool => str_starts_with($member, self::KEY_PREFIX)
-                );
-                if (! empty($benchmarkMembers)) {
-                    $connection->zrem($registryKey, ...$benchmarkMembers);
-                }
-            });
-        }
+        // 3. Clean benchmark members from the any-mode registry even when an
+        // interrupted comparison leaves the store configured for all mode.
+        $context = $storeInstance->getContext();
+        $context->withConnection(function (RedisConnection $connection) use ($context): void {
+            $registryKey = (new TagKeyBuilder(TagMode::Any, $context->prefix()))->registryKey();
+            $members = $connection->zRange($registryKey, 0, -1);
+            $benchmarkMembers = array_filter(
+                $members,
+                fn (string $member): bool => str_starts_with($member, self::KEY_PREFIX)
+            );
+            if (! empty($benchmarkMembers)) {
+                $connection->zrem($registryKey, ...$benchmarkMembers);
+            }
+        });
     }
 
     /**

--- a/src/cache/src/Redis/Console/BenchmarkCommand.php
+++ b/src/cache/src/Redis/Console/BenchmarkCommand.php
@@ -103,11 +103,12 @@ class BenchmarkCommand extends Command
             return self::FAILURE;
         }
 
-        // Validate tag mode if provided
         $tagModeOption = $this->option('tag-mode');
+        $tagMode = is_string($tagModeOption) ? TagMode::tryFrom($tagModeOption) : null;
 
-        if ($tagModeOption !== null && ! in_array($tagModeOption, ['all', 'any'], true)) {
-            $this->error("Invalid tag mode: {$tagModeOption}. Available: all, any");
+        if ($tagModeOption !== null && $tagMode === null) {
+            $availableTagModes = implode(', ', TagMode::supportedValues());
+            $this->error("Invalid tag mode: {$tagModeOption}. Available: {$availableTagModes}");
 
             return self::FAILURE;
         }
@@ -151,7 +152,7 @@ class BenchmarkCommand extends Command
             } else {
                 // Use provided tag mode or current config
                 $store = $context->getStoreInstance();
-                $tagMode = $tagModeOption ?? $store->getTagMode()->value;
+                $tagMode ??= $store->getTagMode();
                 $this->runSuiteWithRuns($tagMode, $context, $runs);
             }
         } catch (BenchmarkMemoryException $exception) {
@@ -330,11 +331,11 @@ class BenchmarkCommand extends Command
         $this->newLine();
 
         $this->info('--- Phase 1: All Mode (Intersection) ---');
-        $allResults = $this->runSuiteWithRuns('all', $context, $runs, returnResults: true);
+        $allResults = $this->runSuiteWithRuns(TagMode::All, $context, $runs, returnResults: true);
 
         $this->newLine();
         $this->info('--- Phase 2: Any Mode (Union) ---');
-        $anyResults = $this->runSuiteWithRuns('any', $context, $runs, returnResults: true);
+        $anyResults = $this->runSuiteWithRuns(TagMode::Any, $context, $runs, returnResults: true);
 
         $this->formatter->displayComparisonTable($allResults, $anyResults);
     }
@@ -344,7 +345,7 @@ class BenchmarkCommand extends Command
      *
      * @return array<string, ScenarioResult>
      */
-    protected function runSuiteWithRuns(string $tagMode, BenchmarkContext $context, int $runs, bool $returnResults = false): array
+    protected function runSuiteWithRuns(TagMode $tagMode, BenchmarkContext $context, int $runs, bool $returnResults = false): array
     {
         /** @var array<int, array<string, ScenarioResult>> $allRunResults */
         $allRunResults = [];
@@ -368,7 +369,7 @@ class BenchmarkCommand extends Command
         $averagedResults = $this->averageResults($allRunResults);
 
         if (! $returnResults) {
-            $this->formatter->displayResultsTable($averagedResults, $tagMode);
+            $this->formatter->displayResultsTable($averagedResults, $tagMode->value);
         }
 
         return $averagedResults;
@@ -379,13 +380,12 @@ class BenchmarkCommand extends Command
      *
      * @return array<string, ScenarioResult>
      */
-    protected function runSuite(string $tagMode, BenchmarkContext $context): array
+    protected function runSuite(TagMode $tagMode, BenchmarkContext $context): array
     {
-        // Set the tag mode on the store
         $store = $context->getStoreInstance();
-        $store->setTagMode(TagMode::fromConfig($tagMode));
+        $store->setTagMode($tagMode);
 
-        $this->line("Tag Mode: <fg=green>{$tagMode}</>");
+        $this->line("Tag Mode: <fg=green>{$tagMode->value}</>");
 
         $results = [];
 
@@ -583,7 +583,11 @@ class BenchmarkCommand extends Command
         $cachePrefix = $storePrefix === null
             ? $config->string('cache.prefix')
             : $config->string($prefixKey);
-        $this->line('   <fg=cyan>redis-cli KEYS "' . $cachePrefix . BenchmarkContext::KEY_PREFIX . '*" | xargs redis-cli DEL</>');
+        $this->line(
+            '   <fg=cyan>redis-cli --scan --pattern '
+            . escapeshellarg($cachePrefix . BenchmarkContext::KEY_PREFIX . '*')
+            . ' | xargs -r -n 1000 redis-cli UNLINK</>'
+        );
     }
 
     /**

--- a/src/cache/src/Redis/Console/BenchmarkCommand.php
+++ b/src/cache/src/Redis/Console/BenchmarkCommand.php
@@ -156,7 +156,7 @@ class BenchmarkCommand extends Command
                 $this->runSuiteWithRuns($tagMode, $context, $runs);
             }
         } catch (BenchmarkMemoryException $exception) {
-            $this->displayMemoryError($exception);
+            $this->displayMemoryError($exception, $context);
 
             return self::FAILURE;
         } finally {
@@ -562,10 +562,8 @@ class BenchmarkCommand extends Command
     /**
      * Display memory exhaustion error with recovery guidance.
      */
-    protected function displayMemoryError(BenchmarkMemoryException $exception): void
+    protected function displayMemoryError(BenchmarkMemoryException $exception, BenchmarkContext $context): void
     {
-        $config = $this->hypervel->make('config');
-
         $this->newLine();
         $this->error('Benchmark aborted due to memory constraints.');
         $this->newLine();
@@ -574,20 +572,18 @@ class BenchmarkCommand extends Command
         $this->warn('Automatic cleanup will run next.');
         $this->line('   If benchmark keys remain, clean them up after fixing the memory issue:');
         $this->newLine();
-        $this->line('   Option 1 - Clear all cache (simple):');
+        $this->line('   Option 1 - Flush the entire Redis database for this connection (removes all keys, not only cache):');
         $this->line('   <fg=cyan>php artisan cache:clear ' . $this->storeName . '</>');
         $this->newLine();
-        $this->line('   Option 2 - Clear only benchmark keys (preserves other cache):');
-        $prefixKey = "cache.stores.{$this->storeName}.prefix";
-        $storePrefix = $config->get($prefixKey);
-        $cachePrefix = $storePrefix === null
-            ? $config->string('cache.prefix')
-            : $config->string($prefixKey);
-        $this->line(
-            '   <fg=cyan>redis-cli --scan --pattern '
-            . escapeshellarg($cachePrefix . BenchmarkContext::KEY_PREFIX . '*')
-            . ' | xargs -r -n 1000 redis-cli UNLINK</>'
-        );
+        $this->line('   Option 2 - Clear benchmark-owned keys only (preserves other cache):');
+
+        foreach ($context->getCleanupPatterns() as $pattern) {
+            $this->line(
+                '   <fg=cyan>redis-cli --scan --pattern '
+                . escapeshellarg($pattern)
+                . ' | xargs -r -n 1000 redis-cli UNLINK</>'
+            );
+        }
     }
 
     /**

--- a/src/cache/src/Redis/Operations/AllTag/Add.php
+++ b/src/cache/src/Redis/Operations/AllTag/Add.php
@@ -39,7 +39,7 @@ class Add
      * @param mixed $value The value to store
      * @param int $seconds TTL in seconds; values below one are stored for one second
      * @param array<string> $tagIds Array of tag identifiers
-     * @return bool True if the key was added (didn't exist), false if it already existed
+     * @return bool True if the key was added; false if it already existed or a write failed
      */
     public function execute(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
@@ -55,34 +55,37 @@ class Add
     /**
      * Execute using pipeline for standard Redis (non-cluster).
      *
-     * Uses SET NX EX for atomic add, then pipelines ZADD commands for all tags.
+     * Pipelines SET NX EX before the ZADD commands for all tags.
      */
     private function executePipeline(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $seconds, $tagIds) {
             $prefix = $this->context->prefix();
+            $serialized = $this->serialization->serialize($connection, $value);
+
+            if ($tagIds === []) {
+                return (bool) $connection->set(
+                    $prefix . $key,
+                    $serialized,
+                    ['EX' => $seconds, 'NX']
+                );
+            }
+
             $score = $this->context->expirationScore($seconds);
+            $pipeline = $connection->pipeline();
 
             // Publish the value attempt before its memberships so concurrent
             // pruning cannot mistake a newly written member for an orphan.
-            $result = $connection->set(
-                $prefix . $key,
-                $this->serialization->serialize($connection, $value),
-                ['EX' => $seconds, 'NX']
-            );
+            $pipeline->set($prefix . $key, $serialized, ['EX' => $seconds, 'NX']);
 
             // Membership is unconditional to preserve existing-key behavior.
-            if (! empty($tagIds)) {
-                $pipeline = $connection->pipeline();
-
-                foreach ($tagIds as $tagId) {
-                    $pipeline->zadd($prefix . $tagId, $score, $key);
-                }
-
-                $pipeline->exec();
+            foreach ($tagIds as $tagId) {
+                $pipeline->zadd($prefix . $tagId, $score, $key);
             }
 
-            return (bool) $result;
+            $results = $pipeline->exec();
+
+            return $results !== false && ! in_array(false, $results, true);
         });
     }
 
@@ -106,12 +109,16 @@ class Add
                 ['EX' => $seconds, 'NX']
             );
 
+            $membershipsSucceeded = true;
+
             // Membership is unconditional to preserve existing-key behavior.
             foreach ($tagIds as $tagId) {
-                $connection->zadd($prefix . $tagId, $score, $key);
+                if ($connection->zadd($prefix . $tagId, $score, $key) === false) {
+                    $membershipsSucceeded = false;
+                }
             }
 
-            return (bool) $result;
+            return (bool) $result && $membershipsSucceeded;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Add.php
+++ b/src/cache/src/Redis/Operations/AllTag/Add.php
@@ -17,8 +17,9 @@ use Hypervel\Redis\RedisConnection;
  * Uses Redis SET with NX (only set if Not eXists) and EX (expiration) flags
  * for atomic "add if not exists" semantics without requiring Lua scripts.
  *
- * Note: Tag entries are always added, even if the key exists. This matches
- * the original behavior where addEntry() is called before checking existence.
+ * Tag entries are published after the value attempt even when the key already
+ * exists, preserving the existing membership behavior without exposing a
+ * metadata-before-value window to concurrent pruning.
  */
 class Add
 {
@@ -54,7 +55,7 @@ class Add
     /**
      * Execute using pipeline for standard Redis (non-cluster).
      *
-     * Pipelines ZADD commands for all tags, then uses SET NX EX for atomic add.
+     * Uses SET NX EX for atomic add, then pipelines ZADD commands for all tags.
      */
     private function executePipeline(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
@@ -62,7 +63,15 @@ class Add
             $prefix = $this->context->prefix();
             $score = $this->context->expirationScore($seconds);
 
-            // Pipeline the ZADD operations for tag tracking
+            // Publish the value attempt before its memberships so concurrent
+            // pruning cannot mistake a newly written member for an orphan.
+            $result = $connection->set(
+                $prefix . $key,
+                $this->serialization->serialize($connection, $value),
+                ['EX' => $seconds, 'NX']
+            );
+
+            // Membership is unconditional to preserve existing-key behavior.
             if (! empty($tagIds)) {
                 $pipeline = $connection->pipeline();
 
@@ -73,13 +82,6 @@ class Add
                 $pipeline->exec();
             }
 
-            // SET key value EX seconds NX - atomic "add if not exists"
-            $result = $connection->set(
-                $prefix . $key,
-                $this->serialization->serialize($connection, $value),
-                ['EX' => $seconds, 'NX']
-            );
-
             return (bool) $result;
         });
     }
@@ -87,8 +89,8 @@ class Add
     /**
      * Execute using sequential commands for Redis Cluster.
      *
-     * Sequential ZADD commands since tags may be in different slots,
-     * then SET NX EX for atomic add.
+     * Uses SET NX EX for atomic add, then sequential ZADD commands because
+     * tags may be in different slots.
      */
     private function executeCluster(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
@@ -96,17 +98,18 @@ class Add
             $prefix = $this->context->prefix();
             $score = $this->context->expirationScore($seconds);
 
-            // ZADD to each tag's sorted set (sequential - cross-slot)
-            foreach ($tagIds as $tagId) {
-                $connection->zadd($prefix . $tagId, $score, $key);
-            }
-
-            // SET key value EX seconds NX - atomic "add if not exists"
+            // Publish the value attempt before its memberships so concurrent
+            // pruning can repair cross-slot races without losing fresh metadata.
             $result = $connection->set(
                 $prefix . $key,
                 $this->serialization->serialize($connection, $value),
                 ['EX' => $seconds, 'NX']
             );
+
+            // Membership is unconditional to preserve existing-key behavior.
+            foreach ($tagIds as $tagId) {
+                $connection->zadd($prefix . $tagId, $score, $key);
+            }
 
             return (bool) $result;
         });

--- a/src/cache/src/Redis/Operations/AllTag/Decrement.php
+++ b/src/cache/src/Redis/Operations/AllTag/Decrement.php
@@ -58,13 +58,14 @@ class Decrement
 
             $pipeline = $connection->pipeline();
 
+            // Publish the counter before its memberships so concurrent pruning
+            // cannot mistake a newly written member for an orphan.
+            $pipeline->decrBy($prefix . $key, $value);
+
             // ZADD NX to each tag's sorted set (only add if not exists)
             foreach ($tagIds as $tagId) {
                 $pipeline->zadd($prefix . $tagId, ['NX'], self::FOREVER_SCORE, $key);
             }
-
-            // DECRBY for the value
-            $pipeline->decrBy($prefix . $key, $value);
 
             $results = $pipeline->exec();
 
@@ -72,8 +73,8 @@ class Decrement
                 return false;
             }
 
-            // Last result is the DECRBY result
-            return end($results);
+            // First result is the DECRBY result
+            return $results[0] ?? false;
         });
     }
 

--- a/src/cache/src/Redis/Operations/AllTag/Decrement.php
+++ b/src/cache/src/Redis/Operations/AllTag/Decrement.php
@@ -85,13 +85,19 @@ class Decrement
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): int|false {
             $prefix = $this->context->prefix();
 
+            // Publish tag memberships only after Redis confirms the counter write.
+            $newValue = $connection->decrBy($prefix . $key, $value);
+
+            if (! is_int($newValue)) {
+                return false;
+            }
+
             // ZADD NX to each tag's sorted set (sequential - cross-slot)
             foreach ($tagIds as $tagId) {
                 $connection->zadd($prefix . $tagId, ['NX'], self::FOREVER_SCORE, $key);
             }
 
-            // DECRBY for the value
-            return $connection->decrBy($prefix . $key, $value);
+            return $newValue;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Forever.php
+++ b/src/cache/src/Redis/Operations/AllTag/Forever.php
@@ -69,8 +69,7 @@ class Forever
 
             $results = $pipeline->exec();
 
-            // First result is the SET - check it succeeded
-            return $results !== false && ($results[0] ?? false) !== false;
+            return $results !== false && ! in_array(false, $results, true);
         });
     }
 
@@ -89,12 +88,16 @@ class Forever
                 return false;
             }
 
+            $membershipsSucceeded = true;
+
             // ZADD to each tag's sorted set (sequential - cross-slot)
             foreach ($tagIds as $tagId) {
-                $connection->zadd($prefix . $tagId, self::FOREVER_SCORE, $key);
+                if ($connection->zadd($prefix . $tagId, self::FOREVER_SCORE, $key) === false) {
+                    $membershipsSucceeded = false;
+                }
             }
 
-            return true;
+            return $membershipsSucceeded;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Forever.php
+++ b/src/cache/src/Redis/Operations/AllTag/Forever.php
@@ -11,8 +11,8 @@ use Hypervel\Redis\RedisConnection;
 /**
  * Store an item in the cache indefinitely with all tag tracking.
  *
- * Combines the ZADD operations for tag tracking with the SET for
- * cache storage in a single connection checkout for efficiency.
+ * Combines SET cache storage with the ZADD tag tracking operations in a
+ * single connection checkout for efficiency.
  *
  * Forever items use a score of -1 in the tag sorted sets, which
  * prevents them from being cleaned by ZREMRANGEBYSCORE operations.
@@ -58,18 +58,19 @@ class Forever
 
             $pipeline = $connection->pipeline();
 
+            // Publish the value before its memberships so concurrent pruning
+            // cannot mistake a newly written member for an orphan.
+            $pipeline->set($prefix . $key, $serialized);
+
             // ZADD to each tag's sorted set with score -1 (forever)
             foreach ($tagIds as $tagId) {
                 $pipeline->zadd($prefix . $tagId, self::FOREVER_SCORE, $key);
             }
 
-            // SET for the cache value (no expiration)
-            $pipeline->set($prefix . $key, $serialized);
-
             $results = $pipeline->exec();
 
-            // Last result is the SET - check it succeeded
-            return $results !== false && end($results) !== false;
+            // First result is the SET - check it succeeded
+            return $results !== false && ($results[0] ?? false) !== false;
         });
     }
 
@@ -82,13 +83,18 @@ class Forever
             $prefix = $this->context->prefix();
             $serialized = $this->serialization->serialize($connection, $value);
 
+            // Publish the value before its memberships so concurrent pruning
+            // can repair cross-slot races without losing fresh metadata.
+            if (! $connection->set($prefix . $key, $serialized)) {
+                return false;
+            }
+
             // ZADD to each tag's sorted set (sequential - cross-slot)
             foreach ($tagIds as $tagId) {
                 $connection->zadd($prefix . $tagId, self::FOREVER_SCORE, $key);
             }
 
-            // SET for the cache value (no expiration)
-            return (bool) $connection->set($prefix . $key, $serialized);
+            return true;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Increment.php
+++ b/src/cache/src/Redis/Operations/AllTag/Increment.php
@@ -58,13 +58,14 @@ class Increment
 
             $pipeline = $connection->pipeline();
 
+            // Publish the counter before its memberships so concurrent pruning
+            // cannot mistake a newly written member for an orphan.
+            $pipeline->incrBy($prefix . $key, $value);
+
             // ZADD NX to each tag's sorted set (only add if not exists)
             foreach ($tagIds as $tagId) {
                 $pipeline->zadd($prefix . $tagId, ['NX'], self::FOREVER_SCORE, $key);
             }
-
-            // INCRBY for the value
-            $pipeline->incrBy($prefix . $key, $value);
 
             $results = $pipeline->exec();
 
@@ -72,8 +73,8 @@ class Increment
                 return false;
             }
 
-            // Last result is the INCRBY result
-            return end($results);
+            // First result is the INCRBY result
+            return $results[0] ?? false;
         });
     }
 

--- a/src/cache/src/Redis/Operations/AllTag/Increment.php
+++ b/src/cache/src/Redis/Operations/AllTag/Increment.php
@@ -85,13 +85,19 @@ class Increment
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tagIds): int|false {
             $prefix = $this->context->prefix();
 
+            // Publish tag memberships only after Redis confirms the counter write.
+            $newValue = $connection->incrBy($prefix . $key, $value);
+
+            if (! is_int($newValue)) {
+                return false;
+            }
+
             // ZADD NX to each tag's sorted set (sequential - cross-slot)
             foreach ($tagIds as $tagId) {
                 $connection->zadd($prefix . $tagId, ['NX'], self::FOREVER_SCORE, $key);
             }
 
-            // INCRBY for the value
-            return $connection->incrBy($prefix . $key, $value);
+            return $newValue;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AllTag/Prune.php
@@ -10,19 +10,9 @@ use Hypervel\Redis\PhpRedis;
 use Hypervel\Redis\RedisConnection;
 
 /**
- * Prune stale and orphaned entries from all tag sorted sets.
+ * Prune stale and orphaned entries from all-mode tag sorted sets.
  *
- * This operation performs a complete cleanup of all-mode tag data:
- * 1. Discovers all tag sorted sets via SCAN (pattern from StoreContext::tagScanPattern())
- * 2. Removes stale entries via ZREMRANGEBYSCORE (scores between 0 and now)
- * 3. Removes orphaned entries where the cache key no longer exists (ZSCAN + EXISTS + ZREM)
- * 4. Deletes empty sorted sets (ZCARD == 0)
- *
- * Forever items (score = -1) are preserved since ZREMRANGEBYSCORE uses 0 as
- * the lower bound, excluding negative scores.
- *
- * @see https://redis.io/commands/scan/
- * @see https://redis.io/commands/zremrangebyscore/
+ * Forever items use a negative score, so expiry pruning preserves them.
  */
 class Prune
 {
@@ -41,6 +31,9 @@ class Prune
 
     /**
      * Execute the prune operation.
+     *
+     * The empty_sets_deleted statistic includes sets found already empty or
+     * absent. Redis deletes a sorted set automatically with its final member.
      *
      * @param int $scanCount Number of keys per SCAN/ZSCAN iteration
      * @return array{tags_scanned: int, stale_entries_removed: int, entries_checked: int, orphans_removed: int, empty_sets_deleted: int}
@@ -76,9 +69,8 @@ class Prune
                 $statistics['entries_checked'] += $orphanResult['checked'];
                 $statistics['orphans_removed'] += $orphanResult['removed'];
 
-                // Step 3: Delete if empty
+                // Step 3: Count sets deleted by their final member removal
                 if ($connection->zCard($tagKey) === 0) {
-                    $connection->del($tagKey);
                     ++$statistics['empty_sets_deleted'];
                 }
             }
@@ -122,41 +114,92 @@ class Prune
             $memberKeys = array_keys($members);
             $checked += count($memberKeys);
 
-            if ($isCluster) {
-                $existsResults = array_map(
-                    fn (string $key): mixed => $connection->exists($prefix . $key),
-                    $memberKeys,
-                );
-            } else {
-                $pipeline = $connection->pipeline();
+            if (! $isCluster) {
+                $keys = [$tagKey];
 
                 foreach ($memberKeys as $key) {
-                    $pipeline->exists($prefix . $key);
+                    $keys[] = $prefix . $key;
                 }
 
-                $existsResults = $pipeline->exec();
+                $pageRemoved = $connection->evalWithShaCache(
+                    $this->removeOrphanedMembersScript(),
+                    $keys,
+                    $memberKeys,
+                );
+
+                $removed += is_int($pageRemoved) ? $pageRemoved : 0;
+                continue;
             }
 
-            // Collect orphaned members (cache key doesn't exist)
             $orphanedMembers = [];
 
-            foreach ($memberKeys as $index => $key) {
-                // EXISTS returns int (0 or 1)
-                if (empty($existsResults[$index])) {
+            foreach ($memberKeys as $key) {
+                if (! $this->keyExists($connection, $prefix . $key)) {
                     $orphanedMembers[] = $key;
                 }
             }
 
-            // Remove orphaned members from the sorted set
-            if (! empty($orphanedMembers)) {
-                $connection->zrem($tagKey, ...$orphanedMembers);
-                $removed += count($orphanedMembers);
+            if ($orphanedMembers === []) {
+                continue;
             }
+
+            $pageRemoved = $connection->zrem($tagKey, ...$orphanedMembers);
+
+            if (! is_int($pageRemoved) || $pageRemoved === 0) {
+                continue;
+            }
+
+            $repaired = 0;
+
+            foreach ($orphanedMembers as $key) {
+                // Cross-slot checks cannot be atomic in Cluster. A writer
+                // publishes the value before membership, so restore only if
+                // the value appeared. Its namespaced key encodes this tag set,
+                // so no separate reverse-index check is needed. Preserve any
+                // score the writer already republished.
+                if ($this->keyExists($connection, $prefix . $key)) {
+                    $connection->zadd($tagKey, ['NX'], -1, $key);
+                    ++$repaired;
+                }
+            }
+
+            // A batch cannot identify which member each concurrent repair
+            // replaced, so statistics can under-count only during that race.
+            $removed += max(0, $pageRemoved - $repaired);
         } while ($iterator !== 0);
 
         return [
             'checked' => $checked,
             'removed' => $removed,
         ];
+    }
+
+    /**
+     * Remove members only while their corresponding cache keys are absent.
+     */
+    protected function removeOrphanedMembersScript(): string
+    {
+        return <<<'LUA'
+            local tagSet = KEYS[1]
+            local removed = 0
+
+            for i = 2, #KEYS do
+                if redis.call('EXISTS', KEYS[i]) == 0 then
+                    removed = removed + redis.call('ZREM', tagSet, ARGV[i - 1])
+                end
+            end
+
+            return removed
+            LUA;
+    }
+
+    /**
+     * Check the current Redis state without treating consecutive reads as stable.
+     *
+     * @phpstan-impure Redis may change between calls.
+     */
+    private function keyExists(RedisConnection $connection, string $key): bool
+    {
+        return (bool) $connection->exists($key);
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AllTag/Prune.php
@@ -145,7 +145,7 @@ class Prune
 
             $pageRemoved = $connection->zrem($tagKey, ...$orphanedMembers);
 
-            if (! is_int($pageRemoved) || $pageRemoved === 0) {
+            if (! is_int($pageRemoved)) {
                 continue;
             }
 

--- a/src/cache/src/Redis/Operations/AllTag/Put.php
+++ b/src/cache/src/Redis/Operations/AllTag/Put.php
@@ -11,8 +11,8 @@ use Hypervel\Redis\RedisConnection;
 /**
  * Store an item in the cache with all tag tracking.
  *
- * Combines the ZADD operations for tag tracking with the SETEX for
- * cache storage in a single connection checkout for efficiency.
+ * Combines SETEX cache storage with the ZADD tag tracking operations in a
+ * single connection checkout for efficiency.
  *
  * Each tag maintains a sorted set where:
  * - Members are cache keys (namespaced)
@@ -52,7 +52,7 @@ class Put
     /**
      * Execute using pipeline for standard Redis (non-cluster).
      *
-     * Pipelines ZADD commands for all tags + SETEX in a single round trip.
+     * Pipelines SETEX and ZADD commands for all tags in a single round trip.
      */
     private function executePipeline(string $key, mixed $value, int $seconds, array $tagIds): bool
     {
@@ -63,18 +63,19 @@ class Put
 
             $pipeline = $connection->pipeline();
 
+            // Publish the value before its memberships so concurrent pruning
+            // cannot mistake a newly written member for an orphan.
+            $pipeline->setex($prefix . $key, $seconds, $serialized);
+
             // ZADD to each tag's sorted set
             foreach ($tagIds as $tagId) {
                 $pipeline->zadd($prefix . $tagId, $score, $key);
             }
 
-            // SETEX for the cache value
-            $pipeline->setex($prefix . $key, $seconds, $serialized);
-
             $results = $pipeline->exec();
 
-            // Last result is the SETEX - check it succeeded
-            return $results !== false && end($results) !== false;
+            // First result is the SETEX - check it succeeded
+            return $results !== false && ($results[0] ?? false) !== false;
         });
     }
 
@@ -91,13 +92,18 @@ class Put
             $score = $this->context->expirationScore($seconds);
             $serialized = $this->serialization->serialize($connection, $value);
 
+            // Publish the value before its memberships so concurrent pruning
+            // can repair cross-slot races without losing fresh metadata.
+            if (! $connection->setex($prefix . $key, $seconds, $serialized)) {
+                return false;
+            }
+
             // ZADD to each tag's sorted set (sequential - cross-slot)
             foreach ($tagIds as $tagId) {
                 $connection->zadd($prefix . $tagId, $score, $key);
             }
 
-            // SETEX for the cache value
-            return (bool) $connection->setex($prefix . $key, $seconds, $serialized);
+            return true;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/Put.php
+++ b/src/cache/src/Redis/Operations/AllTag/Put.php
@@ -74,8 +74,7 @@ class Put
 
             $results = $pipeline->exec();
 
-            // First result is the SETEX - check it succeeded
-            return $results !== false && ($results[0] ?? false) !== false;
+            return $results !== false && ! in_array(false, $results, true);
         });
     }
 
@@ -98,12 +97,16 @@ class Put
                 return false;
             }
 
+            $membershipsSucceeded = true;
+
             // ZADD to each tag's sorted set (sequential - cross-slot)
             foreach ($tagIds as $tagId) {
-                $connection->zadd($prefix . $tagId, $score, $key);
+                if ($connection->zadd($prefix . $tagId, $score, $key) === false) {
+                    $membershipsSucceeded = false;
+                }
             }
 
-            return true;
+            return $membershipsSucceeded;
         });
     }
 }

--- a/src/cache/src/Redis/Operations/AllTag/PutMany.php
+++ b/src/cache/src/Redis/Operations/AllTag/PutMany.php
@@ -11,8 +11,8 @@ use Hypervel\Redis\RedisConnection;
 /**
  * Store multiple items in the cache with all tag tracking.
  *
- * Combines the ZADD operations for all keys to all tags with SETEX
- * for each cache value in a single pipeline for efficiency.
+ * Combines SETEX for each cache value with ZADD operations for all keys and
+ * tags in a single pipeline for efficiency.
  */
 class PutMany
 {
@@ -72,6 +72,14 @@ class PutMany
 
             $pipeline = $connection->pipeline();
 
+            // Publish values before their memberships so concurrent pruning
+            // cannot mistake newly written members for orphans.
+            foreach ($preparedEntries as $namespacedKey => $serialized) {
+                $pipeline->setex($prefix . $namespacedKey, $seconds, $serialized);
+            }
+
+            // Pipeline results are unavailable until exec(), so memberships
+            // cannot be filtered after failed writes without another round trip.
             // Batch ZADD: one command per tag with all cache keys as members
             // ZADD format: key, score1, member1, score2, member2, ...
             foreach ($tagIds as $tagId) {
@@ -81,11 +89,6 @@ class PutMany
                     $zaddArguments[] = $key;
                 }
                 $pipeline->zadd($prefix . $tagId, ...$zaddArguments);
-            }
-
-            // Then all SETEXs
-            foreach ($preparedEntries as $namespacedKey => $serialized) {
-                $pipeline->setex($prefix . $namespacedKey, $seconds, $serialized);
             }
 
             $results = $pipeline->exec();
@@ -114,7 +117,22 @@ class PutMany
                 $preparedEntries[$namespacedKey] = $this->serialization->serialize($connection, $value);
             }
 
-            $namespacedKeys = array_keys($preparedEntries);
+            // Publish values before their memberships so concurrent pruning
+            // can repair cross-slot races without losing fresh metadata.
+            $allSucceeded = true;
+            $namespacedKeys = [];
+
+            foreach ($preparedEntries as $namespacedKey => $serialized) {
+                if ($connection->setex($prefix . $namespacedKey, $seconds, $serialized)) {
+                    $namespacedKeys[] = $namespacedKey;
+                } else {
+                    $allSucceeded = false;
+                }
+            }
+
+            if ($namespacedKeys === []) {
+                return false;
+            }
 
             // Batch ZADD: one command per tag with all cache keys as members
             // Each tag's sorted set is in one slot, so variadic ZADD works in cluster
@@ -125,14 +143,6 @@ class PutMany
                     $zaddArguments[] = $key;
                 }
                 $connection->zadd($prefix . $tagId, ...$zaddArguments);
-            }
-
-            // Then all SETEXs
-            $allSucceeded = true;
-            foreach ($preparedEntries as $namespacedKey => $serialized) {
-                if (! $connection->setex($prefix . $namespacedKey, $seconds, $serialized)) {
-                    $allSucceeded = false;
-                }
             }
 
             return $allSucceeded;

--- a/src/cache/src/Redis/Operations/AllTag/PutMany.php
+++ b/src/cache/src/Redis/Operations/AllTag/PutMany.php
@@ -142,7 +142,9 @@ class PutMany
                     $zaddArguments[] = $score;
                     $zaddArguments[] = $key;
                 }
-                $connection->zadd($prefix . $tagId, ...$zaddArguments);
+                if ($connection->zadd($prefix . $tagId, ...$zaddArguments) === false) {
+                    $allSucceeded = false;
+                }
             }
 
             return $allSucceeded;

--- a/src/cache/src/Redis/Operations/AllTag/Touch.php
+++ b/src/cache/src/Redis/Operations/AllTag/Touch.php
@@ -55,12 +55,15 @@ class Touch
             }
 
             $score = $this->context->expirationScore($seconds);
+            $membershipsSucceeded = true;
 
             foreach ($tagIds as $tagId) {
-                $connection->zadd($prefix . $tagId, $score, $key);
+                if ($connection->zadd($prefix . $tagId, $score, $key) === false) {
+                    $membershipsSucceeded = false;
+                }
             }
 
-            return true;
+            return $membershipsSucceeded;
         });
     }
 

--- a/src/cache/src/Redis/Operations/AnyTag/Decrement.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Decrement.php
@@ -29,12 +29,14 @@ class Decrement
     /**
      * Execute the decrement operation.
      *
+     * Redis errors from standalone Lua execution are thrown.
+     *
      * @param string $key The cache key (without prefix)
      * @param int $value The amount to decrement by
      * @param array<int, int|string> $tags Array of tag names (will be cast to strings)
-     * @return false|int The new value after decrementing, or false on failure
+     * @return false|int The new value, or false when the Cluster counter transaction fails
      */
-    public function execute(string $key, int $value, array $tags): int|bool
+    public function execute(string $key, int $value, array $tags): int|false
     {
         // 1. Cluster Mode: Must use sequential commands
         if ($this->context->isCluster()) {
@@ -48,7 +50,7 @@ class Decrement
     /**
      * Execute for cluster using sequential commands.
      */
-    private function executeCluster(string $key, int $value, array $tags): int|bool
+    private function executeCluster(string $key, int $value, array $tags): int|false
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags) {
             $prefix = $this->context->prefix();
@@ -57,7 +59,14 @@ class Decrement
             $multi = $connection->multi();
             $multi->decrBy($prefix . $key, $value);
             $multi->ttl($prefix . $key);
-            [$newValue, $ttl] = $multi->exec();
+            $results = $multi->exec();
+
+            // Do not publish metadata for a counter write Redis did not confirm.
+            if (! is_array($results) || ! is_int($results[0] ?? null)) {
+                return false;
+            }
+
+            [$newValue, $ttl] = $results;
 
             $tagsKey = $this->context->reverseIndexKey($key);
             $oldTags = $connection->smembers($tagsKey);
@@ -118,7 +127,7 @@ class Decrement
     /**
      * Execute using Lua script for performance.
      */
-    private function executeUsingLua(string $key, int $value, array $tags): int|bool
+    private function executeUsingLua(string $key, int $value, array $tags): int|false
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags) {
             $prefix = $this->context->prefix();

--- a/src/cache/src/Redis/Operations/AnyTag/Increment.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Increment.php
@@ -29,12 +29,14 @@ class Increment
     /**
      * Execute the increment operation.
      *
+     * Redis errors from standalone Lua execution are thrown.
+     *
      * @param string $key The cache key (without prefix)
      * @param int $value The amount to increment by
      * @param array<int, int|string> $tags Array of tag names (will be cast to strings)
-     * @return false|int The new value after incrementing, or false on failure
+     * @return false|int The new value, or false when the Cluster counter transaction fails
      */
-    public function execute(string $key, int $value, array $tags): int|bool
+    public function execute(string $key, int $value, array $tags): int|false
     {
         // 1. Cluster Mode: Must use sequential commands
         if ($this->context->isCluster()) {
@@ -48,7 +50,7 @@ class Increment
     /**
      * Execute for cluster using sequential commands.
      */
-    private function executeCluster(string $key, int $value, array $tags): int|bool
+    private function executeCluster(string $key, int $value, array $tags): int|false
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags) {
             $prefix = $this->context->prefix();
@@ -57,7 +59,14 @@ class Increment
             $multi = $connection->multi();
             $multi->incrBy($prefix . $key, $value);
             $multi->ttl($prefix . $key);
-            [$newValue, $ttl] = $multi->exec();
+            $results = $multi->exec();
+
+            // Do not publish metadata for a counter write Redis did not confirm.
+            if (! is_array($results) || ! is_int($results[0] ?? null)) {
+                return false;
+            }
+
+            [$newValue, $ttl] = $results;
 
             $tagsKey = $this->context->reverseIndexKey($key);
             $oldTags = $connection->smembers($tagsKey);
@@ -118,7 +127,7 @@ class Increment
     /**
      * Execute using Lua script for performance.
      */
-    private function executeUsingLua(string $key, int $value, array $tags): int|bool
+    private function executeUsingLua(string $key, int $value, array $tags): int|false
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value, $tags) {
             $prefix = $this->context->prefix();

--- a/src/cache/src/Redis/Operations/AnyTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Prune.php
@@ -9,20 +9,10 @@ use Hypervel\Redis\PhpRedis;
 use Hypervel\Redis\RedisConnection;
 
 /**
- * Prune orphaned fields from any tag hashes.
+ * Prune orphaned fields and registry entries from any-mode tag hashes.
  *
- * This operation performs a complete cleanup of any-mode tag data:
- * 1. Removes expired tags from the registry (ZREMRANGEBYSCORE)
- * 2. Gets active tags from the registry (ZRANGE)
- * 3. Scans each tag hash for orphaned fields (HSCAN + EXISTS checks)
- * 4. Removes orphaned fields where the cache key no longer exists (HDEL)
- * 5. Deletes empty hashes (HLEN == 0)
- *
- * This cleanup is needed because in lazy flush mode, when cache keys are
- * deleted directly (not via tag flush), the hash field references remain.
- *
- * @see https://redis.io/commands/zremrangebyscore/
- * @see https://redis.io/commands/hscan/
+ * Lazy flush can leave hash fields behind when cache values are deleted
+ * directly instead of through the tagged cache.
  */
 class Prune
 {
@@ -42,8 +32,11 @@ class Prune
     /**
      * Execute the prune operation.
      *
+     * The empty_hashes_deleted statistic includes hashes found already empty or
+     * absent. Redis deletes a hash automatically when its final field is removed.
+     *
      * @param int $scanCount Number of fields per HSCAN iteration
-     * @return array{hashes_scanned: int, fields_checked: int, orphans_removed: int, empty_hashes_deleted: int, expired_tags_removed: int}
+     * @return array{hashes_scanned: int, fields_checked: int, orphans_removed: int, empty_hashes_deleted: int, expired_tags_removed: int, orphaned_tags_removed: int}
      */
     public function execute(int $scanCount = self::DEFAULT_SCAN_COUNT): array
     {
@@ -51,15 +44,15 @@ class Prune
             return $this->executeCluster($scanCount);
         }
 
-        return $this->executePipeline($scanCount);
+        return $this->executeUsingLua($scanCount);
     }
 
     /**
-     * Execute using pipeline for standard Redis.
+     * Execute using bounded Lua operations for standard Redis.
      *
-     * @return array{hashes_scanned: int, fields_checked: int, orphans_removed: int, empty_hashes_deleted: int, expired_tags_removed: int}
+     * @return array{hashes_scanned: int, fields_checked: int, orphans_removed: int, empty_hashes_deleted: int, expired_tags_removed: int, orphaned_tags_removed: int}
      */
-    private function executePipeline(int $scanCount): array
+    private function executeUsingLua(int $scanCount): array
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($scanCount) {
             $prefix = $this->context->prefix();
@@ -72,6 +65,7 @@ class Prune
                 'orphans_removed' => 0,
                 'empty_hashes_deleted' => 0,
                 'expired_tags_removed' => 0,
+                'orphaned_tags_removed' => 0,
             ];
 
             // Step 1: Remove expired tags from registry
@@ -88,7 +82,7 @@ class Prune
             // Step 3: Process each tag hash
             foreach ($tags as $tag) {
                 $tagHash = $this->context->tagHashKey($tag);
-                $result = $this->cleanupTagHashPipeline($connection, $tagHash, $prefix, $scanCount);
+                $result = $this->cleanupTagHashUsingLua($connection, (string) $tag, $tagHash, $prefix, $scanCount);
 
                 ++$stats['hashes_scanned'];
                 $stats['fields_checked'] += $result['checked'];
@@ -97,6 +91,8 @@ class Prune
                 if ($result['deleted']) {
                     ++$stats['empty_hashes_deleted'];
                 }
+
+                $stats['orphaned_tags_removed'] += $result['registry_removed'];
             }
 
             return $stats;
@@ -106,7 +102,7 @@ class Prune
     /**
      * Execute using sequential commands for Redis Cluster.
      *
-     * @return array{hashes_scanned: int, fields_checked: int, orphans_removed: int, empty_hashes_deleted: int, expired_tags_removed: int}
+     * @return array{hashes_scanned: int, fields_checked: int, orphans_removed: int, empty_hashes_deleted: int, expired_tags_removed: int, orphaned_tags_removed: int}
      */
     private function executeCluster(int $scanCount): array
     {
@@ -121,6 +117,7 @@ class Prune
                 'orphans_removed' => 0,
                 'empty_hashes_deleted' => 0,
                 'expired_tags_removed' => 0,
+                'orphaned_tags_removed' => 0,
             ];
 
             // Step 1: Remove expired tags from registry
@@ -137,7 +134,7 @@ class Prune
             // Step 3: Process each tag hash
             foreach ($tags as $tag) {
                 $tagHash = $this->context->tagHashKey($tag);
-                $result = $this->cleanupTagHashCluster($connection, $tagHash, $prefix, $scanCount);
+                $result = $this->cleanupTagHashCluster($connection, (string) $tag, $tagHash, $prefix, $scanCount);
 
                 ++$stats['hashes_scanned'];
                 $stats['fields_checked'] += $result['checked'];
@@ -146,6 +143,8 @@ class Prune
                 if ($result['deleted']) {
                     ++$stats['empty_hashes_deleted'];
                 }
+
+                $stats['orphaned_tags_removed'] += $result['registry_removed'];
             }
 
             return $stats;
@@ -153,12 +152,17 @@ class Prune
     }
 
     /**
-     * Clean up orphaned fields from a single tag hash using pipeline.
+     * Clean up orphaned fields from a single tag hash atomically in bounded pages.
      *
-     * @return array{checked: int, removed: int, deleted: bool}
+     * @return array{checked: int, removed: int, deleted: bool, registry_removed: int}
      */
-    private function cleanupTagHashPipeline(RedisConnection $connection, string $tagHash, string $prefix, int $scanCount): array
-    {
+    private function cleanupTagHashUsingLua(
+        RedisConnection $connection,
+        string $tag,
+        string $tagHash,
+        string $prefix,
+        int $scanCount,
+    ): array {
         $checked = 0;
         $removed = 0;
 
@@ -179,50 +183,47 @@ class Prune
             $fieldKeys = array_keys($fields);
             $checked += count($fieldKeys);
 
-            // Use pipeline to check existence of all cache keys
-            $pipeline = $connection->pipeline();
+            $keys = [$tagHash];
+
             foreach ($fieldKeys as $key) {
-                $pipeline->exists($prefix . $key);
-            }
-            $existsResults = $pipeline->exec();
-
-            // Collect orphaned fields (cache key doesn't exist)
-            $orphanedFields = [];
-            foreach ($fieldKeys as $index => $key) {
-                if (! $existsResults[$index]) {
-                    $orphanedFields[] = $key;
-                }
+                $keys[] = $prefix . $key;
             }
 
-            // Remove orphaned fields
-            if (! empty($orphanedFields)) {
-                $connection->hDel($tagHash, ...$orphanedFields);
-                $removed += count($orphanedFields);
-            }
+            $pageRemoved = $connection->evalWithShaCache(
+                $this->removeOrphanedFieldsScript(),
+                $keys,
+                $fieldKeys,
+            );
+
+            $removed += is_int($pageRemoved) ? $pageRemoved : 0;
         } while ($iterator !== 0);
 
-        // Check if hash is now empty and delete it
-        $deleted = false;
-        $hashLen = $connection->hlen($tagHash);
-        if ($hashLen === 0) {
-            $connection->del($tagHash);
-            $deleted = true;
-        }
+        $finalized = $connection->evalWithShaCache(
+            $this->removeEmptyTagFromRegistryScript(),
+            [$tagHash, $this->context->registryKey()],
+            [$tag],
+        );
 
         return [
             'checked' => $checked,
             'removed' => $removed,
-            'deleted' => $deleted,
+            'deleted' => is_array($finalized) && ($finalized[0] ?? 0) === 1,
+            'registry_removed' => is_array($finalized) && is_int($finalized[1] ?? null) ? $finalized[1] : 0,
         ];
     }
 
     /**
      * Clean up orphaned fields from a single tag hash using sequential commands (cluster mode).
      *
-     * @return array{checked: int, removed: int, deleted: bool}
+     * @return array{checked: int, removed: int, deleted: bool, registry_removed: int}
      */
-    private function cleanupTagHashCluster(RedisConnection $connection, string $tagHash, string $prefix, int $scanCount): array
-    {
+    private function cleanupTagHashCluster(
+        RedisConnection $connection,
+        string $tag,
+        string $tagHash,
+        string $prefix,
+        int $scanCount,
+    ): array {
         $checked = 0;
         $removed = 0;
 
@@ -242,34 +243,123 @@ class Prune
 
             $fieldKeys = array_keys($fields);
             $checked += count($fieldKeys);
-
-            // Check existence sequentially in cluster mode
             $orphanedFields = [];
+
             foreach ($fieldKeys as $key) {
-                if (! $connection->exists($prefix . $key)) {
+                if (! $this->keyExists($connection, $prefix . $key)) {
                     $orphanedFields[] = $key;
                 }
             }
 
-            // Remove orphaned fields
-            if (! empty($orphanedFields)) {
-                $connection->hDel($tagHash, ...$orphanedFields);
-                $removed += count($orphanedFields);
+            if ($orphanedFields === []) {
+                continue;
             }
+
+            $pageRemoved = $connection->hDel($tagHash, ...$orphanedFields);
+
+            if (! is_int($pageRemoved) || $pageRemoved === 0) {
+                continue;
+            }
+
+            $repaired = 0;
+
+            foreach ($orphanedFields as $key) {
+                // Cross-slot checks cannot be atomic in Cluster. Restore only
+                // when the value and its reverse index prove a writer won the
+                // race; HSETNX preserves metadata already republished by it.
+                if ($this->keyExists($connection, $prefix . $key)
+                    && $connection->sismember($this->context->reverseIndexKey($key), $tag)) {
+                    $connection->hsetnx($tagHash, $key, StoreContext::TAG_FIELD_VALUE);
+                    ++$repaired;
+                }
+            }
+
+            // A batch cannot identify which field each concurrent repair
+            // replaced, so statistics can under-count only during that race.
+            $removed += max(0, $pageRemoved - $repaired);
         } while ($iterator !== 0);
 
-        // Check if hash is now empty and delete it
         $deleted = false;
-        $hashLen = $connection->hlen($tagHash);
-        if ($hashLen === 0) {
-            $connection->del($tagHash);
+        $registryRemoved = 0;
+
+        if ($this->tagHashIsEmpty($connection, $tagHash)) {
+            $registryRemoved = (int) $connection->zrem($this->context->registryKey(), $tag);
             $deleted = true;
+
+            // A writer publishes the hash before the registry. If it revived
+            // the hash during the cross-slot cleanup, restore only a missing
+            // registry member and let the writer's real expiry win.
+            if (! $this->tagHashIsEmpty($connection, $tagHash)) {
+                $connection->zadd(
+                    $this->context->registryKey(),
+                    ['NX'],
+                    StoreContext::MAX_EXPIRY,
+                    $tag,
+                );
+
+                $deleted = false;
+                $registryRemoved = 0;
+            }
         }
 
         return [
             'checked' => $checked,
             'removed' => $removed,
             'deleted' => $deleted,
+            'registry_removed' => $registryRemoved,
         ];
+    }
+
+    /**
+     * Remove fields only while their corresponding cache keys are absent.
+     */
+    protected function removeOrphanedFieldsScript(): string
+    {
+        return <<<'LUA'
+            local tagHash = KEYS[1]
+            local removed = 0
+
+            for i = 2, #KEYS do
+                if redis.call('EXISTS', KEYS[i]) == 0 then
+                    removed = removed + redis.call('HDEL', tagHash, ARGV[i - 1])
+                end
+            end
+
+            return removed
+            LUA;
+    }
+
+    /**
+     * Remove an empty tag from the registry in the same atomic operation.
+     */
+    protected function removeEmptyTagFromRegistryScript(): string
+    {
+        return <<<'LUA'
+            if redis.call('HLEN', KEYS[1]) == 0 then
+                return {1, redis.call('ZREM', KEYS[2], ARGV[1])}
+            end
+
+            return {0, 0}
+            LUA;
+    }
+
+    /**
+     * Check the current Redis state without treating consecutive reads as stable.
+     *
+     * @phpstan-impure Redis may change between calls.
+     */
+    private function keyExists(RedisConnection $connection, string $key): bool
+    {
+        return (bool) $connection->exists($key);
+    }
+
+    /**
+     * Check the current hash state without treating consecutive reads as stable.
+     *
+     * @phpstan-impure Redis may change between calls.
+     */
+    private function tagHashIsEmpty(RedisConnection $connection, string $tagHash): bool
+    {
+        return $connection->hlen($tagHash) === 0;
     }
 }

--- a/src/cache/src/Redis/Operations/AnyTag/Prune.php
+++ b/src/cache/src/Redis/Operations/AnyTag/Prune.php
@@ -257,7 +257,7 @@ class Prune
 
             $pageRemoved = $connection->hDel($tagHash, ...$orphanedFields);
 
-            if (! is_int($pageRemoved) || $pageRemoved === 0) {
+            if (! is_int($pageRemoved)) {
                 continue;
             }
 

--- a/src/cache/src/Redis/Operations/Decrement.php
+++ b/src/cache/src/Redis/Operations/Decrement.php
@@ -23,7 +23,7 @@ class Decrement
     /**
      * Execute the decrement operation.
      */
-    public function execute(string $key, int $value = 1): int
+    public function execute(string $key, int $value = 1): int|false
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value) {
             return $connection->decrBy($this->context->prefix() . $key, $value);

--- a/src/cache/src/Redis/Operations/Increment.php
+++ b/src/cache/src/Redis/Operations/Increment.php
@@ -23,7 +23,7 @@ class Increment
     /**
      * Execute the increment operation.
      */
-    public function execute(string $key, int $value = 1): int
+    public function execute(string $key, int $value = 1): int|false
     {
         return $this->context->withConnection(function (RedisConnection $connection) use ($key, $value) {
             return $connection->incrBy($this->context->prefix() . $key, $value);

--- a/src/cache/src/RedisStore.php
+++ b/src/cache/src/RedisStore.php
@@ -166,7 +166,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Increment the value of an item in the cache.
      */
-    public function increment(string $key, int $value = 1): int
+    public function increment(string $key, int $value = 1): int|false
     {
         return $this->getIncrementOperation()->execute($key, $value);
     }
@@ -174,7 +174,7 @@ class RedisStore extends TaggableStore implements CanFlushLocks, LockProvider
     /**
      * Decrement the value of an item in the cache.
      */
-    public function decrement(string $key, int $value = 1): int
+    public function decrement(string $key, int $value = 1): int|false
     {
         return $this->getDecrementOperation()->execute($key, $value);
     }

--- a/src/cache/src/TagMode.php
+++ b/src/cache/src/TagMode.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hypervel\Cache;
 
+use InvalidArgumentException;
+
 /**
  * Tag mode enum - describes the semantic of how tags participate in a
  * taggable store's behavior.
@@ -23,18 +25,45 @@ enum TagMode: string
     case All = 'all';
 
     /**
-     * Create from a config string, falling back to All on invalid input.
+     * Create from a config string.
+     *
+     * @throws InvalidArgumentException
      */
     public static function fromConfig(string $value): self
     {
-        return self::tryFrom($value) ?? self::All;
+        return self::tryFrom($value) ?? throw new InvalidArgumentException(
+            sprintf(
+                'Invalid cache tag mode [%s]. Supported modes are [%s].',
+                $value,
+                implode(', ', self::supportedValues()),
+            )
+        );
     }
 
+    /**
+     * Get the supported configuration values.
+     *
+     * @return list<string>
+     */
+    public static function supportedValues(): array
+    {
+        return array_map(
+            static fn (self $mode): string => $mode->value,
+            self::cases(),
+        );
+    }
+
+    /**
+     * Determine if this is any mode.
+     */
     public function isAnyMode(): bool
     {
         return $this === self::Any;
     }
 
+    /**
+     * Determine if this is all mode.
+     */
     public function isAllMode(): bool
     {
         return $this === self::All;

--- a/src/docs/cache.md
+++ b/src/docs/cache.md
@@ -380,6 +380,8 @@ Cache::decrement('key');
 Cache::decrement('key', $amount);
 ```
 
+When using a Redis cache store with PhpRedis serialization, atomic counters require either `Redis::SERIALIZER_NONE` or the PhpRedis 6.2+ `pack_ignore_numbers` option. See the [PhpRedis serialization documentation](/docs/{{version}}/redis#phpredis-serialization) for configuration details.
+
 <a name="retrieve-store"></a>
 #### Retrieve and Store
 

--- a/src/docs/queues.md
+++ b/src/docs/queues.md
@@ -1786,6 +1786,8 @@ class ProcessPodcast implements ShouldQueue
 
 In this example, the job is released for ten seconds if the application is unable to obtain a Redis lock and will continue to be retried up to 25 times. However, the job will fail if three unhandled exceptions are thrown by the job.
 
+`MaxExceptions` tracks failures using an atomic counter on your default cache store. If that store uses Redis with PhpRedis serialization, configure counters as described in the [cache increment and decrement documentation](/docs/{{version}}/cache#incrementing-decrementing-values).
+
 <a name="stopping-retries-by-exception"></a>
 #### Stopping Retries by Exception
 

--- a/src/docs/redis.md
+++ b/src/docs/redis.md
@@ -33,6 +33,13 @@
 
 [Redis](https://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](https://redis.io/docs/latest/develop/data-types/strings/), [hashes](https://redis.io/docs/latest/develop/data-types/hashes/), [lists](https://redis.io/docs/latest/develop/data-types/lists/), [sets](https://redis.io/docs/latest/develop/data-types/sets/), and [sorted sets](https://redis.io/docs/latest/develop/data-types/sorted-sets/).
 
+<div class="content-list" markdown="1">
+
+- Redis server 6.2+ ([Version Policy](https://redis.io/docs/latest/operate/oss_and_stack/install/version-mgmt/))
+- Valkey 7.2+ ([Version Policy](https://valkey.io/topics/releases/))
+
+</div>
+
 Before using Redis with Hypervel, you should install and enable the [PhpRedis](https://github.com/phpredis/phpredis) PHP extension. Hypervel's Redis integration is built on PhpRedis and uses pooled connections so Redis commands may be executed efficiently across Swoole coroutines.
 
 <a name="configuration"></a>
@@ -111,7 +118,7 @@ Hypervel communicates with Redis using the PhpRedis extension. Standalone connec
 
 A non-zero `read_timeout` is applied both when the Redis socket is opened and as the PhpRedis `Redis::OPT_READ_TIMEOUT` option. A value of `0.0` leaves PHP's `default_socket_timeout` in effect. The optional `name` value sets the client name on standalone Redis connections.
 
-The `context` option accepts stream options directly or nested under an `ssl` or `stream` key. If you need to configure PhpRedis options such as `prefix`, `scan`, `serializer`, `compression`, `compression_level`, `tcp_keepalive`, or `pack_ignore_numbers`, add them to the `options` array. The `pack_ignore_numbers` option requires PhpRedis 6.2 or later and applies only to standalone connections. Connection options override shared options, while a non-null top-level connection `prefix` takes final precedence.
+The `context` option accepts stream options directly or nested under an `ssl` or `stream` key. If you need to configure PhpRedis options such as `prefix`, `scan`, `serializer`, `compression`, `compression_level`, `tcp_keepalive`, or `pack_ignore_numbers`, add them to the `options` array. The `pack_ignore_numbers` option requires PhpRedis 6.2 or later and applies to standalone and Cluster connections. Connection options override shared options, while a non-null top-level connection `prefix` takes final precedence.
 
 <a name="retry-and-backoff-configuration"></a>
 #### Retry and Backoff Configuration
@@ -157,6 +164,8 @@ The PhpRedis extension may also be configured to use a variety of serializers an
 ```
 
 Currently supported serializers include: `Redis::SERIALIZER_NONE` (default), `Redis::SERIALIZER_PHP`, `Redis::SERIALIZER_JSON`, `Redis::SERIALIZER_IGBINARY`, and `Redis::SERIALIZER_MSGPACK`.
+
+Redis atomic counters must remain unencoded. Connections used for atomic increments or decrements should either use `Redis::SERIALIZER_NONE` or enable `pack_ignore_numbers` with PhpRedis 6.2 or later. This applies to standalone and Cluster connections.
 
 When relying on Cache's [serializable class allowlist](/docs/{{version}}/cache#serializable-cached-objects), configure the connection used by the Redis cache store with `Redis::SERIALIZER_NONE`. Options in the shared `options` array also apply to that connection.
 
@@ -525,6 +534,8 @@ $deleted = Redis::flushByPattern('users:*');
 ```
 
 When calling `flushByPattern` on an already-held connection, acquire the connection with `transform: false`.
+
+If Redis cannot delete a scanned batch, `flushByPattern` throws a `RedisException` instead of returning an incomplete count.
 
 <a name="transactions"></a>
 ### Transactions

--- a/src/docs/reverb.md
+++ b/src/docs/reverb.md
@@ -28,6 +28,7 @@
 - [Scaling](#scaling)
     - [Single-Instance Multi-Worker Scaling](#single-instance-multi-worker-scaling)
     - [Multi-Instance Redis Scaling](#multi-instance-redis-scaling)
+    - [Recovering Redis Shared State](#recovering-redis-shared-state)
 - [Events](#events)
 
 <a name="introduction"></a>
@@ -550,6 +551,25 @@ The `REVERB_SCALING_CONNECTION` option selects a named Redis connection from you
 The scaling connection may use a standalone Redis server or Redis Sentinel. Redis Cluster is not supported for Reverb pub / sub scaling because it cannot provide the exact subscriber count required to gather complete presence and channel information. Redis Cluster remains supported for webhook batching when Reverb scaling is disabled. Because Redis state survives application restarts, an unclean shutdown may require stale Reverb state to be cleared operationally.
 
 Once you have enabled Reverb's scaling option and configured Redis, you may run multiple Hypervel Reverb instances behind a load balancer that distributes incoming WebSocket connections evenly among the instances.
+
+<a name="recovering-redis-shared-state"></a>
+### Recovering Redis Shared State
+
+During a normal shutdown, Reverb removes the shared connection, subscription, and presence state owned by the stopping process. If a process or server stops before that cleanup completes, stale state may remain in Redis and affect connection limits or channel information.
+
+Before clearing this state, stop every Reverb node that uses the same Redis endpoint, logical database, and key prefix. You may then inspect the number of matching keys without deleting them:
+
+```shell
+php artisan reverb:clear-state --dry-run
+```
+
+To clear the state, run the command without `--dry-run` and confirm the operation. The `--force` option skips the confirmation prompt for an operator-controlled recovery script:
+
+```shell
+php artisan reverb:clear-state --force
+```
+
+The command also removes short-lived webhook throttle, deduplication, and disconnect-smoothing locks, which Reverb recreates as needed. It does not remove buffered webhook payloads. Start every stopped Reverb node after the command completes.
 
 <a name="events"></a>
 ## Events

--- a/src/horizon/src/Console/HorizonRestartStrategy.php
+++ b/src/horizon/src/Console/HorizonRestartStrategy.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Hypervel\Horizon\Console;
 
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
-use Hypervel\Horizon\PhpBinary;
 use Hypervel\Support\DotenvManager;
 use Hypervel\Watcher\RestartStrategy;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+
+use function Hypervel\Support\artisan_binary;
+use function Hypervel\Support\php_binary;
 
 class HorizonRestartStrategy implements RestartStrategy
 {
@@ -50,7 +52,17 @@ class HorizonRestartStrategy implements RestartStrategy
         usleep(100_000);
 
         if ($this->horizonProcess->isTerminated()) {
-            throw new RuntimeException('Horizon failed to start.');
+            $message = sprintf(
+                'Horizon failed to start with exit code [%s].',
+                $this->horizonProcess->getExitCode() ?? 'unknown',
+            );
+            $errorOutput = trim($this->horizonProcess->getErrorOutput());
+
+            if ($errorOutput !== '') {
+                $message .= ' ' . $errorOutput;
+            }
+
+            throw new RuntimeException($message);
         }
     }
 
@@ -80,12 +92,12 @@ class HorizonRestartStrategy implements RestartStrategy
      */
     protected function createProcess(): Process
     {
-        $command = [PhpBinary::path(), 'artisan', 'horizon'];
+        $command = [php_binary(), artisan_binary(), 'horizon'];
 
-        if ($this->environment) {
+        if ($this->environment !== null && $this->environment !== '') {
             $command[] = '--environment=' . $this->environment;
         }
 
-        return (new Process($command))->setTimeout(null);
+        return (new Process($command, $this->application->basePath()))->setTimeout(null);
     }
 }

--- a/src/queue/src/LuaScripts.php
+++ b/src/queue/src/LuaScripts.php
@@ -121,6 +121,7 @@ LUA;
      * KEYS[2] - The queue we are moving jobs to, for example: queues:foo
      * KEYS[3] - The notification list for the queue we are moving jobs to, for example queues:foo:notify
      * ARGV[1] - The current UNIX timestamp
+     * ARGV[2] - The maximum number of jobs to migrate
      */
     public static function migrateExpiredJobs(): string
     {

--- a/src/queue/src/Worker.php
+++ b/src/queue/src/Worker.php
@@ -900,7 +900,9 @@ class Worker
             $this->cache->put('job-exceptions:' . $uuid, 0, CarbonImmutable::now()->addDay());
         }
 
-        if ($maxExceptions <= $this->cache->increment('job-exceptions:' . $uuid)) {
+        $exceptions = $this->cache->increment('job-exceptions:' . $uuid);
+
+        if (is_int($exceptions) && $maxExceptions <= $exceptions) {
             $this->cache->forget('job-exceptions:' . $uuid);
 
             $this->failJob($job, $e);

--- a/src/redis/src/Operations/FlushByPattern.php
+++ b/src/redis/src/Operations/FlushByPattern.php
@@ -6,6 +6,7 @@ namespace Hypervel\Redis\Operations;
 
 use Hypervel\Redis\RedisConnection;
 use Redis;
+use RedisException;
 
 /**
  * Flush (delete) Redis keys matching a pattern.
@@ -70,6 +71,8 @@ final class FlushByPattern
      * @param string $pattern The pattern to match (e.g., "cache:test:*").
      *                        Should NOT include OPT_PREFIX - it's handled automatically.
      * @return int Number of keys deleted
+     *
+     * @throws RedisException
      */
     public function execute(string $pattern): int
     {
@@ -101,21 +104,23 @@ final class FlushByPattern
     /**
      * Delete a batch of keys.
      *
-     * Uses UNLINK (async delete) when available for better performance,
-     * falls back to DEL for older Redis versions.
-     *
      * @param array<string> $keys Keys to delete (without OPT_PREFIX - phpredis adds it)
      * @return int Number of keys deleted
+     *
+     * @throws RedisException
      */
     private function deleteKeys(array $keys): int
     {
-        if (empty($keys)) {
-            return 0;
-        }
-
-        // UNLINK is non-blocking (async) delete, available since Redis 4.0
+        $this->connection->clearLastError();
         $result = $this->connection->unlink(...$keys);
 
-        return is_int($result) ? $result : 0;
+        if (is_int($result)) {
+            return $result;
+        }
+
+        throw new RedisException(
+            $this->connection->getLastError()
+                ?? 'Redis UNLINK failed while deleting keys by pattern.',
+        );
     }
 }

--- a/src/redis/src/PhpRedisClusterConnection.php
+++ b/src/redis/src/PhpRedisClusterConnection.php
@@ -304,7 +304,10 @@ class PhpRedisClusterConnection extends PhpRedisConnection
                 throw $cancellation;
             }
 
-            throw new ConnectionException('Connection reconnect failed ' . $exception->getMessage());
+            throw new ConnectionException(
+                'Connection reconnect failed: ' . $exception->getMessage(),
+                previous: $exception,
+            );
         }
 
         return $redis;

--- a/src/redis/src/PhpRedisConnection.php
+++ b/src/redis/src/PhpRedisConnection.php
@@ -232,7 +232,10 @@ class PhpRedisConnection extends RedisConnection
                 throw $cancellation;
             }
 
-            throw new ConnectionException('Connection reconnect failed ' . $exception->getMessage());
+            throw new ConnectionException(
+                'Connection reconnect failed: ' . $exception->getMessage(),
+                previous: $exception,
+            );
         }
 
         return $redis;

--- a/src/redis/src/RedisConnection.php
+++ b/src/redis/src/RedisConnection.php
@@ -574,8 +574,10 @@ abstract class RedisConnection extends BaseConnection implements NonCopyableCont
                 $name = strtolower($name);
 
                 if ($name === 'pack_ignore_numbers'
-                    && (! $redis instanceof Redis || ! defined(Redis::class . '::OPT_PACK_IGNORE_NUMBERS'))) {
-                    continue;
+                    && ! defined(Redis::class . '::OPT_PACK_IGNORE_NUMBERS')) {
+                    throw new InvalidRedisOptionException(
+                        'The redis option `pack_ignore_numbers` requires PhpRedis 6.2 or later.'
+                    );
                 }
 
                 if ($name === 'backoff_algorithm') {
@@ -626,7 +628,7 @@ abstract class RedisConnection extends BaseConnection implements NonCopyableCont
             'compression' => Redis::OPT_COMPRESSION,
             'reply_literal' => Redis::OPT_REPLY_LITERAL,
             'compression_level' => Redis::OPT_COMPRESSION_LEVEL,
-            'pack_ignore_numbers' => Redis::OPT_PACK_IGNORE_NUMBERS, // @phpstan-ignore classConstant.notFound (setOptions() skips this option when phpredis predates the constant)
+            'pack_ignore_numbers' => Redis::OPT_PACK_IGNORE_NUMBERS, // @phpstan-ignore classConstant.notFound (setOptions() guards this option before resolving the constant)
             'max_retries' => Redis::OPT_MAX_RETRIES,
             'backoff_algorithm' => Redis::OPT_BACKOFF_ALGORITHM,
             'backoff_base' => Redis::OPT_BACKOFF_BASE,
@@ -1831,6 +1833,8 @@ abstract class RedisConnection extends BaseConnection implements NonCopyableCont
      * @param string $pattern The pattern to match (e.g., "cache:test:*").
      *                        Should NOT include OPT_PREFIX - it's handled automatically.
      * @return int Number of keys deleted
+     *
+     * @throws RedisException
      */
     public function flushByPattern(string $pattern): int
     {

--- a/src/redis/src/RedisProxy.php
+++ b/src/redis/src/RedisProxy.php
@@ -21,6 +21,7 @@ use Hypervel\Redis\Subscriber\Subscriber;
 use Hypervel\Redis\Traits\MultiExec;
 use Hypervel\Support\Arr;
 use Redis;
+use RedisException;
 use Swoole\Coroutine\CanceledException;
 use Throwable;
 
@@ -849,6 +850,8 @@ class RedisProxy implements ConnectionContract
      * @param string $pattern The pattern to match (e.g., "cache:test:*").
      *                        Should NOT include OPT_PREFIX - it's handled automatically.
      * @return int Number of keys deleted
+     *
+     * @throws RedisException
      */
     public function flushByPattern(string $pattern): int
     {

--- a/src/reverb/src/Console/Commands/ClearStateCommand.php
+++ b/src/reverb/src/Console/Commands/ClearStateCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Reverb\Console\Commands;
+
+use Hypervel\Console\Command;
+use Hypervel\Console\ConfirmableTrait;
+use Hypervel\Contracts\Config\Repository as ConfigRepository;
+use Hypervel\Contracts\Redis\Factory as RedisFactory;
+use Hypervel\Redis\RedisConnection;
+use Hypervel\Reverb\Servers\Hypervel\Scaling\RedisSharedState;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'reverb:clear-state')]
+class ClearStateCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     */
+    protected ?string $signature = 'reverb:clear-state
+        {--dry-run : Count matching Reverb shared-state keys without deleting them}
+        {--force : Skip the confirmation prompt}';
+
+    /**
+     * The console command description.
+     */
+    protected string $description = 'Clear Redis-backed Reverb shared state';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(ConfigRepository $config, RedisFactory $redis): int
+    {
+        $connectionName = $config->string('reverb.servers.reverb.scaling.connection');
+        $connection = $redis->connection($connectionName);
+
+        if ($this->option('dry-run') === true) {
+            $count = $connection->withConnection(
+                fn (RedisConnection $rawConnection): int => iterator_count(
+                    $rawConnection->safeScan(RedisSharedState::KEY_PATTERN),
+                ),
+                transform: false,
+            );
+
+            $this->components->info("Found [{$count}] Reverb shared-state keys.");
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->confirmToProceed(
+            'All Reverb nodes sharing this Redis connection, database, and prefix must be stopped before clearing state.',
+            true,
+        )) {
+            return self::FAILURE;
+        }
+
+        $count = $connection->flushByPattern(RedisSharedState::KEY_PATTERN);
+
+        $this->components->info("Cleared [{$count}] Reverb shared-state keys.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/reverb/src/ReverbServiceProvider.php
+++ b/src/reverb/src/ReverbServiceProvider.php
@@ -13,6 +13,7 @@ use Hypervel\Core\Events\OnWorkerExit;
 use Hypervel\RateLimiter\KeyResolver;
 use Hypervel\RateLimiter\Limiter;
 use Hypervel\RateLimiter\WorkerArrayStore;
+use Hypervel\Reverb\Console\Commands\ClearStateCommand;
 use Hypervel\Reverb\Console\Commands\InstallCommand;
 use Hypervel\Reverb\Contracts\ApplicationProvider;
 use Hypervel\Reverb\Contracts\Logger;
@@ -225,7 +226,10 @@ class ReverbServiceProvider extends ServiceProvider
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands([InstallCommand::class]);
+            $this->commands([
+                ClearStateCommand::class,
+                InstallCommand::class,
+            ]);
 
             $this->publishes([
                 __DIR__ . '/../config/reverb.php' => config_path('reverb.php'),

--- a/src/reverb/src/Servers/Hypervel/Scaling/RedisSharedState.php
+++ b/src/reverb/src/Servers/Hypervel/Scaling/RedisSharedState.php
@@ -9,6 +9,14 @@ use Hypervel\Reverb\Servers\Hypervel\Contracts\SharedState;
 
 class RedisSharedState implements SharedState
 {
+    /**
+     * The logical pattern matching all Redis-backed shared-state keys.
+     *
+     * The hash-tag prefix excludes webhook buffers and defines the boundary
+     * cleared by the reverb:clear-state recovery command.
+     */
+    public const string KEY_PATTERN = 'reverb:{*}:*';
+
     protected const string SUBSCRIPTION_KEY_TYPE = 's';
 
     protected const string USER_KEY_TYPE = 'u';

--- a/tests/Cache/CacheFailoverStoreTest.php
+++ b/tests/Cache/CacheFailoverStoreTest.php
@@ -41,6 +41,17 @@ class CacheFailoverStoreTest extends TestCase
         $this->assertSame([['key', 'stdClass']], $handled);
     }
 
+    public function testCountersPreserveEveryContractValidResult(): void
+    {
+        $backingStore = m::mock(Store::class);
+        $backingStore->expects('increment')->with('increment', 2)->andReturnTrue();
+        $backingStore->expects('decrement')->with('decrement', 3)->andReturnFalse();
+        $store = $this->makeFailoverStore(['cache' => $backingStore]);
+
+        $this->assertTrue($store->increment('increment', 2));
+        $this->assertFalse($store->decrement('decrement', 3));
+    }
+
     public function testLockFlushCapabilityRequiresAtLeastOneLockProvider(): void
     {
         $store = $this->makeFailoverStore([

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -645,7 +645,7 @@ class CacheManagerTest extends TestCase
         $this->assertSame(TagMode::Any, $store->getTagMode());
     }
 
-    public function testRedisDriverFallsBackToAllForInvalidTagMode(): void
+    public function testRedisDriverRejectsInvalidTagMode(): void
     {
         $userConfig = [
             'cache' => [
@@ -663,11 +663,12 @@ class CacheManagerTest extends TestCase
         $app = $this->getAppWithRedis($userConfig);
         $cacheManager = new CacheManager($app);
 
-        $repository = $cacheManager->store('redis');
-        $store = $repository->getStore();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid cache tag mode [invalid]. Supported modes are [any, all].'
+        );
 
-        $this->assertInstanceOf(RedisStore::class, $store);
-        $this->assertSame(TagMode::All, $store->getTagMode());
+        $cacheManager->store('redis');
     }
 
     public function testSessionDriverResolvesSessionStore()

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -39,7 +39,7 @@ class CacheNullStoreTest extends TestCase
     {
         $store = new NullStore;
         $this->assertFalse($store->increment('foo'));
-        $this->assertFalse($store->decrement('foo'));
+        $this->assertFalse($store->decrement('foo', 2));
     }
 
     public function testTouchReturnsFalse()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -785,6 +785,17 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testCounterFailuresAreReturnedWithoutCoercion(): void
+    {
+        $store = m::mock(Store::class);
+        $store->expects('increment')->with('increment', 2)->andReturnFalse();
+        $store->expects('decrement')->with('decrement', 3)->andReturnFalse();
+        $repository = new Repository($store);
+
+        $this->assertFalse($repository->increment('increment', 2));
+        $this->assertFalse($repository->decrement('decrement', 3));
+    }
+
     #[DataProvider('dataProviderTestGetSeconds')]
     public function testGetSeconds($duration)
     {

--- a/tests/Cache/Redis/AllTaggedCacheTest.php
+++ b/tests/Cache/Redis/AllTaggedCacheTest.php
@@ -37,9 +37,6 @@ use Swoole\Coroutine\CanceledException;
  */
 class AllTaggedCacheTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testTagEntriesCanBeStoredForever(): void
     {
         $connection = $this->mockConnection();
@@ -48,11 +45,11 @@ class AllTaggedCacheTest extends RedisCacheTestCase
 
         $key = hash('xxh128', '_all:tag:people:entries|_all:tag:author:entries') . ':name';
 
-        // Combined operation: ZADD for both tags + SET (forever uses score -1)
+        // Combined operation: SET + ZADD for both tags (forever uses score -1)
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:people:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:author:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('set')->once()->with("prefix:{$key}", serialize('Sally'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['people', 'author'])->forever('name', 'Sally');
@@ -60,9 +57,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTagEntriesCanBeStoredForeverWithNumericValue(): void
     {
         $connection = $this->mockConnection();
@@ -75,7 +69,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:people:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:author:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('set')->once()->with("prefix:{$key}", 30)->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['people', 'author'])->forever('age', 30);
@@ -83,9 +77,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTagEntriesCanBeIncremented(): void
     {
         $connection = $this->mockConnection();
@@ -94,7 +85,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
 
         $key = hash('xxh128', '_all:tag:votes:entries') . ':person-1';
 
-        // Combined operation: ZADD NX + INCRBY in single pipeline
+        // Combined operation: INCRBY + ZADD NX in single pipeline
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:votes:entries', ['NX'], -1, $key)->andReturn($connection);
         $connection->shouldReceive('incrby')->once()->with("prefix:{$key}", 1)->andReturn($connection);
         $connection->shouldReceive('exec')->once()->andReturn([1, 1]);
@@ -105,9 +96,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame(1, $result);
     }
 
-    /**
-     * @test
-     */
     public function testTagEntriesCanBeDecremented(): void
     {
         $connection = $this->mockConnection();
@@ -116,10 +104,10 @@ class AllTaggedCacheTest extends RedisCacheTestCase
 
         $key = hash('xxh128', '_all:tag:votes:entries') . ':person-1';
 
-        // Combined operation: ZADD NX + DECRBY in single pipeline
+        // Combined operation: DECRBY + ZADD NX in single pipeline
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:votes:entries', ['NX'], -1, $key)->andReturn($connection);
         $connection->shouldReceive('decrby')->once()->with("prefix:{$key}", 1)->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 9]);
+        $connection->shouldReceive('exec')->once()->andReturn([9, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['votes'])->decrement('person-1');
@@ -127,9 +115,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame(9, $result);
     }
 
-    /**
-     * @test
-     */
     public function testStaleEntriesCanBeFlushed(): void
     {
         $connection = $this->mockConnection();
@@ -147,9 +132,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $store->tags(['people'])->flushStale();
     }
 
-    /**
-     * @test
-     */
     public function testPut(): void
     {
         $connection = $this->mockConnection();
@@ -159,11 +141,11 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $key = hash('xxh128', '_all:tag:people:entries|_all:tag:author:entries') . ':name';
         $expectedScore = now()->timestamp + 5;
 
-        // Combined operation: ZADD for both tags + SETEX in single pipeline
+        // Combined operation: SETEX + ZADD for both tags in single pipeline
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:people:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:author:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$key}", 5, serialize('Sally'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['people', 'author'])->put('name', 'Sally', 5);
@@ -171,9 +153,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutWithNumericValue(): void
     {
         $connection = $this->mockConnection();
@@ -187,7 +166,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:people:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:author:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$key}", 5, 30)->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['people', 'author'])->put('age', 30, 5);
@@ -195,9 +174,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutWithArray(): void
     {
         $connection = $this->mockConnection();
@@ -224,8 +200,8 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('setex')->once()->with("prefix:{$namespace}name", 5, serialize('Sally'))->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$namespace}age", 5, 30)->andReturn($connection);
 
-        // Results: 2 ZADDs + 2 SETEXs
-        $connection->shouldReceive('exec')->once()->andReturn([2, 2, true, true]);
+        // Results: 2 SETEXs + 2 ZADDs
+        $connection->shouldReceive('exec')->once()->andReturn([true, true, 2, 2]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['people', 'author'])->put([
@@ -313,9 +289,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame(['users'], $events[2]->tags);
     }
 
-    /**
-     * @test
-     */
     public function testFlush(): void
     {
         $connection = $this->mockConnection();
@@ -347,9 +320,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testClearFlushesTaggedItems(): void
     {
         $connection = $this->mockConnection();
@@ -377,9 +347,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutNullTtlCallsForever(): void
     {
         $connection = $this->mockConnection();
@@ -388,10 +355,10 @@ class AllTaggedCacheTest extends RedisCacheTestCase
 
         $key = hash('xxh128', '_all:tag:users:entries') . ':name';
 
-        // Null TTL should call forever (ZADD with -1 + SET)
+        // Null TTL should call forever (SET + ZADD with -1)
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('set')->once()->with("prefix:{$key}", serialize('John'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['users'])->put('name', 'John', null);
@@ -399,9 +366,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutZeroTtlDeletesKey(): void
     {
         $connection = $this->mockConnection();
@@ -420,9 +384,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyZeroTtlDeletesNamespacedKeys(): void
     {
         $connection = $this->mockConnection();
@@ -447,9 +408,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTouchUpdatesKeyAndTagScores(): void
     {
         $connection = $this->mockConnection();
@@ -477,9 +435,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTouchUpdatesCachedNullKeyAndTagScores(): void
     {
         $connection = $this->mockConnection();
@@ -507,9 +462,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTouchWithNullTtlStoresItemForeverWithTags(): void
     {
         $connection = $this->mockConnection();
@@ -523,7 +475,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('set')->once()->with("prefix:{$key}", serialize('John'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['users'])->touch('name', null);
@@ -531,9 +483,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTouchWithNullTtlPreservesCachedNullSentinel(): void
     {
         $connection = $this->mockConnection();
@@ -553,7 +502,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
                 m::on(fn (string $serialized): bool => unserialize($serialized) === NullSentinel::VALUE)
             )
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['users'])->touch('name', null);
@@ -561,9 +510,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testTouchReturnsFalseForMissingKey(): void
     {
         $connection = $this->mockConnection();
@@ -583,9 +529,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testIncrementWithCustomValue(): void
     {
         $connection = $this->mockConnection();
@@ -596,7 +539,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
 
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:counters:entries', ['NX'], -1, $key)->andReturn($connection);
         $connection->shouldReceive('incrby')->once()->with("prefix:{$key}", 5)->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 15]);
+        $connection->shouldReceive('exec')->once()->andReturn([15, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['counters'])->increment('hits', 5);
@@ -604,9 +547,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame(15, $result);
     }
 
-    /**
-     * @test
-     */
     public function testDecrementWithCustomValue(): void
     {
         $connection = $this->mockConnection();
@@ -617,7 +557,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
 
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:counters:entries', ['NX'], -1, $key)->andReturn($connection);
         $connection->shouldReceive('decrby')->once()->with("prefix:{$key}", 3)->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([0, 7]);
+        $connection->shouldReceive('exec')->once()->andReturn([7, 0]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['counters'])->decrement('stock', 3);
@@ -625,9 +565,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame(7, $result);
     }
 
-    /**
-     * @test
-     */
     public function testRememberReturnsExistingValueOnCacheHit(): void
     {
         $connection = $this->mockConnection();
@@ -645,9 +582,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame('cached_value', $result);
     }
 
-    /**
-     * @test
-     */
     public function testRememberCallsCallbackAndStoresValueOnMiss(): void
     {
         $connection = $this->mockConnection();
@@ -661,11 +595,11 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->with("prefix:{$key}")
             ->andReturnNull();
 
-        // Pipeline for ZADD + SETEX on miss
+        // Pipeline for SETEX + ZADD on miss
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$key}", 60, serialize('computed_value'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $callCount = 0;
         $store = $this->createStore($connection);
@@ -690,7 +624,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$key}", 60, serialize('computed_value'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $captured = [];
         $events = m::mock(Dispatcher::class);
@@ -716,9 +650,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame('0', $keyWritten->key);
     }
 
-    /**
-     * @test
-     */
     public function testRememberDoesNotCallCallbackOnCacheHit(): void
     {
         $connection = $this->mockConnection();
@@ -752,7 +683,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$key}", 60, serialize('computed'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['users'])->rememberNullable('profile', 60, fn () => 'computed');
@@ -777,7 +708,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
                 m::on(fn (string $serialized): bool => unserialize($serialized) === NullSentinel::VALUE)
             )
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['users'])->rememberNullable('profile', 60, fn () => null);
@@ -846,7 +777,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $captured = [];
         $events = m::mock(Dispatcher::class);
@@ -893,9 +824,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertFalse($invoked);
     }
 
-    /**
-     * @test
-     */
     public function testRememberForeverReturnsExistingValueOnCacheHit(): void
     {
         $connection = $this->mockConnection();
@@ -945,9 +873,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertSame('1', $cacheHit->key);
     }
 
-    /**
-     * @test
-     */
     public function testRememberForeverCallsCallbackAndStoresValueOnMiss(): void
     {
         $connection = $this->mockConnection();
@@ -960,11 +885,11 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->with("prefix:{$key}")
             ->andReturnNull();
 
-        // Pipeline for ZADD (score -1) + SET on miss
+        // Pipeline for SET + ZADD (score -1) on miss
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:config:entries', -1, $key)->andReturn($connection);
         $connection->shouldReceive('set')->once()->with("prefix:{$key}", serialize('computed_settings'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['config'])->rememberForever('settings', fn () => 'computed_settings');
@@ -987,7 +912,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
                 m::on(fn (string $serialized): bool => unserialize($serialized) === NullSentinel::VALUE)
             )
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['config'])->rememberForeverNullable('settings', fn () => null);
@@ -1010,7 +935,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
                 m::on(fn (string $serialized): bool => unserialize($serialized) === NullSentinel::VALUE)
             )
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['config'])->searNullable('settings', fn () => null);
@@ -1042,9 +967,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         $this->assertFalse($invoked);
     }
 
-    /**
-     * @test
-     */
     public function testRememberPropagatesExceptionFromCallback(): void
     {
         $connection = $this->mockConnection();
@@ -1065,9 +987,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         });
     }
 
-    /**
-     * @test
-     */
     public function testRememberForeverPropagatesExceptionFromCallback(): void
     {
         $connection = $this->mockConnection();
@@ -1088,9 +1007,6 @@ class AllTaggedCacheTest extends RedisCacheTestCase
         });
     }
 
-    /**
-     * @test
-     */
     public function testRememberWithMultipleTags(): void
     {
         $connection = $this->mockConnection();
@@ -1104,12 +1020,12 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->with("prefix:{$key}")
             ->andReturnNull();
 
-        // Pipeline for ZADDs + SETEX on miss
+        // Pipeline for SETEX + ZADDs on miss
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:users:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('zadd')->once()->with('prefix:_all:tag:posts:entries', $expectedScore, $key)->andReturn($connection);
         $connection->shouldReceive('setex')->once()->with("prefix:{$key}", 120, serialize('activity_data'))->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->tags(['users', 'posts'])->remember('activity', 120, fn () => 'activity_data');
@@ -1157,7 +1073,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->once()
             ->with("prefix:{$key}", 60, serialize('John'))
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $captured = [];
         $tagged = (new Repository($this->createStore($connection), ['store' => 'redis']))->tags(['users']);
@@ -1190,7 +1106,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->once()
             ->with("prefix:{$key}", serialize('John'))
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $captured = [];
         $tagged = (new Repository($this->createStore($connection), ['store' => 'redis']))->tags(['users']);
@@ -1224,7 +1140,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->once()
             ->with("prefix:{$key}", 60, serialize('John'))
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, false]);
+        $connection->shouldReceive('exec')->once()->andReturn([false, 1]);
 
         $captured = [];
         $tagged = (new Repository($this->createStore($connection), ['store' => 'redis']))->tags(['users']);
@@ -1409,7 +1325,7 @@ class AllTaggedCacheTest extends RedisCacheTestCase
             ->once()
             ->with("prefix:{$namespace}age", 60, 30)
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([2, true, true]);
+        $connection->shouldReceive('exec')->once()->andReturn([true, true, 2]);
 
         $captured = [];
         $tagged = (new Repository($this->createStore($connection), ['store' => 'redis']))->tags(['users']);

--- a/tests/Cache/Redis/Console/BenchmarkCommandTest.php
+++ b/tests/Cache/Redis/Console/BenchmarkCommandTest.php
@@ -99,7 +99,44 @@ class BenchmarkCommandTest extends TestCase
         $command->setOutput(new OutputStyle(new ArrayInput([]), $output));
         $command->exposedDisplayMemoryError(new BenchmarkMemoryException(1, 2, 50), 'redis');
 
-        $this->assertStringContainsString('redis-cli KEYS "shared:', $output->fetch());
+        $outputText = $output->fetch();
+
+        $this->assertStringContainsString("redis-cli --scan --pattern 'shared:", $outputText);
+        $this->assertStringContainsString('| xargs -r -n 1000 redis-cli UNLINK', $outputText);
+        $this->assertStringNotContainsString('redis-cli KEYS', $outputText);
+    }
+
+    public function testInvalidTagModeFailsBeforeBenchmarkSetup(): void
+    {
+        $command = new BenchmarkCommand;
+        $command->setHypervel($this->app);
+        $output = new BufferedOutput;
+
+        $this->assertSame(Command::FAILURE, $command->run(
+            new ArrayInput(['--tag-mode' => 'invalid']),
+            $output,
+        ));
+        $this->assertStringContainsString(
+            'Invalid tag mode: invalid. Available: any, all',
+            $output->fetch(),
+        );
+    }
+
+    public function testValidTagModeIsPassedThroughAsAnEnum(): void
+    {
+        $this->mockFullCacheStore('redis');
+        $context = $this->mockBenchmarkContext();
+        $context->expects('getStoreInstance')->andReturn(m::mock(RedisStore::class));
+        $command = $this->createFullCommand($context);
+
+        $this->assertSame(Command::SUCCESS, $command->run(new ArrayInput([
+            '--scale' => 'small',
+            '--runs' => '1',
+            '--tag-mode' => 'any',
+            '--force' => true,
+            '--store' => 'redis',
+        ]), new NullOutput));
+        $this->assertSame(TagMode::Any, $command->tagMode);
     }
 
     public function testSuccessfulBenchmarkCleansUpOnce(): void
@@ -336,6 +373,8 @@ class FullBenchmarkCommand extends BenchmarkCommand
 {
     public bool $comparisonRan = false;
 
+    public ?TagMode $tagMode = null;
+
     /**
      * Create a benchmark command with controlled execution behavior.
      */
@@ -364,5 +403,15 @@ class FullBenchmarkCommand extends BenchmarkCommand
         if ($this->comparisonException !== null) {
             throw $this->comparisonException;
         }
+    }
+
+    /**
+     * Capture the parsed tag mode without running benchmark scenarios.
+     */
+    protected function runSuiteWithRuns(TagMode $tagMode, BenchmarkContext $context, int $runs, bool $returnResults = false): array
+    {
+        $this->tagMode = $tagMode;
+
+        return [];
     }
 }

--- a/tests/Cache/Redis/Console/BenchmarkCommandTest.php
+++ b/tests/Cache/Redis/Console/BenchmarkCommandTest.php
@@ -90,20 +90,62 @@ class BenchmarkCommandTest extends TestCase
         );
     }
 
-    public function testMemoryRecoveryGuidanceInheritsTheSharedPrefixWhenStorePrefixIsOmitted(): void
+    public function testMemoryRecoveryGuidanceIncludesEveryCleanupPattern(): void
     {
-        config()->set('cache.prefix', 'shared:');
+        $patterns = [
+            'value-pattern:*',
+            'namespaced-value-pattern:*',
+            'any-tag-pattern:*',
+            'all-tag-pattern:*',
+        ];
+
+        $context = m::mock(BenchmarkContext::class);
+        $context->expects('getCleanupPatterns')->once()->andReturn($patterns);
 
         $command = $this->createCommand();
         $output = new BufferedOutput;
         $command->setOutput(new OutputStyle(new ArrayInput([]), $output));
-        $command->exposedDisplayMemoryError(new BenchmarkMemoryException(1, 2, 50), 'redis');
+        $command->exposedDisplayMemoryError(new BenchmarkMemoryException(1, 2, 50), 'redis', $context);
 
         $outputText = $output->fetch();
 
-        $this->assertStringContainsString("redis-cli --scan --pattern 'shared:", $outputText);
-        $this->assertStringContainsString('| xargs -r -n 1000 redis-cli UNLINK', $outputText);
+        foreach ($patterns as $pattern) {
+            $this->assertSame(
+                1,
+                substr_count($outputText, escapeshellarg($pattern)),
+                "Recovery guidance should contain pattern [{$pattern}] exactly once.",
+            );
+        }
+
+        $this->assertStringContainsString(
+            'Flush the entire Redis database for this connection (removes all keys, not only cache)',
+            $outputText,
+        );
+        $this->assertSame(4, substr_count($outputText, 'redis-cli --scan --pattern'));
+        $this->assertSame(4, substr_count($outputText, '| xargs -r -n 1000 redis-cli UNLINK'));
         $this->assertStringNotContainsString('redis-cli KEYS', $outputText);
+        $this->assertStringNotContainsString('redis-cli DEL', $outputText);
+    }
+
+    public function testCleanupPatternsInheritTheSharedPrefixWhenStorePrefixIsOmitted(): void
+    {
+        config()->set('cache.prefix', 'shared:');
+
+        $context = new BenchmarkContext(
+            storeName: 'redis',
+            items: 1,
+            tagsPerItem: 1,
+            heavyTags: 1,
+            command: $this->createCommand(),
+            cacheManager: $this->app->make(CacheContract::class),
+        );
+
+        $this->assertSame([
+            'shared:_bench:*',
+            'shared:*:_bench:*',
+            'shared:_any:tag:_bench:*',
+            'shared:_all:tag:_bench:*',
+        ], $context->getCleanupPatterns());
     }
 
     public function testInvalidTagModeFailsBeforeBenchmarkSetup(): void
@@ -304,6 +346,7 @@ class BenchmarkCommandTest extends TestCase
     private function mockBenchmarkContext(?Throwable $cleanupException = null): BenchmarkContext
     {
         $context = m::mock(BenchmarkContext::class);
+        $context->allows('getCleanupPatterns')->andReturn(['cache:_bench:*']);
         $cleanup = $context->shouldReceive('cleanup')->once();
 
         if ($cleanupException === null) {
@@ -361,11 +404,14 @@ class TestableBenchmarkCommand extends BenchmarkCommand
         return $this->storeName;
     }
 
-    public function exposedDisplayMemoryError(BenchmarkMemoryException $exception, string $storeName): void
-    {
+    public function exposedDisplayMemoryError(
+        BenchmarkMemoryException $exception,
+        string $storeName,
+        BenchmarkContext $context,
+    ): void {
         $this->storeName = $storeName;
 
-        parent::displayMemoryError($exception);
+        parent::displayMemoryError($exception, $context);
     }
 }
 

--- a/tests/Cache/Redis/Operations/AllTag/AddTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/AddTest.php
@@ -15,32 +15,28 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class AddTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testAddWithTagsReturnsTrueWhenKeyAdded(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
 
         $connection = $this->mockConnection();
 
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-
-        // ZADD for tag with TTL score
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn($connection);
-
-        $connection->shouldReceive('exec')
-            ->once()
-            ->andReturn([1]);
-
-        // SET NX EX for atomic add
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'), ['EX' => 60, 'NX'])
-            ->andReturn(true);
+            ->andReturn(true)
+            ->ordered();
+
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection)->ordered();
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
+            ->andReturn($connection)
+            ->ordered();
+        $connection->shouldReceive('exec')
+            ->once()
+            ->andReturn([1])
+            ->ordered();
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->add()->execute(
@@ -53,9 +49,6 @@ class AddTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddWithTagsReturnsFalseWhenKeyExists(): void
     {
         $connection = $this->mockConnection();
@@ -82,9 +75,6 @@ class AddTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddWithMultipleTags(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -126,9 +116,6 @@ class AddTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddWithEmptyTagsSkipsPipeline(): void
     {
         $connection = $this->mockConnection();
@@ -153,9 +140,6 @@ class AddTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddInClusterModeUsesSequentialCommands(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -165,17 +149,17 @@ class AddTest extends RedisCacheTestCase
         // Should NOT use pipeline in cluster mode
         $connection->shouldNotReceive('pipeline');
 
-        // Sequential ZADD
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn(1);
-
-        // SET NX EX for atomic add
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'), ['EX' => 60, 'NX'])
-            ->andReturn(true);
+            ->andReturn(true)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
+            ->andReturn(1)
+            ->ordered();
 
         $result = $store->allTagOps()->add()->execute(
             'mykey',
@@ -187,26 +171,23 @@ class AddTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddInClusterModeReturnsFalseWhenKeyExists(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
 
         [$store, , $connection] = $this->createClusterStore();
 
-        // Sequential ZADD (still happens even if key exists)
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn(1);
-
-        // SET NX returns false when key exists (RedisCluster return type is string|bool)
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'), ['EX' => 60, 'NX'])
-            ->andReturn(false);
+            ->andReturn(false)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
+            ->andReturn(1)
+            ->ordered();
 
         $result = $store->allTagOps()->add()->execute(
             'mykey',
@@ -218,9 +199,6 @@ class AddTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddEnforcesMinimumTtlOfOne(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -250,9 +228,6 @@ class AddTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testAddWithNumericValue(): void
     {
         $connection = $this->mockConnection();

--- a/tests/Cache/Redis/Operations/AllTag/AddTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/AddTest.php
@@ -21,13 +21,12 @@ class AddTest extends RedisCacheTestCase
 
         $connection = $this->mockConnection();
 
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection)->ordered();
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'), ['EX' => 60, 'NX'])
-            ->andReturn(true)
+            ->andReturn($connection)
             ->ordered();
-
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection)->ordered();
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
@@ -35,7 +34,7 @@ class AddTest extends RedisCacheTestCase
             ->ordered();
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1])
+            ->andReturn([true, 1])
             ->ordered();
 
         $store = $this->createStore($connection);
@@ -53,16 +52,14 @@ class AddTest extends RedisCacheTestCase
     {
         $connection = $this->mockConnection();
 
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-
-        $connection->shouldReceive('zadd')->andReturn($connection);
-        $connection->shouldReceive('exec')->andReturn([1]);
-
-        // SET NX returns null/false when key already exists
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection)->ordered();
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'), ['EX' => 60, 'NX'])
-            ->andReturn(null);
+            ->andReturn($connection)
+            ->ordered();
+        $connection->shouldReceive('zadd')->andReturn($connection)->ordered();
+        $connection->shouldReceive('exec')->andReturn([false, 1])->ordered();
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->add()->execute(
@@ -85,25 +82,28 @@ class AddTest extends RedisCacheTestCase
 
         $expectedScore = 1121;
 
+        $connection->shouldReceive('set')
+            ->once()
+            ->with('prefix:mykey', serialize('myvalue'), ['EX' => 120, 'NX'])
+            ->andReturn($connection)
+            ->ordered();
+
         // ZADD for each tag
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', $expectedScore, 'mykey')
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:posts:entries', $expectedScore, 'mykey')
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 1]);
-
-        // SET NX EX for atomic add
-        $connection->shouldReceive('set')
-            ->once()
-            ->with('prefix:mykey', serialize('myvalue'), ['EX' => 120, 'NX'])
-            ->andReturn(true);
+            ->andReturn([true, 1, 1])
+            ->ordered();
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->add()->execute(
@@ -158,7 +158,7 @@ class AddTest extends RedisCacheTestCase
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn(1)
+            ->andReturn(0)
             ->ordered();
 
         $result = $store->allTagOps()->add()->execute(
@@ -199,23 +199,89 @@ class AddTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
+    public function testAddReturnsFalseWhenPipelineMembershipWriteFails(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('set')->once()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn([true, false]);
+
+        $store = $this->createStore($connection);
+
+        $this->assertFalse($store->allTagOps()->add()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
+    public function testAddReturnsFalseWhenPipelineExecutionFails(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('set')->once()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn(false);
+
+        $store = $this->createStore($connection);
+
+        $this->assertFalse($store->allTagOps()->add()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
+    public function testAddTreatsZeroPipelineMembershipResultAsSuccess(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('set')->once()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 0]);
+
+        $store = $this->createStore($connection);
+
+        $this->assertTrue($store->allTagOps()->add()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
+    public function testAddReturnsFalseWhenClusterMembershipWriteFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('set')->once()->andReturn(true);
+        $connection->shouldReceive('zadd')->once()->andReturn(false);
+
+        $this->assertFalse($store->allTagOps()->add()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
     public function testAddEnforcesMinimumTtlOfOne(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
         $connection = $this->mockConnection();
 
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('set')
+            ->once()
+            ->with('prefix:mykey', serialize('myvalue'), ['EX' => 1, 'NX'])
+            ->andReturn($connection);
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', 1002, 'mykey')
             ->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1]);
-
-        // TTL should be at least 1
-        $connection->shouldReceive('set')
-            ->once()
-            ->with('prefix:mykey', serialize('myvalue'), ['EX' => 1, 'NX'])
-            ->andReturn(true);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->add()->execute(
@@ -234,14 +300,14 @@ class AddTest extends RedisCacheTestCase
 
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
 
-        $connection->shouldReceive('zadd')->andReturn($connection);
-        $connection->shouldReceive('exec')->andReturn([1]);
-
         // Numeric values are NOT serialized (optimization)
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', 42, ['EX' => 60, 'NX'])
-            ->andReturn(true);
+            ->andReturn($connection);
+
+        $connection->shouldReceive('zadd')->andReturn($connection);
+        $connection->shouldReceive('exec')->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->add()->execute(

--- a/tests/Cache/Redis/Operations/AllTag/DecrementTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/DecrementTest.php
@@ -11,9 +11,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class DecrementTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testDecrementWithTagsInPipelineMode(): void
     {
         $connection = $this->mockConnection();
@@ -46,9 +43,6 @@ class DecrementTest extends RedisCacheTestCase
         $this->assertSame(5, $result);
     }
 
-    /**
-     * @test
-     */
     public function testDecrementWithCustomValue(): void
     {
         $connection = $this->mockConnection();
@@ -79,9 +73,6 @@ class DecrementTest extends RedisCacheTestCase
         $this->assertSame(-5, $result);
     }
 
-    /**
-     * @test
-     */
     public function testDecrementWithMultipleTags(): void
     {
         $connection = $this->mockConnection();
@@ -117,9 +108,6 @@ class DecrementTest extends RedisCacheTestCase
         $this->assertSame(9, $result);
     }
 
-    /**
-     * @test
-     */
     public function testDecrementWithEmptyTags(): void
     {
         $connection = $this->mockConnection();
@@ -146,27 +134,21 @@ class DecrementTest extends RedisCacheTestCase
         $this->assertSame(-1, $result);
     }
 
-    /**
-     * @test
-     */
     public function testDecrementInClusterModeUsesSequentialCommands(): void
     {
         [$store, , $connection] = $this->createClusterStore();
 
-        // Should NOT use pipeline in cluster mode
         $connection->shouldNotReceive('pipeline');
 
-        // Sequential ZADD NX
-        $connection->shouldReceive('zadd')
+        $connection->expects('decrby')
+            ->with('prefix:counter', 1)
+            ->andReturn(0)
+            ->ordered();
+        $connection->expects('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'counter')
-            ->andReturn(1);
-
-        // Sequential DECRBY
-        $connection->shouldReceive('decrby')
-            ->once()
-            ->with('prefix:counter', 1)
-            ->andReturn(0);
+            ->andReturn(1)
+            ->ordered();
 
         $result = $store->allTagOps()->decrement()->execute(
             'counter',
@@ -177,9 +159,20 @@ class DecrementTest extends RedisCacheTestCase
         $this->assertSame(0, $result);
     }
 
-    /**
-     * @test
-     */
+    public function testDecrementInClusterModeDoesNotPublishTagsWhenTheCounterFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+
+        $connection->expects('decrby')->with('prefix:counter', 1)->andReturnFalse();
+        $connection->shouldNotReceive('zadd');
+
+        $this->assertFalse($store->allTagOps()->decrement()->execute(
+            'counter',
+            1,
+            ['_all:tag:users:entries']
+        ));
+    }
+
     public function testDecrementReturnsFalseOnPipelineFailure(): void
     {
         $connection = $this->mockConnection();

--- a/tests/Cache/Redis/Operations/AllTag/DecrementTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/DecrementTest.php
@@ -17,21 +17,21 @@ class DecrementTest extends RedisCacheTestCase
 
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
 
-        // ZADD NX for tag with score -1 (only add if not exists)
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'counter')
-            ->andReturn($connection);
-
-        // DECRBY
         $connection->shouldReceive('decrby')
             ->once()
             ->with('prefix:counter', 1)
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'counter')
+            ->andReturn($connection)
+            ->ordered();
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 5]);
+            ->andReturn([5, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->decrement()->execute(
@@ -61,7 +61,7 @@ class DecrementTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([0, -5]);  // 0 means key already existed (NX condition)
+            ->andReturn([-5, 0]); // 0 means tag membership already existed
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->decrement()->execute(
@@ -96,7 +96,7 @@ class DecrementTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 1, 9]);
+            ->andReturn([9, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->decrement()->execute(

--- a/tests/Cache/Redis/Operations/AllTag/ForeverTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/ForeverTest.php
@@ -11,30 +11,27 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class ForeverTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testForeverStoresValueWithTagsInPipelineMode(): void
     {
         $connection = $this->mockConnection();
 
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
 
-        // ZADD for tag with score -1 (forever)
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', -1, 'mykey')
-            ->andReturn($connection);
-
-        // SET for cache value (no expiration)
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'))
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', -1, 'mykey')
+            ->andReturn($connection)
+            ->ordered();
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->forever()->execute(
@@ -46,9 +43,6 @@ class ForeverTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testForeverWithMultipleTags(): void
     {
         $connection = $this->mockConnection();
@@ -73,7 +67,7 @@ class ForeverTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 1, true]);
+            ->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->forever()->execute(
@@ -85,9 +79,6 @@ class ForeverTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testForeverWithEmptyTags(): void
     {
         $connection = $this->mockConnection();
@@ -114,9 +105,6 @@ class ForeverTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testForeverInClusterModeUsesSequentialCommands(): void
     {
         [$store, , $connection] = $this->createClusterStore();
@@ -124,17 +112,17 @@ class ForeverTest extends RedisCacheTestCase
         // Should NOT use pipeline in cluster mode
         $connection->shouldNotReceive('pipeline');
 
-        // Sequential ZADD with score -1
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', -1, 'mykey')
-            ->andReturn(1);
-
-        // Sequential SET
         $connection->shouldReceive('set')
             ->once()
             ->with('prefix:mykey', serialize('myvalue'))
-            ->andReturn(true);
+            ->andReturn(true)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', -1, 'mykey')
+            ->andReturn(1)
+            ->ordered();
 
         $result = $store->allTagOps()->forever()->execute(
             'mykey',
@@ -145,9 +133,6 @@ class ForeverTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testForeverReturnsFalseOnFailure(): void
     {
         $connection = $this->mockConnection();
@@ -160,7 +145,7 @@ class ForeverTest extends RedisCacheTestCase
         // SET returns false (failure)
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, false]);
+            ->andReturn([false, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->forever()->execute(
@@ -172,9 +157,6 @@ class ForeverTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testForeverUsesCorrectPrefix(): void
     {
         $connection = $this->mockConnection();
@@ -193,7 +175,7 @@ class ForeverTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection, 'custom:');
         $result = $store->allTagOps()->forever()->execute(
@@ -205,9 +187,6 @@ class ForeverTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testForeverWithNumericValue(): void
     {
         $connection = $this->mockConnection();
@@ -224,7 +203,7 @@ class ForeverTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->forever()->execute(

--- a/tests/Cache/Redis/Operations/AllTag/ForeverTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/ForeverTest.php
@@ -31,7 +31,7 @@ class ForeverTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([true, 1]);
+            ->andReturn([true, 0]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->forever()->execute(
@@ -121,7 +121,7 @@ class ForeverTest extends RedisCacheTestCase
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', -1, 'mykey')
-            ->andReturn(1)
+            ->andReturn(0)
             ->ordered();
 
         $result = $store->allTagOps()->forever()->execute(
@@ -155,6 +155,36 @@ class ForeverTest extends RedisCacheTestCase
         );
 
         $this->assertFalse($result);
+    }
+
+    public function testForeverReturnsFalseWhenPipelineMembershipWriteFails(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('set')->once()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn([true, false]);
+
+        $store = $this->createStore($connection);
+
+        $this->assertFalse($store->allTagOps()->forever()->execute(
+            'mykey',
+            'myvalue',
+            ['_all:tag:users:entries']
+        ));
+    }
+
+    public function testForeverReturnsFalseWhenClusterMembershipWriteFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('set')->once()->andReturn(true);
+        $connection->shouldReceive('zadd')->once()->andReturn(false);
+
+        $this->assertFalse($store->allTagOps()->forever()->execute(
+            'mykey',
+            'myvalue',
+            ['_all:tag:users:entries']
+        ));
     }
 
     public function testForeverUsesCorrectPrefix(): void

--- a/tests/Cache/Redis/Operations/AllTag/IncrementTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/IncrementTest.php
@@ -17,21 +17,21 @@ class IncrementTest extends RedisCacheTestCase
 
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
 
-        // ZADD NX for tag with score -1 (only add if not exists)
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'counter')
-            ->andReturn($connection);
-
-        // INCRBY
         $connection->shouldReceive('incrby')
             ->once()
             ->with('prefix:counter', 1)
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'counter')
+            ->andReturn($connection)
+            ->ordered();
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 5]);
+            ->andReturn([5, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->increment()->execute(
@@ -61,7 +61,7 @@ class IncrementTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([0, 15]);  // 0 means key already existed (NX condition)
+            ->andReturn([15, 0]); // 0 means tag membership already existed
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->increment()->execute(

--- a/tests/Cache/Redis/Operations/AllTag/IncrementTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/IncrementTest.php
@@ -11,9 +11,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class IncrementTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testIncrementWithTagsInPipelineMode(): void
     {
         $connection = $this->mockConnection();
@@ -46,9 +43,6 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertSame(5, $result);
     }
 
-    /**
-     * @test
-     */
     public function testIncrementWithCustomValue(): void
     {
         $connection = $this->mockConnection();
@@ -79,9 +73,6 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertSame(15, $result);
     }
 
-    /**
-     * @test
-     */
     public function testIncrementWithMultipleTags(): void
     {
         $connection = $this->mockConnection();
@@ -117,9 +108,6 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertSame(1, $result);
     }
 
-    /**
-     * @test
-     */
     public function testIncrementWithEmptyTags(): void
     {
         $connection = $this->mockConnection();
@@ -146,27 +134,21 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertSame(1, $result);
     }
 
-    /**
-     * @test
-     */
     public function testIncrementInClusterModeUsesSequentialCommands(): void
     {
         [$store, , $connection] = $this->createClusterStore();
 
-        // Should NOT use pipeline in cluster mode
         $connection->shouldNotReceive('pipeline');
 
-        // Sequential ZADD NX
-        $connection->shouldReceive('zadd')
+        $connection->expects('incrby')
+            ->with('prefix:counter', 1)
+            ->andReturn(10)
+            ->ordered();
+        $connection->expects('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'counter')
-            ->andReturn(1);
-
-        // Sequential INCRBY
-        $connection->shouldReceive('incrby')
-            ->once()
-            ->with('prefix:counter', 1)
-            ->andReturn(10);
+            ->andReturn(1)
+            ->ordered();
 
         $result = $store->allTagOps()->increment()->execute(
             'counter',
@@ -177,9 +159,20 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertSame(10, $result);
     }
 
-    /**
-     * @test
-     */
+    public function testIncrementInClusterModeDoesNotPublishTagsWhenTheCounterFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+
+        $connection->expects('incrby')->with('prefix:counter', 1)->andReturnFalse();
+        $connection->shouldNotReceive('zadd');
+
+        $this->assertFalse($store->allTagOps()->increment()->execute(
+            'counter',
+            1,
+            ['_all:tag:users:entries']
+        ));
+    }
+
     public function testIncrementReturnsFalseOnPipelineFailure(): void
     {
         $connection = $this->mockConnection();

--- a/tests/Cache/Redis/Operations/AllTag/PruneTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/PruneTest.php
@@ -8,14 +8,8 @@ use Hypervel\Cache\Redis\Operations\AllTag\Prune;
 use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
 use Hypervel\Tests\Redis\Fixtures\FakeRedisClient;
 
-/**
- * Tests for the AllTag/Prune operation.
- */
 class PruneTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testPruneReturnsEmptyStatsWhenNoTagsFound(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -36,9 +30,6 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(0, $result['empty_sets_deleted']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneRemovesStaleEntriesFromSingleTag(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -68,9 +59,6 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(0, $result['empty_sets_deleted']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneDeletesEmptySortedSets(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -100,9 +88,6 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(1, $result['empty_sets_deleted']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneHandlesMultipleTags(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -136,17 +121,11 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(1, $result['empty_sets_deleted']); // Only posts was empty
     }
 
-    /**
-     * @test
-     */
-    public function testPruneDeduplicatesScanResults(): void
+    public function testPruneProcessesDuplicateScanResults(): void
     {
-        // SafeScan iterates multiple times, returning duplicates
         $fakeClient = new FakeRedisClient(
             scanResults: [
-                // First scan: returns 2 keys, iterator = 100 (continue)
                 ['keys' => ['_all:tag:users:entries', '_all:tag:posts:entries'], 'iterator' => 100],
-                // Second scan: returns 1 duplicate + 1 new, iterator = 0 (done)
                 ['keys' => ['_all:tag:users:entries', '_all:tag:comments:entries'], 'iterator' => 0],
             ],
             zRemRangeByScoreResults: [
@@ -171,19 +150,10 @@ class PruneTest extends RedisCacheTestCase
 
         $result = $operation->execute();
 
-        // Verify scan was called twice (multi-iteration)
         $this->assertSame(2, $fakeClient->getScanCallCount());
-
-        // SafeScan yields each key as encountered (no deduplication in SafeScan itself),
-        // but Prune processes each unique tag once via the generator
-        // Actually, SafeScan is a generator - it yields duplicates if SCAN returns them
-        // The 4 keys scanned means duplicate 'users' was yielded twice
         $this->assertSame(4, $result['tags_scanned']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneUsesCorrectScanPattern(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -202,41 +172,36 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame('custom_prefix:_all:tag:*:entries', $fakeClient->getScanCalls()[0]['pattern']);
     }
 
-    /**
-     * @test
-     */
     public function testPrunePreservesForeverItems(): void
     {
-        // Forever items have score -1, ZREMRANGEBYSCORE uses '0' as lower bound
-        // This test verifies the behavior documentation
         $fakeClient = new FakeRedisClient(
             scanResults: [
                 ['keys' => ['_all:tag:users:entries'], 'iterator' => 0],
             ],
             zRemRangeByScoreResults: [
-                // 0 entries removed because all are forever items (score -1)
                 '_all:tag:users:entries' => 0,
             ],
             zScanResults: [
                 '_all:tag:users:entries' => [['members' => [], 'iterator' => 0]],
             ],
             zCardResults: [
-                '_all:tag:users:entries' => 5, // 5 forever items remain
+                '_all:tag:users:entries' => 5,
             ],
         );
 
         $store = $this->createStoreWithFakeClient($fakeClient);
-        $operation = new Prune($store->getContext());
+        $beforePrune = time();
+        $result = (new Prune($store->getContext()))->execute();
 
-        $result = $operation->execute();
-
+        $expiryRemoval = $fakeClient->getZRemRangeByScoreCalls()[0];
+        $this->assertSame('_all:tag:users:entries', $expiryRemoval['key']);
+        $this->assertSame('0', $expiryRemoval['min']);
+        $this->assertGreaterThanOrEqual($beforePrune, (int) $expiryRemoval['max']);
+        $this->assertLessThanOrEqual(time(), (int) $expiryRemoval['max']);
         $this->assertSame(0, $result['stale_entries_removed']);
         $this->assertSame(0, $result['empty_sets_deleted']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneUsesCustomScanCount(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -254,9 +219,6 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(500, $fakeClient->getScanCalls()[0]['count']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneViaStoreOperationsContainer(): void
     {
         $fakeClient = new FakeRedisClient(
@@ -273,9 +235,6 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(0, $result['tags_scanned']);
     }
 
-    /**
-     * @test
-     */
     public function testPruneRemovesOrphanedEntries(): void
     {
         // Set up: tag has 3 members, but 2 cache keys don't exist (orphans)
@@ -292,13 +251,10 @@ class PruneTest extends RedisCacheTestCase
                     ['members' => ['key1' => 1234567890.0, 'key2' => 1234567891.0, 'key3' => 1234567892.0], 'iterator' => 0],
                 ],
             ],
-            // EXISTS results: key1 exists (1), key2 doesn't (0), key3 exists (1)
-            execResults: [
-                [1, 0, 1], // Pipeline results for EXISTS calls
-            ],
             zCardResults: [
                 '_all:tag:users:entries' => 2, // 2 remaining after orphan removal
             ],
+            evalShaResults: [1],
         );
 
         $store = $this->createStoreWithFakeClient($fakeClient);
@@ -309,11 +265,17 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(3, $result['entries_checked']);
         $this->assertSame(1, $result['orphans_removed']); // key2 was orphaned
 
-        // Verify zRem was called to remove orphan
-        $zRemCalls = $fakeClient->getZRemCalls();
-        $this->assertCount(1, $zRemCalls);
-        $this->assertSame('_all:tag:users:entries', $zRemCalls[0]['key']);
-        $this->assertContains('key2', $zRemCalls[0]['members']);
+        $evalCall = $fakeClient->getEvalShaCalls()[0];
+        $this->assertSame(4, $evalCall['num_keys']);
+        $this->assertSame([
+            '_all:tag:users:entries',
+            'prefix:key1',
+            'prefix:key2',
+            'prefix:key3',
+            'key1',
+            'key2',
+            'key3',
+        ], $evalCall['args']);
     }
 
     public function testPruneContinuesAfterAnEmptyNonterminalMemberPage(): void
@@ -331,12 +293,10 @@ class PruneTest extends RedisCacheTestCase
                     ['members' => ['key1' => 1234567890.0], 'iterator' => 0],
                 ],
             ],
-            execResults: [
-                [1],
-            ],
             zCardResults: [
                 '_all:tag:users:entries' => 1,
             ],
+            evalShaResults: [0],
         );
 
         $store = $this->createStoreWithFakeClient($fakeClient);
@@ -348,9 +308,80 @@ class PruneTest extends RedisCacheTestCase
         $this->assertCount(2, $fakeClient->getZScanCalls());
     }
 
-    /**
-     * @test
-     */
+    public function testClusterPruneBatchesOrphansThatRemainRemoved(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldNotReceive('pipeline');
+        $connection->shouldReceive('isCluster')->once()->andReturn(true);
+        $connection->shouldReceive('getShouldTransform')->once()->andReturn(false);
+        $connection->shouldReceive('masters')->once()->andReturn([['127.0.0.1', 7000]]);
+        $connection->shouldReceive('scan')
+            ->once()
+            ->andReturnUsing(function (&$iterator, $master, $pattern, $count): array {
+                $iterator = 0;
+
+                return ['prefix:_all:tag:users:entries'];
+            });
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zScan')
+            ->once()
+            ->andReturnUsing(function ($tagKey, &$iterator): array {
+                $iterator = 0;
+
+                return ['live' => 1.0, 'orphan1' => 2.0, 'orphan2' => 3.0];
+            });
+        $connection->shouldReceive('exists')->once()->with('prefix:live')->andReturn(1);
+        $connection->shouldReceive('exists')->twice()->with('prefix:orphan1')->andReturn(0);
+        $connection->shouldReceive('exists')->twice()->with('prefix:orphan2')->andReturn(0);
+        $connection->shouldReceive('zrem')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', 'orphan1', 'orphan2')
+            ->andReturn(2);
+        $connection->shouldReceive('zCard')->once()->andReturn(1);
+
+        $result = (new Prune($store->getContext()))->execute();
+
+        $this->assertSame(3, $result['entries_checked']);
+        $this->assertSame(2, $result['orphans_removed']);
+    }
+
+    public function testClusterPruneRepairsMembershipWithoutOverwritingAWriterScore(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('isCluster')->once()->andReturn(true);
+        $connection->shouldReceive('getShouldTransform')->once()->andReturn(false);
+        $connection->shouldReceive('masters')->once()->andReturn([['127.0.0.1', 7000]]);
+        $connection->shouldReceive('scan')
+            ->once()
+            ->andReturnUsing(function (&$iterator, $master, $pattern, $count): array {
+                $iterator = 0;
+
+                return ['prefix:_all:tag:users:entries'];
+            });
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zScan')
+            ->once()
+            ->andReturnUsing(function ($tagKey, &$iterator): array {
+                $iterator = 0;
+
+                return ['raced' => 1.0];
+            });
+        $connection->shouldReceive('exists')
+            ->twice()
+            ->with('prefix:raced')
+            ->andReturn(0, 1);
+        $connection->shouldReceive('zrem')->once()->andReturn(1);
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'raced')
+            ->andReturn(0);
+        $connection->shouldReceive('zCard')->once()->andReturn(1);
+
+        $result = (new Prune($store->getContext()))->execute();
+
+        $this->assertSame(0, $result['orphans_removed']);
+    }
+
     public function testPruneHandlesOptPrefixCorrectly(): void
     {
         // When OPT_PREFIX is set, SCAN pattern needs prefix, but returned keys have it stripped

--- a/tests/Cache/Redis/Operations/AllTag/PruneTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/PruneTest.php
@@ -382,6 +382,43 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(0, $result['orphans_removed']);
     }
 
+    public function testClusterPruneRepairsMembershipAfterConcurrentRemovalReturnsZero(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('isCluster')->once()->andReturn(true);
+        $connection->shouldReceive('getShouldTransform')->once()->andReturn(false);
+        $connection->shouldReceive('masters')->once()->andReturn([['127.0.0.1', 7000]]);
+        $connection->shouldReceive('scan')
+            ->once()
+            ->andReturnUsing(function (&$iterator): array {
+                $iterator = 0;
+
+                return ['prefix:_all:tag:users:entries'];
+            });
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zScan')
+            ->once()
+            ->andReturnUsing(function ($tagKey, &$iterator): array {
+                $iterator = 0;
+
+                return ['raced' => 1.0];
+            });
+        $connection->shouldReceive('exists')
+            ->twice()
+            ->with('prefix:raced')
+            ->andReturn(0, 1);
+        $connection->shouldReceive('zrem')->once()->andReturn(0);
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', ['NX'], -1, 'raced')
+            ->andReturn(0);
+        $connection->shouldReceive('zCard')->once()->andReturn(1);
+
+        $result = (new Prune($store->getContext()))->execute();
+
+        $this->assertSame(0, $result['orphans_removed']);
+    }
+
     public function testPruneHandlesOptPrefixCorrectly(): void
     {
         // When OPT_PREFIX is set, SCAN pattern needs prefix, but returned keys have it stripped

--- a/tests/Cache/Redis/Operations/AllTag/PutManyTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/PutManyTest.php
@@ -19,9 +19,6 @@ class PutManyTest extends RedisCacheTestCase
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
     }
 
-    /**
-     * @test
-     */
     public function testPutManyWithTagsInPipelineMode(): void
     {
         $connection = $this->mockConnection();
@@ -30,28 +27,27 @@ class PutManyTest extends RedisCacheTestCase
 
         $expectedScore = 1061;
 
-        // Variadic ZADD: one command with all members for the tag
-        // Format: key, score1, member1, score2, member2, ...
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo', $expectedScore, 'ns:baz')
-            ->andReturn($connection);
-
-        // SETEX for each key
         $connection->shouldReceive('setex')
             ->once()
             ->with('prefix:ns:foo', 60, serialize('bar'))
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
 
         $connection->shouldReceive('setex')
             ->once()
             ->with('prefix:ns:baz', 60, serialize('qux'))
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
 
-        // Results: 1 ZADD (returns count of new members) + 2 SETEX (return true)
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo', $expectedScore, 'ns:baz')
+            ->andReturn($connection)
+            ->ordered();
+
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([2, true, true]);
+            ->andReturn([true, true, 2]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -64,9 +60,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyWithMultipleTags(): void
     {
         $connection = $this->mockConnection();
@@ -93,7 +86,7 @@ class PutManyTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 1, true]);
+            ->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -106,9 +99,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyWithEmptyTags(): void
     {
         $connection = $this->mockConnection();
@@ -136,9 +126,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyWithEmptyValuesReturnsTrue(): void
     {
         $connection = $this->mockConnection();
@@ -157,9 +144,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyInClusterModeUsesVariadicZadd(): void
     {
         [$store, , $connection] = $this->createClusterStore();
@@ -169,23 +153,23 @@ class PutManyTest extends RedisCacheTestCase
 
         $expectedScore = 1061;
 
-        // Variadic ZADD: one command with all members for the tag
-        // This works in cluster because all members go to ONE sorted set (one slot)
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo', $expectedScore, 'ns:baz')
-            ->andReturn(2);
-
-        // Sequential SETEX for each key
         $connection->shouldReceive('setex')
             ->once()
             ->with('prefix:ns:foo', 60, serialize('bar'))
-            ->andReturn(true);
+            ->andReturn(true)
+            ->ordered();
 
         $connection->shouldReceive('setex')
             ->once()
             ->with('prefix:ns:baz', 60, serialize('qux'))
-            ->andReturn(true);
+            ->andReturn(true)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo', $expectedScore, 'ns:baz')
+            ->andReturn(2)
+            ->ordered();
 
         $result = $store->allTagOps()->putMany()->execute(
             ['foo' => 'bar', 'baz' => 'qux'],
@@ -197,9 +181,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyReturnsFalseOnFailure(): void
     {
         $connection = $this->mockConnection();
@@ -212,7 +193,7 @@ class PutManyTest extends RedisCacheTestCase
         // One SETEX fails
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true, 1, false]);
+            ->andReturn([true, false, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -225,9 +206,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyReturnsFalseOnPipelineFailure(): void
     {
         $connection = $this->mockConnection();
@@ -253,9 +231,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyEnforcesMinimumTtlOfOne(): void
     {
         $connection = $this->mockConnection();
@@ -275,7 +250,7 @@ class PutManyTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -288,9 +263,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyWithNumericValues(): void
     {
         $connection = $this->mockConnection();
@@ -307,7 +279,7 @@ class PutManyTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -320,9 +292,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyUsesCorrectPrefix(): void
     {
         $connection = $this->mockConnection();
@@ -344,7 +313,7 @@ class PutManyTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection, 'custom:');
         $result = $store->allTagOps()->putMany()->execute(
@@ -358,11 +327,9 @@ class PutManyTest extends RedisCacheTestCase
     }
 
     /**
-     * @test
-     *
      * Tests the maximum optimization benefit: multiple keys × multiple tags.
      * Before: O(keys × tags) ZADD commands
-     * After: O(tags) ZADD commands (each with all keys)
+     * After: O(tags) ZADD commands (each with all keys).
      */
     public function testPutManyWithMultipleTagsAndMultipleKeys(): void
     {
@@ -400,10 +367,9 @@ class PutManyTest extends RedisCacheTestCase
             ->with('prefix:ns:c', 60, serialize('val-c'))
             ->andReturn($connection);
 
-        // Results: 2 ZADDs + 3 SETEXs
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([3, 3, true, true, true]);
+            ->andReturn([true, true, true, 3, 3]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -416,9 +382,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyInClusterModeWithMultipleTags(): void
     {
         [$store, , $connection] = $this->createClusterStore();
@@ -457,9 +420,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyInClusterModeWithEmptyTags(): void
     {
         [$store, , $connection] = $this->createClusterStore();
@@ -483,9 +443,6 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutManyInClusterModeReturnsFalseOnSetexFailure(): void
     {
         [$store, , $connection] = $this->createClusterStore();
@@ -494,8 +451,8 @@ class PutManyTest extends RedisCacheTestCase
 
         $connection->shouldReceive('zadd')
             ->once()
-            ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo', $expectedScore, 'ns:bar')
-            ->andReturn(2);
+            ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo')
+            ->andReturn(1);
 
         // First SETEX succeeds, second fails
         $connection->shouldReceive('setex')
@@ -518,9 +475,32 @@ class PutManyTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    public function testPutManyInClusterModeSkipsMembershipsWhenAllWritesFail(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+
+        $connection->shouldReceive('setex')
+            ->once()
+            ->with('prefix:ns:foo', 60, serialize('value1'))
+            ->andReturn(false);
+
+        $connection->shouldReceive('setex')
+            ->once()
+            ->with('prefix:ns:bar', 60, serialize('value2'))
+            ->andReturn(false);
+
+        $connection->shouldNotReceive('zadd');
+
+        $result = $store->allTagOps()->putMany()->execute(
+            ['foo' => 'value1', 'bar' => 'value2'],
+            60,
+            ['_all:tag:users:entries'],
+            'ns:'
+        );
+
+        $this->assertFalse($result);
+    }
+
     public function testPutManyInClusterModeWithEmptyValuesReturnsTrue(): void
     {
         [$store, , $connection] = $this->createClusterStore();

--- a/tests/Cache/Redis/Operations/AllTag/PutManyTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/PutManyTest.php
@@ -47,7 +47,7 @@ class PutManyTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([true, true, 2]);
+            ->andReturn([true, true, 0]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->putMany()->execute(
@@ -168,7 +168,7 @@ class PutManyTest extends RedisCacheTestCase
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', $expectedScore, 'ns:foo', $expectedScore, 'ns:baz')
-            ->andReturn(2)
+            ->andReturn(0)
             ->ordered();
 
         $result = $store->allTagOps()->putMany()->execute(
@@ -229,6 +229,24 @@ class PutManyTest extends RedisCacheTestCase
         );
 
         $this->assertFalse($result);
+    }
+
+    public function testPutManyReturnsFalseWhenPipelineMembershipWriteFails(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('setex')->twice()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn([true, true, false]);
+
+        $store = $this->createStore($connection);
+
+        $this->assertFalse($store->allTagOps()->putMany()->execute(
+            ['foo' => 'bar', 'baz' => 'qux'],
+            60,
+            ['_all:tag:users:entries'],
+            'ns:'
+        ));
     }
 
     public function testPutManyEnforcesMinimumTtlOfOne(): void
@@ -499,6 +517,21 @@ class PutManyTest extends RedisCacheTestCase
         );
 
         $this->assertFalse($result);
+    }
+
+    public function testPutManyInClusterModeReturnsFalseWhenMembershipWriteFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+
+        $connection->shouldReceive('setex')->once()->andReturn(true);
+        $connection->shouldReceive('zadd')->once()->andReturn(false);
+
+        $this->assertFalse($store->allTagOps()->putMany()->execute(
+            ['foo' => 'bar'],
+            60,
+            ['_all:tag:users:entries'],
+            'ns:'
+        ));
     }
 
     public function testPutManyInClusterModeWithEmptyValuesReturnsTrue(): void

--- a/tests/Cache/Redis/Operations/AllTag/PutTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/PutTest.php
@@ -12,9 +12,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class PutTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testPutStoresValueWithTagsInPipelineMode(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -23,21 +20,21 @@ class PutTest extends RedisCacheTestCase
 
         $connection->shouldReceive('pipeline')->once()->andReturn($connection);
 
-        // ZADD for tag
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn($connection);
-
-        // SETEX for cache value
         $connection->shouldReceive('setex')
             ->once()
             ->with('prefix:mykey', 60, serialize('myvalue'))
-            ->andReturn($connection);
+            ->andReturn($connection)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
+            ->andReturn($connection)
+            ->ordered();
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->put()->execute(
@@ -50,9 +47,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutWithMultipleTags(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -81,7 +75,7 @@ class PutTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, 1, true]);
+            ->andReturn([true, 1, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->put()->execute(
@@ -94,9 +88,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutWithEmptyTagsStillStoresValue(): void
     {
         $connection = $this->mockConnection();
@@ -125,9 +116,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutUsesCorrectPrefix(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -148,7 +136,7 @@ class PutTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection, 'custom:');
         $result = $store->allTagOps()->put()->execute(
@@ -161,9 +149,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutReturnsFalseOnFailure(): void
     {
         $connection = $this->mockConnection();
@@ -176,7 +161,7 @@ class PutTest extends RedisCacheTestCase
         // SETEX returns false (failure)
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, false]);
+            ->andReturn([false, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->put()->execute(
@@ -189,9 +174,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutInClusterModeUsesSequentialCommands(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -201,17 +183,17 @@ class PutTest extends RedisCacheTestCase
         // Should NOT use pipeline in cluster mode
         $connection->shouldNotReceive('pipeline');
 
-        // Sequential ZADD
-        $connection->shouldReceive('zadd')
-            ->once()
-            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn(1);
-
-        // Sequential SETEX
         $connection->shouldReceive('setex')
             ->once()
             ->with('prefix:mykey', 60, serialize('myvalue'))
-            ->andReturn(true);
+            ->andReturn(true)
+            ->ordered();
+
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
+            ->andReturn(1)
+            ->ordered();
 
         $result = $store->allTagOps()->put()->execute(
             'mykey',
@@ -223,9 +205,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutEnforcesMinimumTtlOfOne(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -246,7 +225,7 @@ class PutTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->put()->execute(
@@ -259,9 +238,6 @@ class PutTest extends RedisCacheTestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
     public function testPutWithNumericValue(): void
     {
         $connection = $this->mockConnection();
@@ -278,7 +254,7 @@ class PutTest extends RedisCacheTestCase
 
         $connection->shouldReceive('exec')
             ->once()
-            ->andReturn([1, true]);
+            ->andReturn([true, 1]);
 
         $store = $this->createStore($connection);
         $result = $store->allTagOps()->put()->execute(

--- a/tests/Cache/Redis/Operations/AllTag/PutTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/PutTest.php
@@ -174,6 +174,42 @@ class PutTest extends RedisCacheTestCase
         $this->assertFalse($result);
     }
 
+    public function testPutReturnsFalseWhenPipelineMembershipWriteFails(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('setex')->once()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn([true, false]);
+
+        $store = $this->createStore($connection);
+
+        $this->assertFalse($store->allTagOps()->put()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
+    public function testPutTreatsZeroPipelineMembershipResultAsSuccess(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
+        $connection->shouldReceive('setex')->once()->andReturn($connection);
+        $connection->shouldReceive('zadd')->once()->andReturn($connection);
+        $connection->shouldReceive('exec')->once()->andReturn([true, 0]);
+
+        $store = $this->createStore($connection);
+
+        $this->assertTrue($store->allTagOps()->put()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
     public function testPutInClusterModeUsesSequentialCommands(): void
     {
         CarbonImmutable::setTestNow(CarbonImmutable::createFromTimestampUTC('1000.900000'));
@@ -203,6 +239,34 @@ class PutTest extends RedisCacheTestCase
         );
 
         $this->assertTrue($result);
+    }
+
+    public function testPutReturnsFalseWhenClusterMembershipWriteFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('setex')->once()->andReturn(true);
+        $connection->shouldReceive('zadd')->once()->andReturn(false);
+
+        $this->assertFalse($store->allTagOps()->put()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
+    }
+
+    public function testPutTreatsZeroClusterMembershipResultAsSuccess(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('setex')->once()->andReturn(true);
+        $connection->shouldReceive('zadd')->once()->andReturn(0);
+
+        $this->assertTrue($store->allTagOps()->put()->execute(
+            'mykey',
+            'myvalue',
+            60,
+            ['_all:tag:users:entries']
+        ));
     }
 
     public function testPutEnforcesMinimumTtlOfOne(): void

--- a/tests/Cache/Redis/Operations/AllTag/TouchTest.php
+++ b/tests/Cache/Redis/Operations/AllTag/TouchTest.php
@@ -45,9 +45,22 @@ class TouchTest extends RedisCacheTestCase
         $connection->shouldReceive('zadd')
             ->once()
             ->with('prefix:_all:tag:users:entries', 1061, 'mykey')
-            ->andReturn(1);
+            ->andReturn(0);
 
         $this->assertTrue($store->allTagOps()->touch()->execute(
+            'mykey',
+            60,
+            ['_all:tag:users:entries'],
+        ));
+    }
+
+    public function testTouchReturnsFalseWhenClusterMembershipWriteFails(): void
+    {
+        [$store, , $connection] = $this->createClusterStore();
+        $connection->shouldReceive('expire')->once()->andReturn(true);
+        $connection->shouldReceive('zadd')->once()->andReturn(false);
+
+        $this->assertFalse($store->allTagOps()->touch()->execute(
             'mykey',
             60,
             ['_all:tag:users:entries'],

--- a/tests/Cache/Redis/Operations/AnyTag/DecrementTest.php
+++ b/tests/Cache/Redis/Operations/AnyTag/DecrementTest.php
@@ -12,9 +12,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class DecrementTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testDecrementWithTagsReturnsNewValue(): void
     {
         $connection = $this->mockConnection();
@@ -35,5 +32,58 @@ class DecrementTest extends RedisCacheTestCase
         $redis->setTagMode('any');
         $result = $redis->anyTagOps()->decrement()->execute('counter', 5, ['stats']);
         $this->assertSame(5, $result);
+    }
+
+    public function testDecrementWithTagsUpdatesMetadataAfterAClusterCounterSucceeds(): void
+    {
+        [$redis, , $connection] = $this->createClusterStore(tagMode: 'any');
+
+        $connection->expects('multi')->twice()->andReturnSelf();
+        $connection->expects('decrBy')->with('prefix:counter', 5)->andReturnSelf();
+        $connection->expects('ttl')->with('prefix:counter')->andReturnSelf();
+        $connection->expects('exec')->twice()->andReturn([5, -1], []);
+        $connection->expects('smembers')->with('prefix:counter:_any:tags')->andReturn([]);
+        $connection->expects('del')->with('prefix:counter:_any:tags')->andReturnSelf();
+        $connection->expects('sadd')->with('prefix:counter:_any:tags', 'stats')->andReturnSelf();
+        $connection->expects('hSet')
+            ->with('prefix:_any:tag:stats:entries', 'counter', StoreContext::TAG_FIELD_VALUE)
+            ->andReturn(1);
+        $connection->expects('zadd')
+            ->with('prefix:_any:tag:registry', ['GT'], StoreContext::MAX_EXPIRY, 'stats')
+            ->andReturn(1);
+
+        $this->assertSame(5, $redis->anyTagOps()->decrement()->execute('counter', 5, ['stats']));
+    }
+
+    public function testDecrementWithTagsReturnsFalseWithoutMetadataWhenClusterTransactionFails(): void
+    {
+        [$redis, , $connection] = $this->createClusterStore(tagMode: 'any');
+
+        $connection->expects('multi')->andReturnSelf();
+        $connection->expects('decrBy')->with('prefix:counter', 5)->andReturnSelf();
+        $connection->expects('ttl')->with('prefix:counter')->andReturnSelf();
+        $connection->expects('exec')->andReturnFalse();
+        $connection->shouldNotReceive('smembers');
+        $connection->shouldNotReceive('sadd');
+        $connection->shouldNotReceive('hSet');
+        $connection->shouldNotReceive('zadd');
+
+        $this->assertFalse($redis->anyTagOps()->decrement()->execute('counter', 5, ['stats']));
+    }
+
+    public function testDecrementWithTagsReturnsFalseWithoutMetadataWhenClusterCounterFails(): void
+    {
+        [$redis, , $connection] = $this->createClusterStore(tagMode: 'any');
+
+        $connection->expects('multi')->andReturnSelf();
+        $connection->expects('decrBy')->with('prefix:counter', 5)->andReturnSelf();
+        $connection->expects('ttl')->with('prefix:counter')->andReturnSelf();
+        $connection->expects('exec')->andReturn([false, -1]);
+        $connection->shouldNotReceive('smembers');
+        $connection->shouldNotReceive('sadd');
+        $connection->shouldNotReceive('hSet');
+        $connection->shouldNotReceive('zadd');
+
+        $this->assertFalse($redis->anyTagOps()->decrement()->execute('counter', 5, ['stats']));
     }
 }

--- a/tests/Cache/Redis/Operations/AnyTag/IncrementTest.php
+++ b/tests/Cache/Redis/Operations/AnyTag/IncrementTest.php
@@ -12,9 +12,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class IncrementTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testIncrementWithTagsReturnsNewValue(): void
     {
         $connection = $this->mockConnection();
@@ -36,5 +33,58 @@ class IncrementTest extends RedisCacheTestCase
         $redis->setTagMode('any');
         $result = $redis->anyTagOps()->increment()->execute('counter', 5, ['stats']);
         $this->assertSame(15, $result);
+    }
+
+    public function testIncrementWithTagsUpdatesMetadataAfterAClusterCounterSucceeds(): void
+    {
+        [$redis, , $connection] = $this->createClusterStore(tagMode: 'any');
+
+        $connection->expects('multi')->twice()->andReturnSelf();
+        $connection->expects('incrBy')->with('prefix:counter', 5)->andReturnSelf();
+        $connection->expects('ttl')->with('prefix:counter')->andReturnSelf();
+        $connection->expects('exec')->twice()->andReturn([15, -1], []);
+        $connection->expects('smembers')->with('prefix:counter:_any:tags')->andReturn([]);
+        $connection->expects('del')->with('prefix:counter:_any:tags')->andReturnSelf();
+        $connection->expects('sadd')->with('prefix:counter:_any:tags', 'stats')->andReturnSelf();
+        $connection->expects('hSet')
+            ->with('prefix:_any:tag:stats:entries', 'counter', StoreContext::TAG_FIELD_VALUE)
+            ->andReturn(1);
+        $connection->expects('zadd')
+            ->with('prefix:_any:tag:registry', ['GT'], StoreContext::MAX_EXPIRY, 'stats')
+            ->andReturn(1);
+
+        $this->assertSame(15, $redis->anyTagOps()->increment()->execute('counter', 5, ['stats']));
+    }
+
+    public function testIncrementWithTagsReturnsFalseWithoutMetadataWhenClusterTransactionFails(): void
+    {
+        [$redis, , $connection] = $this->createClusterStore(tagMode: 'any');
+
+        $connection->expects('multi')->andReturnSelf();
+        $connection->expects('incrBy')->with('prefix:counter', 5)->andReturnSelf();
+        $connection->expects('ttl')->with('prefix:counter')->andReturnSelf();
+        $connection->expects('exec')->andReturnFalse();
+        $connection->shouldNotReceive('smembers');
+        $connection->shouldNotReceive('sadd');
+        $connection->shouldNotReceive('hSet');
+        $connection->shouldNotReceive('zadd');
+
+        $this->assertFalse($redis->anyTagOps()->increment()->execute('counter', 5, ['stats']));
+    }
+
+    public function testIncrementWithTagsReturnsFalseWithoutMetadataWhenClusterCounterFails(): void
+    {
+        [$redis, , $connection] = $this->createClusterStore(tagMode: 'any');
+
+        $connection->expects('multi')->andReturnSelf();
+        $connection->expects('incrBy')->with('prefix:counter', 5)->andReturnSelf();
+        $connection->expects('ttl')->with('prefix:counter')->andReturnSelf();
+        $connection->expects('exec')->andReturn([false, -1]);
+        $connection->shouldNotReceive('smembers');
+        $connection->shouldNotReceive('sadd');
+        $connection->shouldNotReceive('hSet');
+        $connection->shouldNotReceive('zadd');
+
+        $this->assertFalse($redis->anyTagOps()->increment()->execute('counter', 5, ['stats']));
     }
 }

--- a/tests/Cache/Redis/Operations/AnyTag/PruneTest.php
+++ b/tests/Cache/Redis/Operations/AnyTag/PruneTest.php
@@ -5,30 +5,21 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Cache\Redis\Operations\AnyTag;
 
 use Hypervel\Cache\Redis\Operations\AnyTag\Prune;
+use Hypervel\Cache\Redis\Support\StoreContext;
 use Hypervel\Redis\PhpRedis;
 use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
 use Hypervel\Tests\Redis\Fixtures\FakeRedisClient;
 use Mockery as m;
 
-/**
- * Tests for the AnyTag/Prune operation.
- */
 class PruneTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
-    public function testPruneReturnsEmptyStatsWhenNoActiveTagsInRegistry(): void
+    public function testPruneReturnsEmptyStatsWhenNoActiveTagsRemain(): void
     {
         $connection = $this->mockConnection();
-
-        // ZREMRANGEBYSCORE on registry removes expired tags
         $connection->shouldReceive('zRemRangeByScore')
             ->once()
             ->with('prefix:_any:tag:registry', '-inf', m::type('string'))
-            ->andReturn(2); // 2 expired tags removed
-
-        // ZRANGE returns empty (no active tags)
+            ->andReturn(2);
         $connection->shouldReceive('zRange')
             ->once()
             ->with('prefix:_any:tag:registry', 0, -1)
@@ -36,576 +27,208 @@ class PruneTest extends RedisCacheTestCase
 
         $store = $this->createStore($connection);
         $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
 
-        $result = $operation->execute();
-
-        $this->assertSame(0, $result['hashes_scanned']);
-        $this->assertSame(0, $result['fields_checked']);
-        $this->assertSame(0, $result['orphans_removed']);
-        $this->assertSame(0, $result['empty_hashes_deleted']);
-        $this->assertSame(2, $result['expired_tags_removed']);
+        $this->assertSame([
+            'hashes_scanned' => 0,
+            'fields_checked' => 0,
+            'orphans_removed' => 0,
+            'empty_hashes_deleted' => 0,
+            'expired_tags_removed' => 2,
+            'orphaned_tags_removed' => 0,
+        ], (new Prune($store->getContext()))->execute());
     }
 
-    /**
-     * @test
-     */
-    public function testPruneRemovesOrphanedFieldsFromTagHash(): void
+    public function testPruneRemovesOrphansAtomicallyInBoundedPages(): void
     {
         $connection = $this->mockConnection();
-
-        // Step 1: Remove expired tags from registry
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->with('prefix:_any:tag:registry', '-inf', m::type('string'))
-            ->andReturn(0);
-
-        // Step 2: Get active tags
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->with('prefix:_any:tag:registry', 0, -1)
-            ->andReturn(['users']);
-
-        // Step 3: HSCAN the tag hash
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zRange')->once()->andReturn(['users']);
         $connection->shouldReceive('hScan')
             ->once()
-            ->andReturnUsing(function ($tagHash, &$iterator, $match, $count) {
+            ->with('prefix:_any:tag:users:entries', m::any(), '*', 37)
+            ->andReturnUsing(function ($tagHash, &$iterator): array {
                 $this->assertSame(PhpRedis::initialScanCursor(), $iterator);
                 $iterator = 0;
-                return [
-                    'key1' => '1',
-                    'key2' => '1',
-                    'key3' => '1',
-                ];
+
+                return ['key1' => '1', 'key2' => '1', 'key3' => '1'];
             });
-
-        // Pipeline for EXISTS checks
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-        $connection->shouldReceive('exists')
-            ->times(3)
-            ->andReturn($connection);
-        $connection->shouldReceive('exec')
+        $connection->shouldReceive('evalWithShaCache')
             ->once()
-            ->andReturn([1, 0, 1]); // key2 doesn't exist (orphaned)
-
-        // HDEL orphaned key2
-        $connection->shouldReceive('hDel')
-            ->once()
-            ->with('prefix:_any:tag:users:entries', 'key2')
+            ->with(
+                m::on(fn (string $script): bool => str_contains($script, "redis.call('EXISTS', KEYS[i])")),
+                [
+                    'prefix:_any:tag:users:entries',
+                    'prefix:key1',
+                    'prefix:key2',
+                    'prefix:key3',
+                ],
+                ['key1', 'key2', 'key3'],
+            )
             ->andReturn(1);
-
-        // HLEN to check if hash is empty
-        $connection->shouldReceive('hLen')
+        $connection->shouldReceive('evalWithShaCache')
             ->once()
-            ->with('prefix:_any:tag:users:entries')
-            ->andReturn(2);
+            ->with(
+                m::on(fn (string $script): bool => str_contains($script, "redis.call('ZREM', KEYS[2], ARGV[1])")),
+                ['prefix:_any:tag:users:entries', 'prefix:_any:tag:registry'],
+                ['users'],
+            )
+            ->andReturn([0, 0]);
 
         $store = $this->createStore($connection);
         $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $result = $operation->execute();
+        $result = (new Prune($store->getContext()))->execute(37);
 
         $this->assertSame(1, $result['hashes_scanned']);
         $this->assertSame(3, $result['fields_checked']);
         $this->assertSame(1, $result['orphans_removed']);
         $this->assertSame(0, $result['empty_hashes_deleted']);
-        $this->assertSame(0, $result['expired_tags_removed']);
+        $this->assertSame(0, $result['orphaned_tags_removed']);
     }
 
-    /**
-     * @test
-     */
-    public function testPruneDeletesEmptyHashAfterRemovingOrphans(): void
+    public function testPruneRemovesAnEmptyHashFromTheRegistry(): void
     {
         $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn(['users']);
-
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zRange')->once()->andReturn(['forever-tag']);
         $connection->shouldReceive('hScan')
             ->once()
-            ->andReturnUsing(function ($tagHash, &$iterator, $match, $count) {
+            ->andReturnUsing(function ($tagHash, &$iterator): array {
                 $iterator = 0;
-                return ['key1' => '1'];
+
+                return ['orphan' => '1'];
             });
-
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-        $connection->shouldReceive('exists')->once()->andReturn($connection);
-        $connection->shouldReceive('exec')
+        $connection->shouldReceive('evalWithShaCache')->once()->andReturn(1);
+        $connection->shouldReceive('evalWithShaCache')
             ->once()
-            ->andReturn([0]); // key1 doesn't exist (orphaned)
-
-        $connection->shouldReceive('hDel')
-            ->once()
-            ->with('prefix:_any:tag:users:entries', 'key1')
-            ->andReturn(1);
-
-        // Hash is now empty
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->andReturn(0);
-
-        // Delete empty hash
-        $connection->shouldReceive('del')
-            ->once()
-            ->with('prefix:_any:tag:users:entries')
-            ->andReturn(1);
+            ->with(
+                m::type('string'),
+                ['prefix:_any:tag:forever-tag:entries', 'prefix:_any:tag:registry'],
+                ['forever-tag'],
+            )
+            ->andReturn([1, 1]);
+        $connection->shouldNotReceive('del');
 
         $store = $this->createStore($connection);
         $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
+        $result = (new Prune($store->getContext()))->execute();
 
-        $result = $operation->execute();
-
-        $this->assertSame(1, $result['hashes_scanned']);
-        $this->assertSame(1, $result['fields_checked']);
         $this->assertSame(1, $result['orphans_removed']);
         $this->assertSame(1, $result['empty_hashes_deleted']);
+        $this->assertSame(1, $result['orphaned_tags_removed']);
     }
 
-    /**
-     * @test
-     */
-    public function testPruneHandlesMultipleTagHashes(): void
-    {
-        $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(1); // 1 expired tag removed
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn(['users', 'posts', 'comments']);
-
-        // First tag: users - 2 fields, 1 orphan
-        $connection->shouldReceive('hScan')
-            ->once()
-            ->with('prefix:_any:tag:users:entries', m::any(), '*', m::any())
-            ->andReturnUsing(function ($tagHash, &$iterator) {
-                $iterator = 0;
-                return ['u1' => '1', 'u2' => '1'];
-            });
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-        $connection->shouldReceive('exists')->twice()->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1, 0]);
-        $connection->shouldReceive('hDel')
-            ->once()
-            ->with('prefix:_any:tag:users:entries', 'u2')
-            ->andReturn(1);
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->with('prefix:_any:tag:users:entries')
-            ->andReturn(1);
-
-        // Second tag: posts - 1 field, 0 orphans
-        $connection->shouldReceive('hScan')
-            ->once()
-            ->with('prefix:_any:tag:posts:entries', m::any(), '*', m::any())
-            ->andReturnUsing(function ($tagHash, &$iterator) {
-                $iterator = 0;
-                return ['p1' => '1'];
-            });
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-        $connection->shouldReceive('exists')->once()->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([1]);
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->with('prefix:_any:tag:posts:entries')
-            ->andReturn(1);
-
-        // Third tag: comments - 3 fields, all orphans (hash becomes empty)
-        $connection->shouldReceive('hScan')
-            ->once()
-            ->with('prefix:_any:tag:comments:entries', m::any(), '*', m::any())
-            ->andReturnUsing(function ($tagHash, &$iterator) {
-                $iterator = 0;
-                return ['c1' => '1', 'c2' => '1', 'c3' => '1'];
-            });
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-        $connection->shouldReceive('exists')->times(3)->andReturn($connection);
-        $connection->shouldReceive('exec')->once()->andReturn([0, 0, 0]);
-        $connection->shouldReceive('hDel')
-            ->once()
-            ->with('prefix:_any:tag:comments:entries', 'c1', 'c2', 'c3')
-            ->andReturn(3);
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->with('prefix:_any:tag:comments:entries')
-            ->andReturn(0);
-        $connection->shouldReceive('del')
-            ->once()
-            ->with('prefix:_any:tag:comments:entries')
-            ->andReturn(1);
-
-        $store = $this->createStore($connection);
-        $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $result = $operation->execute();
-
-        $this->assertSame(3, $result['hashes_scanned']);
-        $this->assertSame(6, $result['fields_checked']); // 2 + 1 + 3
-        $this->assertSame(4, $result['orphans_removed']); // 1 + 0 + 3
-        $this->assertSame(1, $result['empty_hashes_deleted']);
-        $this->assertSame(1, $result['expired_tags_removed']);
-    }
-
-    /**
-     * @test
-     */
-    public function testPruneUsesCorrectTagHashKeyFormat(): void
-    {
-        $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->with('custom:_any:tag:registry', '-inf', m::type('string'))
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->with('custom:_any:tag:registry', 0, -1)
-            ->andReturn(['users']);
-
-        // Verify correct tag hash key format
-        $connection->shouldReceive('hScan')
-            ->once()
-            ->with('custom:_any:tag:users:entries', m::any(), '*', m::any())
-            ->andReturnUsing(function ($tagHash, &$iterator) {
-                $iterator = 0;
-                return [];
-            });
-
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->with('custom:_any:tag:users:entries')
-            ->andReturn(0);
-
-        $connection->shouldReceive('del')
-            ->once()
-            ->with('custom:_any:tag:users:entries')
-            ->andReturn(1);
-
-        $store = $this->createStore($connection, 'custom:');
-        $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $operation->execute();
-    }
-
-    /**
-     * @test
-     */
-    public function testPruneClusterModeUsesSequentialExistsChecks(): void
+    public function testClusterPruneBatchesOrphansThatRemainRemoved(): void
     {
         [$store, , $connection] = $this->createClusterStore(tagMode: 'any');
-
-        // Should NOT use pipeline in cluster mode
         $connection->shouldNotReceive('pipeline');
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn(['users']);
-
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zRange')->once()->andReturn(['users']);
         $connection->shouldReceive('hScan')
             ->once()
-            ->andReturnUsing(function ($tagHash, &$iterator) {
+            ->andReturnUsing(function ($tagHash, &$iterator): array {
                 $iterator = 0;
-                return ['key1' => '1', 'key2' => '1'];
+
+                return ['live' => '1', 'orphan1' => '1', 'orphan2' => '1'];
             });
-
-        // Sequential EXISTS checks in cluster mode
-        $connection->shouldReceive('exists')
-            ->once()
-            ->with('prefix:key1')
-            ->andReturn(1);
-        $connection->shouldReceive('exists')
-            ->once()
-            ->with('prefix:key2')
-            ->andReturn(0);
-
+        $connection->shouldReceive('exists')->once()->with('prefix:live')->andReturn(1);
+        $connection->shouldReceive('exists')->twice()->with('prefix:orphan1')->andReturn(0);
+        $connection->shouldReceive('exists')->twice()->with('prefix:orphan2')->andReturn(0);
         $connection->shouldReceive('hDel')
             ->once()
-            ->with('prefix:_any:tag:users:entries', 'key2')
-            ->andReturn(1);
+            ->with('prefix:_any:tag:users:entries', 'orphan1', 'orphan2')
+            ->andReturn(2);
+        $connection->shouldReceive('hLen')->once()->andReturn(1);
 
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->andReturn(1);
+        $result = (new Prune($store->getContext()))->execute();
 
-        $operation = new Prune($store->getContext());
-        $result = $operation->execute();
-
-        $this->assertSame(1, $result['hashes_scanned']);
-        $this->assertSame(2, $result['fields_checked']);
-        $this->assertSame(1, $result['orphans_removed']);
+        $this->assertSame(3, $result['fields_checked']);
+        $this->assertSame(2, $result['orphans_removed']);
     }
 
-    /**
-     * @test
-     */
-    public function testPruneHandlesEmptyHscanResult(): void
+    public function testClusterPruneRepairsAFieldOnlyWhenItIsStillMissing(): void
     {
-        $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn(['users']);
-
-        // HSCAN returns empty (no fields in hash)
+        [$store, , $connection] = $this->createClusterStore(tagMode: 'any');
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zRange')->once()->andReturn(['users']);
         $connection->shouldReceive('hScan')
             ->once()
-            ->andReturnUsing(function ($tagHash, &$iterator) {
+            ->andReturnUsing(function ($tagHash, &$iterator): array {
                 $iterator = 0;
+
+                return ['raced' => '1'];
+            });
+        $connection->shouldReceive('exists')
+            ->twice()
+            ->with('prefix:raced')
+            ->andReturn(0, 1);
+        $connection->shouldReceive('hDel')->once()->andReturn(1);
+        $connection->shouldReceive('sismember')
+            ->once()
+            ->with('prefix:raced:_any:tags', 'users')
+            ->andReturn(true);
+        $connection->shouldReceive('hsetnx')
+            ->once()
+            ->with('prefix:_any:tag:users:entries', 'raced', StoreContext::TAG_FIELD_VALUE)
+            ->andReturn(false);
+        $connection->shouldReceive('hLen')->once()->andReturn(1);
+
+        $result = (new Prune($store->getContext()))->execute();
+
+        $this->assertSame(0, $result['orphans_removed']);
+    }
+
+    public function testClusterPruneRepairsARegistryEntryWithoutOverwritingAWriterScore(): void
+    {
+        [$store, , $connection] = $this->createClusterStore(tagMode: 'any');
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zRange')->once()->andReturn(['users']);
+        $connection->shouldReceive('hScan')
+            ->once()
+            ->andReturnUsing(function ($tagHash, &$iterator): array {
+                $iterator = 0;
+
                 return [];
             });
-
-        // Should still check HLEN
-        $connection->shouldReceive('hLen')
+        $connection->shouldReceive('hLen')->twice()->andReturn(0, 1);
+        $connection->shouldReceive('zrem')
             ->once()
+            ->with('prefix:_any:tag:registry', 'users')
+            ->andReturn(1);
+        $connection->shouldReceive('zadd')
+            ->once()
+            ->with('prefix:_any:tag:registry', ['NX'], StoreContext::MAX_EXPIRY, 'users')
             ->andReturn(0);
 
-        $connection->shouldReceive('del')
-            ->once()
-            ->andReturn(1);
+        $result = (new Prune($store->getContext()))->execute();
 
-        $store = $this->createStore($connection);
-        $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $result = $operation->execute();
-
-        $this->assertSame(1, $result['hashes_scanned']);
-        $this->assertSame(0, $result['fields_checked']);
-        $this->assertSame(0, $result['orphans_removed']);
-        $this->assertSame(1, $result['empty_hashes_deleted']);
+        $this->assertSame(0, $result['empty_hashes_deleted']);
+        $this->assertSame(0, $result['orphaned_tags_removed']);
     }
 
-    /**
-     * @test
-     */
-    public function testPruneHandlesHscanWithMultipleIterations(): void
-    {
-        // Use FakeRedisClient stub for proper reference parameter handling
-        // (Mockery's andReturnUsing doesn't propagate &$iterator modifications)
-        $registryKey = 'prefix:_any:tag:registry';
-        $tagHashKey = 'prefix:_any:tag:users:entries';
-
-        $fakeClient = new FakeRedisClient(
-            scanResults: [],
-            execResults: [
-                [1, 0], // First EXISTS batch: key1 exists, key2 orphaned
-                [0],    // Second EXISTS batch: key3 orphaned
-            ],
-            hScanResults: [
-                $tagHashKey => [
-                    // First hScan: returns 2 fields, iterator = 100 (continue)
-                    ['fields' => ['key1' => '1', 'key2' => '1'], 'iterator' => 100],
-                    // Second hScan: returns 1 field, iterator = 0 (done)
-                    ['fields' => ['key3' => '1'], 'iterator' => 0],
-                ],
-            ],
-            zRangeResults: [
-                $registryKey => ['users'],
-            ],
-            hLenResults: [
-                $tagHashKey => 1, // 1 field remaining after cleanup
-            ],
-        );
-
-        $store = $this->createStoreWithFakeClient($fakeClient, tagMode: 'any');
-
-        $operation = new Prune($store->getContext());
-        $result = $operation->execute();
-
-        // Verify hScan was called twice (multi-iteration)
-        $this->assertSame(2, $fakeClient->getHScanCallCount());
-
-        // Verify stats
-        $this->assertSame(1, $result['hashes_scanned']);
-        $this->assertSame(3, $result['fields_checked']); // 2 + 1 fields
-        $this->assertSame(2, $result['orphans_removed']); // key2 + key3
-    }
-
-    public function testPruneContinuesAfterAnEmptyNonterminalHashPage(): void
+    public function testPruneContinuesAfterEmptyAndNonterminalHashPages(): void
     {
         $registryKey = 'prefix:_any:tag:registry';
         $tagHashKey = 'prefix:_any:tag:users:entries';
         $fakeClient = new FakeRedisClient(
-            execResults: [
-                [1],
-            ],
             hScanResults: [
                 $tagHashKey => [
                     ['fields' => [], 'iterator' => 100],
-                    ['fields' => ['key1' => '1'], 'iterator' => 0],
+                    ['fields' => ['key1' => '1'], 'iterator' => 50],
+                    ['fields' => ['key2' => '1'], 'iterator' => 0],
                 ],
             ],
             zRangeResults: [
                 $registryKey => ['users'],
             ],
-            hLenResults: [
-                $tagHashKey => 1,
-            ],
+            evalShaResults: [1, 0, [0, 0]],
         );
 
         $store = $this->createStoreWithFakeClient($fakeClient, tagMode: 'any');
-        $operation = new Prune($store->getContext());
+        $result = (new Prune($store->getContext()))->execute();
 
-        $result = $operation->execute();
-
-        $this->assertSame(1, $result['fields_checked']);
-        $this->assertSame(2, $fakeClient->getHScanCallCount());
-    }
-
-    /**
-     * @test
-     */
-    public function testPruneUsesCustomScanCount(): void
-    {
-        $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn(['users']);
-
-        // HSCAN should use custom count
-        $connection->shouldReceive('hScan')
-            ->once()
-            ->with(m::any(), m::any(), '*', 500)
-            ->andReturnUsing(function ($tagHash, &$iterator) {
-                $iterator = 0;
-                return [];
-            });
-
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('del')
-            ->once()
-            ->andReturn(1);
-
-        $store = $this->createStore($connection);
-        $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $operation->execute(500);
-    }
-
-    /**
-     * @test
-     */
-    public function testPruneViaStoreOperationsContainer(): void
-    {
-        $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn([]);
-
-        $store = $this->createStore($connection);
-        $store->setTagMode('any');
-
-        // Access via the operations container
-        $result = $store->anyTagOps()->prune()->execute();
-
-        $this->assertSame(0, $result['hashes_scanned']);
-    }
-
-    /**
-     * @test
-     */
-    public function testPruneRemovesExpiredTagsFromRegistry(): void
-    {
-        $connection = $this->mockConnection();
-
-        // 5 expired tags removed
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->with('prefix:_any:tag:registry', '-inf', m::type('string'))
-            ->andReturn(5);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn([]);
-
-        $store = $this->createStore($connection);
-        $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $result = $operation->execute();
-
-        $this->assertSame(5, $result['expired_tags_removed']);
-    }
-
-    /**
-     * @test
-     */
-    public function testPruneDoesNotRemoveNonOrphanedFields(): void
-    {
-        $connection = $this->mockConnection();
-
-        $connection->shouldReceive('zRemRangeByScore')
-            ->once()
-            ->andReturn(0);
-
-        $connection->shouldReceive('zRange')
-            ->once()
-            ->andReturn(['users']);
-
-        $connection->shouldReceive('hScan')
-            ->once()
-            ->andReturnUsing(function ($tagHash, &$iterator) {
-                $iterator = 0;
-                return ['key1' => '1', 'key2' => '1', 'key3' => '1'];
-            });
-
-        $connection->shouldReceive('pipeline')->once()->andReturn($connection);
-        $connection->shouldReceive('exists')->times(3)->andReturn($connection);
-        $connection->shouldReceive('exec')
-            ->once()
-            ->andReturn([1, 1, 1]); // All keys exist
-
-        // Should NOT call hDel since no orphans
-        $connection->shouldNotReceive('hDel');
-
-        $connection->shouldReceive('hLen')
-            ->once()
-            ->andReturn(3);
-
-        $store = $this->createStore($connection);
-        $store->setTagMode('any');
-        $operation = new Prune($store->getContext());
-
-        $result = $operation->execute();
-
-        $this->assertSame(1, $result['hashes_scanned']);
-        $this->assertSame(3, $result['fields_checked']);
-        $this->assertSame(0, $result['orphans_removed']);
-        $this->assertSame(0, $result['empty_hashes_deleted']);
+        $this->assertSame(3, $fakeClient->getHScanCallCount());
+        $this->assertCount(3, $fakeClient->getEvalShaCalls());
+        $this->assertSame(2, $result['fields_checked']);
+        $this->assertSame(1, $result['orphans_removed']);
     }
 }

--- a/tests/Cache/Redis/Operations/AnyTag/PruneTest.php
+++ b/tests/Cache/Redis/Operations/AnyTag/PruneTest.php
@@ -177,6 +177,38 @@ class PruneTest extends RedisCacheTestCase
         $this->assertSame(0, $result['orphans_removed']);
     }
 
+    public function testClusterPruneRepairsAFieldAfterConcurrentRemovalReturnsZero(): void
+    {
+        [$store, , $connection] = $this->createClusterStore(tagMode: 'any');
+        $connection->shouldReceive('zRemRangeByScore')->once()->andReturn(0);
+        $connection->shouldReceive('zRange')->once()->andReturn(['users']);
+        $connection->shouldReceive('hScan')
+            ->once()
+            ->andReturnUsing(function ($tagHash, &$iterator): array {
+                $iterator = 0;
+
+                return ['raced' => '1'];
+            });
+        $connection->shouldReceive('exists')
+            ->twice()
+            ->with('prefix:raced')
+            ->andReturn(0, 1);
+        $connection->shouldReceive('hDel')->once()->andReturn(0);
+        $connection->shouldReceive('sismember')
+            ->once()
+            ->with('prefix:raced:_any:tags', 'users')
+            ->andReturn(true);
+        $connection->shouldReceive('hsetnx')
+            ->once()
+            ->with('prefix:_any:tag:users:entries', 'raced', StoreContext::TAG_FIELD_VALUE)
+            ->andReturn(false);
+        $connection->shouldReceive('hLen')->once()->andReturn(1);
+
+        $result = (new Prune($store->getContext()))->execute();
+
+        $this->assertSame(0, $result['orphans_removed']);
+    }
+
     public function testClusterPruneRepairsARegistryEntryWithoutOverwritingAWriterScore(): void
     {
         [$store, , $connection] = $this->createClusterStore(tagMode: 'any');

--- a/tests/Cache/Redis/Operations/DecrementTest.php
+++ b/tests/Cache/Redis/Operations/DecrementTest.php
@@ -11,9 +11,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class DecrementTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testDecrementMethodProperlyCallsRedis(): void
     {
         $connection = $this->mockConnection();
@@ -24,9 +21,6 @@ class DecrementTest extends RedisCacheTestCase
         $this->assertEquals(4, $result);
     }
 
-    /**
-     * @test
-     */
     public function testDecrementOnNonExistentKeyReturnsDecrementedValue(): void
     {
         // Redis DECRBY on non-existent key initializes to 0, then decrements
@@ -35,5 +29,15 @@ class DecrementTest extends RedisCacheTestCase
 
         $redis = $this->createStore($connection);
         $this->assertSame(-1, $redis->decrement('counter'));
+    }
+
+    public function testDecrementReturnsFalseWhenRedisRejectsTheOperation(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->expects('decrby')->with('prefix:foo', 1)->andReturnFalse();
+
+        $redis = $this->createStore($connection);
+
+        $this->assertFalse($redis->decrement('foo'));
     }
 }

--- a/tests/Cache/Redis/Operations/IncrementTest.php
+++ b/tests/Cache/Redis/Operations/IncrementTest.php
@@ -11,9 +11,6 @@ use Hypervel\Tests\Cache\Redis\RedisCacheTestCase;
  */
 class IncrementTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testIncrementMethodProperlyCallsRedis(): void
     {
         $connection = $this->mockConnection();
@@ -24,9 +21,6 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertEquals(6, $result);
     }
 
-    /**
-     * @test
-     */
     public function testIncrementOnNonExistentKeyReturnsIncrementedValue(): void
     {
         // Redis INCRBY on non-existent key initializes to 0, then increments
@@ -37,9 +31,6 @@ class IncrementTest extends RedisCacheTestCase
         $this->assertSame(1, $redis->increment('counter'));
     }
 
-    /**
-     * @test
-     */
     public function testIncrementWithLargeValue(): void
     {
         $connection = $this->mockConnection();
@@ -47,5 +38,15 @@ class IncrementTest extends RedisCacheTestCase
 
         $redis = $this->createStore($connection);
         $this->assertSame(1000005, $redis->increment('foo', 1000000));
+    }
+
+    public function testIncrementReturnsFalseWhenRedisRejectsTheOperation(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->expects('incrby')->with('prefix:foo', 1)->andReturnFalse();
+
+        $redis = $this->createStore($connection);
+
+        $this->assertFalse($redis->increment('foo'));
     }
 }

--- a/tests/Cache/Redis/RedisStoreTest.php
+++ b/tests/Cache/Redis/RedisStoreTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Cache\Redis;
 
+use Hypervel\Cache\Redis\AllTaggedCache;
+use Hypervel\Cache\Redis\AnyTaggedCache;
 use Hypervel\Cache\RedisLock;
 use Hypervel\Cache\RedisStore;
 use Hypervel\Cache\TagMode;
 use Hypervel\Contracts\Redis\Factory as Redis;
 use Hypervel\Redis\RedisProxy;
 use Hypervel\Support\ClassInvoker;
+use InvalidArgumentException;
 use Mockery as m;
 use ReflectionClass;
 use ReflectionNamedType;
@@ -23,9 +26,6 @@ use ReflectionProperty;
  */
 class RedisStoreTest extends RedisCacheTestCase
 {
-    /**
-     * @test
-     */
     public function testGetAndSetPrefix(): void
     {
         $connection = $this->mockConnection();
@@ -38,9 +38,17 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertEmpty($redis->getPrefix());
     }
 
-    /**
-     * @test
-     */
+    public function testCounterFailuresAreReturnedWithoutCoercion(): void
+    {
+        $connection = $this->mockConnection();
+        $connection->expects('incrby')->with('prefix:increment', 2)->andReturnFalse();
+        $connection->expects('decrby')->with('prefix:decrement', 3)->andReturnFalse();
+        $redis = $this->createStore($connection);
+
+        $this->assertFalse($redis->increment('increment', 2));
+        $this->assertFalse($redis->decrement('decrement', 3));
+    }
+
     public function testSetConnectionClearsCachedInstances(): void
     {
         $connection1 = $this->mockConnection();
@@ -72,9 +80,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertSame('value2', $redis->get('foo'));
     }
 
-    /**
-     * @test
-     */
     public function testSetPrefixClearsCachedOperations(): void
     {
         $connection = $this->mockConnection();
@@ -169,9 +174,6 @@ class RedisStoreTest extends RedisCacheTestCase
         }
     }
 
-    /**
-     * @test
-     */
     public function testTagsReturnsAllTaggedCache(): void
     {
         $connection = $this->mockConnection();
@@ -179,12 +181,9 @@ class RedisStoreTest extends RedisCacheTestCase
 
         $tagged = $redis->tags(['users', 'posts']);
 
-        $this->assertInstanceOf(\Hypervel\Cache\Redis\AllTaggedCache::class, $tagged);
+        $this->assertInstanceOf(AllTaggedCache::class, $tagged);
     }
 
-    /**
-     * @test
-     */
     public function testTagsWithSingleTagAsString(): void
     {
         $connection = $this->mockConnection();
@@ -192,12 +191,9 @@ class RedisStoreTest extends RedisCacheTestCase
 
         $tagged = $redis->tags('users');
 
-        $this->assertInstanceOf(\Hypervel\Cache\Redis\AllTaggedCache::class, $tagged);
+        $this->assertInstanceOf(AllTaggedCache::class, $tagged);
     }
 
-    /**
-     * @test
-     */
     public function testTagsWithVariadicArguments(): void
     {
         $connection = $this->mockConnection();
@@ -205,12 +201,9 @@ class RedisStoreTest extends RedisCacheTestCase
 
         $tagged = $redis->tags('users', 'posts', 'comments');
 
-        $this->assertInstanceOf(\Hypervel\Cache\Redis\AllTaggedCache::class, $tagged);
+        $this->assertInstanceOf(AllTaggedCache::class, $tagged);
     }
 
-    /**
-     * @test
-     */
     public function testDefaultTagModeIsAll(): void
     {
         $connection = $this->mockConnection();
@@ -219,9 +212,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertSame(TagMode::All, $redis->getTagMode());
     }
 
-    /**
-     * @test
-     */
     public function testSetTagModeReturnsStoreInstance(): void
     {
         $connection = $this->mockConnection();
@@ -233,9 +223,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertSame(TagMode::Any, $redis->getTagMode());
     }
 
-    /**
-     * @test
-     */
     public function testTagsReturnsAnyTaggedCacheWhenInAnyMode(): void
     {
         $connection = $this->mockConnection();
@@ -244,12 +231,9 @@ class RedisStoreTest extends RedisCacheTestCase
 
         $tagged = $redis->tags(['users', 'posts']);
 
-        $this->assertInstanceOf(\Hypervel\Cache\Redis\AnyTaggedCache::class, $tagged);
+        $this->assertInstanceOf(AnyTaggedCache::class, $tagged);
     }
 
-    /**
-     * @test
-     */
     public function testTagsReturnsAllTaggedCacheWhenInAllMode(): void
     {
         $connection = $this->mockConnection();
@@ -258,25 +242,22 @@ class RedisStoreTest extends RedisCacheTestCase
 
         $tagged = $redis->tags(['users', 'posts']);
 
-        $this->assertInstanceOf(\Hypervel\Cache\Redis\AllTaggedCache::class, $tagged);
+        $this->assertInstanceOf(AllTaggedCache::class, $tagged);
     }
 
-    /**
-     * @test
-     */
-    public function testSetTagModeFallsBackToAllForInvalidMode(): void
+    public function testSetTagModeRejectsInvalidMode(): void
     {
         $connection = $this->mockConnection();
         $redis = $this->createStore($connection);
 
-        $redis->setTagMode('invalid');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid cache tag mode [invalid]. Supported modes are [any, all].'
+        );
 
-        $this->assertSame(TagMode::All, $redis->getTagMode());
+        $redis->setTagMode('invalid');
     }
 
-    /**
-     * @test
-     */
     public function testTouchUsesPlainExpireInAllMode(): void
     {
         $connection = $this->mockConnection();
@@ -290,9 +271,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertTrue($redis->touch('key', 60));
     }
 
-    /**
-     * @test
-     */
     public function testTouchUsesAnyTagMetadataOperationInAnyMode(): void
     {
         $connection = $this->mockConnection();
@@ -306,9 +284,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertTrue($redis->touch('key', 60));
     }
 
-    /**
-     * @test
-     */
     public function testForgetUsesPlainDeleteInAllMode(): void
     {
         $connection = $this->mockConnection();
@@ -322,9 +297,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertTrue($redis->forget('key'));
     }
 
-    /**
-     * @test
-     */
     public function testForgetUsesAnyTagMetadataOperationInAnyMode(): void
     {
         $connection = $this->mockConnection();
@@ -338,9 +310,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertTrue($redis->forget('key'));
     }
 
-    /**
-     * @test
-     */
     public function testLockReturnsRedisLockInstance(): void
     {
         $redisProxy = m::mock(RedisProxy::class);
@@ -358,9 +327,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertInstanceOf(RedisLock::class, $lock);
     }
 
-    /**
-     * @test
-     */
     public function testLockWithOwner(): void
     {
         $redisProxy = m::mock(RedisProxy::class);
@@ -378,9 +344,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertInstanceOf(RedisLock::class, $lock);
     }
 
-    /**
-     * @test
-     */
     public function testRestoreLockReturnsRedisLockInstance(): void
     {
         $redisProxy = m::mock(RedisProxy::class);
@@ -398,9 +361,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertInstanceOf(RedisLock::class, $lock);
     }
 
-    /**
-     * @test
-     */
     public function testSetLockConnectionReturnsSelf(): void
     {
         $connection = $this->mockConnection();
@@ -411,9 +371,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertSame($redis, $result);
     }
 
-    /**
-     * @test
-     */
     public function testLockUsesLockConnectionWhenSet(): void
     {
         $redisProxy = m::mock(RedisProxy::class);
@@ -434,9 +391,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertInstanceOf(RedisLock::class, $lock);
     }
 
-    /**
-     * @test
-     */
     public function testGetRedisReturnsRedis(): void
     {
         $redisFactory = m::mock(Redis::class);
@@ -450,9 +404,6 @@ class RedisStoreTest extends RedisCacheTestCase
         $this->assertSame($redisFactory, $redis->getRedis());
     }
 
-    /**
-     * @test
-     */
     public function testConnectionReturnsRedisProxy(): void
     {
         $redisProxy = m::mock(RedisProxy::class);

--- a/tests/Cache/TagModeTest.php
+++ b/tests/Cache/TagModeTest.php
@@ -6,6 +6,8 @@ namespace Hypervel\Tests\Cache;
 
 use Hypervel\Cache\TagMode;
 use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TagModeTest extends TestCase
 {
@@ -19,10 +21,24 @@ class TagModeTest extends TestCase
         $this->assertSame(TagMode::All, TagMode::fromConfig('all'));
     }
 
-    public function testFromConfigFallsBackToAllOnUnknown(): void
+    #[DataProvider('invalidTagModes')]
+    public function testFromConfigRejectsInvalidModes(string $mode): void
     {
-        $this->assertSame(TagMode::All, TagMode::fromConfig('garbage'));
-        $this->assertSame(TagMode::All, TagMode::fromConfig(''));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Invalid cache tag mode [{$mode}]. Supported modes are [any, all]."
+        );
+
+        TagMode::fromConfig($mode);
+    }
+
+    public static function invalidTagModes(): array
+    {
+        return [
+            'unknown' => ['garbage'],
+            'case mismatch' => ['ANY'],
+            'empty' => [''],
+        ];
     }
 
     public function testIsAnyModeIsTrueForAnyCase(): void

--- a/tests/Coordinator/TimerTest.php
+++ b/tests/Coordinator/TimerTest.php
@@ -343,13 +343,19 @@ class TimerTest extends TestCase
             $id = 0;
             $timer = new Timer;
             $identifier = uniqid();
-            $timer->tick(0.001, function () use (&$id) {
+            $completed = new Channel(1);
+            $timer->tick(0.001, function () use (&$id, $completed) {
                 ++$id;
                 if ($id >= 10) {
+                    $completed->push(true);
+
                     return Timer::STOP;
                 }
             }, $identifier);
-            usleep(20000);
+            $this->assertTrue(
+                $completed->pop(1.0),
+                'The recurring timer did not stop after its tenth tick within 1 second.',
+            );
             $this->assertSame(10, $id);
         });
     }
@@ -378,17 +384,22 @@ class TimerTest extends TestCase
             $logger->shouldReceive('error')->once()->with((string) $exception);
             $timer = new Timer($logger);
             $calls = 0;
+            $completed = new Channel(1);
 
-            $timer->tick(0.001, function () use (&$calls, $exception): ?string {
+            $timer->tick(0.001, function () use (&$calls, $completed, $exception): ?string {
                 if (++$calls === 1) {
                     throw $exception;
                 }
 
+                $completed->push(true);
+
                 return Timer::STOP;
             }, uniqid());
 
-            usleep(10_000);
-
+            $this->assertTrue(
+                $completed->pop(1.0),
+                'The recurring timer did not reach its second tick within 1 second.',
+            );
             $this->assertSame(2, $calls);
         });
     }
@@ -406,17 +417,22 @@ class TimerTest extends TestCase
             $this->wait(function (): void {
                 $timer = new Timer;
                 $calls = 0;
+                $completed = new Channel(1);
 
-                $timer->tick(0.001, function () use (&$calls): ?string {
+                $timer->tick(0.001, function () use (&$calls, $completed): ?string {
                     if (++$calls === 1) {
                         throw new RuntimeException('recurring timer fallback failed');
                     }
 
+                    $completed->push(true);
+
                     return Timer::STOP;
                 }, uniqid());
 
-                usleep(10_000);
-
+                $this->assertTrue(
+                    $completed->pop(1.0),
+                    'The recurring timer did not reach its second tick within 1 second.',
+                );
                 $this->assertSame(2, $calls);
             });
 

--- a/tests/Horizon/Console/HorizonRestartStrategyTest.php
+++ b/tests/Horizon/Console/HorizonRestartStrategyTest.php
@@ -12,12 +12,105 @@ use Hypervel\Support\Env;
 use Hypervel\Testbench\TestCase;
 use Hypervel\Testing\ParallelTesting;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use RuntimeException;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Process\Process;
 
 class HorizonRestartStrategyTest extends TestCase
 {
+    #[DataProvider('environments')]
+    #[RunInSeparateProcess]
+    public function testStartsHorizonFromTheApplicationDirectoryWithTheConfiguredEnvironment(string $environment): void
+    {
+        [$files, $applicationPath, $application] = $this->createTemporaryApplication(
+            'horizon-real-process',
+            <<<'PHP'
+<?php
+
+file_put_contents(__DIR__ . '/result.json', json_encode([
+    'working_directory' => getcwd(),
+    'arguments' => $argv,
+], JSON_THROW_ON_ERROR));
+
+usleep(1_000_000);
+PHP,
+        );
+        $strategy = new HorizonRestartStrategy($application, new NullOutput, $environment);
+
+        try {
+            $strategy->start();
+
+            $resultPath = $applicationPath . '/result.json';
+            $deadline = microtime(true) + 2;
+
+            while (! $files->exists($resultPath) && microtime(true) < $deadline) {
+                usleep(10_000);
+            }
+
+            $result = json_decode($files->get($resultPath), true, flags: JSON_THROW_ON_ERROR);
+
+            $this->assertSame($applicationPath, $result['working_directory']);
+            $this->assertSame('artisan', basename($result['arguments'][0]));
+            $this->assertSame(['horizon', '--environment=' . $environment], array_slice($result['arguments'], 1));
+        } finally {
+            $strategy->stop();
+            $files->deleteDirectory($applicationPath);
+        }
+    }
+
+    public static function environments(): array
+    {
+        return [
+            'named environment' => ['staging'],
+            'zero-named environment' => ['0'],
+        ];
+    }
+
+    #[DataProvider('startupFailures')]
+    #[RunInSeparateProcess]
+    public function testStartupFailureIncludesAvailableProcessDetails(
+        int $exitCode,
+        string $errorOutput,
+        string $expectedMessage,
+    ): void {
+        $process = m::mock(Process::class);
+        $process->expects('start')->once();
+        $process->expects('isTerminated')->once()->andReturnTrue();
+        $process->expects('getExitCode')->once()->andReturn($exitCode);
+        $process->expects('getErrorOutput')->once()->andReturn($errorOutput);
+
+        $strategy = new class($this->app, new NullOutput, null, $process) extends HorizonRestartStrategy {
+            public function __construct(
+                ApplicationContract $application,
+                NullOutput $output,
+                ?string $environment,
+                private Process $process,
+            ) {
+                parent::__construct($application, $output, $environment);
+            }
+
+            protected function createProcess(): Process
+            {
+                return $this->process;
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $strategy->start();
+    }
+
+    public static function startupFailures(): array
+    {
+        return [
+            'stderr' => [7, "broken configuration\n", 'Horizon failed to start with exit code [7]. broken configuration'],
+            'empty stderr' => [9, '', 'Horizon failed to start with exit code [9].'],
+        ];
+    }
+
     #[RunInSeparateProcess]
     public function testStartAndRestartReloadTheConfiguredEnvironmentBeforeCreatingTheProcess(): void
     {
@@ -73,5 +166,26 @@ class HorizonRestartStrategyTest extends TestCase
             Env::flushState();
             $files->deleteDirectory($tempDir);
         }
+    }
+
+    /**
+     * Create a temporary application containing an Artisan script.
+     *
+     * @return array{Filesystem, string, ApplicationContract}
+     */
+    private function createTemporaryApplication(string $name, string $script): array
+    {
+        $applicationPath = ParallelTesting::tempDir($name) . ' with spaces';
+        $files = new Filesystem;
+        $files->deleteDirectory($applicationPath);
+        $files->ensureDirectoryExists($applicationPath);
+        $files->put($applicationPath . '/.env', '');
+        $files->put($applicationPath . '/artisan', $script);
+
+        $application = m::mock(ApplicationContract::class);
+        $application->expects('environmentFilePath')->andReturn($applicationPath . '/.env');
+        $application->expects('basePath')->andReturn($applicationPath);
+
+        return [$files, $applicationPath, $application];
     }
 }

--- a/tests/HttpServer/ResponseBridgeTest.php
+++ b/tests/HttpServer/ResponseBridgeTest.php
@@ -532,7 +532,7 @@ class ResponseBridgeTest extends TestCase
         try {
             BinaryFileResponse::trustXSendfileTypeHeader();
             $request = Request::create('/', 'HEAD', server: [
-                'HTTP_X_SENDFILE_TYPE' => 'X-Custom-Sendfile',
+                'HTTP_X_SENDFILE_TYPE' => 'X-LIGHTTPD-send-file',
             ]);
             $response = new BinaryFileResponse($path);
             $response->deleteFileAfterSend();
@@ -541,7 +541,7 @@ class ResponseBridgeTest extends TestCase
 
             $swooleResponse->shouldNotReceive('sendfile');
             $swooleResponse->shouldNotReceive('write');
-            $swooleResponse->shouldReceive('header')->with('X-Custom-Sendfile', $path)->andReturnTrue();
+            $swooleResponse->shouldReceive('header')->with('X-LIGHTTPD-send-file', $path)->andReturnTrue();
             $swooleResponse->shouldReceive('end')->once()->withNoArgs()->andReturnTrue();
 
             ResponseBridge::send($response, $swooleResponse, withBody: false, request: $request);

--- a/tests/Integration/Cache/Redis/BenchmarkContextTest.php
+++ b/tests/Integration/Cache/Redis/BenchmarkContextTest.php
@@ -48,6 +48,15 @@ class BenchmarkContextTest extends RedisCacheIntegrationTestCase
 
         [$benchmarkKeys, $unrelatedKeys] = $this->seedBenchmarkAndUnrelatedKeys();
 
+        $registryKey = $this->anyModeRegistryKey();
+        $this->redis()->zadd(
+            $registryKey,
+            StoreContext::MAX_EXPIRY,
+            '_bench:registry-tag',
+            StoreContext::MAX_EXPIRY,
+            'unrelated-tag',
+        );
+
         $this->benchmarkContext()->cleanup();
 
         foreach ($benchmarkKeys as $key) {
@@ -57,6 +66,9 @@ class BenchmarkContextTest extends RedisCacheIntegrationTestCase
         foreach ($unrelatedKeys as $key) {
             $this->assertRedisKeyExists($key);
         }
+
+        $this->assertFalse($this->redis()->zScore($registryKey, '_bench:registry-tag'));
+        $this->assertNotFalse($this->redis()->zScore($registryKey, 'unrelated-tag'));
     }
 
     /**

--- a/tests/Integration/Cache/Redis/BenchmarkContextTest.php
+++ b/tests/Integration/Cache/Redis/BenchmarkContextTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Cache\Redis;
+
+use Hypervel\Cache\Redis\Console\Benchmark\BenchmarkContext;
+use Hypervel\Cache\Redis\Support\StoreContext;
+use Hypervel\Cache\TagMode;
+use Hypervel\Console\Command;
+use Hypervel\Contracts\Cache\Factory as CacheContract;
+use Mockery as m;
+
+class BenchmarkContextTest extends RedisCacheIntegrationTestCase
+{
+    public function testCleanupRemovesEveryBenchmarkKeyFamilyAndPreservesUnrelatedKeysInAnyMode(): void
+    {
+        $this->setTagMode(TagMode::Any);
+
+        [$benchmarkKeys, $unrelatedKeys] = $this->seedBenchmarkAndUnrelatedKeys();
+
+        $registryKey = $this->anyModeRegistryKey();
+        $this->redis()->zadd(
+            $registryKey,
+            StoreContext::MAX_EXPIRY,
+            '_bench:registry-tag',
+            StoreContext::MAX_EXPIRY,
+            'unrelated-tag',
+        );
+
+        $this->benchmarkContext()->cleanup();
+
+        foreach ($benchmarkKeys as $key) {
+            $this->assertRedisKeyNotExists($key);
+        }
+
+        foreach ($unrelatedKeys as $key) {
+            $this->assertRedisKeyExists($key);
+        }
+
+        $this->assertFalse($this->redis()->zScore($registryKey, '_bench:registry-tag'));
+        $this->assertNotFalse($this->redis()->zScore($registryKey, 'unrelated-tag'));
+    }
+
+    public function testCleanupRemovesEveryBenchmarkKeyFamilyAndPreservesUnrelatedKeysInAllMode(): void
+    {
+        $this->setTagMode(TagMode::All);
+
+        [$benchmarkKeys, $unrelatedKeys] = $this->seedBenchmarkAndUnrelatedKeys();
+
+        $this->benchmarkContext()->cleanup();
+
+        foreach ($benchmarkKeys as $key) {
+            $this->assertRedisKeyNotExists($key);
+        }
+
+        foreach ($unrelatedKeys as $key) {
+            $this->assertRedisKeyExists($key);
+        }
+    }
+
+    /**
+     * Create a benchmark context for the Redis integration store.
+     */
+    private function benchmarkContext(): BenchmarkContext
+    {
+        return new BenchmarkContext(
+            storeName: 'redis',
+            items: 1,
+            tagsPerItem: 1,
+            heavyTags: 1,
+            command: m::mock(Command::class),
+            cacheManager: $this->app->make(CacheContract::class),
+        );
+    }
+
+    /**
+     * Seed every benchmark key family and unrelated boundary keys.
+     *
+     * @return array{array<string>, array<string>}
+     */
+    private function seedBenchmarkAndUnrelatedKeys(): array
+    {
+        $prefix = $this->getCachePrefix();
+        $benchmarkKeys = [
+            $prefix . '_bench:plain-value',
+            $prefix . '0123456789abcdef:_bench:all-mode-value',
+            $prefix . '_any:tag:_bench:any-mode-tag:entries',
+            $prefix . '_all:tag:_bench:all-mode-tag:entries',
+        ];
+        $unrelatedKeys = [
+            $prefix . 'unrelated-value',
+            $prefix . '_benchmark:value',
+        ];
+
+        foreach ([...$benchmarkKeys, ...$unrelatedKeys] as $key) {
+            $this->redis()->set($key, 'value');
+        }
+
+        return [$benchmarkKeys, $unrelatedKeys];
+    }
+}

--- a/tests/Integration/Cache/Redis/PruneIntegrationTest.php
+++ b/tests/Integration/Cache/Redis/PruneIntegrationTest.php
@@ -116,6 +116,7 @@ class PruneIntegrationTest extends RedisCacheIntegrationTestCase
 
         // Verify hash exists
         $this->assertRedisKeyExists($this->anyModeTagKey('user:1'));
+        $this->assertTrue($this->anyModeRegistryHasTag('user:1'));
 
         // Delete the cache key outside the metadata-aware forget path to
         // simulate an orphaned field left by another invalidation path.
@@ -125,10 +126,13 @@ class PruneIntegrationTest extends RedisCacheIntegrationTestCase
         $this->assertTrue($this->anyModeTagHasEntry('user:1', 'post:1'));
 
         // Run prune
-        $this->store()->anyTagOps()->prune()->execute();
+        $result = $this->store()->anyTagOps()->prune()->execute();
 
-        // Hash should be deleted (was empty after orphan removal)
+        // The final HDEL removes the hash; prune also removes its registry member.
         $this->assertRedisKeyNotExists($this->anyModeTagKey('user:1'));
+        $this->assertFalse($this->anyModeRegistryHasTag('user:1'));
+        $this->assertSame(1, $result['empty_hashes_deleted']);
+        $this->assertSame(1, $result['orphaned_tags_removed']);
     }
 
     public function testAnyModePrunePreservesValidFields(): void
@@ -238,11 +242,14 @@ class PruneIntegrationTest extends RedisCacheIntegrationTestCase
 
         // Orphaned field in user:1
         $this->assertTrue($this->anyModeTagHasEntry('user:1', 'post:1'));
+        $this->assertTrue($this->anyModeRegistryHasTag('user:1'));
 
         // Prune should remove it
-        $this->store()->anyTagOps()->prune()->execute();
+        $result = $this->store()->anyTagOps()->prune()->execute();
 
         $this->assertFalse($this->anyModeTagHasEntry('user:1', 'post:1'));
+        $this->assertFalse($this->anyModeRegistryHasTag('user:1'));
+        $this->assertSame(1, $result['orphaned_tags_removed']);
     }
 
     // =========================================================================
@@ -361,7 +368,7 @@ class PruneIntegrationTest extends RedisCacheIntegrationTestCase
     // REGISTRY CLEANUP (ANY MODE)
     // =========================================================================
 
-    public function testAnyModePruneRemovesStaleTagsFromRegistry(): void
+    public function testAnyModeFlushRemovesTagsFromRegistry(): void
     {
         $this->setTagMode(TagMode::Any);
 

--- a/tests/Integration/Reverb/ClearStateCommandTest.php
+++ b/tests/Integration/Reverb/ClearStateCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Integration\Reverb;
+
+use Hypervel\Console\Command as HypervelCommand;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Foundation\Testing\Concerns\InteractsWithRedis;
+use Hypervel\Redis\RedisConnection;
+use Hypervel\Redis\RedisProxy;
+use Hypervel\Reverb\Servers\Hypervel\Scaling\RedisSharedState;
+use Hypervel\Support\Facades\Redis;
+use Hypervel\Tests\Reverb\ReverbTestCase;
+
+class ClearStateCommandTest extends ReverbTestCase
+{
+    use InteractsWithRedis;
+
+    /**
+     * Define environment setup.
+     */
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app->make('config')->set('reverb.servers.reverb.scaling.connection', 'default');
+    }
+
+    public function testDryRunAndClearAffectOnlyRedisSharedState(): void
+    {
+        if ($this->usingRedisCluster()) {
+            $this->markTestSkipped('Reverb scaling requires a standalone or Sentinel Redis connection.');
+        }
+
+        $redis = Redis::connection('default');
+        $this->seedSharedState($redis);
+
+        $survivors = [
+            'reverb:webhook:{app}:buffer' => 'buffer',
+            'reverb:webhook:{app}:flush' => 'flush',
+            'reverb:webhook:{app}:processing' => 'processing',
+            'reverb:message:123' => 'message',
+            'unrelated:key' => 'unrelated',
+        ];
+
+        foreach ($survivors as $key => $value) {
+            $redis->set($key, $value);
+        }
+
+        $this->assertSame(7, $this->sharedStateKeyCount($redis));
+
+        $this->artisan('reverb:clear-state', ['--dry-run' => true])
+            ->expectsOutputToContain('Found [7] Reverb shared-state keys.')
+            ->assertExitCode(HypervelCommand::SUCCESS);
+
+        $this->assertSame(7, $this->sharedStateKeyCount($redis));
+
+        foreach ($survivors as $key => $value) {
+            $this->assertSame($value, $redis->get($key));
+        }
+
+        $this->artisan('reverb:clear-state', ['--force' => true])
+            ->expectsOutputToContain('Cleared [7] Reverb shared-state keys.')
+            ->assertExitCode(HypervelCommand::SUCCESS);
+
+        $this->assertSame(0, $this->sharedStateKeyCount($redis));
+
+        foreach ($survivors as $key => $value) {
+            $this->assertSame($value, $redis->get($key));
+        }
+    }
+
+    private function seedSharedState(RedisProxy $redis): void
+    {
+        $state = new RedisSharedState($redis);
+
+        $this->assertTrue($state->acquireConnectionSlot('app', 100));
+        $state->subscribe('app', 'presence-channel');
+        $state->subscribe('app', 'presence-channel', 'user');
+        $this->assertTrue($state->trySubscriptionCountLock('app', 'presence-channel', 60_000));
+        $this->assertTrue($state->tryCacheMissLock('app', 'presence-channel', 60_000));
+        $state->setSmoothingPending('app', 'presence-channel', 60_000);
+        $state->setMemberSmoothingPending('app', 'presence-channel', 'user', 60_000);
+    }
+
+    private function sharedStateKeyCount(RedisProxy $redis): int
+    {
+        return $redis->withConnection(
+            fn (RedisConnection $connection): int => iterator_count(
+                $connection->safeScan(RedisSharedState::KEY_PATTERN),
+            ),
+            transform: false,
+        );
+    }
+}

--- a/tests/Integration/Reverb/ClearStateCommandTest.php
+++ b/tests/Integration/Reverb/ClearStateCommandTest.php
@@ -9,13 +9,26 @@ use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Foundation\Testing\Concerns\InteractsWithRedis;
 use Hypervel\Redis\RedisConnection;
 use Hypervel\Redis\RedisProxy;
+use Hypervel\Reverb\ReverbServiceProvider;
 use Hypervel\Reverb\Servers\Hypervel\Scaling\RedisSharedState;
 use Hypervel\Support\Facades\Redis;
-use Hypervel\Tests\Reverb\ReverbTestCase;
+use Hypervel\Testbench\TestCase;
 
-class ClearStateCommandTest extends ReverbTestCase
+class ClearStateCommandTest extends TestCase
 {
     use InteractsWithRedis;
+
+    /**
+     * Get package providers.
+     *
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders(ApplicationContract $app): array
+    {
+        return [
+            ReverbServiceProvider::class,
+        ];
+    }
 
     /**
      * Define environment setup.

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use Exception;
 use Hypervel\Container\Container;
 use Hypervel\Context\CoroutineContext;
+use Hypervel\Contracts\Cache\Repository as CacheContract;
 use Hypervel\Contracts\Container\Container as ContainerContract;
 use Hypervel\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Hypervel\Contracts\Events\Dispatcher as EventDispatcher;
@@ -1020,6 +1021,43 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldNotHaveReceived('dispatch', [m::type(JobProcessed::class)]);
     }
 
+    public function testJobIsFailedWhenTheMaxExceptionsCounterReachesTheLimit(): void
+    {
+        $exception = new RuntimeException('Job failed.');
+        $job = new WorkerFakeJob;
+        $job->maxExceptions = 3;
+        $cache = m::mock(CacheContract::class);
+        $cache->expects('get')->with('job-exceptions:' . $job->uuid)->andReturnTrue();
+        $cache->expects('increment')->with('job-exceptions:' . $job->uuid)->andReturn(3);
+        $cache->expects('forget')->with('job-exceptions:' . $job->uuid)->andReturnTrue();
+        $worker = $this->getWorker()->setCache($cache);
+
+        $worker->markJobAsFailedIfWillExceedMaxExceptionsForTest($job, $exception);
+
+        $this->assertSame($exception, $job->failedWith);
+    }
+
+    public function testBooleanMaxExceptionsCounterResultsDoNotFailTheJob(): void
+    {
+        foreach ([false, true] as $counterResult) {
+            $exception = new RuntimeException('Job failed.');
+            $job = new WorkerFakeJob;
+            $job->maxExceptions = 0;
+            $cache = m::mock(CacheContract::class);
+            $cache->expects('get')->with('job-exceptions:' . $job->uuid)->andReturnTrue();
+            $cache->expects('increment')->with('job-exceptions:' . $job->uuid)->andReturn($counterResult);
+            $cache->shouldNotReceive('forget');
+            $worker = $this->getWorker()->setCache($cache);
+
+            $worker->markJobAsFailedIfWillExceedMaxExceptionsForTest($job, $exception);
+
+            $this->assertNull(
+                $job->failedWith,
+                sprintf('The boolean counter result [%s] failed the job.', $counterResult ? 'true' : 'false'),
+            );
+        }
+    }
+
     public function testJobBasedMaxRetries()
     {
         $job = new WorkerFakeJob(function ($job) {
@@ -1563,6 +1601,11 @@ class InsomniacWorker extends Worker
             jobsAdmitted: 0,
             hasRunningJobs: $hasRunningJobs,
         );
+    }
+
+    public function markJobAsFailedIfWillExceedMaxExceptionsForTest(Job $job, Throwable $exception): void
+    {
+        parent::markJobAsFailedIfWillExceedMaxExceptions('default', $job, $exception);
     }
 
     protected function supportsAsyncSignals(): bool

--- a/tests/Redis/Fixtures/FakeRedisClient.php
+++ b/tests/Redis/Fixtures/FakeRedisClient.php
@@ -124,6 +124,11 @@ class FakeRedisClient extends Redis
     private string $optPrefix = '';
 
     /**
+     * The last simulated Redis error.
+     */
+    private ?string $lastError = null;
+
+    /**
      * Configured zScan results per key.
      *
      * @var array<string, array<int, array{members: array<string, float>, iterator: int}>>
@@ -305,6 +310,32 @@ class FakeRedisClient extends Redis
             Redis::OPT_PREFIX => $this->optPrefix,
             default => null,
         };
+    }
+
+    /**
+     * Clear the last simulated Redis error.
+     */
+    public function clearLastError(): bool
+    {
+        $this->lastError = null;
+
+        return true;
+    }
+
+    /**
+     * Get the last simulated Redis error.
+     */
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    /**
+     * Set the last simulated Redis error.
+     */
+    public function setFakeLastError(?string $lastError): void
+    {
+        $this->lastError = $lastError;
     }
 
     /**
@@ -509,5 +540,6 @@ class FakeRedisClient extends Redis
         $this->execCallIndex = 0;
         $this->inPipeline = false;
         $this->pipelineQueue = [];
+        $this->lastError = null;
     }
 }

--- a/tests/Redis/Fixtures/FakeRedisClient.php
+++ b/tests/Redis/Fixtures/FakeRedisClient.php
@@ -171,6 +171,32 @@ class FakeRedisClient extends Redis
     private array $zRemRangeByScoreResults = [];
 
     /**
+     * Recorded zRemRangeByScore calls for assertions.
+     *
+     * @var array<int, array{key: string, min: string, max: string}>
+     */
+    private array $zRemRangeByScoreCalls = [];
+
+    /**
+     * Configured EVALSHA results in call order.
+     *
+     * @var array<int, mixed>
+     */
+    private array $evalShaResults = [];
+
+    /**
+     * Current EVALSHA call index.
+     */
+    private int $evalShaCallIndex = 0;
+
+    /**
+     * Recorded EVALSHA calls for assertions.
+     *
+     * @var array<int, array{sha: string, args: array<mixed>, num_keys: int}>
+     */
+    private array $evalShaCalls = [];
+
+    /**
      * Create a new fake Redis client.
      *
      * @param array<int, array{keys: array<string>, iterator: int}> $scanResults Configured scan results
@@ -182,6 +208,7 @@ class FakeRedisClient extends Redis
      * @param array<string, array<int, array{members: array<string, float>, iterator: int}>> $zScanResults Configured zScan results
      * @param array<string, int> $zCardResults Configured zCard results per key
      * @param array<string, int> $zRemRangeByScoreResults Configured zRemRangeByScore results per key
+     * @param array<int, mixed> $evalShaResults Configured EVALSHA results in call order
      */
     public function __construct(
         array $scanResults = [],
@@ -193,6 +220,7 @@ class FakeRedisClient extends Redis
         array $zScanResults = [],
         array $zCardResults = [],
         array $zRemRangeByScoreResults = [],
+        array $evalShaResults = [],
     ) {
         // Note: We intentionally do NOT call parent::__construct() to avoid
         // any connection attempts. This fake client never connects to Redis.
@@ -205,6 +233,7 @@ class FakeRedisClient extends Redis
         $this->zScanResults = $zScanResults;
         $this->zCardResults = $zCardResults;
         $this->zRemRangeByScoreResults = $zRemRangeByScoreResults;
+        $this->evalShaResults = $evalShaResults;
     }
 
     /**
@@ -339,6 +368,30 @@ class FakeRedisClient extends Redis
     }
 
     /**
+     * Simulate EVALSHA without connecting to Redis.
+     */
+    public function evalSha(string $sha1, array $args = [], int $num_keys = 0): mixed
+    {
+        $this->evalShaCalls[] = [
+            'sha' => $sha1,
+            'args' => $args,
+            'num_keys' => $num_keys,
+        ];
+
+        return $this->evalShaResults[$this->evalShaCallIndex++] ?? 0;
+    }
+
+    /**
+     * Get recorded EVALSHA calls for assertions.
+     *
+     * @return array<int, array{sha: string, args: array<mixed>, num_keys: int}>
+     */
+    public function getEvalShaCalls(): array
+    {
+        return $this->evalShaCalls;
+    }
+
+    /**
      * Simulate zRange to get sorted set members.
      *
      * @return array<string>|false|Redis
@@ -428,7 +481,20 @@ class FakeRedisClient extends Redis
             $this->pipelineQueue[] = ['method' => 'zRemRangeByScore', 'args' => [$key, $min, $max]];
             return $this;
         }
+
+        $this->zRemRangeByScoreCalls[] = ['key' => $key, 'min' => $min, 'max' => $max];
+
         return $this->zRemRangeByScoreResults[$key] ?? 0;
+    }
+
+    /**
+     * Get recorded zRemRangeByScore calls for test assertions.
+     *
+     * @return array<int, array{key: string, min: string, max: string}>
+     */
+    public function getZRemRangeByScoreCalls(): array
+    {
+        return $this->zRemRangeByScoreCalls;
     }
 
     /**
@@ -537,6 +603,9 @@ class FakeRedisClient extends Redis
         $this->zScanCallIndex = [];
         $this->zScanCalls = [];
         $this->zRemCalls = [];
+        $this->zRemRangeByScoreCalls = [];
+        $this->evalShaCallIndex = 0;
+        $this->evalShaCalls = [];
         $this->execCallIndex = 0;
         $this->inPipeline = false;
         $this->pipelineQueue = [];

--- a/tests/Redis/Operations/FlushByPatternTest.php
+++ b/tests/Redis/Operations/FlushByPatternTest.php
@@ -11,6 +11,7 @@ use Hypervel\Tests\Redis\Fixtures\FakeRedisClient;
 use Hypervel\Tests\Redis\Fixtures\PhpRedisConnectionStub;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
+use RedisException;
 
 /**
  * Tests for FlushByPattern - pattern-based key deletion with OPT_PREFIX handling.
@@ -58,6 +59,10 @@ class FlushByPatternTest extends TestCase
         );
 
         [$connection] = $this->createConnectionWithClient($client);
+        $connection->shouldReceive('clearLastError')
+            ->once()
+            ->andReturnUsing(fn (): bool => $client->clearLastError());
+        $connection->shouldNotReceive('getLastError');
         $connection->shouldReceive('unlink')
             ->once()
             ->with('cache:test:key1', 'cache:test:key2', 'cache:test:key3')
@@ -176,25 +181,66 @@ class FlushByPatternTest extends TestCase
         $this->assertSame(3, $deletedCount);
     }
 
-    public function testFlushHandlesUnlinkReturningNonInteger(): void
+    public function testFlushThrowsTheNativeErrorWhenUnlinkFails(): void
     {
         $client = new FakeRedisClient(
             scanResults: [
                 ['keys' => ['cache:test:key1'], 'iterator' => 0],
             ],
         );
+        $client->setFakeLastError('stale error');
 
         [$connection] = $this->createConnectionWithClient($client);
-        // unlink might return false on error
+        $connection->shouldReceive('clearLastError')
+            ->once()
+            ->andReturnUsing(fn (): bool => $client->clearLastError());
+        $connection->shouldReceive('getLastError')
+            ->once()
+            ->andReturnUsing(fn (): ?string => $client->getLastError());
         $connection->shouldReceive('unlink')
             ->once()
-            ->andReturn(false);
+            ->andReturnUsing(function () use ($client): false {
+                $this->assertNull($client->getLastError());
 
-        $flushByPattern = new FlushByPattern($connection);
+                $client->setFakeLastError('UNLINK is not permitted');
 
-        $deletedCount = $flushByPattern->execute('cache:test:*');
+                return false;
+            });
 
-        $this->assertSame(0, $deletedCount);
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage('UNLINK is not permitted');
+
+        (new FlushByPattern($connection))->execute('cache:test:*');
+    }
+
+    public function testFlushThrowsAStableErrorWhenUnlinkFailsWithoutANativeError(): void
+    {
+        $client = new FakeRedisClient(
+            scanResults: [
+                ['keys' => ['cache:test:key1'], 'iterator' => 0],
+            ],
+        );
+        $client->setFakeLastError('stale error');
+
+        [$connection] = $this->createConnectionWithClient($client);
+        $connection->shouldReceive('clearLastError')
+            ->once()
+            ->andReturnUsing(fn (): bool => $client->clearLastError());
+        $connection->shouldReceive('getLastError')
+            ->once()
+            ->andReturnUsing(fn (): ?string => $client->getLastError());
+        $connection->shouldReceive('unlink')
+            ->once()
+            ->andReturnUsing(function () use ($client): false {
+                $this->assertNull($client->getLastError());
+
+                return false;
+            });
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage('Redis UNLINK failed while deleting keys by pattern.');
+
+        (new FlushByPattern($connection))->execute('cache:test:*');
     }
 
     public function testFlushPassesPatternToSafeScan(): void

--- a/tests/Redis/PhpRedisClusterConnectionTest.php
+++ b/tests/Redis/PhpRedisClusterConnectionTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Redis;
 use RedisCluster;
 use RedisException;
+use RuntimeException;
 use Swoole\Coroutine\CanceledException;
 use Throwable;
 
@@ -49,6 +50,34 @@ class PhpRedisClusterConnectionTest extends TestCase
             $this->fail('Expected the cancellation to escape.');
         } catch (CanceledException $exception) {
             $this->assertSame($cancellation, $exception);
+        }
+    }
+
+    public function testClusterCreationPreservesTheUnderlyingFailure(): void
+    {
+        $failure = new RuntimeException('cluster unavailable');
+
+        try {
+            new class($this->getContainer(), $this->getMockedPool(), $this->clusterConfig(), $failure) extends PhpRedisClusterConnection {
+                public function __construct(
+                    ContainerContract $container,
+                    PoolInterface $pool,
+                    array $config,
+                    private RuntimeException $failure,
+                ) {
+                    parent::__construct($container, $pool, $config);
+                }
+
+                protected function formatClusterPassword(): mixed
+                {
+                    throw $this->failure;
+                }
+            };
+
+            $this->fail('Expected Redis Cluster creation to fail.');
+        } catch (ConnectionException $exception) {
+            $this->assertSame('Connection reconnect failed: cluster unavailable', $exception->getMessage());
+            $this->assertSame($failure, $exception->getPrevious());
         }
     }
 
@@ -520,6 +549,10 @@ class PhpRedisClusterConnectionTest extends TestCase
 
     public function testClusterOptionsUseNativeFailoverAndTcpKeepaliveConstants(): void
     {
+        if (! defined(Redis::class . '::OPT_PACK_IGNORE_NUMBERS')) {
+            $this->markTestSkipped('PhpRedis does not support OPT_PACK_IGNORE_NUMBERS.');
+        }
+
         $connection = new class($this->getContainer(), $this->getMockedPool(), $this->clusterConfig(['options' => ['failover' => RedisCluster::FAILOVER_DISTRIBUTE, 'tcp_keepalive' => 30, 'pack_ignore_numbers' => true]])) extends PhpRedisClusterConnectionStub {
             public function setOptionsForTest(RedisCluster $redis): void
             {
@@ -532,6 +565,9 @@ class PhpRedisClusterConnectionTest extends TestCase
             ->andReturnTrue();
         $redis->expects('setOption')
             ->with(Redis::OPT_TCP_KEEPALIVE, 30)
+            ->andReturnTrue();
+        $redis->expects('setOption')
+            ->with(Redis::OPT_PACK_IGNORE_NUMBERS, true)
             ->andReturnTrue();
         $this->expectDefaultConnectionOptions($redis);
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -16,6 +16,7 @@ use Hypervel\Events\Dispatcher;
 use Hypervel\Pool\Events\ReleaseConnection;
 use Hypervel\Pool\Exceptions\ConnectionException;
 use Hypervel\Pool\PoolOption;
+use Hypervel\Redis\Exceptions\InvalidRedisOptionException;
 use Hypervel\Redis\Exceptions\LuaScriptException;
 use Hypervel\Redis\PhpRedisClusterConnection;
 use Hypervel\Redis\PhpRedisConnection;
@@ -952,6 +953,27 @@ class RedisConnectionTest extends TestCase
             $this->fail('Expected the cancellation to escape.');
         } catch (CanceledException $exception) {
             $this->assertSame($cancellation, $exception);
+        }
+    }
+
+    public function testSentinelResolutionPreservesTheUnderlyingFailure(): void
+    {
+        $failure = new RuntimeException('sentinel unavailable');
+        $sentinelFactory = m::mock(RedisSentinelFactory::class);
+        $sentinelFactory->expects('resolveMaster')->andThrow($failure);
+        $container = m::mock(ContainerContract::class);
+        $container->expects('make')
+            ->with(RedisSentinelFactory::class)
+            ->andReturn($sentinelFactory);
+        $container->shouldReceive('bound')->with('events')->andReturnFalse();
+        $container->shouldReceive('has')->andReturnFalse();
+
+        try {
+            new PhpRedisConnection($container, $this->getMockedPool(), $this->sentinelConfig());
+            $this->fail('Expected Sentinel resolution to fail.');
+        } catch (ConnectionException $exception) {
+            $this->assertSame('Connection reconnect failed: sentinel unavailable', $exception->getMessage());
+            $this->assertSame($failure, $exception->getPrevious());
         }
     }
 
@@ -3056,6 +3078,36 @@ class RedisConnectionTest extends TestCase
         };
     }
 
+    public function testReconnectRejectsNamedPackIgnoreNumbersWhenPhpRedisDoesNotSupportIt(): void
+    {
+        if (defined(Redis::class . '::OPT_PACK_IGNORE_NUMBERS')) {
+            $this->markTestSkipped('PhpRedis supports OPT_PACK_IGNORE_NUMBERS.');
+        }
+
+        $pool = $this->getMockedPool();
+        $redis = m::mock(Redis::class);
+        $redis->shouldReceive('setOption')->andReturnTrue();
+
+        $this->expectException(InvalidRedisOptionException::class);
+        $this->expectExceptionMessage('The redis option `pack_ignore_numbers` requires PhpRedis 6.2 or later.');
+
+        new class($this->getContainer(), $pool, $this->standaloneConfig(['options' => ['pack_ignore_numbers' => true]]), $redis) extends PhpRedisConnection {
+            public function __construct(
+                ContainerContract $container,
+                PoolInterface $pool,
+                array $config,
+                private Redis $fakeRedis,
+            ) {
+                parent::__construct($container, $pool, $config);
+            }
+
+            protected function createRedis(array $config): Redis
+            {
+                return $this->fakeRedis;
+            }
+        };
+    }
+
     public function testReconnectSetsConnectionLevelPhpRedisOptions(): void
     {
         $pool = $this->getMockedPool();
@@ -3148,7 +3200,7 @@ class RedisConnectionTest extends TestCase
         $pool = $this->getMockedPool();
         $redis = m::mock(Redis::class);
 
-        $this->expectException(\Hypervel\Redis\Exceptions\InvalidRedisOptionException::class);
+        $this->expectException(InvalidRedisOptionException::class);
         $this->expectExceptionMessage('Algorithm [bogus] is not a valid PhpRedis backoff algorithm.');
 
         $redis->shouldReceive('setOption')->andReturnTrue();
@@ -3175,7 +3227,7 @@ class RedisConnectionTest extends TestCase
         $pool = $this->getMockedPool();
         $redis = m::mock(Redis::class);
 
-        $this->expectException(\Hypervel\Redis\Exceptions\InvalidRedisOptionException::class);
+        $this->expectException(InvalidRedisOptionException::class);
         $this->expectExceptionMessage('The redis option key `bogus` is invalid.');
 
         $redis->shouldReceive('setOption')->andReturnTrue();

--- a/tests/Reverb/Console/Commands/ClearStateCommandTest.php
+++ b/tests/Reverb/Console/Commands/ClearStateCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Reverb\Console\Commands;
+
+use Hypervel\Console\Command as HypervelCommand;
+use Hypervel\Contracts\Redis\Factory as RedisFactory;
+use Hypervel\Redis\RedisConnection;
+use Hypervel\Redis\RedisProxy;
+use Hypervel\Reverb\Servers\Hypervel\Scaling\RedisSharedState;
+use Hypervel\Tests\Reverb\ReverbTestCase;
+use Mockery as m;
+
+class ClearStateCommandTest extends ReverbTestCase
+{
+    public function testDryRunCountsKeysWithoutConfirmationOrDeletion(): void
+    {
+        $rawConnection = m::mock(RedisConnection::class);
+        $rawConnection->expects('safeScan')
+            ->with(RedisSharedState::KEY_PATTERN)
+            ->andReturn((static function () {
+                yield 'first';
+                yield 'second';
+            })());
+
+        $connection = m::mock(RedisProxy::class);
+        $connection->expects('withConnection')
+            ->withArgs(fn (callable $callback, bool $transform): bool => $transform === false)
+            ->andReturnUsing(
+                fn (callable $callback, bool $transform): int => $callback($rawConnection),
+            );
+        $connection->shouldNotReceive('flushByPattern');
+        $this->bindRedisConnection($connection);
+
+        $this->artisan('reverb:clear-state', ['--dry-run' => true])
+            ->expectsOutputToContain('Found [2] Reverb shared-state keys.')
+            ->assertExitCode(HypervelCommand::SUCCESS);
+    }
+
+    public function testDestructiveRunCanBeCancelledInAnyEnvironment(): void
+    {
+        $connection = m::mock(RedisProxy::class);
+        $connection->shouldNotReceive('flushByPattern');
+        $this->bindRedisConnection($connection);
+
+        $this->artisan('reverb:clear-state')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'no')
+            ->expectsOutputToContain('Command cancelled.')
+            ->assertExitCode(HypervelCommand::FAILURE);
+    }
+
+    public function testConfirmedDestructiveRunClearsSharedState(): void
+    {
+        $connection = m::mock(RedisProxy::class);
+        $connection->expects('flushByPattern')
+            ->with(RedisSharedState::KEY_PATTERN)
+            ->andReturn(7);
+        $this->bindRedisConnection($connection);
+
+        $this->artisan('reverb:clear-state')
+            ->expectsConfirmation('Are you sure you want to run this command?', 'yes')
+            ->expectsOutputToContain('Cleared [7] Reverb shared-state keys.')
+            ->assertExitCode(HypervelCommand::SUCCESS);
+    }
+
+    public function testForceSkipsConfirmation(): void
+    {
+        $connection = m::mock(RedisProxy::class);
+        $connection->expects('flushByPattern')
+            ->with(RedisSharedState::KEY_PATTERN)
+            ->andReturn(7);
+        $this->bindRedisConnection($connection);
+
+        $this->artisan('reverb:clear-state', ['--force' => true])
+            ->expectsOutputToContain('Cleared [7] Reverb shared-state keys.')
+            ->assertExitCode(HypervelCommand::SUCCESS);
+    }
+
+    private function bindRedisConnection(RedisProxy $connection): void
+    {
+        config()->set('reverb.servers.reverb.scaling.connection', 'queue');
+
+        $redis = m::mock(RedisFactory::class);
+        $redis->expects('connection')->with('queue')->andReturn($connection);
+
+        $this->app->instance('redis', $redis);
+    }
+}

--- a/tests/Reverb/DisabledReverbServiceProviderTest.php
+++ b/tests/Reverb/DisabledReverbServiceProviderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Reverb;
+
+use Hypervel\Console\Command as HypervelCommand;
+use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+
+class DisabledReverbServiceProviderTest extends ReverbTestCase
+{
+    /**
+     * Define environment setup.
+     */
+    protected function defineEnvironment(ApplicationContract $app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app->make('config')->set('reverb.enabled', false);
+    }
+
+    public function testRegistersClearStateCommandWhenReverbIsDisabled(): void
+    {
+        $this->artisan('list')
+            ->expectsOutputToContain('reverb:clear-state')
+            ->assertExitCode(HypervelCommand::SUCCESS);
+    }
+}

--- a/tests/Reverb/Servers/Hypervel/Scaling/RedisSharedStateTest.php
+++ b/tests/Reverb/Servers/Hypervel/Scaling/RedisSharedStateTest.php
@@ -11,6 +11,43 @@ use Mockery as m;
 
 class RedisSharedStateTest extends TestCase
 {
+    public function testRecoveryPatternMatchesGeneratedSharedStateKeysOnly(): void
+    {
+        $state = new class(m::mock(RedisProxy::class)) extends RedisSharedState {
+            /**
+             * Get the generated shared-state keys.
+             *
+             * @return list<string>
+             */
+            public function keysForTest(string $appId, string $channel, string $userId): array
+            {
+                return [
+                    $this->key(self::CONNECTION_KEY_TYPE, $appId),
+                    $this->channelKey($appId, $channel),
+                    $this->userKey($appId, $channel, $userId),
+                    $this->key(self::SUBSCRIPTION_COUNT_LOCK_KEY_TYPE, $appId, $channel),
+                    $this->key(self::CACHE_MISS_LOCK_KEY_TYPE, $appId, $channel),
+                    $this->key(self::CHANNEL_SMOOTHING_KEY_TYPE, $appId, $channel),
+                    $this->key(self::MEMBER_SMOOTHING_KEY_TYPE, $appId, $channel, $userId),
+                ];
+            }
+        };
+
+        foreach ($state->keysForTest('app', 'presence-channel', 'user') as $key) {
+            $this->assertTrue(fnmatch(RedisSharedState::KEY_PATTERN, $key), $key);
+        }
+
+        foreach ([
+            'reverb:webhook:{app}:buffer',
+            'reverb:webhook:{app}:flush',
+            'reverb:webhook:{app}:processing',
+            'reverb:message:123',
+            'unrelated:key',
+        ] as $key) {
+            $this->assertFalse(fnmatch(RedisSharedState::KEY_PATTERN, $key), $key);
+        }
+    }
+
     public function testPresenceSubscribeUsesOneAtomicScript(): void
     {
         $redis = m::mock(RedisProxy::class);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1412,8 +1412,8 @@ EOT,
             ['foo' => 'baz'],
         ]));
 
-        $response->assertJson(function (AssertableJson $json) {
-        });
+        $this->assertSame($response, $response->assertJson(function (AssertableJson $json) {
+        }));
     }
 
     public function testAssertJsonWithFluentHasAnyThrows(): void
@@ -1840,10 +1840,10 @@ EOT,
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
-        $response->assertJsonMissingExact(['id' => 2]);
+        $this->assertSame($response, $response->assertJsonMissingExact(['id' => 2]));
 
         // This is missing because bar has changed to baz
-        $response->assertJsonMissingExact(['id' => 20, 'foo' => 'baz']);
+        $this->assertSame($response, $response->assertJsonMissingExact(['id' => 20, 'foo' => 'baz']));
     }
 
     public function testAssertJsonMissingExactCanFail(): void
@@ -2470,7 +2470,7 @@ EOT,
             (new Response)->setContent(json_encode($data))
         );
 
-        $testResponse->assertJsonMissingValidationErrors();
+        $this->assertSame($testResponse, $testResponse->assertJsonMissingValidationErrors());
     }
 
     public function testAssertJsonMissingValidationErrorsWithoutArgumentCanFail(): void


### PR DESCRIPTION
## Summary

This PR fixes operational paths that could hide failures, retain stale Redis state, or publish cache metadata for values that were never written:

- adds a manual recovery command for stale Redis-backed Reverb shared state;
- makes bounded Redis deletion report native failures instead of returning a false zero count;
- corrects Redis counter contracts, option handling, and exception chains;
- rejects invalid cache tag modes instead of silently changing their meaning;
- makes tagged-cache cleanup safe around concurrent writers and keeps benchmark recovery patterns complete;
- prevents boolean cache results from being treated as queue exception counts; and
- starts Horizon with executable paths, the application working directory, and useful startup diagnostics.

## Reverb recovery

Hypervel keeps connection, subscription, and presence state in Redis so every Reverb worker and node shares one exact view. Normal shutdown removes that state, but a hard process or machine failure cannot run the cleanup.

The new `reverb:clear-state` command provides an explicit recovery path. It uses the configured scaling connection, scans only keys owned by `RedisSharedState`, supports `--dry-run`, and requires confirmation unless `--force` is supplied. Webhook buffers and unrelated Redis data are not touched.

The documented procedure is stop every Reverb node sharing the state, inspect or clear it, then start the nodes again. The command is never run automatically and adds no work to normal Reverb traffic.

## Redis and cache correctness

Pattern cleanup continues to use bounded `SCAN` batches and `UNLINK`. If a batch fails, Hypervel now reports the native Redis error. It does not fall back to synchronous `DEL`, which could block Redis while arbitrary values are freed.

The Redis connector applies PhpRedis numeric packing options consistently to standalone and Cluster clients. Sentinel and Cluster connection wrappers also retain the original exception as their cause.

Redis increment and decrement operations now match the existing cache store contract by preserving `false`. Invalid `tag_mode` configuration fails with both accepted values in the error instead of silently selecting `all`.

Tagged-cache pruning now owns its metadata completely. Standalone Redis handles each bounded scan page atomically in Lua and removes empty any-mode registry entries. Redis Cluster batches candidate removals, rechecks cross-slot state, and repairs metadata only when a concurrent writer proves it still belongs. Repair commands use `NX`, so they cannot overwrite newer metadata.

All-mode writers publish values before memberships without adding commands or round trips. Cluster batch writes publish memberships only for successful values. Benchmark recovery output derives every cleanup pattern from `BenchmarkContext`, and integration coverage verifies that recovery and prune operations leave no owned metadata behind.

The Redis guide now states the supported Redis and Valkey server versions and explains the serializer settings required by atomic counters.

## Queue and Horizon behavior

The queue worker treats only integer cache results as exception counts. Contract-valid booleans no longer fail a job or clear its retry state.

Horizon builds its array-form process command from raw executable paths, runs it from the application base path, and preserves named environments including `"0"`. If the process exits during startup, the exception includes its exit code and stderr when available. Shell-escaped binary paths remain limited to the existing shell command-string builders.

## Compatibility and cost

The changes preserve Laravel's public contracts. The Reverb command is additive, cache return types now match the existing contract, and invalid Hypervel-specific configuration fails earlier and clearly.

There is no added steady-state I/O, locking, or polling. Reverb recovery runs only when invoked by an operator. Tag validation happens when a store is created. Tagged-cache writers issue the same commands in a safer order. Standalone prune uses one bounded script per page, while Cluster prune batches removals before the required cross-slot rechecks.

The recurring Timer tests now wait for the callback that proves continuation or stopping instead of relying on fixed scheduling delays. This changes test synchronization only.

## Verification

The formatter, static analysis, full parallel suite, Testbench package-mode suite, and dogfood suite pass. Focused Redis, cache, queue, Horizon, Reverb, and Redis-backed recovery coverage also passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `reverb:clear-state` to inspect and remove stale Redis-backed Reverb state with dry-run, confirmation, and force options.
  - Improved Redis cache tag cleanup to remove orphaned metadata while preserving concurrent updates.

- **Bug Fixes**
  - Redis cache counters now accurately report failures and avoid invalid tag metadata.
  - Redis cleanup and connection failures now provide clearer errors.
  - Improved queue failure-counter handling and Horizon startup diagnostics.

- **Documentation**
  - Expanded Redis, cache, queue, and Reverb recovery guidance, including supported server versions and configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->