### PR TITLE
Fix Eloquent identity and morph map handling

### DIFF
--- a/docs/plans/2026-08-31-1555-eloquent-null-identity-and-dictionary-safety.md
+++ b/docs/plans/2026-08-31-1555-eloquent-null-identity-and-dictionary-safety.md
@@ -1,0 +1,387 @@
+# Eloquent null identity and dictionary safety implementation plan
+
+## Status and authority
+
+This plan owns the `fix/eloquent-null-identity` branch. It covers the complete current-Laravel ports discovered through [laravel/framework#59019](https://github.com/laravel/framework/pull/59019) and [laravel/framework#60954](https://github.com/laravel/framework/pull/60954), the null-identity gaps those changes expose in Hypervel, the verified callback failure in duplicate detection, and the integer morph-alias failures exposed by making the public morph-map types truthful.
+
+The pull requests identify the changed surface only. At implementation start, fetch both `origin/0.4` and Laravel `13.x`, update this branch if its base has advanced, and verify the Laravel reference checkout is at the fetched `13.x` head. Before editing each file, compare the full current Laravel file and tests with Hypervel, then merge the current implementation while preserving Hypervel's native types, `newInstance()` behavior, strict comparison policy, Swoole-safe static-state documentation, and other approved adaptations. Port every source and test file from each pull request; do not copy the historical patch when `13.x` has since changed the same code.
+
+## Outcome
+
+Stop null model and relation keys from becoming PHP array offsets, colliding with valid empty-string or zero keys, or losing float precision during dictionary matching. Raw integer `IN` primitives must discard null before casting so they cannot manufacture an unbound `0` literal. Identity-dependent refresh, aggregate, and collection-query operations must fail with `MissingAttributeException` before constructing an unsafe or incomplete key constraint when the required primary key is absent. Integer morph aliases, including `0`, must round-trip through inverse lookup, model serialization, class-string morph queries, association, and eager loading while the database representation remains a string. Morph association must use the configured owner-key column for every value, reject scalar input that cannot identify a morph type, enforce required maps for class-string queries, and support null as both sides of the `whereMorphedTo()` predicate. Duplicate detection with a callback must compare the callback's mapped values rather than applying Eloquent model comparison to scalars.
+
+The final code keeps Laravel's current dictionary semantics for valid keys and ports its null-key behavior. It does not preserve Hypervel's earlier keyless `duplicates()` output: Laravel treats Eloquent dictionary/set operations as operations on persisted models with keys, and closed [laravel/framework#31141](https://github.com/laravel/framework/issues/31141) with `toBase()` as the path for ordinary collection behavior. No Swoole or coroutine constraint justifies the old Hypervel branch.
+
+## Invariants and design limits
+
+- Null never reaches a PHP array offset or `array_flip()` in the changed dictionary paths.
+- Null never reaches the integer cast in `whereIntegerInRaw()`; after null removal, the existing grammar continues to compile empty `IN` lists as `0 = 1` and empty `NOT IN` lists as `1 = 1`.
+- `''`, `0`, `'0'`, integer keys, numeric strings, stringable values, and backed/unit enums remain valid. Float keys are normalized to strings so values such as `1.5` and `1.9` cannot both become integer offset `1`.
+- Morph-map keys remain `int|string`, but model morph types are serialized as strings because every standard morph schema helper creates a string type column. Numeric PHP array-key normalization must not break eager loading, and the string-key eager path must retain valid foreign keys `0`, `'0'`, and `''`.
+- A raw null morph type or `''` means no relation. A null morph type is skipped before reading the foreign key; normalized null foreign keys are skipped independently.
+- `MorphTo::associate()` chooses the configured owner-key column from configuration alone. Values `0`, `''`, and null must not switch the write to the model primary key because every lazy and eager read still uses the configured owner key. Non-model scalar input is rejected before either morph column or the loaded relation is mutated.
+- Required morph maps apply equally to model instances and model class strings passed to `whereMorphedTo()` or `whereNotMorphedTo()`. Registered map keys, including class-shaped legacy aliases, and unregistered stored alias strings remain valid. The normal non-strict query path adds no class loading or model construction.
+- `whereNotMorphedTo($relation, null)` compiles `IS NOT NULL`, the exact inverse of `whereMorphedTo($relation, null)`; its `orWhere` wrapper inherits the same behavior.
+- Keyless models may still exist in ordinary Eloquent collections and `modelKeys()` still reports their null key. Do not invent object identity, synthetic dictionary keys, or supported set semantics for them.
+- `find()` retains its existing loose compatibility for two non-null keys, but neither the requested key nor a model key may be null. Keep a short comment because the deliberate loose comparison is an exception to the repository's strict-comparison rule.
+- `fresh()` ignores unsaved models, including unsaved models with manually assigned keys. It validates every existing model key before issuing a query and performs no query when no existing models remain.
+- `loadAggregate()` requires a key for every model because it cannot load an aggregate without row identity. This is based on key presence, not `exists`: the existing soft-deleted-model test uses models with `exists === false` and retained keys and must keep passing.
+- `toQuery()` retains its existing empty-collection and mixed-model validation order, then requires a key for every model. A null key must never reach the integer-key `whereKey()` path, where it is cast to `0` and can target a legitimate zero-keyed row during a bulk mutation.
+- Null requested keys in both `only()` and `except()` are discarded. This removes `only()`'s `array_flip()` warning and prevents `except([null])` from deleting a valid `''`-keyed model.
+- No new shared/static state, cache, registry, I/O fallback, query, compatibility switch, exception class, or generic identity abstraction is added. `fresh()` removes a pointless query for all-unsaved input.
+- Routine null guards and casts need no comments. Remove the obsolete keyless-comparator comment and tests. Keep only documentation that describes a real public requirement.
+
+## Upstream inventory and current-source findings
+
+### Laravel #59019
+
+The pull request changed six source files and added no tests:
+
+1. `Eloquent/Collection.php`
+2. `Relations/BelongsTo.php`
+3. `Relations/BelongsToMany.php`
+4. `Relations/Concerns/InteractsWithDictionary.php`
+5. `Relations/HasOneOrMany.php`
+6. `Relations/MorphTo.php`
+
+All six current `13.x` files remain authoritative. Later source changes matter:
+
+- `InteractsWithDictionary` now handles `UnitEnum` through `enum_value()` as well as the original null/string/integer and stringable cases. Hypervel already has the enum branch, so merge the current ordering and add the truthful native return type rather than replacing it with the historical version.
+- Current `HasOneOrMany` also rejects a null parent/local key. Hypervel already has that later guard; add the missing result/foreign-key guard without removing it.
+- Current `MorphTo::matchToMorphParents()` normalizes both an explicit owner key and `getKey()` before checking for null. Hypervel already matches this current form; add the missing dictionary-input guards without regressing it.
+
+### Laravel #60954
+
+The pull request changed `Relations/Relation.php` and added `DatabaseEloquentRelationTest::testGetMorphedModel()`. Port both from current `13.x`. Hypervel's current `string` parameter contradicts its own numeric morph-map test and `getMorphAlias(): int|string`: a numeric alias round trip currently throws a `TypeError`, and null from a nullable morph column does the same.
+
+The current Laravel PHPDocs still describe some morph maps as string-keyed despite accepting and testing integer aliases. Hypervel must adapt those declarations to the real `int|string` key shape rather than porting a known-wrong type.
+
+### Hypervel-specific findings
+
+- `Collection::find()` still equates unrelated null identities through `null == null`; a non-null empty-string request can also match a null model key through loose comparison.
+- `Collection::fresh()` passes null and unsaved manual keys into bound `whereIn()` and reads a null dictionary offset after the query. Bound null cannot alias integer zero here; the guard is required for parity with individual `Model::fresh()`, a useful missing-identity exception, and removal of the pointless unsaved-key query.
+- `Collection::loadAggregate()` passes null keys into `whereKey()`. On integer-key models that first becomes raw `id in (0)` and can aggregate a legitimate zero-keyed row; the method then fails through `null->getAttributes()`, either while inspecting an empty result collection or while hydrating a mixed collection.
+- `Collection::toQuery()` passes `modelKeys()` directly to `whereKey()`. For an integer-key model, `whereIntegerInRaw()` casts a null key to `0`, so a collection query can target a row the keyless model does not identify.
+- `Query\Builder::whereIntegerInRaw()` is the shared owner of the null-to-zero conversion. Its `whereIntegerNotInRaw()` and both `orWhere` variants delegate to the same method, and the grammar emits its integer values as unbound SQL literals.
+- `Collection::only()` warns when `array_flip()` receives null. `except()` is warning-free but treats null as `''` and removes a legitimate empty-string identity.
+- `Collections\Collection::duplicates($callback)` chooses its comparator from `$this` after `$items` has been mapped. Eloquent mapping to scalar callback values returns a base collection, but the current code still selects Eloquent's comparator and calls `Model::is()` on an integer.
+- The earlier Hypervel comparator branch and three keyless duplicate tests preserve incidental behavior that becomes unreachable once `getDictionary()` skips null. They must be removed rather than left dead or rewritten to pin another unsupported output.
+- `Collection::modelKeys()` currently documents `array-key` even though its public behavior includes null for keyless models; correct the PHPDoc while editing the owner.
+- `BelongsToMany::buildDictionary()` and `HasOneOrMany::buildDictionary()` document integer-only inner keys even though their associative branches preserve input keys; use the truthful current-upstream array-key shape.
+- Integer morph aliases are supported by Laravel's current morph-map PHPDocs and by #60954, but Hypervel's strict `Model::getMorphClass(): string` returns an integer alias directly and throws. `Relation::getMorphAlias()` also loses alias `0` through `?:`.
+- `MorphTo::buildDictionary()` drops morph types `0` and `'0'` through a truthiness check. Numeric-string dictionary keys then become integers, which violate four string-only alias parameters during eager loading. Its string-key gather path also filters out valid zero and empty-string foreign keys; the new null foreign-key guard now owns absence.
+- The class-string branches of `whereMorphedTo()` and `whereNotMorphedTo()` duplicate inverse lookup without converting an integer alias to the string representation stored in morph columns. This makes class-string and model-instance calls bind different types and can fail or coerce incorrectly across database drivers.
+- `MorphTo::associate()` tests the configured owner-key value for truthiness before choosing a column. This writes the primary key for configured owner-key values `0`, `''`, or null, while every read path queries the configured owner-key column. Its inherited scalar native union is required for signature compatibility with `BelongsTo`, but scalar input silently clears both morph columns and leaves the scalar as the loaded relation despite the narrower `MorphTo` PHPDoc.
+- Strict morph-map enforcement occurs through `Model::getMorphClass()`, so the class-string branches of `whereMorphedTo()` and `whereNotMorphedTo()` currently bypass it. The negative method also rejects null through its empty-collection path even though the positive method treats null as `IS NULL`.
+- A strict query guard must check both morph-map values and keys. A class-shaped registered key is a valid stored morph identity, but checking values alone mistakes it for an unmapped model class. The query call site also holds only a class string; constructing that model merely to create `ClassMorphViolationException` fails for abstract models and can run model boot logic on an exception path.
+
+## Implementation
+
+Work one file at a time. Before each edit, read the complete Hypervel file and complete current Laravel `13.x` counterpart in non-overlapping chunks, plus the relevant tests. Historical pull-request diffs are not implementation input.
+
+### 1. Normalize dictionary keys and port all six #59019 owners
+
+Update `src/database/src/Eloquent/Relations/Concerns/InteractsWithDictionary.php` from current `13.x`, adapted to Hypervel typing:
+
+```php
+protected function getDictionaryKey(mixed $attribute): int|string|null
+{
+    if (is_null($attribute) || is_string($attribute) || is_int($attribute)) {
+        return $attribute;
+    }
+
+    if (is_object($attribute)) {
+        if (method_exists($attribute, '__toString')) {
+            return $attribute->__toString();
+        }
+
+        if ($attribute instanceof UnitEnum) {
+            return enum_value($attribute);
+        }
+
+        throw new InvalidArgumentException('Model attribute value is an object but does not have a __toString method.');
+    }
+
+    return (string) $attribute;
+}
+```
+
+Keep the current upstream branch order. If PHPStan cannot infer the enum helper's `int|string` result, narrow that one return locally with `@var`; do not widen `enum_value()`, reorder branches, add a cast that changes enum values, or suppress the error globally.
+
+Merge the current `13.x` guards into:
+
+| Hypervel file | Required result |
+|---|---|
+| `src/database/src/Eloquent/Collection.php` | `merge()` and `getDictionary()` skip null keys; `diff()` always retains a null-keyed source item; `intersect()` never retains one. Keep `newInstance()` rather than Laravel's `new static` so custom collection state survives. |
+| `src/database/src/Eloquent/Relations/BelongsTo.php` | Skip null related keys while building the result dictionary and skip null parent foreign keys while looking up results. Remove Hypervel's `?? ''` fallback. |
+| `src/database/src/Eloquent/Relations/BelongsToMany.php` | Skip null parent keys and null pivot foreign keys. Preserve associative result keys and correct the return PHPDoc accordingly. |
+| `src/database/src/Eloquent/Relations/HasOneOrMany.php` | Skip null child foreign keys while retaining the already-ported null parent/local-key guard. Correct the dictionary return PHPDoc to allow associative result keys, matching current `13.x`. |
+| `src/database/src/Eloquent/Relations/MorphTo.php` | Skip a model when either normalized morph type or foreign key is null. Retain current `13.x` owner-key normalization and null guard already present in Hypervel. |
+
+Do not add comments to these direct guards. Their purpose is clear from the code.
+
+### 2. Complete Collection identity boundaries
+
+Update the same Eloquent `Collection` owner without adding a general identity helper whose callers have different rules.
+
+**`find()`**
+
+For scalar input, return `value($default)` before scanning when the requested key is null. This keeps `Arr::first()`'s lazy closure-default behavior for both `find(null)` and `find(new UnsavedModel)`. Otherwise resolve the candidate model key once inside the predicate, require `$modelKey !== null`, and retain the existing loose comparison.
+
+For array or `Arrayable` input, keep the empty-collection fast path, then resolve the key name from the original first model before filtering. Discard null requested keys and exclude models whose key is null before the existing loose `whereIn()` match. Resolving the key name first avoids dereferencing `first()` after an all-keyless collection has been filtered empty. The two-sided filter prevents `find([null])`, empty-string, and zero requests from returning an unrelated keyless model while preserving valid loose compatibility between non-null keys and the existing return type.
+
+**`fresh()`**
+
+Build a collection-keyed map of existing model keys before the query:
+
+```php
+$modelKeys = [];
+
+foreach ($this->items as $collectionKey => $item) {
+    if (! $item->exists) {
+        continue;
+    }
+
+    $key = $item->getKey();
+
+    if ($key === null) {
+        throw new MissingAttributeException($item, $item->getKeyName());
+    }
+
+    $modelKeys[$collectionKey] = $key;
+}
+```
+
+Return a new empty collection before querying when the map is empty. Pass only `array_values($modelKeys)` to `whereIn()`. Use the stored keys, normalized through `getDictionaryKey()`, to rebuild the result under the original collection keys, omitting rows that no longer exist. This removes repeated key reads, preserves collection keys and custom `newInstance()` state, removes the current filter/map PHPStan suppression if it is no longer needed, and never queries an unsaved manual key. Add `@throws MissingAttributeException` to this changed public method only.
+
+**`loadAggregate()`**
+
+Resolve each source model key once into a collection-keyed map before the query. Throw `MissingAttributeException($item, $item->getKeyName())` for any null key, regardless of `exists`. Pass the stored values to `whereKey()` and reuse the stored key for aggregate-result lookup and hydration. If every source row has been physically deleted, return the original collection unchanged before inspecting aggregate attributes. If only some rows are missing, skip those source items with a bare closure return while hydrating every surviving row. Do not remove missing source items, synthesize zero aggregate values, clear stale aggregate attributes, throw for a concurrent hard delete, or return `false` from the `each()` callback. Preserve support for soft-deleted models with retained keys, one aggregate query, original attribute/cast synchronization, and the six direct convenience wrappers. The direct method and all six wrappers are also reached through the corresponding model methods; `loadMorphCount()` reaches the same guard on each related-model subcollection. Add `@throws MissingAttributeException` to this changed public method only.
+
+**`toQuery()`**
+
+After the existing empty-collection and mixed-model checks, resolve each model key once while preserving collection keys. Throw `MissingAttributeException($model, $model->getKeyName())` when any key is null, before calling `newModelQuery()` or `whereKey()`. Pass only the validated key array to `whereKey()`. Keep the existing `LogicException` precedence for empty and mixed collections, preserve valid zero keys, and add `@throws MissingAttributeException` alongside the existing exception annotation.
+
+Do not add exception annotations to the older `Model` key helpers or a selected subset of their transitive callers; that would be a separate incomplete audit.
+
+**`only()` and `except()`**
+
+Normalize requested keys and pass them through `Arr::whereNotNull()` before calling `Arr::only()` or `Arr::except()`. This uses an existing primitive, preserves `0` and `''`, and avoids a new helper or duplicated manual callback.
+
+**Types and dead code**
+
+- Correct `modelKeys()` to `@return array<array-key, null|array-key>`; `array_map()` preserves an associative collection's keys, and the public result must continue to include null values.
+- Reduce Eloquent `duplicateComparator()` back to the model identity comparison. Delete its keyless fallback and explanatory comment because null keys can no longer enter the no-key `unique()` dictionary.
+- Delete the three tests that preserve the former keyless duplicate output. Do not add replacements that promise a new keyless `duplicates()` result.
+
+### 3. Port current #60954 and make morph-map types truthful
+
+Update `src/database/src/Eloquent/Relations/Relation.php`:
+
+- port the current `getMorphedModel()` null early return;
+- use the native parameter `int|string|null` and existing `?string` return;
+- change the `static::$morphMap` property PHPDoc to `array<int|string, class-string<Model>>`;
+- widen both parameter and return PHPDocs on `enforceMorphMap()`, `morphMap()`, and `buildMorphMapFromModels()` to integer-or-string keys. `buildMorphMapFromModels()` must describe integer keys on both sides because its non-list branch returns the supplied map unchanged, while its list branch remains string-keyed by table name;
+- preserve list input for table-derived maps, the worker-lifetime warnings, merge behavior, `flushState()`, and `getMorphAlias(): int|string`.
+
+Port the complete current `DatabaseEloquentRelationTest::testGetMorphedModel()` into Hypervel, adding only required Hypervel adaptations such as strict types, namespace, and `: void`. Keep all four upstream assertions: string alias, integer alias, missing alias, and null alias. Remove the stale `Illuminate` test PHPDoc already present in that file while editing it; the local type is evident and the comment is wrong.
+
+No relationship-guide change is needed for this parity/type correction. The public docs already describe the inverse lookup without promising a string-only argument.
+
+### 4. Remove null before raw integer-list casting
+
+Update `src/database/src/Query/Builder.php` at the shared `whereIntegerInRaw()` primitive. After converting `Arrayable` input and flattening nested values, pass the flattened array through `Arr::whereNotNull()` before the existing integer-cast loop:
+
+```php
+$values = Arr::whereNotNull(Arr::flatten($values));
+
+foreach ($values as &$value) {
+    $value = (int) ($value instanceof BackedEnum ? $value->value : $value);
+}
+```
+
+Do not add caller-specific filtering to Eloquent `whereKey()`, `whereKeyNot()`, relation eager constraints, or Scout. `whereIntegerNotInRaw()` and both `orWhere` variants already delegate to this one owner. Preserve the existing coercion of non-null numeric/string/enum input and the grammar's established empty-list behavior; no compensating condition or special case is needed.
+
+Keep this as a distinct logical slice from the Eloquent caller guards. The primitive's correct behavior is to remove absent list values, while `Collection::toQuery()` must still reject a keyless model rather than silently build a query for fewer models. Current Laravel `13.x` has the same primitive bug, so this slice can be proposed upstream independently from the Eloquent ports and duplicate-comparator fix.
+
+### 5. Fix duplicate comparison after mapping
+
+Update `src/collections/src/Collection.php` at the owning algorithm:
+
+```php
+$compare = $items->duplicateComparator($strict);
+```
+
+The mapped collection owns the comparison semantics: scalar callback output is a base collection and needs scalar comparison; identity mapping remains an Eloquent collection and keeps model comparison. Retain `$this->newInstance()` for the return value because the method's `static` return contract requires the caller's collection type. Do not alter `map()`, widen return types, or add a special Eloquent branch.
+
+Add one Eloquent regression for `duplicates('id')`. Existing no-callback tests continue to cover Eloquent model identity, so do not duplicate them.
+
+### 6. Complete integer morph-alias round trips
+
+Update `src/database/src/Eloquent/Relations/Relation.php` so `getMorphAlias()` falls back only when strict `array_search()` returns `false`. A valid alias `0` must remain integer `0` at this inverse-lookup API.
+
+Update `src/database/src/Eloquent/Concerns/HasRelationships.php` at `getMorphClass()`:
+
+- perform one strict `array_search()`;
+- return `(string) $alias` only when found, preserving the public string return and every downstream relation/package contract;
+- retain the existing pivot and required-map miss behavior;
+- restore current Laravel's `@throws ClassMorphViolationException` annotation.
+
+Update `src/database/src/Eloquent/Concerns/QueriesRelationships.php` in the class-string branches of both `whereMorphedTo()` and `whereNotMorphedTo()`:
+
+```php
+$model = (string) Relation::getMorphAlias($model);
+```
+
+This removes duplicate map searches and makes class-string queries bind the same string value that model association writes. Restore current Laravel's `@throws InvalidArgumentException` annotation on both direct methods; do not add it to the `orWhere` wrappers.
+
+Update `src/database/src/Eloquent/Relations/MorphTo.php`:
+
+- read the raw morph type once and skip only raw `''` immediately;
+- normalize the morph type and skip normalized null before reading the foreign key, preserving projected/null-type behavior;
+- normalize the foreign key and skip null independently;
+- remove `array_filter()` from the string-key branch of `gatherKeysByType()` so zero and empty-string foreign identities survive;
+- widen alias-value parameters on `getResultsByType()`, `gatherKeysByType()`, `createModelByType()`, and `matchToMorphParents()` to `int|string`. Column-name parameters and properties remain string.
+- in `associate()`, reject non-`Model`, non-null input with `InvalidArgumentException` before changing state, then choose the associated column with `$this->ownerKey ?? $model->getKeyName()`. Do not inspect the owner-key value when choosing between columns.
+
+Do not add a cache, alias helper, downstream union types, or a second serialization format. PHP array keys force numeric strings to integers; the four parameter widenings are the direct representation of that fact.
+
+Update `src/database/src/Eloquent/Concerns/QueriesRelationships.php`:
+
+- resolve class-string morph query values through one protected helper shared by `whereMorphedTo()` and `whereNotMorphedTo()`;
+- read the morph map once; when morph maps are required, reject an actual model class absent from both the map values and keys with `ClassMorphViolationException`; check values, then keys with `array_key_exists()`, before `is_a()` so mapped classes avoid autoload work and every stored alias remains valid;
+- keep the normal non-strict path as the existing `Relation::getMorphAlias()` lookup and string cast, with no model construction;
+- add an early null branch to `whereNotMorphedTo()` that calls `whereNotNull()` with the supplied boolean, and widen its direct and `orWhere` PHPDocs to include null.
+
+Update `ClassMorphViolationException` to accept `object|string`, derive the class name without constructing a model, and pass the class string directly from the helper. Existing object callers remain unchanged. Do not broaden `Relation::getMorphAlias()`, add a public resolver API, or duplicate the strict-map condition in both query methods.
+
+### 7. Document the primary-key requirement at canonical surfaces
+
+Make targeted sentence-level edits at the three canonical sections in two files:
+
+- `src/docs/eloquent.md`, under **Refreshing Models**: state that a persisted model must have its primary key loaded before `fresh()` or `refresh()`, otherwise `MissingAttributeException` is thrown.
+- `src/docs/eloquent-collections.md`, under **`fresh($with = [])`**: state the same collection precondition and link to the individual-model refresh section rather than repeating detail.
+- `src/docs/eloquent-collections.md`, under **`toQuery()`**: state that every model must have a primary key because the returned builder is constrained by those keys, otherwise `MissingAttributeException` is thrown. Keep this beside the existing canonical `$users->toQuery()->update([...])` example, which demonstrates why incomplete or null-to-zero key constraints are data-safety bugs rather than harmless empty queries.
+
+Do not add a database README difference, Laravel porting-guide entry, or aggregate documentation. The dictionary changes are correctness fixes and Laravel parity; `loadAggregate()` already fails without identity and only gains a useful exception; the refresh and collection-query sections are the places users look for the changed public behavior.
+
+## Test plan
+
+### Red phase on unchanged source
+
+Add or port tests one file at a time and run that file immediately before changing production source. Every new regression must fail on unchanged code through a wrong result, wrong exception, or promoted PHP warning/deprecation. `phpunit.xml.dist` already enables `failOnWarning`; add `--fail-on-deprecation` to promote PHP deprecations. Judge red/green by the process exit status: PHPUnit 13 can print `OK, but there were issues!` while correctly exiting non-zero for a promoted deprecation. Do not add custom error-handler machinery merely to make a test red.
+
+On unchanged source, the initial focused PHP 8.5 files are clean apart from one deprecation triggered only by the three obsolete keyless duplicate tests that this change removes. Treat any other deprecation during implementation as a new finding to investigate rather than suppressing or working around it.
+
+### `tests/Database/DatabaseEloquentCollectionTest.php`
+
+- scalar and array forms of `find()` do not match a null request or an unrelated keyless model and do not let a keyless model shadow legitimate `''` or zero keys. Use a lazy closure default for the scalar null case so the early return proves the existing default semantics are preserved.
+- the array `find()` case includes an all-keyless collection, proving the key name is captured from the original first model before filtering and no empty-result dereference occurs.
+- `getDictionary()` skips a trailing keyless model instead of overwriting a legitimate `''` entry.
+- `merge()` does not let a keyless incoming model overwrite a legitimate `''` entry.
+- `diff()` retains a keyless source model when the comparison collection contains a legitimate `''` key.
+- `intersect()` does not treat a keyless source model as intersecting a legitimate `''` key.
+- `only([null])` returns no model and emits no warning; `except([null])` retains a legitimate `''`-keyed model.
+- `duplicates('id')` returns the duplicate scalar values without calling the Eloquent comparator on integers.
+- `toQuery()` rejects a null model key with `MissingAttributeException` before invoking `newModelQuery()` or `whereKey()`; retain the existing valid-key and empty-collection tests, and preserve the mixed-model `LogicException` by keeping its source check before the new key loop.
+- Remove only the three obsolete keyless duplicate tests. Keep the keyed duplicate and custom-collection-state tests.
+- Extend the existing custom-collection-state test with a non-empty `find([1, 2])` result, proving the added filtering preserves the custom collection type and state.
+
+Use real `CollectionModel` instances and `setKeyType('string')` for the empty-string identity; do not add a fixture class solely for that setting.
+
+### `tests/Database/DatabaseQueryBuilderTest.php`
+
+- extend the existing `testWhereIntegerInRaw()` with `[1, null]` and assert the exact SQL is `select * from "users" where "id" in (1)`, not `in (1, 0)`;
+- extend the existing `testWhereIntegerNotInRaw()` with `[1, null]` and assert the exact SQL is `select * from "users" where "id" not in (1)`, not `not in (1, 0)`;
+- retain the existing ordinary, nested, enum, `orWhere`, and empty-list coverage. Do not duplicate the two assertions through every delegating wrapper: both polarity and all wrappers share `whereIntegerInRaw()`.
+
+### Relation matching tests
+
+- `tests/Database/DatabaseEloquentBelongsToTest.php`
+  - cover both guards independently: a null related key cannot match a parent foreign key `''`, and a null parent foreign key cannot match a related key `''`;
+  - extend the existing matching coverage with related/foreign values `1.5` and `1.9`, proving current float-to-integer array-key collision and deprecation are gone;
+  - type the touched builder/related properties and inline foreign-key fixtures with the narrowest truthful native types, using `mixed` only where the same fixture intentionally receives several forms.
+- `tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php`
+  - prove a null parent key does not match a pivot key `''`;
+  - prove a null pivot key does not match a parent key `''`;
+  - type the touched fixture property.
+- `tests/Database/EloquentHasOneOrManyDeprecationTest.php`
+  - add a child with a null foreign key and a parent with local key `''`; assert no match;
+  - retain both existing parent-null tests and type the fixture property as `mixed = null`.
+- `tests/Database/DatabaseEloquentMorphToTest.php`
+  - add a model with a real morph type and null foreign key; assert it is absent from the eager-load dictionary;
+  - add one dictionary case proving morph types `0` and `'0'` are retained while `''` and null are skipped; omit the foreign-key property from the null-type fixture so the guard order is observable without custom error handling;
+  - widen the existing `AccessibleMorphTo` proxy parameter to `int|string`;
+  - retain the current object owner-key normalization test and type the touched builder/related properties.
+
+Do not add a separate boolean-key matrix or direct protected-trait test. The float BelongsTo case proves scalar normalization through a public relation path; existing enum and stringable relation tests cover the object branches.
+
+### Identity-query integration tests
+
+- `tests/Integration/Database/EloquentCollectionFreshTest.php`
+  - with missing-attribute strictness disabled, a persisted projection without its primary key throws `MissingAttributeException`; enable the query log immediately before the call, invoke it inside `try`, call `$this->fail()` on the next line, catch only `MissingAttributeException`, assert its message, then assert the failed operation issued no query. Do not use `expectException()`, because it would skip the query-log assertion;
+  - a collection containing only an unsaved model with a manually assigned key returns an empty collection without issuing a query;
+  - retain the existing deleted-row behavior.
+- `tests/Integration/Database/EloquentCollectionLoadCountTest.php`
+  - with missing-attribute strictness disabled, a projection without its primary key throws `MissingAttributeException` through `loadCount()`; use the same narrow `try` / fail / catch pattern and assert the query log remains empty after the catch;
+  - retain the existing soft-deleted-model test as the control proving that `exists === false` with a retained key remains supported;
+  - physically delete one source row through a separate query, assert the aggregate load still issues one query, hydrates the surviving row, and leaves the missing source item without a synthesized aggregate attribute;
+  - physically delete every source row through a separate query, assert the aggregate load still issues one query and returns the same collection with its source attributes unchanged.
+
+### Complete upstream test port
+
+- `tests/Database/DatabaseEloquentRelationTest.php`
+  - port the complete current `13.x` `testGetMorphedModel()` from #60954 with all four assertions;
+  - extend the existing inverse-alias test with a non-list map and strict assertion that alias `0` is returned as integer `0`;
+  - retain the existing numeric morph-map and alias tests.
+
+### Integer morph-alias integration and query tests
+
+- `tests/Integration/Database/EloquentMorphToEagerLoadTest.php`
+  - add a dedicated plain string-key model/table with no cast, `incrementing = false`, and `keyType = 'string'`;
+  - configure a non-list morph map with alias `0`, associate a new comment to a model whose primary key is `'0'`, and assert the in-memory morph type is exactly string `'0'` before saving;
+  - eager-load only that comment and assert it resolves the same model. This covers string serialization, integer dictionary aliases, `createModelByType()`, zero preservation in `gatherKeysByType()`, and parent matching in one supported round trip.
+- `tests/Database/DatabaseEloquentBuilderTest.php`
+  - after the existing morph-map alias test, add one method covering both `whereMorphedTo()` and `whereNotMorphedTo()` class-string calls under alias `0`;
+  - assert both bindings are exactly `['0']` with `assertSame()`; do not duplicate the setup in separate tests or repeat the delegating `orWhere` wrappers.
+
+### Morph association and query policy tests
+
+- `tests/Database/DatabaseEloquentMorphToTest.php`
+  - use real parent and related models and construct the relation under `Relation::noConstraints()` so strict assertions do not rely on Mockery's loose argument matching;
+  - prove a configured owner-key value `0` is written as integer `0` rather than falling back to a different primary key;
+  - prove a configured owner-key value null writes null rather than a different primary key; omit a separate `''` case because no value branch remains;
+  - prove scalar input throws `InvalidArgumentException` before either stored morph column or the loaded relation changes.
+- `tests/Database/DatabaseEloquentBuilderTest.php`
+- make the existing mapped class-string query test use `enforceMorphMap()`, proving mapped classes remain valid in strict mode;
+- add separate positive- and negative-query regressions proving an unmapped model class throws `ClassMorphViolationException`; both direct methods own a distinct string branch even though resolution is shared;
+- add one shared-setup test proving a registered class-shaped alias and an unregistered plain stored alias both bind unchanged under strict maps;
+- add one test proving an abstract unmapped model class throws `ClassMorphViolationException` rather than being instantiated;
+- add one direct `whereNotMorphedTo(..., null)` assertion for exact `IS NOT NULL` SQL and no bindings. Existing `orWhereNotMorphedTo()` tests already prove boolean forwarding, so do not duplicate the null branch through the wrapper.
+
+Laravel #59019 introduced no tests, and current `13.x` has no later dedicated regressions for those guards. The focused Hypervel tests above supply the missing coverage without inventing unsupported keyless set semantics.
+
+## Verification and review
+
+1. During the red phase, run each changed test file immediately with `./vendor/bin/phpunit --no-progress --fail-on-deprecation <file>` and confirm its new regression fails for the intended old behavior by checking the non-zero exit status, not PHPUnit's summary wording. Warning failure already comes from `phpunit.xml.dist`.
+2. After each source file, rerun its focused test method or file. A file that contains regressions for a later source slice may be filtered until that slice is implemented; run the complete file once all of its owners are updated.
+3. Run all eleven changed test files together on the local PHP version with the configured warning failure and `--fail-on-deprecation`.
+4. Run the same focused files in `ghcr.io/hypervel/components-ci:php8.5-swoole6.2.2` with `--fail-on-deprecation`. This directly verifies the PHP 8.5 failures without reproducing the entire CI matrix.
+5. Run targeted PHPStan while finalizing `InteractsWithDictionary` and `Collection` typing. Fix real declarations first; use one local `@var` for `enum_value()` only if needed. Add no global ignore.
+6. At the completed checkpoint, run `composer fix` once. It owns formatting, both PHPStan configurations, the parallel component suite, Testbench package tests, and dogfood tests; do not rerun those full commands separately at the same checkpoint.
+7. Inspect `git diff --check`, the full branch diff, and every changed method's callers/callees. Confirm current `13.x` parity, valid zero/empty/enum/stringable behavior, raw integer-list behavior through Eloquent `whereKey()` / `whereKeyNot()`, relation eager constraints, and Scout, custom collection state, deleted-model aggregate behavior, all seven direct collection aggregate entry points and their model/morph delegations, `toQuery()`'s empty/mixed/key validation order, integer morph aliases through writes, inverse lookup, eager loading, and both class-string query polarities, morph-map static cleanup, and absence of stale comments, tests, ignores, imports, or documentation.
+8. Request peer code review after the full self-review. Apply review fixes one file at a time, rerun affected tests, and repeat the full checkpoint only if the fixes can affect wider checks.
+
+## Completion criteria
+
+- Every file and every test introduced by Laravel #59019 and #60954 is accounted for, with current `13.x` source and tests—not historical patches—used for implementation.
+- The changed dictionary paths emit no null-offset, float-key, or `array_flip()` issues on PHP 8.5, and raw integer `IN`/`NOT IN` lists never convert null into literal zero.
+- Null cannot alias `''`; valid `''`, zero, enum, stringable, integer, and float identities retain the documented behavior above.
+- Missing identity fails before refresh or aggregate SQL, or before a collection query's key constraint, with `MissingAttributeException`; unsaved refresh input performs no query; soft-deleted aggregate input with a retained key remains valid; `toQuery()` cannot turn null into integer key `0`.
+- Integer and null morph aliases work and all morph-map types describe integer and string keys truthfully.
+- Integer morph aliases serialize to string morph-column values and work through association, eager loading, inverse lookup, and positive/negative class-string morph queries, including alias and foreign key zero.
+- Morph association uses the configured owner-key column for zero, empty-string, and null values; scalar input fails before mutation; strict maps reject unmapped model class strings in both query polarities without instantiating them, while stored aliases remain queryable; and null positive/negative morph predicates compile as `IS NULL` / `IS NOT NULL`.
+- Callback duplicate detection works for scalar mapped values while no-callback Eloquent comparison remains intact.
+- The obsolete comparator branch, its comment, its three tests, stale test typing/docs, and superseded PHPStan suppression are gone.
+- Canonical refresh and `toQuery()` documentation is accurate, with no duplicate README or porting-guide entry.
+- `composer fix`, focused PHP 8.5 checks, final self-review, and peer review are green.

--- a/docs/plans/2026-08-31-1555-eloquent-null-identity-and-dictionary-safety.md
+++ b/docs/plans/2026-08-31-1555-eloquent-null-identity-and-dictionary-safety.md
@@ -8,7 +8,7 @@ The pull requests identify the changed surface only. At implementation start, fe
 
 ## Outcome
 
-Stop null model and relation keys from becoming PHP array offsets, colliding with valid empty-string or zero keys, or losing float precision during dictionary matching. Raw integer `IN` primitives must discard null before casting so they cannot manufacture an unbound `0` literal. Identity-dependent refresh, aggregate, and collection-query operations must fail with `MissingAttributeException` before constructing an unsafe or incomplete key constraint when the required primary key is absent. Integer morph aliases, including `0`, must round-trip through inverse lookup, model serialization, class-string morph queries, association, and eager loading while the database representation remains a string. Morph association must use the configured owner-key column for every value, reject scalar input that cannot identify a morph type, enforce required maps for class-string queries, and support null as both sides of the `whereMorphedTo()` predicate. Duplicate detection with a callback must compare the callback's mapped values rather than applying Eloquent model comparison to scalars.
+Stop null model and relation keys from becoming PHP array offsets, colliding with valid empty-string or zero keys, or losing float precision during dictionary matching. Raw integer `IN` primitives must discard null before casting so they cannot manufacture an unbound `0` literal. Identity-dependent refresh, aggregate, and collection-query operations must fail with `MissingAttributeException` before constructing an unsafe or incomplete key constraint when the required primary key is absent. Aggregate hydration must use the selected primary key only to match result rows, never overwrite or synchronize the source model's identity. Integer morph aliases, including `0`, must round-trip through inverse lookup, model serialization, class-string morph queries, association, and eager loading while the database representation remains a string. Morph association must use the configured owner-key column for every value, reject scalar input that cannot identify a morph type, enforce required maps for class-string queries, and support null as both sides of the `whereMorphedTo()` predicate. Duplicate detection with a callback must compare the callback's mapped values rather than applying Eloquent model comparison to scalars.
 
 The final code keeps Laravel's current dictionary semantics for valid keys and ports its null-key behavior. It does not preserve Hypervel's earlier keyless `duplicates()` output: Laravel treats Eloquent dictionary/set operations as operations on persisted models with keys, and closed [laravel/framework#31141](https://github.com/laravel/framework/issues/31141) with `toBase()` as the path for ordinary collection behavior. No Swoole or coroutine constraint justifies the old Hypervel branch.
 
@@ -19,13 +19,14 @@ The final code keeps Laravel's current dictionary semantics for valid keys and p
 - `''`, `0`, `'0'`, integer keys, numeric strings, stringable values, and backed/unit enums remain valid. Float keys are normalized to strings so values such as `1.5` and `1.9` cannot both become integer offset `1`.
 - Morph-map keys remain `int|string`, but model morph types are serialized as strings because every standard morph schema helper creates a string type column. Numeric PHP array-key normalization must not break eager loading, and the string-key eager path must retain valid foreign keys `0`, `'0'`, and `''`.
 - A raw null morph type or `''` means no relation. A null morph type is skipped before reading the foreign key; normalized null foreign keys are skipped independently.
-- `MorphTo::associate()` chooses the configured owner-key column from configuration alone. Values `0`, `''`, and null must not switch the write to the model primary key because every lazy and eager read still uses the configured owner key. Non-model scalar input is rejected before either morph column or the loaded relation is mutated.
+- `MorphTo::associate()` chooses the configured owner-key column from configuration alone. Values `0`, `''`, and null must not switch the write to the model primary key because every lazy and eager read still uses the configured owner key. Non-model scalar input is rejected before either morph column or the loaded relation is mutated, and every associated-model value is resolved before either parent attribute is written.
 - Required morph maps apply equally to model instances and model class strings passed to `whereMorphedTo()` or `whereNotMorphedTo()`. Registered map keys, including class-shaped legacy aliases, and unregistered stored alias strings remain valid. The normal non-strict query path adds no class loading or model construction.
 - `whereNotMorphedTo($relation, null)` compiles `IS NOT NULL`, the exact inverse of `whereMorphedTo($relation, null)`; its `orWhere` wrapper inherits the same behavior.
 - Keyless models may still exist in ordinary Eloquent collections and `modelKeys()` still reports their null key. Do not invent object identity, synthetic dictionary keys, or supported set semantics for them.
 - `find()` retains its existing loose compatibility for two non-null keys, but neither the requested key nor a model key may be null. Keep a short comment because the deliberate loose comparison is an exception to the repository's strict-comparison rule.
 - `fresh()` ignores unsaved models, including unsaved models with manually assigned keys. It validates every existing model key before issuing a query and performs no query when no existing models remain.
 - `loadAggregate()` requires a key for every model because it cannot load an aggregate without row identity. This is based on key presence, not `exists`: the existing soft-deleted-model test uses models with `exists === false` and retained keys and must keep passing.
+- The primary key selected by `loadAggregate()` is matching metadata, not an aggregate attribute. It must not be force-filled or synchronized onto the source model, including when the source model's current key differs from its original key.
 - `toQuery()` retains its existing empty-collection and mixed-model validation order, then requires a key for every model. A null key must never reach the integer-key `whereKey()` path, where it is cast to `0` and can target a legitimate zero-keyed row during a bulk mutation.
 - Null requested keys in both `only()` and `except()` are discarded. This removes `only()`'s `array_flip()` warning and prevents `except([null])` from deleting a valid `''`-keyed model.
 - No new shared/static state, cache, registry, I/O fallback, query, compatibility switch, exception class, or generic identity abstraction is added. `fresh()` removes a pointless query for all-unsaved input.
@@ -61,6 +62,7 @@ The current Laravel PHPDocs still describe some morph maps as string-keyed despi
 - `Collection::find()` still equates unrelated null identities through `null == null`; a non-null empty-string request can also match a null model key through loose comparison.
 - `Collection::fresh()` passes null and unsaved manual keys into bound `whereIn()` and reads a null dictionary offset after the query. Bound null cannot alias integer zero here; the guard is required for parity with individual `Model::fresh()`, a useful missing-identity exception, and removal of the pointless unsaved-key query.
 - `Collection::loadAggregate()` passes null keys into `whereKey()`. On integer-key models that first becomes raw `id in (0)` and can aggregate a legitimate zero-keyed row; the method then fails through `null->getAttributes()`, either while inspecting an empty result collection or while hydrating a mixed collection.
+- `Collection::loadAggregate()` attempts to exclude the selected primary key with `Arr::except(array_keys($attributes), $keyName)`. Because the attribute names are values in that list, the exclusion removes nothing. Hydration then force-fills and synchronizes the query result's primary key; after a model's current key is changed, this overwrites its original identity and makes a later `save()` target the wrong row.
 - `Collection::toQuery()` passes `modelKeys()` directly to `whereKey()`. For an integer-key model, `whereIntegerInRaw()` casts a null key to `0`, so a collection query can target a row the keyless model does not identify.
 - `Query\Builder::whereIntegerInRaw()` is the shared owner of the null-to-zero conversion. Its `whereIntegerNotInRaw()` and both `orWhere` variants delegate to the same method, and the grammar emits its integer values as unbound SQL literals.
 - `Collection::only()` warns when `array_flip()` receives null. `except()` is warning-free but treats null as `''` and removes a legitimate empty-string identity.
@@ -158,6 +160,19 @@ Return a new empty collection before querying when the map is empty. Pass only `
 
 Resolve each source model key once into a collection-keyed map before the query. Throw `MissingAttributeException($item, $item->getKeyName())` for any null key, regardless of `exists`. Pass the stored values to `whereKey()` and reuse the stored key for aggregate-result lookup and hydration. If every source row has been physically deleted, return the original collection unchanged before inspecting aggregate attributes. If only some rows are missing, skip those source items with a bare closure return while hydrating every surviving row. Do not remove missing source items, synthesize zero aggregate values, clear stale aggregate attributes, throw for a concurrent hard delete, or return `false` from the `each()` callback. Preserve support for soft-deleted models with retained keys, one aggregate query, original attribute/cast synchronization, and the six direct convenience wrappers. The direct method and all six wrappers are also reached through the corresponding model methods; `loadMorphCount()` reaches the same guard on each related-model subcollection. Add `@throws MissingAttributeException` to this changed public method only.
 
+Keep the aggregate query result as a collection through empty-result and attribute discovery. Then build the result map with `$this->getDictionary($models)` and normalize the stored source key with `getDictionaryKey()` for lookup. This accepts the builder's iterable base-collection return, uses the owning model-dictionary primitive without a PHPStan suppression or second collection allocation, and prevents distinct float identities from becoming the same PHP integer array key.
+
+Exclude the selected primary key from the result model's attribute map before collecting the hydrateable attribute names:
+
+```php
+$attributes = array_keys(Arr::except(
+    $models->first()->getAttributes(),
+    $keyName
+));
+```
+
+This keeps the key available for dictionary matching but prevents `forceFill()` and `syncOriginalAttributes()` from changing the source model's identity. Do not add a special key rollback, dirty-state repair, or save guard.
+
 **`toQuery()`**
 
 After the existing empty-collection and mixed-model checks, resolve each model key once while preserving collection keys. Throw `MissingAttributeException($model, $model->getKeyName())` when any key is null, before calling `newModelQuery()` or `whereKey()`. Pass only the validated key array to `whereKey()`. Keep the existing `LogicException` precedence for empty and mixed collections, preserve valid zero keys, and add `@throws MissingAttributeException` alongside the existing exception annotation.
@@ -243,6 +258,7 @@ Update `src/database/src/Eloquent/Relations/MorphTo.php`:
 - remove `array_filter()` from the string-key branch of `gatherKeysByType()` so zero and empty-string foreign identities survive;
 - widen alias-value parameters on `getResultsByType()`, `gatherKeysByType()`, `createModelByType()`, and `matchToMorphParents()` to `int|string`. Column-name parameters and properties remain string.
 - in `associate()`, reject non-`Model`, non-null input with `InvalidArgumentException` before changing state, then choose the associated column with `$this->ownerKey ?? $model->getKeyName()`. Do not inspect the owner-key value when choosing between columns.
+- resolve both the configured owner-key value and `getMorphClass()` result before either parent attribute is written. The owner-key read already preceded mutation; the behavior change is that strict morph-map validation can no longer leave the parent with a new foreign key and stale morph type.
 
 Do not add a cache, alias helper, downstream union types, or a second serialization format. PHP array keys force numeric strings to integers; the four parameter widenings are the direct representation of that fact.
 
@@ -294,6 +310,7 @@ Use real `CollectionModel` instances and `setKeyType('string')` for the empty-st
 - extend the existing `testWhereIntegerInRaw()` with `[1, null]` and assert the exact SQL is `select * from "users" where "id" in (1)`, not `in (1, 0)`;
 - extend the existing `testWhereIntegerNotInRaw()` with `[1, null]` and assert the exact SQL is `select * from "users" where "id" not in (1)`, not `not in (1, 0)`;
 - retain the existing ordinary, nested, enum, `orWhere`, and empty-list coverage. Do not duplicate the two assertions through every delegating wrapper: both polarity and all wrappers share `whereIntegerInRaw()`.
+- add `: void` to both changed raw-integer test methods so the modified code follows the repository's full-typing rule.
 
 ### Relation matching tests
 
@@ -327,6 +344,8 @@ Do not add a separate boolean-key matrix or direct protected-trait test. The flo
   - retain the existing soft-deleted-model test as the control proving that `exists === false` with a retained key remains supported;
   - physically delete one source row through a separate query, assert the aggregate load still issues one query, hydrates the surviving row, and leaves the missing source item without a synthesized aggregate attribute;
   - physically delete every source row through a separate query, assert the aggregate load still issues one query and returns the same collection with its source attributes unchanged.
+  - use a dedicated decimal-key model and related table to prove distinct float identities receive their own aggregate counts. Store exact decimal values `1.25` and `1.75`, set `incrementing = false`, route `whereKey()` through bound predicates with `keyType = 'string'`, and cast the primary key to `float` so the unchanged result map reaches the raw PHP float-key collision instead of an earlier integer-query coercion. The `1.25` model's count assertion owns the behavioral red; float-to-integer deprecations are secondary evidence.
+  - load one existing integer-key post, change its current key to another existing post's key, then call `loadCount()`. Assert the aggregate follows the current key while the original key remains the originally loaded identity and the key stays dirty. Do not call `save()`; preserving the original key directly proves that its later update predicate remains safe without turning the regression into a database-write test.
 
 ### Complete upstream test port
 
@@ -334,6 +353,7 @@ Do not add a separate boolean-key matrix or direct protected-trait test. The flo
   - port the complete current `13.x` `testGetMorphedModel()` from #60954 with all four assertions;
   - extend the existing inverse-alias test with a non-list map and strict assertion that alias `0` is returned as integer `0`;
   - retain the existing numeric morph-map and alias tests.
+  - add `: void` to the four existing test methods changed by this branch; do not sweep untouched legacy methods in the file.
 
 ### Integer morph-alias integration and query tests
 
@@ -352,6 +372,7 @@ Do not add a separate boolean-key matrix or direct protected-trait test. The flo
   - prove a configured owner-key value `0` is written as integer `0` rather than falling back to a different primary key;
   - prove a configured owner-key value null writes null rather than a different primary key; omit a separate `''` case because no value branch remains;
   - prove scalar input throws `InvalidArgumentException` before either stored morph column or the loaded relation changes.
+  - require a morph map that excludes the associated model and prove `ClassMorphViolationException` leaves the original foreign key, morph type, and loaded relation unchanged. The foreign-key assertion owns the behavioral red; the other two characterize the complete unchanged state. Rely on the suite subscriber for morph-map cleanup.
 - `tests/Database/DatabaseEloquentBuilderTest.php`
 - make the existing mapped class-string query test use `enforceMorphMap()`, proving mapped classes remain valid in strict mode;
 - add separate positive- and negative-query regressions proving an unmapped model class throws `ClassMorphViolationException`; both direct methods own a distinct string branch even though resolution is shared;
@@ -370,7 +391,7 @@ Laravel #59019 introduced no tests, and current `13.x` has no later dedicated re
 5. Run targeted PHPStan while finalizing `InteractsWithDictionary` and `Collection` typing. Fix real declarations first; use one local `@var` for `enum_value()` only if needed. Add no global ignore.
 6. At the completed checkpoint, run `composer fix` once. It owns formatting, both PHPStan configurations, the parallel component suite, Testbench package tests, and dogfood tests; do not rerun those full commands separately at the same checkpoint.
 7. Inspect `git diff --check`, the full branch diff, and every changed method's callers/callees. Confirm current `13.x` parity, valid zero/empty/enum/stringable behavior, raw integer-list behavior through Eloquent `whereKey()` / `whereKeyNot()`, relation eager constraints, and Scout, custom collection state, deleted-model aggregate behavior, all seven direct collection aggregate entry points and their model/morph delegations, `toQuery()`'s empty/mixed/key validation order, integer morph aliases through writes, inverse lookup, eager loading, and both class-string query polarities, morph-map static cleanup, and absence of stale comments, tests, ignores, imports, or documentation.
-8. Request peer code review after the full self-review. Apply review fixes one file at a time, rerun affected tests, and repeat the full checkpoint only if the fixes can affect wider checks.
+8. Request peer code review after the full self-review. Apply review fixes one file at a time and rerun affected tests. For these aggregate-mapping and morph-association review fixes, run the union of the eleven changed test files and every measured caller test file for `loadAggregate()` and `MorphTo::associate()` (37 files) with `--fail-on-deprecation`, plus targeted PHPStan, changed-file formatting, and `git diff --check`; do not repeat the full checkpoint.
 
 ## Completion criteria
 
@@ -378,6 +399,7 @@ Laravel #59019 introduced no tests, and current `13.x` has no later dedicated re
 - The changed dictionary paths emit no null-offset, float-key, or `array_flip()` issues on PHP 8.5, and raw integer `IN`/`NOT IN` lists never convert null into literal zero.
 - Null cannot alias `''`; valid `''`, zero, enum, stringable, integer, and float identities retain the documented behavior above.
 - Missing identity fails before refresh or aggregate SQL, or before a collection query's key constraint, with `MissingAttributeException`; unsaved refresh input performs no query; soft-deleted aggregate input with a retained key remains valid; `toQuery()` cannot turn null into integer key `0`.
+- Aggregate hydration never overwrites or synchronizes the source model's primary key; a changed current key remains dirty against the identity originally loaded from the database.
 - Integer and null morph aliases work and all morph-map types describe integer and string keys truthfully.
 - Integer morph aliases serialize to string morph-column values and work through association, eager loading, inverse lookup, and positive/negative class-string morph queries, including alias and foreign key zero.
 - Morph association uses the configured owner-key column for zero, empty-string, and null values; scalar input fails before mutation; strict maps reject unmapped model class strings in both query polarities without instantiating them, while stored aliases remain queryable; and null positive/negative morph predicates compile as `IS NULL` / `IS NOT NULL`.

--- a/src/collections/src/Collection.php
+++ b/src/collections/src/Collection.php
@@ -338,7 +338,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $uniqueItems = $items->unique(null, $strict);
 
-        $compare = $this->duplicateComparator($strict);
+        $compare = $items->duplicateComparator($strict);
 
         $duplicates = $this->newInstance();
 

--- a/src/database/src/ClassMorphViolationException.php
+++ b/src/database/src/ClassMorphViolationException.php
@@ -16,9 +16,9 @@ class ClassMorphViolationException extends RuntimeException
     /**
      * Create a new exception instance.
      */
-    public function __construct(object $model)
+    public function __construct(object|string $model)
     {
-        $class = get_class($model);
+        $class = is_object($model) ? $model::class : $model;
 
         parent::__construct("No morph map defined for model [{$class}].");
 

--- a/src/database/src/Eloquent/Collection.php
+++ b/src/database/src/Eloquent/Collection.php
@@ -150,20 +150,21 @@ class Collection extends BaseCollection implements QueueableCollection
             ->whereKey(array_values($modelKeys))
             ->select($keyName)
             ->withAggregate($relations, $column, $function) // @phpstan-ignore method.notFound (withAggregate is on Eloquent\Builder; PHPStan loses type through chain)
-            ->get()
-            ->keyBy($keyName);
+            ->get();
 
         if ($models->isEmpty()) {
             return $this;
         }
 
-        $attributes = Arr::except(
-            array_keys($models->first()->getAttributes()),
+        $attributes = array_keys(Arr::except(
+            $models->first()->getAttributes(),
             $keyName
-        );
+        ));
 
-        $this->each(function ($item, $collectionKey) use ($models, $attributes, $modelKeys) {
-            $aggregateModel = $models->get($modelKeys[$collectionKey]);
+        $modelsByKey = $this->getDictionary($models);
+
+        $this->each(function ($item, $collectionKey) use ($modelsByKey, $attributes, $modelKeys) {
+            $aggregateModel = $modelsByKey[$this->getDictionaryKey($modelKeys[$collectionKey])] ?? null;
 
             if ($aggregateModel === null) {
                 return;

--- a/src/database/src/Eloquent/Collection.php
+++ b/src/database/src/Eloquent/Collection.php
@@ -47,10 +47,23 @@ class Collection extends BaseCollection implements QueueableCollection
                 return $this->newInstance();
             }
 
-            return $this->whereIn($this->first()->getKeyName(), $key);
+            $keyName = $this->first()->getKeyName();
+
+            return $this
+                ->filter(fn ($model) => $model->getKey() !== null)
+                ->whereIn($keyName, Arr::whereNotNull($key));
         }
 
-        return Arr::first($this->items, fn ($model) => $model->getKey() == $key, $default);
+        if ($key === null) {
+            return value($default);
+        }
+
+        return Arr::first($this->items, function ($model) use ($key) {
+            $modelKey = $model->getKey();
+
+            // Numeric model keys intentionally retain their existing loose scalar compatibility.
+            return $modelKey !== null && $modelKey == $key;
+        }, $default);
     }
 
     /**
@@ -109,6 +122,8 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of aggregations over relationship's column onto the collection.
      *
      * @param  array<array-key, array|(callable(\Hypervel\Database\Eloquent\Relations\Relation<*, *, *>): mixed)|string>|string  $relations
+     *
+     * @throws MissingAttributeException
      */
     public function loadAggregate(array|string $relations, string $column, ?string $function = null): static
     {
@@ -116,24 +131,49 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this;
         }
 
-        $models = $this->first()->newModelQuery()
-            ->whereKey($this->modelKeys())
-            ->select($this->first()->getKeyName())
+        $modelKeys = [];
+
+        foreach ($this->items as $collectionKey => $item) {
+            $key = $item->getKey();
+
+            if ($key === null) {
+                throw new MissingAttributeException($item, $item->getKeyName());
+            }
+
+            $modelKeys[$collectionKey] = $key;
+        }
+
+        $model = $this->first();
+        $keyName = $model->getKeyName();
+
+        $models = $model->newModelQuery()
+            ->whereKey(array_values($modelKeys))
+            ->select($keyName)
             ->withAggregate($relations, $column, $function) // @phpstan-ignore method.notFound (withAggregate is on Eloquent\Builder; PHPStan loses type through chain)
             ->get()
-            ->keyBy($this->first()->getKeyName());
+            ->keyBy($keyName);
+
+        if ($models->isEmpty()) {
+            return $this;
+        }
 
         $attributes = Arr::except(
             array_keys($models->first()->getAttributes()),
-            $models->first()->getKeyName()
+            $keyName
         );
 
-        $this->each(function ($model) use ($models, $attributes) {
-            $extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
+        $this->each(function ($item, $collectionKey) use ($models, $attributes, $modelKeys) {
+            $aggregateModel = $models->get($modelKeys[$collectionKey]);
 
-            $model->forceFill($extraAttributes)
+            if ($aggregateModel === null) {
+                return;
+            }
+
+            $extraAttributes = Arr::only($aggregateModel->getAttributes(), $attributes);
+
+            $item->forceFill($extraAttributes)
                 ->syncOriginalAttributes($attributes)
-                ->mergeCasts($models->get($model->getKey())->getCasts());
+                ->mergeCasts($aggregateModel->getCasts());
         });
 
         return $this;
@@ -369,7 +409,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the array of primary keys.
      *
-     * @return array<int, array-key>
+     * @return array<array-key, null|array-key>
      */
     public function modelKeys(): array
     {
@@ -388,7 +428,11 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary();
 
         foreach ($items as $item) {
-            $dictionary[$this->getDictionaryKey($item->getKey())] = $item;
+            $key = $this->getDictionaryKey($item->getKey());
+
+            if ($key !== null) {
+                $dictionary[$key] = $item;
+            }
         }
 
         return $this->newInstance(array_values($dictionary));
@@ -435,6 +479,8 @@ class Collection extends BaseCollection implements QueueableCollection
      * Reload a fresh model instance from the database for all the entities.
      *
      * @param array<array-key, string>|string $with
+     *
+     * @throws MissingAttributeException
      */
     public function fresh(array|string $with = []): static
     {
@@ -442,17 +488,45 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->newInstance();
         }
 
+        $modelKeys = [];
+
+        foreach ($this->items as $collectionKey => $item) {
+            if (! $item->exists) {
+                continue;
+            }
+
+            $key = $item->getKey();
+
+            if ($key === null) {
+                throw new MissingAttributeException($item, $item->getKeyName());
+            }
+
+            $modelKeys[$collectionKey] = $key;
+        }
+
+        if ($modelKeys === []) {
+            return $this->newInstance();
+        }
+
         $model = $this->first();
 
         $freshModels = $model->newQueryWithoutScopes()
             ->with(is_string($with) ? func_get_args() : $with)
-            ->whereIn($model->getKeyName(), $this->modelKeys())
+            ->whereIn($model->getKeyName(), array_values($modelKeys))
             ->get()
             ->getDictionary(); // @phpstan-ignore method.notFound (getDictionary is on Eloquent\Collection; PHPStan loses type through chain)
 
-        // @phpstan-ignore return.type (filter/map chain returns correct type at runtime)
-        return $this->filter(fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))
-            ->map(fn ($model) => $freshModels[$model->getKey()]);
+        $freshItems = [];
+
+        foreach ($modelKeys as $collectionKey => $key) {
+            $dictionaryKey = $this->getDictionaryKey($key);
+
+            if (isset($freshModels[$dictionaryKey])) {
+                $freshItems[$collectionKey] = $freshModels[$dictionaryKey];
+            }
+        }
+
+        return $this->newInstance($freshItems);
     }
 
     /**
@@ -468,7 +542,9 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary($items);
 
         foreach ($this->items as $item) {
-            if (! isset($dictionary[$this->getDictionaryKey($item->getKey())])) {
+            $key = $this->getDictionaryKey($item->getKey());
+
+            if ($key === null || ! isset($dictionary[$key])) {
                 $diff->add($item);
             }
         }
@@ -493,7 +569,9 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary($items);
 
         foreach ($this->items as $item) {
-            if (isset($dictionary[$this->getDictionaryKey($item->getKey())])) {
+            $key = $this->getDictionaryKey($item->getKey());
+
+            if ($key !== null && isset($dictionary[$key])) {
                 $intersect->add($item);
             }
         }
@@ -517,7 +595,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Returns only the models from the collection with the specified keys.
+     * Return only the models from the collection with the specified keys.
      *
      * @param null|array<array-key, mixed> $keys
      */
@@ -528,13 +606,16 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->newInstance($this->items);
         }
 
-        $dictionary = Arr::only($this->getDictionary(), array_map($this->getDictionaryKey(...), (array) $keys));
+        $dictionary = Arr::only(
+            $this->getDictionary(),
+            Arr::whereNotNull(array_map($this->getDictionaryKey(...), (array) $keys))
+        );
 
         return $this->newInstance(array_values($dictionary));
     }
 
     /**
-     * Returns all models in the collection except the models with specified keys.
+     * Return all models in the collection except the models with specified keys.
      *
      * @param null|array<array-key, mixed> $keys
      */
@@ -545,7 +626,10 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->newInstance($this->items);
         }
 
-        $dictionary = Arr::except($this->getDictionary(), array_map($this->getDictionaryKey(...), (array) $keys));
+        $dictionary = Arr::except(
+            $this->getDictionary(),
+            Arr::whereNotNull(array_map($this->getDictionaryKey(...), (array) $keys))
+        );
 
         return $this->newInstance(array_values($dictionary));
     }
@@ -659,7 +743,11 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = [];
 
         foreach ($items as $value) {
-            $dictionary[$this->getDictionaryKey($value->getKey())] = $value;
+            $key = $this->getDictionaryKey($value->getKey());
+
+            if ($key !== null) {
+                $dictionary[$key] = $value;
+            }
         }
 
         return $dictionary;
@@ -763,13 +851,7 @@ class Collection extends BaseCollection implements QueueableCollection
     #[Override]
     protected function duplicateComparator(bool $strict): callable
     {
-        // unique() collapses keyless models into a single dictionary entry, so the
-        // comparator must agree with it or an unsaved model can misreport later keyed items.
-        return fn ($a, $b) => $a->is($b)
-            || ($a->getKey() === null
-                && $b->getKey() === null
-                && $a->getTable() === $b->getTable()
-                && $a->getConnectionName() === $b->getConnectionName());
+        return fn ($a, $b) => $a->is($b);
     }
 
     /**
@@ -899,6 +981,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * @return \Hypervel\Database\Eloquent\Builder<TModel>
      *
      * @throws LogicException
+     * @throws MissingAttributeException
      */
     public function toQuery(): Builder
     {
@@ -914,6 +997,18 @@ class Collection extends BaseCollection implements QueueableCollection
             throw new LogicException('Unable to create query for collection with mixed types.');
         }
 
-        return $model->newModelQuery()->whereKey($this->modelKeys());
+        $modelKeys = [];
+
+        foreach ($this->items as $item) {
+            $key = $item->getKey();
+
+            if ($key === null) {
+                throw new MissingAttributeException($item, $item->getKeyName());
+            }
+
+            $modelKeys[] = $key;
+        }
+
+        return $model->newModelQuery()->whereKey($modelKeys);
     }
 }

--- a/src/database/src/Eloquent/Concerns/HasRelationships.php
+++ b/src/database/src/Eloquent/Concerns/HasRelationships.php
@@ -898,13 +898,16 @@ trait HasRelationships
 
     /**
      * Get the class name for polymorphic relations.
+     *
+     * @throws ClassMorphViolationException
      */
     public function getMorphClass(): string
     {
         $morphMap = Relation::morphMap();
+        $alias = array_search(static::class, $morphMap, true);
 
-        if (! empty($morphMap) && in_array(static::class, $morphMap)) {
-            return array_search(static::class, $morphMap, true);
+        if ($alias !== false) {
+            return (string) $alias;
         }
 
         if (static::class === Pivot::class) {

--- a/src/database/src/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/database/src/Eloquent/Concerns/QueriesRelationships.php
@@ -6,8 +6,10 @@ namespace Hypervel\Database\Eloquent\Concerns;
 
 use BadMethodCallException;
 use Closure;
+use Hypervel\Database\ClassMorphViolationException;
 use Hypervel\Database\Eloquent\Builder;
 use Hypervel\Database\Eloquent\Collection as EloquentCollection;
+use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\RelationNotFoundException;
 use Hypervel\Database\Eloquent\Relations\BelongsTo;
 use Hypervel\Database\Eloquent\Relations\BelongsToMany;
@@ -555,6 +557,9 @@ trait QueriesRelationships
      *
      * @param  \Hypervel\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param null|\Hypervel\Database\Eloquent\Model|iterable<int, \Hypervel\Database\Eloquent\Model>|string $model
+     *
+     * @throws ClassMorphViolationException
+     * @throws InvalidArgumentException
      */
     public function whereMorphedTo(MorphTo|string $relation, mixed $model, string $boolean = 'and'): static
     {
@@ -568,11 +573,7 @@ trait QueriesRelationships
         }
 
         if (is_string($model)) {
-            $morphMap = Relation::morphMap();
-
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
-                $model = array_search($model, $morphMap, true);
-            }
+            $model = $this->getMorphTypeForQuery($model);
 
             // @phpstan-ignore method.notFound (getMorphType exists on MorphTo, not base Relation)
             return $this->where($relation->qualifyColumn($relation->getMorphType()), $model, null, $boolean);
@@ -600,7 +601,10 @@ trait QueriesRelationships
      * Add a not morph-to relationship condition to the query.
      *
      * @param  \Hypervel\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param \Hypervel\Database\Eloquent\Model|iterable<int, \Hypervel\Database\Eloquent\Model>|string $model
+     * @param null|\Hypervel\Database\Eloquent\Model|iterable<int, \Hypervel\Database\Eloquent\Model>|string $model
+     *
+     * @throws ClassMorphViolationException
+     * @throws InvalidArgumentException
      */
     public function whereNotMorphedTo(MorphTo|string $relation, mixed $model, string $boolean = 'and'): static
     {
@@ -608,12 +612,13 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($relation);
         }
 
-        if (is_string($model)) {
-            $morphMap = Relation::morphMap();
+        if (is_null($model)) {
+            // @phpstan-ignore method.notFound, return.type (getMorphType exists on MorphTo; mixin returns $this at runtime)
+            return $this->whereNotNull($relation->qualifyColumn($relation->getMorphType()), $boolean);
+        }
 
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
-                $model = array_search($model, $morphMap, true);
-            }
+        if (is_string($model)) {
+            $model = $this->getMorphTypeForQuery($model);
 
             return $this->whereNot(fn ($query) => $query->whereNullSafeEquals(
                 // @phpstan-ignore method.notFound (getMorphType exists on MorphTo, not base Relation)
@@ -655,11 +660,33 @@ trait QueriesRelationships
      * Add a not morph-to relationship condition to the query with an "or where" clause.
      *
      * @param  \Hypervel\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
-     * @param \Hypervel\Database\Eloquent\Model|iterable<int, \Hypervel\Database\Eloquent\Model>|string $model
+     * @param null|\Hypervel\Database\Eloquent\Model|iterable<int, \Hypervel\Database\Eloquent\Model>|string $model
      */
     public function orWhereNotMorphedTo(MorphTo|string $relation, mixed $model): static
     {
         return $this->whereNotMorphedTo($relation, $model, 'or');
+    }
+
+    /**
+     * Resolve the morph type for a relationship query.
+     *
+     * @throws ClassMorphViolationException
+     */
+    protected function getMorphTypeForQuery(string $model): string
+    {
+        if (Relation::requiresMorphMap()) {
+            $morphMap = Relation::morphMap();
+
+            if (
+                ! in_array($model, $morphMap, true)
+                && ! array_key_exists($model, $morphMap)
+                && is_a($model, Model::class, true)
+            ) {
+                throw new ClassMorphViolationException($model);
+            }
+        }
+
+        return (string) Relation::getMorphAlias($model);
     }
 
     /**

--- a/src/database/src/Eloquent/Relations/BelongsTo.php
+++ b/src/database/src/Eloquent/Relations/BelongsTo.php
@@ -145,7 +145,9 @@ class BelongsTo extends Relation
         foreach ($results as $result) {
             $attribute = $this->getDictionaryKey($this->getRelatedKeyFrom($result));
 
-            $dictionary[$attribute] = $result;
+            if ($attribute !== null) {
+                $dictionary[$attribute] = $result;
+            }
         }
 
         // Once we have the dictionary constructed, we can loop through all the parents
@@ -154,8 +156,8 @@ class BelongsTo extends Relation
         foreach ($models as $model) {
             $attribute = $this->getDictionaryKey($this->getForeignKeyFrom($model));
 
-            if (isset($dictionary[$attribute ?? ''])) {
-                $model->setRelation($relation, $dictionary[$attribute ?? '']);
+            if ($attribute !== null && isset($dictionary[$attribute])) {
+                $model->setRelation($relation, $dictionary[$attribute]);
             }
         }
 

--- a/src/database/src/Eloquent/Relations/BelongsToMany.php
+++ b/src/database/src/Eloquent/Relations/BelongsToMany.php
@@ -258,7 +258,7 @@ class BelongsToMany extends Relation
         foreach ($models as $model) {
             $key = $this->getDictionaryKey($model->{$this->parentKey});
 
-            if (isset($dictionary[$key])) {
+            if ($key !== null && isset($dictionary[$key])) {
                 $model->setRelation(
                     $relation,
                     $this->related->newCollection($dictionary[$key])
@@ -273,7 +273,7 @@ class BelongsToMany extends Relation
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param \Hypervel\Database\Eloquent\Collection<int, TRelatedModel> $results
-     * @return array<list<TRelatedModel>>
+     * @return array<array<array-key, TRelatedModel>>
      */
     protected function buildDictionary(EloquentCollection $results): array
     {
@@ -286,6 +286,10 @@ class BelongsToMany extends Relation
 
         foreach ($results as $key => $result) {
             $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+
+            if ($value === null) {
+                continue;
+            }
 
             if ($isAssociative) {
                 $dictionary[$value][$key] = $result;

--- a/src/database/src/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/database/src/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -16,8 +16,12 @@ trait InteractsWithDictionary
      *
      * @throws InvalidArgumentException
      */
-    protected function getDictionaryKey(mixed $attribute): mixed
+    protected function getDictionaryKey(mixed $attribute): int|string|null
     {
+        if (is_null($attribute) || is_string($attribute) || is_int($attribute)) {
+            return $attribute;
+        }
+
         if (is_object($attribute)) {
             if (method_exists($attribute, '__toString')) {
                 return $attribute->__toString();
@@ -30,6 +34,6 @@ trait InteractsWithDictionary
             throw new InvalidArgumentException('Model attribute value is an object but does not have a __toString method.');
         }
 
-        return $attribute;
+        return (string) $attribute;
     }
 }

--- a/src/database/src/Eloquent/Relations/HasOneOrMany.php
+++ b/src/database/src/Eloquent/Relations/HasOneOrMany.php
@@ -174,7 +174,7 @@ abstract class HasOneOrMany extends Relation
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param \Hypervel\Database\Eloquent\Collection<int, TRelatedModel> $results
-     * @return array<array<int, TRelatedModel>>
+     * @return array<array<array-key, TRelatedModel>>
      */
     protected function buildDictionary(EloquentCollection $results): array
     {
@@ -186,6 +186,10 @@ abstract class HasOneOrMany extends Relation
 
         foreach ($results as $key => $item) {
             $pairKey = $this->getDictionaryKey($item->{$foreign});
+
+            if ($pairKey === null) {
+                continue;
+            }
 
             if ($isAssociative) {
                 $dictionary[$pairKey][$key] = $item;

--- a/src/database/src/Eloquent/Relations/MorphTo.php
+++ b/src/database/src/Eloquent/Relations/MorphTo.php
@@ -237,19 +237,17 @@ class MorphTo extends BelongsTo
             throw new InvalidArgumentException('MorphTo relationships may only be associated with a model instance or null.');
         }
 
+        $foreignKeyValue = null;
+        $morphClass = null;
+
         if ($model instanceof Model) {
-            $foreignKey = $this->ownerKey ?? $model->getKeyName();
+            $foreignKeyValue = $model->{$this->ownerKey ?? $model->getKeyName()};
+            $morphClass = $model->getMorphClass();
         }
 
-        $this->parent->setAttribute(
-            $this->foreignKey,
-            $model instanceof Model ? $model->{$foreignKey} : null
-        );
+        $this->parent->setAttribute($this->foreignKey, $foreignKeyValue);
 
-        $this->parent->setAttribute(
-            $this->morphType,
-            $model instanceof Model ? $model->getMorphClass() : null
-        );
+        $this->parent->setAttribute($this->morphType, $morphClass);
 
         return $this->parent->setRelation($this->relationName, $model);
     }

--- a/src/database/src/Eloquent/Relations/MorphTo.php
+++ b/src/database/src/Eloquent/Relations/MorphTo.php
@@ -10,6 +10,7 @@ use Hypervel\Database\Eloquent\Collection as EloquentCollection;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Hypervel\Support\Arr;
+use InvalidArgumentException;
 use Override;
 
 /**
@@ -94,15 +95,28 @@ class MorphTo extends BelongsTo
         $isAssociative = Arr::isAssoc($models->all());
 
         foreach ($models as $key => $model) {
-            if ($model->{$this->morphType}) {
-                $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
-                $foreignKeyKey = $this->getDictionaryKey($model->{$this->foreignKey});
+            $morphType = $model->{$this->morphType};
 
-                if ($isAssociative) {
-                    $this->dictionary[$morphTypeKey][$foreignKeyKey][$key] = $model;
-                } else {
-                    $this->dictionary[$morphTypeKey][$foreignKeyKey][] = $model;
-                }
+            if ($morphType === '') {
+                continue;
+            }
+
+            $morphTypeKey = $this->getDictionaryKey($morphType);
+
+            if ($morphTypeKey === null) {
+                continue;
+            }
+
+            $foreignKeyKey = $this->getDictionaryKey($model->{$this->foreignKey});
+
+            if ($foreignKeyKey === null) {
+                continue;
+            }
+
+            if ($isAssociative) {
+                $this->dictionary[$morphTypeKey][$foreignKeyKey][$key] = $model;
+            } else {
+                $this->dictionary[$morphTypeKey][$foreignKeyKey][] = $model;
             }
         }
     }
@@ -128,7 +142,7 @@ class MorphTo extends BelongsTo
      *
      * @return \Hypervel\Database\Eloquent\Collection<int, TRelatedModel>
      */
-    protected function getResultsByType(string $type): EloquentCollection
+    protected function getResultsByType(int|string $type): EloquentCollection
     {
         $instance = $this->createModelByType($type);
 
@@ -159,13 +173,13 @@ class MorphTo extends BelongsTo
     /**
      * Gather all of the foreign keys for a given type.
      */
-    protected function gatherKeysByType(string $type, string $keyType): array
+    protected function gatherKeysByType(int|string $type, string $keyType): array
     {
         return $keyType !== 'string'
             ? array_keys($this->dictionary[$type])
             : array_map(function ($modelId) {
                 return (string) $modelId;
-            }, array_filter(array_keys($this->dictionary[$type])));
+            }, array_keys($this->dictionary[$type]));
     }
 
     /**
@@ -173,7 +187,7 @@ class MorphTo extends BelongsTo
      *
      * @return TRelatedModel
      */
-    public function createModelByType(string $type): Model
+    public function createModelByType(int|string $type): Model
     {
         $class = Model::getActualClassNameForMorph($type);
 
@@ -195,7 +209,7 @@ class MorphTo extends BelongsTo
      *
      * @param \Hypervel\Database\Eloquent\Collection<int, TRelatedModel> $results
      */
-    protected function matchToMorphParents(string $type, EloquentCollection $results): void
+    protected function matchToMorphParents(int|string $type, EloquentCollection $results): void
     {
         foreach ($results as $result) {
             $ownerKey = $this->getDictionaryKey(! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey());
@@ -213,14 +227,18 @@ class MorphTo extends BelongsTo
      *
      * @param null|TRelatedModel $model
      * @return TDeclaringModel
+     *
+     * @throws InvalidArgumentException
      */
     #[Override]
     public function associate(Model|string|int|null $model): Model
     {
+        if ($model !== null && ! $model instanceof Model) {
+            throw new InvalidArgumentException('MorphTo relationships may only be associated with a model instance or null.');
+        }
+
         if ($model instanceof Model) {
-            $foreignKey = $this->ownerKey && $model->{$this->ownerKey}
-                ? $this->ownerKey
-                : $model->getKeyName();
+            $foreignKey = $this->ownerKey ?? $model->getKeyName();
         }
 
         $this->parent->setAttribute(

--- a/src/database/src/Eloquent/Relations/Relation.php
+++ b/src/database/src/Eloquent/Relations/Relation.php
@@ -65,7 +65,7 @@ abstract class Relation implements BuilderContract
     /**
      * An array to map morph names to their class names in the database.
      *
-     * @var array<string, class-string<\Hypervel\Database\Eloquent\Model>>
+     * @var array<int|string, class-string<\Hypervel\Database\Eloquent\Model>>
      */
     public static array $morphMap = [];
 
@@ -426,7 +426,8 @@ abstract class Relation implements BuilderContract
      * Boot-only. Sets both worker-wide morph state (requireMorphMap + morphMap)
      * shared by every coroutine.
      *
-     * @param array<string, class-string<\Hypervel\Database\Eloquent\Model>> $map
+     * @param array<int|string, class-string<\Hypervel\Database\Eloquent\Model>> $map
+     * @return array<int|string, class-string<\Hypervel\Database\Eloquent\Model>>
      */
     public static function enforceMorphMap(array $map, bool $merge = true): array
     {
@@ -442,8 +443,8 @@ abstract class Relation implements BuilderContract
      * worker lifetime and applies to every polymorphic resolution across all
      * coroutines.
      *
-     * @param null|array<string, class-string<\Hypervel\Database\Eloquent\Model>> $map
-     * @return array<string, class-string<\Hypervel\Database\Eloquent\Model>>
+     * @param null|array<int|string, class-string<\Hypervel\Database\Eloquent\Model>> $map
+     * @return array<int|string, class-string<\Hypervel\Database\Eloquent\Model>>
      */
     public static function morphMap(?array $map = null, bool $merge = true): array
     {
@@ -459,10 +460,10 @@ abstract class Relation implements BuilderContract
     }
 
     /**
-     * Builds a table-keyed array from model class names.
+     * Build a table-keyed array from model class names.
      *
-     * @param null|array<string, class-string<\Hypervel\Database\Eloquent\Model>>|list<class-string<\Hypervel\Database\Eloquent\Model>> $models
-     * @return null|array<string, class-string<\Hypervel\Database\Eloquent\Model>>
+     * @param null|array<int|string, class-string<\Hypervel\Database\Eloquent\Model>> $models
+     * @return null|array<int|string, class-string<\Hypervel\Database\Eloquent\Model>>
      */
     protected static function buildMorphMapFromModels(?array $models = null): ?array
     {
@@ -480,8 +481,12 @@ abstract class Relation implements BuilderContract
      *
      * @return null|class-string<\Hypervel\Database\Eloquent\Model>
      */
-    public static function getMorphedModel(string $alias): ?string
+    public static function getMorphedModel(int|string|null $alias): ?string
     {
+        if (is_null($alias)) {
+            return null;
+        }
+
         return static::$morphMap[$alias] ?? null;
     }
 
@@ -492,7 +497,9 @@ abstract class Relation implements BuilderContract
      */
     public static function getMorphAlias(string $className): int|string
     {
-        return array_search($className, static::$morphMap, strict: true) ?: $className;
+        $alias = array_search($className, static::$morphMap, strict: true);
+
+        return $alias !== false ? $alias : $className;
     }
 
     /**

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -1236,7 +1236,7 @@ class Builder implements BuilderContract
             $values = $values->toArray();
         }
 
-        $values = Arr::flatten($values);
+        $values = Arr::whereNotNull(Arr::flatten($values));
 
         foreach ($values as &$value) {
             $value = (int) ($value instanceof BackedEnum ? $value->value : $value);

--- a/src/docs/eloquent-collections.md
+++ b/src/docs/eloquent-collections.md
@@ -173,6 +173,8 @@ $users = $users->fresh();
 $users = $users->fresh('comments');
 ```
 
+Every persisted model in the collection must have its primary key loaded, as described in the [refreshing models](/docs/{{version}}/eloquent#refreshing-models) documentation. Otherwise, Hypervel will throw a `Hypervel\Database\Eloquent\MissingAttributeException` exception.
+
 <a name="method-intersect"></a>
 #### `intersect($items)` {.collection-method}
 
@@ -322,6 +324,8 @@ $users->toQuery()->update([
 ```
 
 The collection may not be empty and must contain models of the same type.
+
+Every model in the collection must have its primary key loaded because the returned query is constrained by those keys. Otherwise, Hypervel will throw a `Hypervel\Database\Eloquent\MissingAttributeException` exception.
 
 <a name="method-unique"></a>
 #### `unique($key = null, $strict = false)` {.collection-method}

--- a/src/docs/eloquent.md
+++ b/src/docs/eloquent.md
@@ -503,6 +503,8 @@ $flight = Flight::where('number', 'FR 900')->first();
 $freshFlight = $flight->fresh();
 ```
 
+A persisted model must have its primary key loaded before calling either method. Otherwise, Hypervel will throw a `Hypervel\Database\Eloquent\MissingAttributeException` exception.
+
 The `refresh` method will re-hydrate the existing model using fresh data from the database. In addition, all of its loaded relationships will be refreshed as well:
 
 ```php

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -55,6 +55,40 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $this->assertContains($result1, $models[0]->foo);
     }
 
+    public function testModelsWithNullParentKeysAreNotMatchedToEmptyStringPivotKeys(): void
+    {
+        $relation = $this->getRelation();
+
+        $model = new class extends Model {
+            protected array $attributes = ['parent_key' => null];
+        };
+
+        $result = (object) [
+            'pivot' => (object) ['foreign_key' => ''],
+        ];
+
+        $relation->match([$model], Collection::wrap($result), 'foo');
+
+        $this->assertFalse($model->relationLoaded('foo'));
+    }
+
+    public function testModelsWithNullPivotKeysAreNotMatchedToEmptyStringParentKeys(): void
+    {
+        $relation = $this->getRelation();
+
+        $model = new class extends Model {
+            protected array $attributes = ['parent_key' => ''];
+        };
+
+        $result = (object) [
+            'pivot' => (object) ['foreign_key' => null],
+        ];
+
+        $relation->match([$model], Collection::wrap($result), 'foo');
+
+        $this->assertFalse($model->relationLoaded('foo'));
+    }
+
     protected function getRelation()
     {
         $builder = m::mock(Builder::class);
@@ -82,5 +116,5 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
 
 class ModelStub extends Model
 {
-    public $foreign_key = 'foreign.value';
+    public string $foreign_key = 'foreign.value';
 }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -14,9 +14,9 @@ use Mockery as m;
 
 class DatabaseEloquentBelongsToTest extends TestCase
 {
-    protected $builder;
+    protected Builder $builder;
 
-    protected $related;
+    protected Model $related;
 
     public function testBelongsToWithDefault()
     {
@@ -154,6 +154,67 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertEquals(2, $models[1]->foo->getAttribute('id'));
         $this->assertSame('3', (string) $models[2]->foo->getAttribute('id'));
         $this->assertEquals(5, $models[3]->foo->getAttribute('id')->value);
+    }
+
+    public function testModelsWithNullRelatedKeysAreNotMatchedToEmptyStringForeignKeys(): void
+    {
+        $relation = $this->getRelation();
+
+        $result = new class extends Model {
+            protected array $attributes = ['id' => null];
+        };
+
+        $model = new ModelStub;
+        $model->foreign_key = '';
+
+        $relation->match([$model], new Collection([$result]), 'foo');
+
+        $this->assertFalse($model->relationLoaded('foo'));
+    }
+
+    public function testModelsWithNullForeignKeysAreNotMatchedToEmptyStringRelatedKeys(): void
+    {
+        $relation = $this->getRelation();
+
+        $result = new class extends Model {
+            protected string $keyType = 'string';
+
+            protected array $attributes = ['id' => ''];
+        };
+
+        $model = new ModelStub;
+        $model->foreign_key = null;
+
+        $relation->match([$model], new Collection([$result]), 'foo');
+
+        $this->assertFalse($model->relationLoaded('foo'));
+    }
+
+    public function testModelsWithFloatKeysAreProperlyMatchedToParents(): void
+    {
+        $relation = $this->getRelation();
+
+        $result1 = new class extends Model {
+            protected string $keyType = 'string';
+
+            protected array $attributes = ['id' => 1.5];
+        };
+
+        $result2 = new class extends Model {
+            protected string $keyType = 'string';
+
+            protected array $attributes = ['id' => 1.9];
+        };
+
+        $model1 = new ModelStub;
+        $model1->foreign_key = 1.5;
+        $model2 = new ModelStub;
+        $model2->foreign_key = 1.9;
+
+        $models = $relation->match([$model1, $model2], new Collection([$result1, $result2]), 'foo');
+
+        $this->assertSame($result1, $models[0]->foo);
+        $this->assertSame($result2, $models[1]->foo);
     }
 
     public function testAssociateMethodSetsForeignKeyOnModel()
@@ -428,22 +489,22 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
 class ModelStub extends Model
 {
-    public $foreign_key = 'foreign.value';
+    public mixed $foreign_key = 'foreign.value';
 }
 
 class AnotherModelStub extends Model
 {
-    public $foreign_key = 'foreign.value.two';
+    public string $foreign_key = 'foreign.value.two';
 }
 
 class ModelStubWithZeroId extends Model
 {
-    public $foreign_key = 0;
+    public int $foreign_key = 0;
 }
 
 class MissingModelStub extends Model
 {
-    public $foreign_key;
+    public mixed $foreign_key = null;
 }
 
 class ModelStubWithBackedEnumCast extends Model

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Database\DatabaseEloquentBuilderTest;
 use BadMethodCallException;
 use Closure;
 use Hypervel\Database\BinaryParameter;
+use Hypervel\Database\ClassMorphViolationException;
 use Hypervel\Database\Connection;
 use Hypervel\Database\ConnectionInterface;
 use Hypervel\Database\ConnectionResolverInterface;
@@ -2270,6 +2271,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "model_parent_stubs" where "model_parent_stubs"."morph_type" is null', $builder->toSql());
     }
 
+    public function testWhereNotMorphedToNull(): void
+    {
+        $model = new ModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        $builder = $model->whereNotMorphedTo('morph', null);
+
+        $this->assertSame('select * from "model_parent_stubs" where "model_parent_stubs"."morph_type" is not null', $builder->toSql());
+        $this->assertSame([], $builder->getBindings());
+    }
+
     public function testWhereNotMorphedTo()
     {
         $model = new ModelParentStub;
@@ -2555,21 +2567,88 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame([ModelCloseRelatedStub::class], $builder->getBindings());
     }
 
-    public function testWhereMorphedToAlias()
+    public function testWhereMorphedToAlias(): void
     {
         $model = new ModelParentStub;
         $this->mockConnectionForModel($model, '');
 
-        Relation::morphMap([
+        Relation::enforceMorphMap([
             'alias' => ModelCloseRelatedStub::class,
         ]);
 
         $builder = $model->whereMorphedTo('morph', ModelCloseRelatedStub::class);
 
         $this->assertSame('select * from "model_parent_stubs" where "model_parent_stubs"."morph_type" = ?', $builder->toSql());
-        $this->assertEquals(['alias'], $builder->getBindings());
+        $this->assertSame(['alias'], $builder->getBindings());
+    }
 
-        Relation::morphMap([], false);
+    public function testWhereMorphedToAcceptsStoredAliasesWhenMorphMapIsRequired(): void
+    {
+        $model = new ModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        Relation::enforceMorphMap([
+            ModelCloseRelatedStub::class => ModelFarRelatedStub::class,
+        ]);
+
+        $classAliasBuilder = $model->whereMorphedTo('morph', ModelCloseRelatedStub::class);
+        $plainAliasBuilder = $model->whereMorphedTo('morph', 'legacy-alias');
+
+        $this->assertSame([ModelCloseRelatedStub::class], $classAliasBuilder->getBindings());
+        $this->assertSame(['legacy-alias'], $plainAliasBuilder->getBindings());
+    }
+
+    public function testWhereMorphedToClassRequiresMorphMap(): void
+    {
+        $model = new ModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        Relation::requireMorphMap();
+
+        $this->expectException(ClassMorphViolationException::class);
+
+        $model->whereMorphedTo('morph', ModelCloseRelatedStub::class);
+    }
+
+    public function testWhereMorphedToAbstractClassRequiresMorphMap(): void
+    {
+        $model = new ModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        Relation::requireMorphMap();
+
+        $this->expectException(ClassMorphViolationException::class);
+
+        $model->whereMorphedTo('morph', AbstractModelRelatedStub::class);
+    }
+
+    public function testWhereNotMorphedToClassRequiresMorphMap(): void
+    {
+        $model = new ModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        Relation::requireMorphMap();
+
+        $this->expectException(ClassMorphViolationException::class);
+
+        $model->whereNotMorphedTo('morph', ModelCloseRelatedStub::class);
+    }
+
+    public function testWhereMorphedToClassUsesIntegerAliasForBothPolarities(): void
+    {
+        $model = new ModelParentStub;
+        $this->mockConnectionForModel($model, '');
+
+        Relation::morphMap([
+            0 => ModelCloseRelatedStub::class,
+            2 => ModelFarRelatedStub::class,
+        ]);
+
+        $builder = $model->whereMorphedTo('morph', ModelCloseRelatedStub::class);
+        $negativeBuilder = $model->whereNotMorphedTo('morph', ModelCloseRelatedStub::class);
+
+        $this->assertSame(['0'], $builder->getBindings());
+        $this->assertSame(['0'], $negativeBuilder->getBindings());
     }
 
     public function testWhereKeyMethodWithInt()
@@ -3545,6 +3624,10 @@ class ModelCloseRelatedStub extends Model
     {
         return $this->hasMany(ModelOtherFarRelatedStub::class);
     }
+}
+
+abstract class AbstractModelRelatedStub extends Model
+{
 }
 
 class ModelFarRelatedStub extends Model

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Database\DatabaseEloquentCollectionTest;
 use Hypervel\Database\Capsule\Manager as DB;
 use Hypervel\Database\Eloquent\Builder;
 use Hypervel\Database\Eloquent\Collection;
+use Hypervel\Database\Eloquent\MissingAttributeException;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Model as Eloquent;
 use Hypervel\Database\Eloquent\ModelNotFoundException;
@@ -258,6 +259,25 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([2, 3], $c->find([2, 3, 4])->pluck('id')->all());
     }
 
+    public function testFindDoesNotMatchNullModelKeys(): void
+    {
+        $keyless = new CollectionModel;
+        $emptyString = (new CollectionModel)->setKeyType('string')->forceFill(['id' => '']);
+        $zero = (new CollectionModel)->forceFill(['id' => 0]);
+
+        $collection = new Collection([$keyless, $emptyString, $zero]);
+
+        $this->assertSame('default', $collection->find(null, fn () => 'default'));
+        $this->assertSame('default', $collection->find(new CollectionModel, fn () => 'default'));
+        $this->assertSame($emptyString, $collection->find('', fn () => $this->fail()));
+        $this->assertSame($zero, $collection->find(0, fn () => $this->fail()));
+        $this->assertSame([], $collection->find([null])->all());
+        $this->assertSame([$emptyString], $collection->find([''])->values()->all());
+        $this->assertSame([$zero], $collection->find([0])->values()->all());
+
+        $this->assertSame([], (new Collection([$keyless]))->find([''])->all());
+    }
+
     public function testFindOrFailFindsModelById()
     {
         $mockModel = m::mock(Model::class);
@@ -357,6 +377,26 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one, $two, $three]), $c1->merge($c2));
     }
 
+    public function testCollectionDictionarySkipsNullModelKeys(): void
+    {
+        $emptyString = (new CollectionModel)->setKeyType('string')->forceFill(['id' => '']);
+
+        $this->assertSame(
+            ['' => $emptyString],
+            (new Collection([$emptyString, new CollectionModel]))->getDictionary()
+        );
+    }
+
+    public function testCollectionMergeSkipsNullModelKeys(): void
+    {
+        $emptyString = (new CollectionModel)->setKeyType('string')->forceFill(['id' => '']);
+
+        $this->assertSame(
+            [$emptyString],
+            (new Collection([$emptyString]))->merge([new CollectionModel])->all()
+        );
+    }
+
     public function testMap()
     {
         $one = m::mock(Model::class);
@@ -430,6 +470,17 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c1->diff($c2));
     }
 
+    public function testCollectionDiffRetainsNullKeyedModels(): void
+    {
+        $keyless = new CollectionModel;
+        $emptyString = (new CollectionModel)->setKeyType('string')->forceFill(['id' => '']);
+
+        $this->assertSame(
+            [$keyless],
+            (new Collection([$keyless]))->diff(new Collection([$emptyString]))->all()
+        );
+    }
+
     public function testCollectionReturnsDuplicateBasedOnlyOnKeys()
     {
         $one = new CollectionModel;
@@ -452,46 +503,15 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertSame([1 => $two, 2 => $three], $duplicates);
     }
 
-    public function testCollectionRetainsDictionaryDuplicateSemanticsForKeylessModels(): void
+    public function testCollectionReturnsDuplicatesUsingCallbackValues(): void
     {
-        $first = new CollectionModel;
-        $second = new CollectionModel;
-        $third = new CollectionModel;
-
-        $models = Collection::make([$first, $second, $third]);
-
-        $this->assertSame([1 => $second, 2 => $third], $models->duplicates()->all());
-        $this->assertSame([1 => $second, 2 => $third], $models->duplicatesStrict()->all());
-    }
-
-    public function testKeylessModelsDoNotPoisonLaterKeyedDuplicateDetection(): void
-    {
-        $keyless = new CollectionModel;
-        $keyed = new CollectionModel;
-        $keyed->id = 1;
-
-        $models = Collection::make([$keyless, $keyed]);
-
-        $this->assertSame([], $models->duplicates()->all());
-        $this->assertSame([], $models->duplicatesStrict()->all());
-    }
-
-    public function testCollectionDuplicateDetectionPreservesKeylessTableAndConnectionDistinctions(): void
-    {
-        $firstTable = (new CollectionModel)->setTable('first_models');
-        $secondTable = (new CollectionModel)->setTable('second_models');
+        $first = (new CollectionModel)->forceFill(['id' => 1]);
+        $second = (new CollectionModel)->forceFill(['id' => 1]);
+        $third = (new CollectionModel)->forceFill(['id' => 2]);
 
         $this->assertSame(
-            [0 => $firstTable],
-            Collection::make([$firstTable, $secondTable])->duplicates()->all()
-        );
-
-        $firstConnection = (new CollectionModel)->setConnection('first');
-        $secondConnection = (new CollectionModel)->setConnection('second');
-
-        $this->assertSame(
-            [0 => $firstConnection],
-            Collection::make([$firstConnection, $secondConnection])->duplicates()->all()
+            [1 => 1],
+            Collection::make([$first, $second, $third])->duplicates('id')->all()
         );
     }
 
@@ -526,6 +546,16 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c2 = new Collection([$two, $three]);
 
         $this->assertEquals(new Collection([$two]), $c1->intersect($c2));
+    }
+
+    public function testCollectionIntersectExcludesNullKeyedModels(): void
+    {
+        $emptyString = (new CollectionModel)->setKeyType('string')->forceFill(['id' => '']);
+
+        $this->assertSame(
+            [],
+            (new Collection([new CollectionModel]))->intersect(new Collection([$emptyString]))->all()
+        );
     }
 
     public function testCollectionReturnsUniqueItems()
@@ -599,6 +629,15 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c->except([2, 3]));
     }
 
+    public function testOnlyAndExceptIgnoreNullKeys(): void
+    {
+        $emptyString = (new CollectionModel)->setKeyType('string')->forceFill(['id' => '']);
+        $collection = new Collection([$emptyString]);
+
+        $this->assertSame([], $collection->only([null])->all());
+        $this->assertSame([$emptyString], $collection->except([null])->all());
+    }
+
     public function testNewInstanceIsUsedByEloquentCollectionMethods(): void
     {
         $one = new CollectionModel;
@@ -640,12 +679,17 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertSame('model-tag', $except->tag);
         $this->assertSame([$one], $except->values()->all());
 
+        $found = $collection->find([1, 2]);
+        $this->assertInstanceOf(TestEloquentCollectionWithExtraState::class, $found);
+        $this->assertSame('model-tag', $found->tag);
+        $this->assertSame([$one, $two], $found->values()->all());
+
         $empty = new TestEloquentCollectionWithExtraState([], 'empty-tag');
 
-        $found = $empty->find([1]);
-        $this->assertInstanceOf(TestEloquentCollectionWithExtraState::class, $found);
-        $this->assertSame('empty-tag', $found->tag);
-        $this->assertEmpty($found->all());
+        $emptyFound = $empty->find([1]);
+        $this->assertInstanceOf(TestEloquentCollectionWithExtraState::class, $emptyFound);
+        $this->assertSame('empty-tag', $emptyFound->tag);
+        $this->assertEmpty($emptyFound->all());
 
         $fresh = $empty->fresh();
         $this->assertInstanceOf(TestEloquentCollectionWithExtraState::class, $fresh);
@@ -872,6 +916,25 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection;
         $c->toQuery();
+    }
+
+    public function testConvertingCollectionWithoutModelKeysToQueryThrowsException(): void
+    {
+        $model = m::mock(CollectionModel::class)->makePartial();
+        $model->shouldReceive('getKey')->once()->andReturn(null);
+        $model->shouldReceive('getKeyName')->once()->andReturn('id');
+        $model->shouldNotReceive('newModelQuery');
+
+        $this->expectException(MissingAttributeException::class);
+
+        (new Collection([$model]))->toQuery();
+    }
+
+    public function testConvertingMixedCollectionToQueryChecksTypesBeforeModelKeys(): void
+    {
+        $this->expectException(LogicException::class);
+
+        (new Collection([new CollectionModel, new User]))->toQuery();
     }
 
     public function testLoadExistsShouldCastBool()

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -16,13 +16,14 @@ use Hypervel\Database\Query\Grammars\Grammar;
 use Hypervel\Database\Query\Processors\Processor;
 use Hypervel\Tests\Database\Fixtures\TestEnum;
 use Hypervel\Tests\TestCase;
+use InvalidArgumentException;
 use Mockery as m;
 
 class DatabaseEloquentMorphToTest extends TestCase
 {
-    protected $builder;
+    protected Builder $builder;
 
-    protected $related;
+    protected Model $related;
 
     protected function addMockConnection(Model $model): void
     {
@@ -86,6 +87,34 @@ class DatabaseEloquentMorphToTest extends TestCase
                 ],
             ],
         ], $dictionary);
+    }
+
+    public function testLookupDictionaryExcludesModelsWithNullForeignKeys(): void
+    {
+        $relation = $this->getRelation();
+        $relation->addEagerConstraints([
+            (object) ['morph_type' => 'morph_type_1', 'foreign_key' => null],
+        ]);
+
+        $this->assertSame([], $relation->getDictionary());
+    }
+
+    public function testLookupDictionaryRetainsZeroMorphTypesAndSkipsEmptyTypes(): void
+    {
+        $relation = $this->getRelation();
+        $relation->addEagerConstraints([
+            $integerZero = (object) ['morph_type' => 0, 'foreign_key' => 'integer-zero'],
+            $stringZero = (object) ['morph_type' => '0', 'foreign_key' => 'string-zero'],
+            (object) ['morph_type' => '', 'foreign_key' => 'empty'],
+            (object) ['morph_type' => null],
+        ]);
+
+        $this->assertSame([
+            0 => [
+                'integer-zero' => [$integerZero],
+                'string-zero' => [$stringZero],
+            ],
+        ], $relation->getDictionary());
     }
 
     public function testMorphToWithDefault()
@@ -205,6 +234,89 @@ class DatabaseEloquentMorphToTest extends TestCase
         $parent->shouldReceive('setRelation')->once()->with('relation', null);
 
         $relation->associate(null);
+    }
+
+    public function testAssociateMethodUsesConfiguredOwnerKeyWithZeroValue(): void
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new MorphToAssociateRelatedStub);
+
+        $parent = new MorphToAssociateParentStub;
+        $associate = (new MorphToAssociateRelatedStub)->forceFill([
+            'model_id' => 7,
+            'custom_key' => 0,
+        ]);
+
+        $relation = Relation::noConstraints(fn () => new MorphTo(
+            $builder,
+            $parent,
+            'foreign_key',
+            'custom_key',
+            'morph_type',
+            'relation'
+        ));
+
+        $this->assertSame($parent, $relation->associate($associate));
+        $this->assertSame(0, $parent->getAttribute('foreign_key'));
+        $this->assertSame(MorphToAssociateRelatedStub::class, $parent->getAttribute('morph_type'));
+        $this->assertSame($associate, $parent->getRelation('relation'));
+    }
+
+    public function testAssociateMethodUsesConfiguredOwnerKeyWithNullValue(): void
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new MorphToAssociateRelatedStub);
+
+        $parent = new MorphToAssociateParentStub;
+        $associate = (new MorphToAssociateRelatedStub)->forceFill([
+            'model_id' => 7,
+            'custom_key' => null,
+        ]);
+
+        $relation = Relation::noConstraints(fn () => new MorphTo(
+            $builder,
+            $parent,
+            'foreign_key',
+            'custom_key',
+            'morph_type',
+            'relation'
+        ));
+
+        $this->assertSame($parent, $relation->associate($associate));
+        $this->assertNull($parent->getAttribute('foreign_key'));
+        $this->assertSame(MorphToAssociateRelatedStub::class, $parent->getAttribute('morph_type'));
+        $this->assertSame($associate, $parent->getRelation('relation'));
+    }
+
+    public function testAssociateMethodRejectsScalarValuesBeforeChangingTheParent(): void
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new MorphToAssociateRelatedStub);
+
+        $parent = (new MorphToAssociateParentStub)->forceFill([
+            'foreign_key' => 'original-id',
+            'morph_type' => 'original-type',
+        ]);
+
+        $relation = Relation::noConstraints(fn () => new MorphTo(
+            $builder,
+            $parent,
+            'foreign_key',
+            'custom_key',
+            'morph_type',
+            'relation'
+        ));
+
+        try {
+            $relation->associate(5);
+            $this->fail('Expected an invalid argument exception.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('MorphTo relationships may only be associated with a model instance or null.', $exception->getMessage());
+        }
+
+        $this->assertSame('original-id', $parent->getAttribute('foreign_key'));
+        $this->assertSame('original-type', $parent->getAttribute('morph_type'));
+        $this->assertFalse($parent->relationLoaded('relation'));
     }
 
     public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
@@ -460,9 +572,18 @@ class RelatedStub extends Model
     protected ?string $table = 'related_stubs';
 }
 
+class MorphToAssociateParentStub extends Model
+{
+}
+
+class MorphToAssociateRelatedStub extends Model
+{
+    protected string $primaryKey = 'model_id';
+}
+
 class AccessibleMorphTo extends MorphTo
 {
-    public function callMatchToMorphParents(string $type, EloquentCollection $results): void
+    public function callMatchToMorphParents(int|string $type, EloquentCollection $results): void
     {
         $this->matchToMorphParents($type, $results);
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Database\DatabaseEloquentMorphToTest;
 
+use Hypervel\Database\ClassMorphViolationException;
 use Hypervel\Database\Connection;
 use Hypervel\Database\ConnectionResolverInterface;
 use Hypervel\Database\Eloquent\Builder;
@@ -317,6 +318,44 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertSame('original-id', $parent->getAttribute('foreign_key'));
         $this->assertSame('original-type', $parent->getAttribute('morph_type'));
         $this->assertFalse($parent->relationLoaded('relation'));
+    }
+
+    public function testAssociateMethodRejectsUnmappedModelsBeforeChangingTheParent(): void
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn(new MorphToAssociateRelatedStub);
+
+        $parent = (new MorphToAssociateParentStub)->forceFill([
+            'foreign_key' => 'original-id',
+            'morph_type' => 'original-type',
+        ]);
+        $originalRelation = new MorphToAssociateRelatedStub;
+        $parent->setRelation('relation', $originalRelation);
+        $associate = (new MorphToAssociateRelatedStub)->forceFill([
+            'custom_key' => 7,
+        ]);
+
+        $relation = Relation::noConstraints(fn () => new MorphTo(
+            $builder,
+            $parent,
+            'foreign_key',
+            'custom_key',
+            'morph_type',
+            'relation'
+        ));
+
+        Relation::requireMorphMap();
+
+        try {
+            $relation->associate($associate);
+            $this->fail('Expected a class morph violation exception.');
+        } catch (ClassMorphViolationException $exception) {
+            $this->assertSame(MorphToAssociateRelatedStub::class, $exception->model);
+        }
+
+        $this->assertSame('original-id', $parent->getAttribute('foreign_key'));
+        $this->assertSame('original-type', $parent->getAttribute('morph_type'));
+        $this->assertSame($originalRelation, $parent->getRelation('relation'));
     }
 
     public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -60,7 +60,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $relation->touch();
     }
 
-    public function testCanDisableParentTouchingForAllModels()
+    public function testCanDisableParentTouchingForAllModels(): void
     {
         $related = m::mock(NoTouchingModelStub::class)->makePartial();
         $related->shouldReceive('getUpdatedAtColumn')->never();
@@ -226,7 +226,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertFalse($relatedChild::isIgnoringTouch());
     }
 
-    public function testSettingMorphMapWithNumericArrayUsesTheTableNames()
+    public function testSettingMorphMapWithNumericArrayUsesTheTableNames(): void
     {
         Relation::morphMap([ResetModelStub::class]);
 
@@ -235,7 +235,7 @@ class DatabaseEloquentRelationTest extends TestCase
         ], Relation::morphMap());
     }
 
-    public function testSettingMorphMapWithNumericKeys()
+    public function testSettingMorphMapWithNumericKeys(): void
     {
         Relation::morphMap([1 => 'App\User']);
 
@@ -254,7 +254,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertNull(Relation::getMorphedModel(null));
     }
 
-    public function testGetMorphAlias()
+    public function testGetMorphAlias(): void
     {
         Relation::morphMap(['user' => 'App\User', 0 => 'App\Team']);
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -62,7 +62,6 @@ class DatabaseEloquentRelationTest extends TestCase
 
     public function testCanDisableParentTouchingForAllModels()
     {
-        /** @var \Illuminate\Tests\Database\NoTouchingModelStub $related */
         $related = m::mock(NoTouchingModelStub::class)->makePartial();
         $related->shouldReceive('getUpdatedAtColumn')->never();
         $related->shouldReceive('freshTimestampString')->never();
@@ -234,8 +233,6 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertEquals([
             'reset' => ResetModelStub::class,
         ], Relation::morphMap());
-
-        Relation::morphMap([], false);
     }
 
     public function testSettingMorphMapWithNumericKeys()
@@ -245,15 +242,24 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertEquals([
             1 => 'App\User',
         ], Relation::morphMap());
+    }
 
-        Relation::morphMap([], false);
+    public function testGetMorphedModel(): void
+    {
+        Relation::morphMap(['user' => 'App\User', 1 => 'App\Team']);
+
+        $this->assertSame('App\User', Relation::getMorphedModel('user'));
+        $this->assertSame('App\Team', Relation::getMorphedModel(1));
+        $this->assertNull(Relation::getMorphedModel('does_not_exist'));
+        $this->assertNull(Relation::getMorphedModel(null));
     }
 
     public function testGetMorphAlias()
     {
-        Relation::morphMap(['user' => 'App\User']);
+        Relation::morphMap(['user' => 'App\User', 0 => 'App\Team']);
 
         $this->assertSame('user', Relation::getMorphAlias('App\User'));
+        $this->assertSame(0, Relation::getMorphAlias('App\Team'));
         $this->assertSame('Does\Not\Exist', Relation::getMorphAlias('Does\Not\Exist'));
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1372,7 +1372,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testWhereIntegerInRaw()
+    public function testWhereIntegerInRaw(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', [
@@ -1404,7 +1404,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testWhereIntegerNotInRaw()
+    public function testWhereIntegerNotInRaw(): void
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerNotInRaw('id', ['1a', 2]);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1390,6 +1390,10 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where "id" in (1, 2, 3, 5)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntegerInRaw('id', [1, null]);
+        $this->assertSame('select * from "users" where "id" in (1)', $builder->toSql());
     }
 
     public function testOrWhereIntegerInRaw()
@@ -1406,6 +1410,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereIntegerNotInRaw('id', ['1a', 2]);
         $this->assertSame('select * from "users" where "id" not in (1, 2)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntegerNotInRaw('id', [1, null]);
+        $this->assertSame('select * from "users" where "id" not in (1)', $builder->toSql());
     }
 
     public function testOrWhereIntegerNotInRaw()

--- a/tests/Database/EloquentHasOneOrManyDeprecationTest.php
+++ b/tests/Database/EloquentHasOneOrManyDeprecationTest.php
@@ -58,6 +58,25 @@ class EloquentHasOneOrManyDeprecationTest extends TestCase
         $this->assertNull($models[1]->foo);
     }
 
+    public function testHasManyMatchWithNullForeignKey(): void
+    {
+        $relation = $this->getHasManyRelation();
+
+        $result = new HasOneOrManyDeprecationModelStub;
+        $result->foreign_key = null;
+
+        $model = new HasOneOrManyDeprecationModelStub;
+        $model->id = '';
+
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array) {
+            return new Collection($array);
+        });
+
+        $models = $relation->match([$model], new Collection([$result]), 'foo');
+
+        $this->assertNull($models[0]->foo);
+    }
+
     protected function getHasManyRelation(): HasMany
     {
         $queryBuilder = m::mock(QueryBuilder::class);
@@ -93,5 +112,7 @@ class EloquentHasOneOrManyDeprecationTest extends TestCase
 
 class HasOneOrManyDeprecationModelStub extends Model
 {
-    public $foreign_key;
+    protected string $keyType = 'string';
+
+    public mixed $foreign_key = null;
 }

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\Database;
 
 use Hypervel\Database\Eloquent\Collection as EloquentCollection;
+use Hypervel\Database\Eloquent\MissingAttributeException;
+use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Schema\Blueprint;
+use Hypervel\Support\Facades\DB;
 use Hypervel\Support\Facades\Schema;
 use Hypervel\Tests\Integration\Database\Fixtures\User;
 
@@ -35,5 +38,37 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
 
         $this->assertCount(1, $freshCollection);
         $this->assertInstanceOf(EloquentCollection::class, $freshCollection);
+    }
+
+    public function testFreshRejectsPersistedModelsMissingThePrimaryKeyWithoutQuerying(): void
+    {
+        Model::preventAccessingMissingAttributes(false);
+
+        $user = User::create(['email' => 'partial@example.com']);
+        $partialUser = User::query()->select('email')->findOrFail($user->id);
+
+        DB::enableQueryLog();
+
+        try {
+            new EloquentCollection([$partialUser])->fresh();
+            $this->fail('Expected a missing attribute exception.');
+        } catch (MissingAttributeException $exception) {
+            $this->assertStringContainsString('The attribute [id]', $exception->getMessage());
+        }
+
+        $this->assertSame([], DB::getQueryLog());
+    }
+
+    public function testFreshIgnoresUnsavedModelsWithAssignedKeysWithoutQuerying(): void
+    {
+        $user = new User;
+        $user->id = 123;
+
+        DB::enableQueryLog();
+
+        $freshCollection = new EloquentCollection([$user])->fresh();
+
+        $this->assertTrue($freshCollection->isEmpty());
+        $this->assertSame([], DB::getQueryLog());
     }
 }

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\Database\EloquentCollectionLoadCountTest;
 
 use Hypervel\Database\Eloquent\Collection;
+use Hypervel\Database\Eloquent\MissingAttributeException;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\SoftDeletes;
 use Hypervel\Database\Schema\Blueprint;
@@ -79,6 +80,55 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $this->assertCount(1, DB::getQueryLog());
         $this->assertSame('2', (string) $posts[0]->comments_count);
         $this->assertSame('0', (string) $posts[1]->comments_count);
+    }
+
+    public function testLoadCountSkipsHardDeletedModels(): void
+    {
+        $posts = Post::all();
+
+        DB::table('posts')->where('id', $posts[0]->getKey())->delete();
+
+        DB::enableQueryLog();
+
+        $posts->loadCount('comments');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertFalse(array_key_exists('comments_count', $posts[0]->getAttributes()));
+        $this->assertSame('0', (string) $posts[1]->comments_count);
+    }
+
+    public function testLoadCountLeavesCollectionUnchangedWhenAllModelsAreHardDeleted(): void
+    {
+        $posts = Post::all();
+
+        DB::table('posts')->delete();
+
+        DB::enableQueryLog();
+
+        $result = $posts->loadCount('comments');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame($posts, $result);
+        $this->assertFalse(array_key_exists('comments_count', $posts[0]->getAttributes()));
+        $this->assertFalse(array_key_exists('comments_count', $posts[1]->getAttributes()));
+    }
+
+    public function testLoadCountRejectsModelsMissingThePrimaryKeyWithoutQuerying(): void
+    {
+        Model::preventAccessingMissingAttributes(false);
+
+        $post = Post::query()->select('some_default_value')->firstOrFail();
+
+        DB::enableQueryLog();
+
+        try {
+            new Collection([$post])->loadCount('comments');
+            $this->fail('Expected a missing attribute exception.');
+        } catch (MissingAttributeException $exception) {
+            $this->assertStringContainsString('The attribute [id]', $exception->getMessage());
+        }
+
+        $this->assertSame([], DB::getQueryLog());
     }
 
     public function testLoadCountWithArrayOfRelations()

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Integration\Database\EloquentCollectionLoadCountTest;
 use Hypervel\Database\Eloquent\Collection;
 use Hypervel\Database\Eloquent\MissingAttributeException;
 use Hypervel\Database\Eloquent\Model;
+use Hypervel\Database\Eloquent\Relations\HasMany;
 use Hypervel\Database\Eloquent\SoftDeletes;
 use Hypervel\Database\Schema\Blueprint;
 use Hypervel\Support\Facades\DB;
@@ -31,6 +32,15 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         Schema::create('likes', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('float_key_posts', function (Blueprint $table) {
+            $table->decimal('id', 4, 2)->primary();
+        });
+
+        Schema::create('float_key_comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->decimal('float_key_post_id', 4, 2);
         });
 
         $post = Post::create();
@@ -146,6 +156,41 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $this->assertSame('0', (string) $posts[1]->likes_count);
     }
 
+    public function testLoadCountMatchesDistinctFloatPrimaryKeys(): void
+    {
+        $firstPost = FloatKeyPost::create(['id' => 1.25]);
+        $secondPost = FloatKeyPost::create(['id' => 1.75]);
+
+        $firstPost->comments()->save(new FloatKeyComment);
+        $secondPost->comments()->saveMany([new FloatKeyComment, new FloatKeyComment]);
+
+        $posts = FloatKeyPost::query()->orderBy('id')->get();
+
+        $this->assertSame(1.25, $posts[0]->getKey());
+        $this->assertSame(1.75, $posts[1]->getKey());
+
+        $posts->loadCount('comments');
+
+        $this->assertSame('1', (string) $posts[0]->comments_count);
+        $this->assertSame('2', (string) $posts[1]->comments_count);
+    }
+
+    public function testLoadCountPreservesTheOriginalPrimaryKeyWhenTheCurrentKeyHasChanged(): void
+    {
+        $post = Post::query()->findOrFail(1);
+        $otherPost = Post::query()->findOrFail(2);
+        $originalKey = $post->getKey();
+
+        $post->setAttribute($post->getKeyName(), $otherPost->getKey());
+
+        Collection::make([$post])->loadCount('comments');
+
+        $this->assertSame('0', (string) $post->comments_count);
+        $this->assertSame($originalKey, $post->getOriginal($post->getKeyName()));
+        $this->assertSame($otherPost->getKey(), $post->getKey());
+        $this->assertTrue($post->isDirty($post->getKeyName()));
+    }
+
     public function testLoadCountDoesNotOverrideAttributesWithDefaultValue()
     {
         $post = Post::first();
@@ -185,6 +230,34 @@ class Comment extends Model
 }
 
 class Like extends Model
+{
+    public bool $timestamps = false;
+}
+
+class FloatKeyPost extends Model
+{
+    public bool $incrementing = false;
+
+    protected string $keyType = 'string';
+
+    protected array $fillable = ['id'];
+
+    protected array $casts = [
+        'id' => 'float',
+    ];
+
+    public bool $timestamps = false;
+
+    /**
+     * Get the comments for the post.
+     */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(FloatKeyComment::class);
+    }
+}
+
+class FloatKeyComment extends Model
 {
     public bool $timestamps = false;
 }

--- a/tests/Integration/Database/EloquentMorphToEagerLoadTest.php
+++ b/tests/Integration/Database/EloquentMorphToEagerLoadTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Integration\Database\EloquentMorphToEagerLoadTest;
 use Hypervel\Contracts\Database\Eloquent\CastsAttributes;
 use Hypervel\Database\Eloquent\Model;
 use Hypervel\Database\Eloquent\Relations\MorphTo;
+use Hypervel\Database\Eloquent\Relations\Relation;
 use Hypervel\Database\Schema\Blueprint;
 use Hypervel\Support\Facades\Schema;
 use Hypervel\Tests\Integration\Database\DatabaseTestCase;
@@ -24,6 +25,10 @@ class EloquentMorphToEagerLoadTest extends DatabaseTestCase
         });
 
         Schema::create('videos', function (Blueprint $table) {
+            $table->string('id')->primary();
+        });
+
+        Schema::create('zero_string_models', function (Blueprint $table) {
             $table->string('id')->primary();
         });
 
@@ -77,6 +82,23 @@ class EloquentMorphToEagerLoadTest extends DatabaseTestCase
         $this->assertInstanceOf(Video::class, $comments[0]->commentable);
         $this->assertSame('550e8400-e29b-41d4-a716-446655440000', (string) $comments[0]->commentable->id);
     }
+
+    public function testEagerLoadingResolvesIntegerMorphAliasWithZeroStringPrimaryKey(): void
+    {
+        Relation::morphMap([0 => ZeroStringModel::class, 2 => Post::class], false);
+
+        $model = ZeroStringModel::create(['id' => '0']);
+        $comment = new Comment;
+        $comment->commentable()->associate($model);
+
+        $this->assertSame('0', $comment->commentable_type);
+
+        $comment->save();
+
+        $loadedComment = Comment::with('commentable')->findOrFail($comment->getKey());
+
+        $this->assertTrue($model->is($loadedComment->commentable));
+    }
 }
 
 enum ArticleSlug: string
@@ -102,6 +124,17 @@ class Article extends Model
     protected array $casts = ['slug' => ArticleSlug::class];
 
     protected array $fillable = ['slug'];
+}
+
+class ZeroStringModel extends Model
+{
+    public bool $timestamps = false;
+
+    public bool $incrementing = false;
+
+    protected string $keyType = 'string';
+
+    protected array $fillable = ['id'];
 }
 
 class Comment extends Model

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -94,7 +94,7 @@ assertType('bool', $collection->contains(function ($user) {
 }));
 assertType('bool', $collection->contains('string', '=', 'string'));
 
-assertType('array<int, (int|string)>', $collection->modelKeys());
+assertType('array<int|string|null>', $collection->modelKeys());
 
 assertType('Hypervel\Database\Eloquent\Collection<int, User>', $collection->merge($collection));
 assertType('Hypervel\Database\Eloquent\Collection<int, User>', $collection->merge([new User]));


### PR DESCRIPTION
Null model keys could flow into dictionary, collection, and raw integer query paths. Depending on the path, they could collide with an empty string, be cast to zero, match the wrong model, or fail after a query had already run.

This PR ports the current Laravel null-key and inverse morph-map changes from [laravel/framework#59019](https://github.com/laravel/framework/pull/59019) and [laravel/framework#60954](https://github.com/laravel/framework/pull/60954), then fixes the related gaps exposed in Hypervel:

- Relation and collection dictionaries skip missing identities while preserving empty strings, zero, floats, enums, and stringable values.
- `fresh`, aggregate loading, and `toQuery` reject missing required primary keys before building incomplete constraints.
- Aggregate loading leaves source models unchanged when their rows disappear and continues hydrating rows that still exist.
- Raw integer `IN` and `NOT IN` lists discard null before casting.
- Integer morph aliases work through inverse lookup, serialization, association, eager loading, and positive and negative relationship queries.
- `MorphTo::associate` uses its configured owner key for every value and rejects scalar input before changing state.
- Required morph maps apply to model class strings without constructing models.
- Callback-based duplicate detection compares the mapped values.

The public API remains Laravel-compatible. The behavior changes are limited to missing identities, invalid morph association input, and paths that previously matched or queried the wrong value or raised an unrelated runtime error.

This PR adds focused coverage for collection operations, relation matching, query generation, refresh and aggregate loading, morph association, eager loading, and morph query conditions. It also documents the primary-key requirement for refresh and collection queries. The repository checks and focused PHP 8.5 deprecation checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Eloquent relationship handling for models with null, empty, zero, or missing keys.
  * Added validation when required primary keys are unavailable, with clearer exceptions.
  * Fixed morph-map lookups, including integer and falsy aliases.
  * Prevented invalid values from being associated with morph relationships.
  * Excluded null values from raw integer-list query filters.
  * Corrected duplicate detection and collection comparison behavior.

* **Documentation**
  * Documented primary-key requirements for refreshing models and building collection queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->