### PR TITLE
Defer PHPStan reflection until method resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -308,7 +308,7 @@
         "mockery/mockery": "1.6.x-dev",
         "opis/json-schema": "^2.6.0",
         "pda/pheanstalk": "^8.0.2",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "2.2.9",
         "phpunit/phpunit": "^13.0.3",
         "pusher/pusher-php-server": "^7.2",
         "resend/resend-php": "^1.0",

--- a/src/database/src/PHPStan/ForwardedFluentMethodExtension.php
+++ b/src/database/src/PHPStan/ForwardedFluentMethodExtension.php
@@ -35,8 +35,8 @@ class ForwardedFluentMethodExtension implements MethodsClassReflectionExtension
         'withcan',
     ];
 
-    /** @var list<string> */
-    private readonly array $passthru;
+    /** @var null|list<string> */
+    private ?array $passthru = null;
 
     /** @var array<string, false|MethodReflection> */
     private array $methods = [];
@@ -48,13 +48,6 @@ class ForwardedFluentMethodExtension implements MethodsClassReflectionExtension
      */
     public function __construct(private readonly ReflectionProvider $reflectionProvider)
     {
-        /** @var list<string> $passthru */
-        $passthru = $this->reflectionProvider
-            ->getClass(EloquentBuilder::class)
-            ->getNativeReflection()
-            ->getDefaultProperties()['passthru'];
-
-        $this->passthru = $passthru;
         $this->scope = new OutOfClassScope;
     }
 
@@ -122,7 +115,7 @@ class ForwardedFluentMethodExtension implements MethodsClassReflectionExtension
         ClassReflection $classReflection,
         string $methodName,
     ): ?MethodReflection {
-        if (in_array(strtolower($methodName), $this->passthru, strict: true)) {
+        if (in_array(strtolower($methodName), $this->passthruMethods(), strict: true)) {
             return null;
         }
 
@@ -165,7 +158,7 @@ class ForwardedFluentMethodExtension implements MethodsClassReflectionExtension
         $queryBuilder = $this->reflectionProvider->getClass(QueryBuilder::class);
 
         if ($queryBuilder->hasNativeMethod($methodName)) {
-            if (in_array(strtolower($methodName), $this->passthru, strict: true)
+            if (in_array(strtolower($methodName), $this->passthruMethods(), strict: true)
                 || ! $this->returnsStatic($queryBuilder->getNativeMethod($methodName))) {
                 return null;
             }
@@ -182,6 +175,26 @@ class ForwardedFluentMethodExtension implements MethodsClassReflectionExtension
         $method = $this->eloquentBuilderType($relatedType)->getMethod($methodName, $this->scope);
 
         return new ForwardedFluentMethodReflection($classReflection, $method);
+    }
+
+    /**
+     * Return the Eloquent builder passthru methods.
+     *
+     * @return list<string>
+     */
+    private function passthruMethods(): array
+    {
+        if ($this->passthru === null) {
+            /** @var list<string> $passthru */
+            $passthru = $this->reflectionProvider
+                ->getClass(EloquentBuilder::class)
+                ->getNativeReflection()
+                ->getDefaultProperties()['passthru'];
+
+            $this->passthru = $passthru;
+        }
+
+        return $this->passthru;
     }
 
     /**

--- a/tests/Database/ForwardedFluentMethodExtensionTest.php
+++ b/tests/Database/ForwardedFluentMethodExtensionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Database;
+
+use Hypervel\Database\PHPStan\ForwardedFluentMethodExtension;
+use Hypervel\Tests\TestCase;
+use PHPStan\Reflection\ReflectionProvider;
+
+class ForwardedFluentMethodExtensionTest extends TestCase
+{
+    public function testDoesNotReflectClassesDuringConstruction(): void
+    {
+        $reflectionProvider = $this->createMock(ReflectionProvider::class);
+        $reflectionProvider->expects($this->never())->method('getClass');
+
+        new ForwardedFluentMethodExtension($reflectionProvider);
+    }
+}


### PR DESCRIPTION
`ForwardedFluentMethodExtension` currently reflects `EloquentBuilder` while PHPStan constructs its extension container. That can populate parser state before analysis starts.

This PR defers the passthru lookup until the extension first resolves a forwarded method and adds focused coverage for construction. It also temporarily pins PHPStan to 2.2.9 while the 2.2.10 multi-worker path is investigated.