### PR TITLE
Fix local queue identity reporting

### DIFF
--- a/src/bus/src/Dispatcher.php
+++ b/src/bus/src/Dispatcher.php
@@ -92,6 +92,7 @@ class Dispatcher implements QueueingDispatcher
         $uses = class_uses_recursive($command);
 
         if (isset($uses[InteractsWithQueue::class], $uses[Queueable::class]) && ! $command->job) {
+            // This synthetic job was never queued, so "sync" only labels its inline execution.
             $command->setJob(new SyncJob($this->container, json_encode([]), 'sync', 'sync'));
         }
 

--- a/src/foundation/config/queue.php
+++ b/src/foundation/config/queue.php
@@ -41,7 +41,9 @@ return [
     | Omitting a database or Redis connection selects the corresponding
     | default connection. Database, Beanstalkd, and Redis retry timeouts
     | default to 60 seconds when omitted. Connection records for drivers
-    | without named queues may omit the "queue" member.
+    | without named queues may omit the "queue" member. The sync, background,
+    | and deferred drivers do not support configurable queue names and ignore
+    | a "queue" member on their connections.
     |
     | Except for sync and database, a dispatch waits for the most recently
     | started applicable transaction and its enclosing stack to commit.

--- a/src/queue/src/BackgroundQueue.php
+++ b/src/queue/src/BackgroundQueue.php
@@ -15,6 +15,11 @@ use Throwable;
 class BackgroundQueue extends SyncQueue
 {
     /**
+     * The name of the default queue.
+     */
+    protected string $default = 'background';
+
+    /**
      * The exception callback that should be used for handling uncaught exceptions in background execution.
      *
      * @var null|callable

--- a/src/queue/src/DeferredQueue.php
+++ b/src/queue/src/DeferredQueue.php
@@ -15,6 +15,11 @@ use Throwable;
 class DeferredQueue extends SyncQueue
 {
     /**
+     * The name of the default queue.
+     */
+    protected string $default = 'deferred';
+
+    /**
      * The exception callback that should be used for handling uncaught exceptions in defer.
      *
      * @var null|callable

--- a/src/queue/src/Jobs/SyncJob.php
+++ b/src/queue/src/Jobs/SyncJob.php
@@ -61,6 +61,6 @@ class SyncJob extends Job
      */
     public function getQueue(): string
     {
-        return 'sync';
+        return $this->queue;
     }
 }

--- a/src/queue/src/SyncQueue.php
+++ b/src/queue/src/SyncQueue.php
@@ -21,6 +21,11 @@ use Throwable;
 class SyncQueue extends Queue implements QueueContract
 {
     /**
+     * The name of the default queue.
+     */
+    protected string $default = 'sync';
+
+    /**
      * Create a new sync queue instance.
      */
     public function __construct(
@@ -195,7 +200,9 @@ class SyncQueue extends Queue implements QueueContract
      */
     protected function resolveJob(string $payload, ?string $queue): SyncJob
     {
-        return new SyncJob($this->container, $payload, $this->connectionName, $queue ?? 'sync');
+        $queue = $queue === null || $queue === '' ? $this->default : $queue;
+
+        return new SyncJob($this->container, $payload, $this->connectionName, $queue);
     }
 
     /**

--- a/tests/Queue/QueueBackgroundQueueTest.php
+++ b/tests/Queue/QueueBackgroundQueueTest.php
@@ -16,8 +16,10 @@ use Hypervel\Coordinator\Timer;
 use Hypervel\Database\DatabaseTransactionsManager;
 use Hypervel\Engine\Channel;
 use Hypervel\Engine\Coroutine as EngineCoroutine;
+use Hypervel\Events\Dispatcher as EventsDispatcher;
 use Hypervel\Queue\Attributes\Delay;
 use Hypervel\Queue\BackgroundQueue;
+use Hypervel\Queue\Events\JobProcessing;
 use Hypervel\Queue\InteractsWithQueue;
 use Hypervel\Queue\Jobs\SyncJob;
 use Hypervel\Support\CarbonImmutable;
@@ -46,6 +48,35 @@ class QueueBackgroundQueueTest extends TestCase
 
         $this->assertInstanceOf(SyncJob::class, $_SERVER['__background.test'][0]);
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__background.test'][1]);
+    }
+
+    public function testJobsReportTheirResolvedQueueName(): void
+    {
+        $background = new BackgroundQueue;
+        $background->setConnectionName('background-connection');
+        $container = $this->getContainer();
+        $events = new EventsDispatcher($container);
+        $observed = [];
+
+        $events->listen(JobProcessing::class, static function (JobProcessing $event) use (&$observed): void {
+            $observed[] = [$event->connectionName, $event->job->getQueue()];
+        });
+
+        $container->instance('events', $events);
+        $container->instance(Dispatcher::class, $events);
+        $background->setContainer($container);
+
+        foreach ([
+            [null, 'background'],
+            ['', 'background'],
+            ['emails', 'emails'],
+            // A queue named "0" is valid and must not be treated as empty.
+            ['0', '0'],
+        ] as [$queue, $expected]) {
+            $observed = [];
+            run(fn () => $background->push(BackgroundQueueTestHandler::class, queue: $queue));
+            $this->assertSame([['background-connection', $expected]], $observed);
+        }
     }
 
     public function testPushSnapshotsMutableJobBeforeBackgroundExecution(): void

--- a/tests/Queue/QueueDeferredQueueTest.php
+++ b/tests/Queue/QueueDeferredQueueTest.php
@@ -16,7 +16,9 @@ use Hypervel\Coordinator\Timer;
 use Hypervel\Database\DatabaseTransactionsManager;
 use Hypervel\Engine\Channel;
 use Hypervel\Engine\Coroutine as EngineCoroutine;
+use Hypervel\Events\Dispatcher as EventsDispatcher;
 use Hypervel\Queue\DeferredQueue;
+use Hypervel\Queue\Events\JobProcessing;
 use Hypervel\Queue\InteractsWithQueue;
 use Hypervel\Queue\Jobs\SyncJob;
 use Hypervel\Support\CarbonImmutable;
@@ -45,6 +47,35 @@ class QueueDeferredQueueTest extends TestCase
 
         $this->assertInstanceOf(SyncJob::class, $_SERVER['__deferred.test'][0]);
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__deferred.test'][1]);
+    }
+
+    public function testJobsReportTheirResolvedQueueName(): void
+    {
+        $deferred = new DeferredQueue;
+        $deferred->setConnectionName('deferred-connection');
+        $container = $this->getContainer();
+        $events = new EventsDispatcher($container);
+        $observed = [];
+
+        $events->listen(JobProcessing::class, static function (JobProcessing $event) use (&$observed): void {
+            $observed[] = [$event->connectionName, $event->job->getQueue()];
+        });
+
+        $container->instance('events', $events);
+        $container->instance(Dispatcher::class, $events);
+        $deferred->setContainer($container);
+
+        foreach ([
+            [null, 'deferred'],
+            ['', 'deferred'],
+            ['emails', 'emails'],
+            // A queue named "0" is valid and must not be treated as empty.
+            ['0', '0'],
+        ] as [$queue, $expected]) {
+            $observed = [];
+            run(fn () => $deferred->push(DeferredQueueTestHandler::class, queue: $queue));
+            $this->assertSame([['deferred-connection', $expected]], $observed);
+        }
     }
 
     public function testPushSnapshotsMutableJobBeforeCoroutineEnd(): void

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -73,6 +73,35 @@ class QueueSyncQueueTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__sync.test'][1]);
     }
 
+    public function testJobsReportTheirResolvedQueueName(): void
+    {
+        $sync = new SyncQueue;
+        $sync->setConnectionName('sync-connection');
+        $container = $this->getContainer();
+        $events = new EventsDispatcher($container);
+        $observed = [];
+
+        $events->listen(JobProcessing::class, static function (JobProcessing $event) use (&$observed): void {
+            $observed[] = [$event->connectionName, $event->job->getQueue()];
+        });
+
+        $container->instance('events', $events);
+        $container->instance(EventDispatcher::class, $events);
+        $sync->setContainer($container);
+
+        foreach ([
+            [null, 'sync'],
+            ['', 'sync'],
+            ['emails', 'emails'],
+            // A queue named "0" is valid and must not be treated as empty.
+            ['0', '0'],
+        ] as [$queue, $expected]) {
+            $observed = [];
+            $sync->push(SyncQueueTestHandler::class, queue: $queue);
+            $this->assertSame([['sync-connection', $expected]], $observed);
+        }
+    }
+
     public function testFailedJobGetsHandledWhenAnExceptionIsThrown()
     {
         unset($_SERVER['__sync.failed']);


### PR DESCRIPTION
## Summary

Local queue jobs now report the queue name that was resolved for the dispatch. Background and deferred jobs use their own driver names by default, while explicit queue names remain visible to lifecycle listeners and monitoring integrations.

## Problem

SyncJob stored the resolved queue name but getQueue() always returned sync. This made every background and deferred job look like sync work and discarded explicit names supplied through onQueue(). The connection name remained correct, but the destination name did not.

That affects every consumer of queue lifecycle events, including breadcrumbs, traces, logs, and application listeners.

## Change

- Return the stored queue name from SyncJob.
- Give sync, background, and deferred drivers their own protected default queue name.
- Treat only null and an empty string as an omitted queue, preserving valid names such as 0.
- Keep connection identity and queue identity separate.
- Clarify that local driver connection records do not provide a configurable default queue.
- Document the synthetic sync label used by dispatchNow(), where no real queue exists.

The change adds no public API and no extra runtime machinery.

## Testing

- Queue package test suite
- Queue lifecycle coverage for sync, background, and deferred drivers
- Sentry and log queue consumers
- Bus dispatcher tests
- PHPStan
- PHP CS Fixer