### PR TITLE
Fix translation and view lifecycle ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Anything found follows When to Stop and Report — "the task didn't ask me to fi
 
 During implementation, run new or changed test files immediately. After completing a coherent implementation slice, run the affected package or focused test suite.
 
-At a meaningful checkpoint—such as before code review or after completing a substantial slice—run `composer fix` once. It runs the full formatter, PHPStan, parallel test suite, and Testbench tests, so do not run those full checks separately at the same checkpoint.
+At a meaningful checkpoint—such as before code review or after completing a substantial slice—run `composer fix` once. It runs `lint:fix`, both PHPStan configurations, the full parallel suite, the Testbench suite, and dogfood tests, so do not run those full checks separately at the same checkpoint.
 
 After review fixes, run the relevant targeted tests. Repeat `composer fix` only when the changes warrant another full-repository check.
 

--- a/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
@@ -28,17 +28,6 @@ Resolve every genuine issue retained in this master plan against the current 0.4
 
 Each row is an implementation requirement. Test names are descriptive; use the repository's established test file for that component or create the narrowly corresponding file.
 
-### Translation and views
-
-| ID | Proposed implementation | Required tests |
-|---:|---|---|
-| 2 | Stop automatically retaining every parsed key on NamespacedItemResolver. Keep setParsedKey and flushParsedKeys exactly as the public explicit cache API, but parse ordinary keys directly; the explode/str_contains work is cheaper and safer than a per-call context lookup or an arbitrary worker cache cap. | Arbitrary validation/translation keys do not grow worker state; explicitly seeded parsed keys still hit and flush; parse output remains identical; a focused microbenchmark confirms the uncached parser is not a material translation regression. |
-| 3 | Keep successful translation groups in the worker cache, but store empty/missing locale-group results only in execution-local negative state. This avoids permanent attacker-driven locale growth without repeating filesystem probes inside one request/job. | Thousands of missing locales leave worker loaded state unchanged; one execution probes a missing/legitimate-empty group once; a later execution can discover a newly added translation; positive groups remain worker-cached. |
-| 5 | Extract `Translator::get()`'s lookup body into a protected internal method with separate substitution replacements and missing-key-callback replacements. `get()` passes `$replace` for both; `choice()` passes `[]` for substitution and the caller's `$replace` to the missing callback, then substitutes only after plural segment selection. Keep every public signature unchanged and do not duplicate lookup. | Callback receives locale, key, and exact replacements; a replacement containing a pipe does not alter plural selection; normal translation replacement remains once-only. |
-| 6 | Widen ViewException::render to mixed and forward all native Laravel exception render results. Keep report as bool or null. | String, array, View, Responsable, Response, and null render forwarding; bool/null report forwarding; original exception behavior when methods are absent. |
-| 7 | Retain the worker cache only for existing named views, whose keyspace is application-defined. For raw inline component source, derive the deterministic xxh128 view name and keep only execution-local reuse; ensure the source file exists on the first use in that execution. Make view:clear clear the execution-local marker so an immediate re-render recreates the source. Do not add an arbitrary eviction cap. | Named views reuse worker state; thousands of unique inline sources do not grow the worker map; repeated inline render in one execution avoids repeated stats; delete/view:clear then render recreates the source; no cross-component collision. |
-| 8 | Preserve the public abstract Engines\Engine base, but make getLastRendered return nullable string to match its initialized state. | Anonymous concrete subclass returns null before render and the rendered path afterward. |
-
 ### Mail, notifications, collections, and support
 
 | ID | Proposed implementation | Required tests |
@@ -77,10 +66,9 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 
 Use package-sized commits that remain reviewable and bisectable. The following order avoids building fixes on obsolete primitives:
 
-1. Translation and views: 2, 3, 5-8.
-2. Mail, notifications, and data representation: 21, 23, 26, 30-32, 34-35, 82.
-3. Image and pagination: 83-87, 89-92.
-4. Vonage notification channel port followed by Horizon wiring: 160.
+1. Mail, notifications, and data representation: 21, 23, 26, 30-32, 34-35, 82.
+2. Image and pagination: 83-87, 89-92.
+3. Vonage notification channel port followed by Horizon wiring: 160.
 
 Do not combine unrelated packages merely because their findings have the same severity.
 

--- a/docs/plans/2026-08-31-1849-components-translation-view-lifecycle-remediation-plan.md
+++ b/docs/plans/2026-08-31-1849-components-translation-view-lifecycle-remediation-plan.md
@@ -1,0 +1,383 @@
+# Translation and View Lifecycle Audit Remediation Plan
+
+## Outcome
+
+Resolve audit findings #2, #3, and #5–8 without adding request-time filesystem polling, arbitrary cache limits, or cross-process coordination. The finished code must:
+
+- stop automatically retaining request-derived translation keys and missing locale/group combinations for the worker lifetime;
+- preserve positive translation caching and exact Laravel-shaped translation output while fixing plural missing-key callback input;
+- forward the full exception-rendering result Laravel permits and expose the view engine's real nullable initial state;
+- preserve content-addressed reuse for stable and finite inline-view variants while repairing stale mappings after explicit deletion or clearing;
+- keep warmed inline and named views on their existing paths with no new filesystem, context, or cache-classification work;
+- preserve Laravel's public APIs and Factory substitution seam while correcting overly narrow return declarations;
+- document only the practical inline-template performance guidance, with no README or Laravel porting-guide entry;
+- remove findings #2, #3, and #5–8 from the master audit ledger after this plan owns their completed implementation.
+
+## Settled decisions and evidence
+
+| Area | Decision |
+|---|---|
+| Parsed translation keys | `NamespacedItemResolver::parseKey()` no longer writes every key to `$parsed`. Explicit `setParsedKey()` and `flushParsedKeys()` remain unchanged. The measured warmed parse cost is about 0.25 microseconds per lookup, while 100,000 unique cached keys retained roughly 38 MiB. High-cardinality validation keys are predominantly misses, so positive-only framework seeding adds coupling without helping the harmful path. |
+| Missing groups | Non-empty groups remain in worker-held `Translator::$loaded`; `[]` results are retained only for the current execution. FileLoader and ArrayLoader both use `[]` for a missing or legitimately empty group, so execution ownership avoids permanent negative state while allowing a later execution to discover new translations. |
+| Missing-group state shape | Each Translator receives a worker-unique context key from a monotonic identity counter. A small mutable `ReplicableContext` state avoids quadratic copy-on-write growth: measured 1,000/5,000/10,000 misses were about 23x/123x/263x faster than rewriting a nested context array. The counter is identity, is never reset, and receives the same warning as `Logger::$nextFamilyId`. |
+| Missing-group hot path | Positive groups retain the existing first `isset()` return. A local Swoole-coroutine microbenchmark measured the repeated-empty-group guard at a median additional 152 ns per lookup, or about 0.046 ms for 300 translations. This is noise-level even for translation-heavy requests. Do not worker-cache default/fallback misses: locale alone does not bound request-derived namespace/group keys, and permanent negative state would hide later custom-loader results. |
+| Choice lookup | Lookup substitutions and missing-callback replacements are separate inputs. `get()` supplies the caller's replacements to both. `choice()` supplies no lookup substitutions, supplies the caller's exact replacements to the missing callback, selects the plural segment, then applies replacements once. Automatic `count` remains post-lookup. |
+| Translation extension shape | `choice()` no longer happens to invoke an override of public `get()`. That internal call chain is not a documented Laravel extension point; preserving it would require duplicate lookup or execution-context plumbing. Public signatures and observable translation behavior remain compatible. |
+| View exception | `ViewException::render()` returns `mixed` because Handler passes truthy results through `Router::toResponse()`, which supports strings, arrays, views, Responsable values, and responses. `report(): ?bool` remains correct: Hypervel documents void/bool report methods and only `false` has framework meaning. |
+| Inline cache policy | Content-addressed caching stays unchanged. Stable source and finite variants converge to a bounded set and benefit from worker reuse. Continually unique Blade source grows both per-worker indexes and shared disk artifacts, so a RAM-only cap would add substantial machinery, degrade finite-variant reuse, and leave the root pattern intact. Documentation is the proportionate safeguard. |
+| Inline deletion | `BladeCompiler::render(..., deleteCachedView: true)` forgets only the anonymous component's exact content mapping after unlinking its source. The normalized name, finder path, path-engine entry, and compiled marker remain valid because republication uses the same content-addressed name/path and byte-identical source. A global Component flush here would regress a supported per-call API by discarding unrelated view and reflection caches. |
+| Inline source ownership | `Blade::render()` always treats its input as raw Blade source, even when the same string is an existing view name. Its private anonymous Component overrides `resolveView()` to use the existing content-addressed cache and creator directly. Normal Components retain Laravel's named-view resolution seam and protected method signatures. |
+| View clearing | In-process `view:clear` flushes all Component view/reflection caches and all compiler markers after deletion attempts, before rethrowing an accumulated deletion failure. Those coarse resets are appropriate for a rare administrative operation. Active worker processes still require a reload; changing `server:reload` is not part of this slice. |
+| Compiler coupling | The exact inline deletion fix and compiler mtime correction ship together. Once a missing source correctly reports expired, a stale Component mapping would otherwise turn the second default-cache render from an accidental stale-compiled success into `FileNotFoundException`. |
+| Inline disk artifacts | Content-addressed source and compiled files remain shared across workers and are owned by the existing explicit `view:clear` lifecycle. No hidden eviction, retention policy, or automatic cleanup is added. |
+| Compiler expiry | `Filesystem::lastModified()` returns `int|false`; its suppression means the existing `ErrorException` catch is unreachable. Explicit value checks make a missing source/compiled file expired and let `compile()` report the precise source error. When an unchanged compiled file disappears before `compile()` reads its mtime, `compile()` republishes the contents it already produced instead of recreating an empty file with `touch()`. |
+| Documentation | Add one concise Blade warning recommending stable inline component source with changing values passed as data or slots. Dynamic source remains supported. This is usage/performance guidance, not a Laravel API difference. |
+
+## Reference baseline
+
+- Current `examples/laravel/framework` still automatically caches every parsed namespaced key, stores empty translation groups on the request-owned Translator, and routes `choice()` through `get($key, [])`. Hypervel keeps the public API but adapts ownership for a shared worker singleton.
+- Current Laravel `Component` deliberately holds `Illuminate\Contracts\View\Factory`, even though Laravel's concrete View holds the concrete Factory. Hypervel must preserve that substitution seam.
+- Current Laravel Component, Factory, and FileViewFinder use the same content-addressed name, path-engine, and located-view caches. Hypervel preserves that reuse for stable and finite variants; automatic disk retention is also unchanged.
+- Current Laravel `ViewException::render()` is untyped and forwards the previous exception result; Hypervel's `?Response` was an incorrect narrowing.
+- Current Laravel `Engine::$lastRendered` is initially null despite the documented string return. Nothing in either framework extends this abstract class: first-party engines implement the View Engine contract directly, so this is dormant public extension scaffolding rather than an active runtime base. Hypervel's native return must still describe its actual state. A third-party subclass that mutates this property would share it through the worker-lifetime EngineResolver singleton; no current consumer or supported failure justifies adding coroutine state.
+- Current Laravel `Compiler::isExpired()` retains the exception catch, but Hypervel's concrete Filesystem suppresses `filemtime()` warnings and returns `false`, making value checks the correct local implementation.
+- No related `docs/todo.md` item belongs in this slice. Server reload behavior, cross-process invalidation, and repository-wide PHPStan suppression work remain separate owner-approved work.
+
+## Implementation
+
+### 1. Stop automatic parsed-key retention (#2)
+
+Files:
+
+- `src/support/src/NamespacedItemResolver.php`
+- `tests/Support/SupportNamespacedItemResolverTest.php`
+
+Keep the existing explicit-cache fast path, then return a newly parsed value without storing it:
+
+```php
+if (isset($this->parsed[$key])) {
+    return $this->parsed[$key];
+}
+
+return ! str_contains($key, '::')
+    ? $this->parseBasicSegments(explode('.', $key))
+    : $this->parseNamespacedSegments($key);
+```
+
+Update `$parsed` and the surrounding comments to describe explicitly seeded values. Add a conditional sentence to `setParsedKey()` explaining that entries remain for the resolver instance's lifetime and therefore for the worker lifetime when called on the shared Translator; do not incorrectly label every resolver instance Boot-only.
+
+Tests must prove:
+
+- ordinary basic and namespaced parsing remains identical;
+- repeated ordinary parses invoke parsing again and leave `$parsed` empty;
+- validation-shaped/arbitrary keys do not accumulate;
+- an explicitly seeded value bypasses parsing;
+- `flushParsedKeys()` removes only explicit entries and restores direct parsing.
+
+Do not add Translator-side positive seeding, a context lookup, an eviction cap, or a replacement cache.
+
+### 2. Keep empty translation groups execution-local (#3)
+
+Files:
+
+- `src/translation/src/MissingTranslationGroups.php` (new)
+- `src/translation/src/Translator.php`
+- `tests/Translation/TranslationTranslatorTest.php`
+- `tests/Translation/CoroutineIsolationTest.php`
+
+Add a final package-internal `MissingTranslationGroups implements ReplicableContext`. Finality protects the replication invariant: no subclass can add state that `replicate()` fails to copy. It owns only a nested boolean map and the operations Translator needs: `has`, `mark`, `forget`, and `replicate`. `forget` unsets only the requested leaf; empty parents are unobservable and disappear with the execution-scoped object. Replication returns an independent object with the same recorded misses.
+
+Give each Translator a unique context key:
+
+```php
+protected const string MISSING_GROUPS_CONTEXT_KEY_PREFIX = '__translation.missing_groups.';
+
+// Identity generator: never reset in flushState().
+protected static int $nextTranslatorId = 0;
+
+protected readonly string $missingGroupsContextKey;
+```
+
+Assign it in the constructor. Mirror Logger's full warning that resetting the counter can alias a new Translator to state retained under a destroyed instance's key. `Translator::flushState()` continues to flush macros only and must not reset this counter.
+
+Do not register `MissingTranslationGroups` with `AfterEachTestSubscriber`. It exists only inside `CoroutineContext`, whose existing subscriber cleanup already flushes it between tests.
+
+Keep the positive path first in `load()`:
+
+```php
+if ($this->isLoaded($namespace, $group, $locale)) {
+    return;
+}
+
+if ($this->missingTranslationGroups()?->has($namespace, $group, $locale)) {
+    return;
+}
+```
+
+Create the state lazily only when marking the first empty result. After a successful loader call and pending-line replay:
+
+- non-empty lines go to worker-held `$loaded` exactly as today;
+- empty lines mark the execution state and do not enter `$loaded`;
+- loader exceptions leave pending lines and state unchanged.
+
+Use `$this->loaded[$namespace][$group][$locale] ?? []` in `getLine()`. Keep `isLoaded()` as the exact positive worker-cache predicate. Before `addLines()` queues a line for a group not positively loaded, clear that group's execution miss so the next lookup reloads and replays the pending operation. `setLoaded()` replaces positives, clears pending lines, and forgets this Translator's whole missing-groups context key.
+
+Tests must prove:
+
+- a missing and a legitimately empty group are loaded once within one execution;
+- a later execution probes again and can discover newly available lines;
+- thousands of arbitrary locale/group misses leave `$loaded` unchanged and produce exactly the same number of distinct execution-owned markers;
+- positive groups remain worker-cached across executions;
+- two Translator instances do not suppress one another;
+- copied coroutine contexts receive independent state objects;
+- `addLines()` after a miss becomes visible and preserves call order;
+- `setLoaded()` clears both pending operations and current execution misses;
+- exceptions do not consume pending operations or install a negative marker;
+- the identity counter survives `flushState()`.
+
+This is Translator lifecycle state, not the cache package's negative-caching feature.
+
+### 3. Separate lookup and plural substitutions (#5)
+
+Files:
+
+- `src/translation/src/Translator.php`
+- `tests/Translation/TranslationTranslatorTest.php`
+- `tests/Integration/Translation/TranslatorTest.php`
+
+Extract the current `get()` lookup body into one protected internal method with separate arrays for line substitutions and missing-callback replacements. Keep every public signature unchanged:
+
+```php
+public function get(...): array|string
+{
+    $locale = $locale ?: $this->getLocale();
+
+    return $this->getTranslation($key, $replace, $replace, $locale, $fallback);
+}
+
+public function choice(...): string
+{
+    $locale = $this->localeForChoice($key, $locale);
+
+    $line = $this->ensureStringTranslation(
+        $key,
+        $this->getTranslation($key, [], $replace, $locale, true),
+    );
+
+    if (is_countable($number)) {
+        $number = count($number);
+    }
+
+    $replace['count'] ??= $number;
+
+    return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
+}
+```
+
+`localeForChoice()` must normalize a missing locale to the current locale and use that locale when no fallback was configured:
+
+```php
+$locale = $locale ?: $this->getLocale();
+
+return $this->hasForLocale($key, $locale) ? $locale : ($this->fallback ?: $locale);
+```
+
+This preserves the callback locale and avoids an empty-locale loader probe. It also lets implicit `singular|plural` lines select correctly when a missing-key callback supplies them and no fallback locale was configured.
+
+The exact helper names may follow the surrounding Laravel naming, but there must be one lookup implementation and one shared protected string assertion used by `string()` and `choice()`. Declare the new internal `getTranslation()` locale as `string` because both public paths normalize caller input before reaching it. Keep protected `handleMissingTranslationKey(?string)` and `localeArray(?string)` unchanged: Laravel documents both nullable extension contracts, and subclasses may call them directly even though first-party lookup paths supply a concrete locale. Preserve the current exception text for non-string values.
+
+Expand `handleMissingKeysUsing()`'s method docblock with the precise `null|callable(string, array, ?string, bool): ?string` shape and state that the callback receives key, caller-supplied replacements, locale, and fallback flag. Normal `get()` and `choice()` calls supply a concrete locale; null remains possible only through the preserved protected extension path. State that `choice()` supplies only caller replacements and applies automatic `count` to the selected result afterward.
+
+Replace the five implementation-mocking choice tests with behavior tests. Cover:
+
+- exact key, locale, fallback flag, and caller replacement array seen by a missing callback;
+- no implicit `count` in callback input unless the caller supplied it;
+- automatic and custom count output;
+- a replacement containing `|` cannot alter plural segment selection;
+- replacements occur only after selection and exactly once;
+- Countable, array, integer, and float inputs;
+- fallback-locale selection;
+- array translations still throw the existing string error;
+- `get()` continues to provide the same replacement set to lookup and callback.
+- `has()` still suppresses the missing-key callback through the extracted lookup.
+- an unset fallback keeps the current locale for the callback and implicit plural selection.
+
+### 4. Correct view exception and engine types (#6, #8)
+
+Files:
+
+- `src/view/src/ViewException.php`
+- `src/view/src/Engines/Engine.php`
+- `tests/View/ViewExceptionTest.php` (new)
+- `tests/View/ViewEngineTest.php` (new)
+- `tests/Integration/View/RenderableViewExceptionTest.php`
+
+Change only `ViewException::render(Request): mixed` and remove the now-unused Response import. Forward the previous exception's render result unchanged and retain null when no render method exists. Keep `report(): ?bool` and its false default.
+
+Direct tests must cover string, array, View contract, Responsable, Symfony/Hypervel response, false, and null render values; report true, false, null, and absent report/render methods. Keep one integration test proving Handler and Router still normalize a renderable view exception end to end.
+
+Change `Engines\Engine::getLastRendered()` to `?string`. Test an anonymous concrete subclass returning null before it records a path and the path afterward. Do not add lifecycle state or change unrelated engine classes.
+
+Both new direct test files extend `Hypervel\Tests\TestCase`. `ViewException::report()` does not require Testbench because `Container::getInstance()` creates the minimal container it needs; do not boot a full application for either unit test.
+
+### 5. Repair inline-view invalidation without replacing cache ownership (#7)
+
+Files:
+
+- `src/view/src/Component.php`
+- `src/view/src/Compilers/BladeCompiler.php`
+- `src/foundation/src/Console/ViewClearCommand.php`
+- `tests/View/ComponentTest.php`
+- `tests/Integration/View/BladeTest.php`
+- `tests/Integration/Foundation/Console/ViewClearCommandTest.php`
+
+#### Exact runtime invalidation
+
+Expand `$bladeViewCache`'s property docblock with only this concise WHY: content-addressed mappings intentionally remain worker-cached so stable and finite variants stay warm. Keep storage guidance in the user documentation rather than growing an audit essay in source.
+
+Centralize the existing content key in a protected static Component helper so lookup and eviction cannot drift:
+
+```php
+protected static function bladeViewCacheKey(string $contents): string
+{
+    return hash('xxh128', sprintf('%s::%s', static::class, $contents));
+}
+
+public static function forgetBladeView(string $contents): void
+{
+    unset(static::$bladeViewCache[static::bladeViewCacheKey($contents)]);
+}
+```
+
+Use the helper from `extractBladeViewFromString()`. Mark the forgetter `@internal`: public visibility is required only for the BladeCompiler call across classes, not to create an application-facing extension API. It is a normal runtime operation and therefore receives no Boot-only warning.
+
+The private anonymous Component inside `BladeCompiler::render()` must type its promoted template property and override `resolveView()` to resolve raw source directly through the existing content-addressed cache and creator:
+
+```php
+public function __construct(protected string $template)
+{
+}
+
+public function render(): string
+{
+    return $this->template;
+}
+
+public function resolveView(): string
+{
+    return self::$bladeViewCache[self::bladeViewCacheKey($this->template)]
+        ??= $this->createBladeViewFromString($this->factory(), $this->template);
+}
+```
+
+Do not change `Component::extractBladeViewFromString()`'s protected signature. Normal components may return a named view and must retain that Laravel extension contract. `Blade::render()` accepts raw source, so its private component must not reinterpret a literal template as a named application view or delete that application's template when `deleteCachedView` is enabled.
+
+Place `bladeViewCacheKey()` beside `extractBladeViewFromString()` and `createBladeViewFromString()`. Place `forgetBladeView()` with the existing `flushCache()`, `forgetFactory()`, and `forgetComponentsResolver()` static lifecycle group rather than appending either method to the class.
+
+`BladeCompiler::render()` retains the anonymous Component and original string in its completion closure. When `deleteCachedView` is true, unlink the source and call `$component::forgetBladeView($string)`. Do not clear unrelated Component caches or the compiler marker:
+
+- the next render misses only this Component mapping and republishes the same source path;
+- Factory normalization, finder, and engine caches still point to that correct path;
+- an existing compiled file was produced from identical source and remains valid.
+
+Add one short WHY beside the exact forget: the other view caches remain valid because the source is republished at the same content-addressed path. Do not repeat the full lifecycle explanation in code.
+
+This exact forget must ship with the compiler mtime correction in step 6. With caching enabled, the current `false >= int` comparison accidentally serves compiled output after source deletion. Once a missing source correctly reports expired, retaining the stale Component mapping would instead make the second render attempt to compile a missing file.
+
+#### Administrative invalidation
+
+Move `CompilerEngine::forgetCompiledOrNotExpired()` in `ViewClearCommand` from before enumeration to after all deletion attempts. Call `Component::flushCache()` beside it before rethrowing any accumulated deletion exception. Flushing after the loop covers cache entries repopulated during deletion as far as an in-process command can; it does not claim to invalidate separate worker processes. The missing-path and glob-failure guards still throw before invalidation because no deletion occurred and no cache can have become stale. `view:cache` already calls `view:clear` in the same process and inherits this behavior.
+
+Tests must prove:
+
+- stable and finite A/B inline variants retain their existing cache reuse;
+- two consecutive `Blade::render(..., deleteCachedView: true)` calls succeed with both `view.cache` enabled and disabled, using two test methods with `#[DefineEnvironment]` callbacks so each mode is configured before the Blade compiler singleton resolves;
+- after two distinct strings have populated the anonymous class's shared Component cache, deleting one forgets only its entry and leaves the other's mapping intact; inspect the cache directly so the case discriminates against a later replacement with `Component::flushCache()`;
+- in-process `view:clear` followed by the same component render recreates the source and compiled output;
+- a deletion failure still flushes Component and compiler caches before the command rethrows;
+- `Component::flushCache()` continues to force recreation;
+- named views, creator/composer dispatch, observers, and custom Factory substitution remain unchanged.
+- raw inline source that equals a named view renders literally and leaves the application view file intact when deletion is enabled.
+
+Do not add a direct Factory path, custom capability, execution state, generation, reverse index, compiler classifier, filesystem poll, lock, LRU, automatic disk pruning, or arbitrary cap.
+
+### 6. Make compiler expiry failures precise
+
+Files:
+
+- `src/view/src/Compilers/Compiler.php`
+- `tests/View/ViewBladeCompilerTest.php`
+
+After the existing compiled-file and timestamp-check gates, read the source and compiled mtimes explicitly:
+
+```php
+$sourceModified = $this->files->lastModified($path);
+
+if ($sourceModified === false) {
+    return true;
+}
+
+$compiledModified = $this->files->lastModified($compiled);
+
+return $compiledModified === false || $sourceModified >= $compiledModified;
+```
+
+Remove the unreachable `ErrorException` catch, import, `@throws ErrorException` tag, and race comment. A missing source is expired so `compile()` reaches `Filesystem::get()` and throws the precise `FileNotFoundException`; a compiled file disappearing after the first existence check is also expired.
+
+Cover source `false`, compiled `false`, source newer/equal/older, disabled caching, disabled timestamp checks, and the compile boundary's precise missing-source exception.
+
+Also correct `BladeCompiler::compile()` after an unchanged compiled hash. Read both mtimes, handle the compiled side first, and atomically republish `$contents` when the compiled file disappeared. If only the source disappeared, leave the valid compiled file unchanged. Compare and `touch()` only when both mtimes are integers. Cover source-only `false`, compiled-only `false`, and both `false`; the last case proves `view:clear` cannot leave the current inline render without compiled output.
+
+### 7. Document stable inline templates and retire duplicate audit text
+
+Files:
+
+- `src/docs/blade.md`
+- `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`
+
+In **Rendering Inline Blade Templates**, after the `deleteCachedView` example, add one short warning that also covers components returning raw Blade source:
+
+> Keep inline Blade templates stable and pass changing values as view data or slots. Hypervel caches and stores each distinct template string separately for reuse, so continually generating unique Blade source grows worker memory and stored view artifacts.
+
+Do not claim dynamic source is unsupported or uncached. Do not add a README differences section or porting-guide entry: all public Laravel APIs remain available and the changes are correctness, typing, ownership, and performance fixes.
+
+After implementation and verification, remove findings #2, #3, and #5–8 plus their completed slice references from the master audit plan. This plan becomes the single detailed record.
+
+## Explicit exclusions
+
+- Do not change `Translator::addLines()`'s existing dotted-key precondition.
+- Do not change the `view.finder` binding lifetime.
+- Do not delete compiled output when `Blade::render(..., deleteCachedView: true)` deletes its source; compiled artifacts remain under `view:clear` ownership.
+- Do not add cross-process invalidation, reload detection, deployment watchers, IPC, leases, or filesystem polling.
+- Do not add an arbitrary LRU/TTL/configuration option or RAM-only cache bound for inline sources.
+- Do not expand this slice into the repository-wide PHPStan suppression audit.
+
+## Verification
+
+Run each changed test file immediately while implementing, then run the focused groups:
+
+```shell
+./vendor/bin/phpunit --no-progress tests/Support/SupportNamespacedItemResolverTest.php
+./vendor/bin/phpunit --no-progress tests/Translation/TranslationTranslatorTest.php
+./vendor/bin/phpunit --no-progress tests/Translation/CoroutineIsolationTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Translation/TranslatorTest.php
+./vendor/bin/phpunit --no-progress tests/View/ComponentTest.php
+./vendor/bin/phpunit --no-progress tests/View/ViewBladeCompilerTest.php
+./vendor/bin/phpunit --no-progress tests/View/ViewCompilerEngineTest.php
+./vendor/bin/phpunit --no-progress tests/View/ViewExceptionTest.php
+./vendor/bin/phpunit --no-progress tests/View/ViewEngineTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/View/BladeTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/View/RenderableViewExceptionTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Foundation/Console/ViewClearCommandTest.php
+```
+
+At the implementation checkpoint run `composer fix` once. It owns formatting, PHPStan, the full parallel suite, and Testbench verification. If it fails, correct with targeted checks, inspect the `fix` script, then run the failed and remaining stages as required by `AGENTS.md`.
+
+Final review must trace:
+
+- every static/singleton/context state transition and cleanup hook;
+- parent/child coroutine replication for translation miss state;
+- exact versus coarse inline-view invalidation and all unaffected Factory/finder/compiler caches;
+- the coupled missing-source mtime and `deleteCachedView` behavior under both cache modes;
+- Laravel API signatures, protected extension behavior, and documentation classification;
+- warmed named/inline render paths for new I/O, allocations, context access, or cache scans.

--- a/docs/plans/2026-08-31-1849-components-translation-view-lifecycle-remediation-plan.md
+++ b/docs/plans/2026-08-31-1849-components-translation-view-lifecycle-remediation-plan.md
@@ -371,7 +371,7 @@ Run each changed test file immediately while implementing, then run the focused 
 ./vendor/bin/phpunit --no-progress tests/Integration/Foundation/Console/ViewClearCommandTest.php
 ```
 
-At the implementation checkpoint run `composer fix` once. It owns formatting, PHPStan, the full parallel suite, and Testbench verification. If it fails, correct with targeted checks, inspect the `fix` script, then run the failed and remaining stages as required by `AGENTS.md`.
+At the implementation checkpoint run `composer fix` once. It owns `lint:fix`, both PHPStan configurations, the full parallel suite, the Testbench suite, and dogfood tests. If it fails, correct with targeted checks, inspect the `fix` script, then run the failed and remaining stages as required by `AGENTS.md`.
 
 Final review must trace:
 

--- a/src/docs/blade.md
+++ b/src/docs/blade.md
@@ -1939,6 +1939,9 @@ return Blade::render(
 );
 ```
 
+> [!WARNING]
+> Keep inline Blade templates stable and pass changing values as view data or slots. Hypervel caches and stores each distinct template string separately for reuse, so continually generating unique Blade source grows worker memory and stored view artifacts.
+
 <a name="rendering-blade-fragments"></a>
 ## Rendering Blade Fragments
 

--- a/src/foundation/src/Console/ViewClearCommand.php
+++ b/src/foundation/src/Console/ViewClearCommand.php
@@ -6,6 +6,7 @@ namespace Hypervel\Foundation\Console;
 
 use Hypervel\Console\Command;
 use Hypervel\Filesystem\Filesystem;
+use Hypervel\View\Component;
 use Hypervel\View\Engines\CompilerEngine;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -46,8 +47,6 @@ class ViewClearCommand extends Command
             throw new RuntimeException('View path not found.');
         }
 
-        CompilerEngine::forgetCompiledOrNotExpired();
-
         $views = $this->files->glob("{$path}/*");
 
         if ($views === false) {
@@ -69,6 +68,9 @@ class ViewClearCommand extends Command
                 $exception ??= $throwable;
             }
         }
+
+        Component::flushCache();
+        CompilerEngine::forgetCompiledOrNotExpired();
 
         if ($exception !== null) {
             throw $exception;

--- a/src/support/src/Facades/Lang.php
+++ b/src/support/src/Facades/Lang.php
@@ -20,7 +20,7 @@ namespace Hypervel\Support\Facades;
  * @method static \Hypervel\Contracts\Translation\Loader getLoader()
  * @method static string getLocale()
  * @method static \Hypervel\Translation\MessageSelector getSelector()
- * @method static \Hypervel\Translation\Translator handleMissingKeysUsing(callable|null $callback)
+ * @method static \Hypervel\Translation\Translator handleMissingKeysUsing(null|callable $callback)
  * @method static bool has(string $key, string|null $locale = null, bool $fallback = true)
  * @method static bool hasForLocale(string $key, string|null $locale = null)
  * @method static bool hasMacro(string $name)

--- a/src/support/src/NamespacedItemResolver.php
+++ b/src/support/src/NamespacedItemResolver.php
@@ -7,7 +7,7 @@ namespace Hypervel\Support;
 class NamespacedItemResolver
 {
     /**
-     * A cache of the parsed items.
+     * The explicitly seeded parsed items.
      */
     protected array $parsed = [];
 
@@ -16,28 +16,13 @@ class NamespacedItemResolver
      */
     public function parseKey(string $key): array
     {
-        // If we've already parsed the given key, we'll return the cached version we
-        // already have, as this will save us some processing. We cache off every
-        // key we parse so we can quickly return it on all subsequent requests.
         if (isset($this->parsed[$key])) {
             return $this->parsed[$key];
         }
 
-        // If the key does not contain a double colon, it means the key is not in a
-        // namespace, and is just a regular configuration item. Namespaces are a
-        // tool for organizing configuration items for things such as modules.
-        if (! str_contains($key, '::')) {
-            $segments = explode('.', $key);
-
-            $parsed = $this->parseBasicSegments($segments);
-        } else {
-            $parsed = $this->parseNamespacedSegments($key);
-        }
-
-        // Once we have the parsed array of this key's elements, such as its groups
-        // and namespace, we will cache each array inside a simple list that has
-        // the key and the parsed array for quick look-ups for later requests.
-        return $this->parsed[$key] = $parsed;
+        return ! str_contains($key, '::')
+            ? $this->parseBasicSegments(explode('.', $key))
+            : $this->parseNamespacedSegments($key);
     }
 
     /**
@@ -82,6 +67,9 @@ class NamespacedItemResolver
 
     /**
      * Set the parsed value of a key.
+     *
+     * Entries remain cached for this resolver instance's lifetime, which is the
+     * worker lifetime when called on the shared translator.
      */
     public function setParsedKey(string $key, array $parsed): void
     {

--- a/src/translation/src/MissingTranslationGroups.php
+++ b/src/translation/src/MissingTranslationGroups.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Translation;
+
+use Hypervel\Context\ReplicableContext;
+
+/**
+ * Keep empty translation-group results isolated to one execution.
+ *
+ * Mutable context avoids replacing a growing context array for every miss,
+ * while replication gives child coroutines an independent snapshot.
+ *
+ * @internal
+ */
+final class MissingTranslationGroups implements ReplicableContext
+{
+    /**
+     * The translation groups missing from the current execution.
+     *
+     * @var array<string, array<string, array<string, true>>>
+     */
+    private array $groups = [];
+
+    /**
+     * Determine if a translation group is missing.
+     */
+    public function has(string $namespace, string $group, string $locale): bool
+    {
+        return isset($this->groups[$namespace][$group][$locale]);
+    }
+
+    /**
+     * Mark a translation group as missing.
+     */
+    public function mark(string $namespace, string $group, string $locale): void
+    {
+        $this->groups[$namespace][$group][$locale] = true;
+    }
+
+    /**
+     * Forget a missing translation group.
+     */
+    public function forget(string $namespace, string $group, string $locale): void
+    {
+        unset($this->groups[$namespace][$group][$locale]);
+    }
+
+    /**
+     * Create an independent copy with the same state.
+     */
+    public function replicate(): static
+    {
+        $copy = new self;
+        $copy->groups = $this->groups;
+
+        return $copy;
+    }
+}

--- a/src/translation/src/Translator.php
+++ b/src/translation/src/Translator.php
@@ -34,6 +34,19 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     protected const string MISSING_KEY_HANDLING_CONTEXT_KEY = '__translation.handle_missing_keys';
 
     /**
+     * Context key prefix for translation groups missing from one execution.
+     */
+    protected const string MISSING_GROUPS_CONTEXT_KEY_PREFIX = '__translation.missing_groups.';
+
+    /**
+     * The next worker-unique translator identifier.
+     *
+     * This is an identity generator, not resettable state. Resetting it can
+     * alias a new translator to context retained under a destroyed translator's key.
+     */
+    protected static int $nextTranslatorId = 0;
+
+    /**
      * The fallback locale used by the translator.
      */
     protected string $fallback = '';
@@ -44,7 +57,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     protected string $locale;
 
     /**
-     * The array of loaded translation groups.
+     * The array of loaded translation groups. Empty loader results are excluded.
      */
     protected array $loaded = [];
 
@@ -54,6 +67,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @var array<string, array<string, array<string, list<array{item: string, value: mixed}>>>>
      */
     protected array $pendingLines = [];
+
+    /**
+     * The coroutine-local key for this translator's missing groups.
+     */
+    protected readonly string $missingGroupsContextKey;
 
     /**
      * The message selector.
@@ -91,6 +109,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         protected Loader $loader,
         string $locale
     ) {
+        $this->missingGroupsContextKey = self::MISSING_GROUPS_CONTEXT_KEY_PREFIX . ++self::$nextTranslatorId;
+
         $this->setBaseLocale($locale);
     }
 
@@ -130,6 +150,19 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locale = $locale ?: $this->getLocale();
 
+        return $this->getTranslation($key, $replace, $replace, $locale, $fallback);
+    }
+
+    /**
+     * Get the translation using separate line and missing-key replacements.
+     */
+    protected function getTranslation(
+        string $key,
+        array $lineReplacements,
+        array $missingKeyReplacements,
+        string $locale,
+        bool $fallback
+    ): array|string {
         // For JSON translations, there is only one file per locale, so we will simply load
         // that file and then we will be ready to check the array for the key. These are
         // only one level deep so we do not need to do any fancy searching through it.
@@ -154,7 +187,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                     $group,
                     $languageLineLocale,
                     $item,
-                    $replace
+                    $lineReplacements
                 ))) {
                     return $line;
                 }
@@ -162,7 +195,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
             $key = $this->handleMissingTranslationKey(
                 $key,
-                $replace,
+                $missingKeyReplacements,
                 $locale,
                 $fallback
             );
@@ -171,7 +204,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?? $key, $replace);
+        return $this->makeReplacements($line ?? $key, $lineReplacements);
     }
 
     /**
@@ -181,8 +214,17 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function string(string $key, array $replace = [], ?string $locale = null, bool $fallback = true): string
     {
-        $value = $this->get($key, $replace, $locale, $fallback);
+        return $this->ensureStringTranslation(
+            $key,
+            $this->get($key, $replace, $locale, $fallback)
+        );
+    }
 
+    /**
+     * Ensure a translation value is a string.
+     */
+    protected function ensureStringTranslation(string $key, array|string $value): string
+    {
         if (! is_string($value)) {
             throw new InvalidArgumentException(
                 sprintf('Translation value for key [%s] must be a string, %s given.', $key, gettype($value))
@@ -217,10 +259,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function choice(string $key, array|Countable|float|int $number, array $replace = [], ?string $locale = null): string
     {
-        $line = $this->string(
+        $locale = $this->localeForChoice($key, $locale);
+
+        $line = $this->ensureStringTranslation(
             $key,
-            [],
-            $locale = $this->localeForChoice($key, $locale)
+            $this->getTranslation($key, [], $replace, $locale, true)
         );
 
         // If the given "number" is actually an array or countable we will simply count the
@@ -230,9 +273,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $number = count($number);
         }
 
-        if (! isset($replace['count'])) {
-            $replace['count'] = $number;
-        }
+        $replace['count'] ??= $number;
 
         return $this->makeReplacements(
             $this->getSelector()->choose($line, $number, $locale),
@@ -247,7 +288,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locale = $locale ?: $this->getLocale();
 
-        return $this->hasForLocale($key, $locale) ? $locale : $this->fallback;
+        return $this->hasForLocale($key, $locale) ? $locale : ($this->fallback ?: $locale);
     }
 
     /**
@@ -257,10 +298,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $this->load($namespace, $group, $locale);
 
-        $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
+        $line = Arr::get($this->loaded[$namespace][$group][$locale] ?? [], $item);
 
-        // Loaders return an empty array for missing or empty groups, so only a
-        // requested item may use an empty array as its translation value.
+        // The empty default represents a group missing from this execution, so only
+        // a requested item may use an empty array as its translation value.
         if (is_string($line) || (is_array($line) && ($line !== [] || $item !== null))) {
             return $this->makeReplacements($line, $replace);
         }
@@ -336,6 +377,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 continue;
             }
 
+            $this->missingTranslationGroups()?->forget($namespace, $group, $locale);
+
             $this->pendingLines[$namespace][$group][$locale][] = [
                 'item' => $item,
                 'value' => $value,
@@ -352,6 +395,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             return;
         }
 
+        if ($this->missingTranslationGroups()?->has($namespace, $group, $locale)) {
+            return;
+        }
+
         // The loader is responsible for returning the array of language lines for the
         // given namespace, group, and locale. We'll set the lines in this array of
         // lines that have already been loaded so that we can easily access them.
@@ -361,9 +408,16 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             Arr::set($lines, $pendingLine['item'], $pendingLine['value']);
         }
 
-        $this->loaded[$namespace][$group][$locale] = $lines;
-
         unset($this->pendingLines[$namespace][$group][$locale]);
+
+        if ($lines === []) {
+            // Keep empty results execution-scoped so later executions can discover new lines.
+            $this->markMissingTranslationGroup($namespace, $group, $locale);
+
+            return;
+        }
+
+        $this->loaded[$namespace][$group][$locale] = $lines;
     }
 
     /**
@@ -372,6 +426,34 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     protected function isLoaded(string $namespace, string $group, string $locale): bool
     {
         return isset($this->loaded[$namespace][$group][$locale]);
+    }
+
+    /**
+     * Get the translation groups missing from the current execution.
+     */
+    protected function missingTranslationGroups(): ?MissingTranslationGroups
+    {
+        /** @var null|MissingTranslationGroups $missingTranslationGroups */
+        $missingTranslationGroups = CoroutineContext::get($this->missingGroupsContextKey);
+
+        return $missingTranslationGroups;
+    }
+
+    /**
+     * Mark a translation group as missing from the current execution.
+     */
+    protected function markMissingTranslationGroup(string $namespace, string $group, string $locale): void
+    {
+        $missingTranslationGroups = $this->missingTranslationGroups();
+
+        if ($missingTranslationGroups === null) {
+            CoroutineContext::set(
+                $this->missingGroupsContextKey,
+                $missingTranslationGroups = new MissingTranslationGroups
+            );
+        }
+
+        $missingTranslationGroups->mark($namespace, $group, $locale);
     }
 
     /**
@@ -423,8 +505,14 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Register a callback that is responsible for handling missing translation keys.
      *
+     * The callback receives the key, caller-supplied replacements, locale, and
+     * fallback flag. Choice lookups add the automatic count replacement only
+     * after selecting the plural form.
+     *
      * Boot-only. The callback is stored on the shared Translator instance and
      * affects every subsequent missing-key lookup in the worker.
+     *
+     * @param null|callable(string, array, ?string, bool): ?string $callback
      */
     public function handleMissingKeysUsing(?callable $callback): static
     {
@@ -624,6 +712,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         // Supplied groups are already loaded, so load() cannot replay pending operations.
         $this->pendingLines = [];
+
+        CoroutineContext::forget($this->missingGroupsContextKey);
     }
 
     /**

--- a/src/view/src/Compilers/BladeCompiler.php
+++ b/src/view/src/Compilers/BladeCompiler.php
@@ -187,10 +187,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
             return;
         }
 
-        $lastModified = $this->files->lastModified($this->getPath());
+        $sourceModified = $this->files->lastModified($this->getPath());
+        $compiledModified = $this->files->lastModified($compiledPath);
 
-        if ($lastModified >= $this->files->lastModified($compiledPath)) {
-            touch($compiledPath, $lastModified + 1);
+        if ($compiledModified === false) {
+            $this->files->replace($compiledPath, $contents);
+
+            return;
+        }
+
+        if ($sourceModified !== false && $sourceModified >= $compiledModified) {
+            touch($compiledPath, $sourceModified + 1);
         }
     }
 
@@ -319,16 +326,31 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public static function render(string $string, array $data = [], bool $deleteCachedView = false): string
     {
         $component = new class($string) extends Component {
-            protected $template;
-
-            public function __construct($template)
+            /**
+             * Create a new inline Blade component instance.
+             */
+            public function __construct(protected string $template)
             {
-                $this->template = $template;
             }
 
-            public function render(): View|Htmlable|Closure|string
+            /**
+             * Get the inline Blade source.
+             */
+            public function render(): string
             {
                 return $this->template;
+            }
+
+            /**
+             * Resolve the inline Blade source to its temporary view.
+             *
+             * Blade::render() receives raw source, so a literal template that
+             * matches a view name must not resolve to that application view.
+             */
+            public function resolveView(): string
+            {
+                return self::$bladeViewCache[self::bladeViewCacheKey($this->template)]
+                    ??= $this->createBladeViewFromString($this->factory(), $this->template);
             }
         };
 
@@ -336,9 +358,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
             ->make(ViewFactory::class)
             ->make($component->resolveView(), $data);
 
-        return tap($view->render(), function () use ($view, $deleteCachedView) {
+        return tap($view->render(), function () use ($component, $string, $view, $deleteCachedView) {
             if ($deleteCachedView) {
                 @unlink($view->getPath());
+
+                // Other view caches remain valid because this source is republished at the same content-addressed path.
+                $component::forgetBladeView($string);
             }
         });
     }

--- a/src/view/src/Compilers/Compiler.php
+++ b/src/view/src/Compilers/Compiler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\View\Compilers;
 
-use ErrorException;
 use Hypervel\Filesystem\Filesystem;
 use Hypervel\Support\Str;
 use InvalidArgumentException;
@@ -37,8 +36,6 @@ abstract class Compiler
 
     /**
      * Determine if the view at the given path is expired.
-     *
-     * @throws ErrorException
      */
     public function isExpired(string $path): bool
     {
@@ -59,16 +56,15 @@ abstract class Compiler
             return false;
         }
 
-        try {
-            return $this->files->lastModified($path) >= $this->files->lastModified($compiled);
-        } catch (ErrorException $exception) {
-            // The compiled file might have been deleted between the initial check and lastModified() call
-            if (! $this->files->exists($compiled)) {
-                return true;
-            }
+        $sourceModified = $this->files->lastModified($path);
 
-            throw $exception;
+        if ($sourceModified === false) {
+            return true;
         }
+
+        $compiledModified = $this->files->lastModified($compiled);
+
+        return $compiledModified === false || $sourceModified >= $compiledModified;
     }
 
     /**

--- a/src/view/src/Component.php
+++ b/src/view/src/Component.php
@@ -48,6 +48,8 @@ abstract class Component
     /**
      * The cache of blade view names, keyed by contents.
      *
+     * Content-addressed mappings remain worker-cached so stable and finite variants stay warm.
+     *
      * @var array<string, string>
      */
     protected static array $bladeViewCache = [];
@@ -149,11 +151,11 @@ abstract class Component
     }
 
     /**
-     * Create a Blade view with the raw component string content.
+     * Resolve and cache the Blade view for the given component string.
      */
     protected function extractBladeViewFromString(string $contents): string
     {
-        $key = hash('xxh128', sprintf('%s::%s', static::class, $contents));
+        $key = static::bladeViewCacheKey($contents);
 
         if (isset(static::$bladeViewCache[$key])) {
             return static::$bladeViewCache[$key];
@@ -164,6 +166,14 @@ abstract class Component
         }
 
         return static::$bladeViewCache[$key] = $this->createBladeViewFromString($this->factory(), $contents);
+    }
+
+    /**
+     * Get the cache key for the given Blade view contents.
+     */
+    protected static function bladeViewCacheKey(string $contents): string
+    {
+        return hash('xxh128', sprintf('%s::%s', static::class, $contents));
     }
 
     /**
@@ -290,6 +300,7 @@ abstract class Component
             'withAttributes',
             'flushCache',
             'flushState',
+            'forgetBladeView',
             'forgetFactory',
             'forgetComponentsResolver',
             'ignoredParameterNames',
@@ -380,8 +391,9 @@ abstract class Component
     /**
      * Flush the component's cached state.
      *
-     * Boot or tests only. Clears the worker-wide reflection and view caches
-     * shared by every coroutine; next render rebuilds them.
+     * Boot or tests only when called directly. Clears the worker-wide reflection
+     * and view caches shared by every coroutine; next render rebuilds them. The
+     * view:clear command owns runtime invalidation.
      */
     public static function flushCache(): void
     {
@@ -390,6 +402,16 @@ abstract class Component
         static::$methodCache = [];
         static::$propertyCache = [];
         static::$ignoredParameterNames = [];
+    }
+
+    /**
+     * Forget the cached Blade view name for the given contents.
+     *
+     * @internal
+     */
+    public static function forgetBladeView(string $contents): void
+    {
+        unset(static::$bladeViewCache[static::bladeViewCacheKey($contents)]);
     }
 
     /**

--- a/src/view/src/Engines/CompilerEngine.php
+++ b/src/view/src/Engines/CompilerEngine.php
@@ -146,8 +146,9 @@ class CompilerEngine extends PhpEngine
     /**
      * Clear the cache of views that were compiled or not expired.
      *
-     * Boot or tests only. Clears the worker-wide compile-check cache shared
-     * by every coroutine; concurrent compilations may re-check disk redundantly.
+     * Boot or tests only when called directly. Clears the worker-wide compile-check
+     * cache shared by every coroutine; concurrent compilations may re-check disk
+     * redundantly. The view:clear command owns runtime invalidation.
      */
     public static function forgetCompiledOrNotExpired(): void
     {

--- a/src/view/src/Engines/Engine.php
+++ b/src/view/src/Engines/Engine.php
@@ -14,7 +14,7 @@ abstract class Engine
     /**
      * Get the last view that was rendered.
      */
-    public function getLastRendered(): string
+    public function getLastRendered(): ?string
     {
         return $this->lastRendered;
     }

--- a/src/view/src/ViewException.php
+++ b/src/view/src/ViewException.php
@@ -8,7 +8,6 @@ use ErrorException;
 use Hypervel\Container\Container;
 use Hypervel\Http\Request;
 use Hypervel\Support\Reflector;
-use Symfony\Component\HttpFoundation\Response;
 
 class ViewException extends ErrorException
 {
@@ -29,7 +28,7 @@ class ViewException extends ErrorException
     /**
      * Render the exception into an HTTP response.
      */
-    public function render(Request $request): ?Response
+    public function render(Request $request): mixed
     {
         $exception = $this->getPrevious();
 

--- a/tests/Integration/Foundation/Console/ViewClearCommandTest.php
+++ b/tests/Integration/Foundation/Console/ViewClearCommandTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\Foundation\Console;
 
 use Hypervel\Filesystem\Filesystem;
+use Hypervel\Support\Facades\Blade;
 use Hypervel\Testbench\TestCase;
+use Hypervel\View\Component;
 use Mockery as m;
 use RuntimeException;
 
@@ -41,6 +43,25 @@ class ViewClearCommandTest extends TestCase
             ->assertSuccessful();
 
         $this->assertSame(['.', '..'], scandir($this->compiledPath));
+    }
+
+    public function testViewClearCommandAllowsInlineViewsToBeRenderedAgainInTheSameProcess(): void
+    {
+        $contents = 'Hello {{ $name }}';
+        $source = $this->compiledPath . '/' . hash('xxh128', $contents) . '.blade.php';
+        $compiled = $this->app->make('blade.compiler')->getCompiledPath($source);
+
+        $this->assertSame('Hello Taylor', Blade::render($contents, ['name' => 'Taylor']));
+        $this->assertFileExists($source);
+        $this->assertFileExists($compiled);
+
+        $this->artisan('view:clear')->assertSuccessful();
+
+        $this->assertFileDoesNotExist($source);
+        $this->assertFileDoesNotExist($compiled);
+        $this->assertSame('Hello Taylor', Blade::render($contents, ['name' => 'Taylor']));
+        $this->assertFileExists($source);
+        $this->assertFileExists($compiled);
     }
 
     public function testViewClearCommandFailsWhenCompiledViewsCannotBeEnumerated(): void
@@ -80,6 +101,40 @@ class ViewClearCommandTest extends TestCase
         $this->artisan('view:clear');
     }
 
+    public function testViewClearCommandFlushesInProcessCachesBeforeRethrowingDeletionFailure(): void
+    {
+        $contents = 'Hello {{ $name }}';
+        $this->assertSame('Hello Taylor', Blade::render($contents, ['name' => 'Taylor']));
+        $this->assertSame('Hello Taylor', Blade::render($contents, ['name' => 'Taylor']));
+
+        $component = new ViewClearInlineComponent;
+        $engine = $this->app->make('view.engine.resolver')->resolve('blade');
+        (fn () => static::$compiledOrNotExpired = ['view' => true])->call($engine);
+
+        $this->assertNotSame([], (fn () => static::$bladeViewCache)->call($component));
+        $this->assertNotSame([], (fn () => static::$compiledOrNotExpired)->call($engine));
+
+        $view = $this->compiledPath . '/view.php';
+        $exception = new RuntimeException('deletion failed');
+        $files = m::mock(Filesystem::class);
+        $files->shouldReceive('glob')->once()->with($this->compiledPath . '/*')->andReturn([$view]);
+        $files->shouldReceive('isDirectory')->once()->with($view)->andReturnFalse();
+        $files->shouldReceive('delete')->once()->with($view)->andThrow($exception);
+        $this->app->instance(Filesystem::class, $files);
+
+        $caught = null;
+
+        try {
+            $this->artisan('view:clear');
+        } catch (RuntimeException $throwable) {
+            $caught = $throwable;
+        }
+
+        $this->assertSame($exception, $caught);
+        $this->assertSame([], (fn () => static::$bladeViewCache)->call($component));
+        $this->assertSame([], (fn () => static::$compiledOrNotExpired)->call($engine));
+    }
+
     public function testViewClearCommandAcceptsConcurrentDisappearance(): void
     {
         $view = $this->compiledPath . '/view.php';
@@ -96,5 +151,13 @@ class ViewClearCommandTest extends TestCase
         $this->artisan('view:clear')
             ->expectsOutputToContain('Compiled views cleared successfully.')
             ->assertSuccessful();
+    }
+}
+
+class ViewClearInlineComponent extends Component
+{
+    public function render(): string
+    {
+        return 'View clear';
     }
 }

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -108,6 +108,27 @@ class TranslatorTest extends TestCase
         $this->assertSame('ht', $missingLocale);
     }
 
+    public function testChoicePassesCallerReplacementsToMissingKeyCallback(): void
+    {
+        $received = null;
+        $translator = $this->app->make('translator');
+
+        $translator->handleMissingKeysUsing(function (string $key, array $replace, string $locale, bool $fallback) use (&$received): string {
+            $received = [$key, $replace, $locale, $fallback];
+
+            return '{1} Hello :name|[2,*] Hello :name, you have :count messages';
+        });
+
+        $this->assertSame(
+            'Hello Taylor, you have 3 messages',
+            $translator->choice('missing.greeting', 3, ['name' => 'Taylor'])
+        );
+        $this->assertSame(
+            ['missing.greeting', ['name' => 'Taylor'], 'en', true],
+            $received
+        );
+    }
+
     public function testFileValidationDoesNotAttemptToTranslateAlreadyTranslatedMessages(): void
     {
         $keysLookedUp = [];

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Integration\View;
 
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Filesystem\Filesystem;
 use Hypervel\Support\Facades\Blade;
 use Hypervel\Support\Facades\Config;
 use Hypervel\Support\Facades\View;
+use Hypervel\Testbench\Attributes\DefineEnvironment;
 use Hypervel\Testbench\TestCase;
+use Hypervel\Testing\ParallelTesting;
 use Hypervel\View\Component;
 use Mockery as m;
 use Override;
@@ -31,6 +34,41 @@ class BladeTest extends TestCase
     public function testRenderingBladeString(): void
     {
         $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor']));
+    }
+
+    public function testRenderingBladeStringDoesNotResolveOrDeleteAMatchingNamedView(): void
+    {
+        $files = new Filesystem;
+        $directory = ParallelTesting::tempDir('BladeRawTemplateCollision');
+        $viewPath = $directory . '/literal-collision.blade.php';
+
+        try {
+            $files->deleteDirectory($directory);
+            $files->ensureDirectoryExists($directory);
+            $files->put($viewPath, 'Named application view');
+            View::addLocation($directory);
+
+            $this->assertTrue(View::exists('literal-collision'));
+            $this->assertSame('literal-collision', Blade::render('literal-collision', deleteCachedView: true));
+            $this->assertTrue($files->exists($viewPath));
+            $this->assertSame('Named application view', View::make('literal-collision')->render());
+        } finally {
+            $files->deleteDirectory($directory);
+        }
+    }
+
+    #[DefineEnvironment('withViewCacheEnabled')]
+    public function testRenderingAndDeletingSameBladeStringTwiceWithViewCacheEnabled(): void
+    {
+        $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor'], true));
+        $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor'], true));
+    }
+
+    #[DefineEnvironment('withViewCacheDisabled')]
+    public function testRenderingAndDeletingSameBladeStringTwiceWithViewCacheDisabled(): void
+    {
+        $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor'], true));
+        $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor'], true));
     }
 
     public function testRenderingBladeLongMaxpathlenString(): void
@@ -251,6 +289,16 @@ class BladeTest extends TestCase
     protected function defineEnvironment(ApplicationContract $app): void
     {
         $app->make('config')->set('view.paths', [__DIR__ . '/templates']);
+    }
+
+    protected function withViewCacheEnabled(ApplicationContract $app): void
+    {
+        $app->make('config')->set('view.cache', true);
+    }
+
+    protected function withViewCacheDisabled(ApplicationContract $app): void
+    {
+        $app->make('config')->set('view.cache', false);
     }
 }
 

--- a/tests/Integration/View/RenderableViewExceptionTest.php
+++ b/tests/Integration/View/RenderableViewExceptionTest.php
@@ -25,6 +25,21 @@ class RenderableViewExceptionTest extends TestCase
         $response->assertSee('This is a renderable exception.');
     }
 
+    public function testResponseRenderedByExceptionThrownInViewGetsHandled(): void
+    {
+        Route::get('/', function () {
+            return View::make('renderable-exception', [
+                'exception' => new ResponseRenderableException,
+            ]);
+        });
+
+        $response = $this->get('/');
+
+        $response->assertStatus(418);
+        $response->assertHeader('X-View-Exception', 'handled');
+        $response->assertSee('This is a response renderable exception.');
+    }
+
     protected function defineEnvironment(ApplicationContract $app): void
     {
         $app->make('config')->set('view.paths', [__DIR__ . '/templates']);
@@ -33,8 +48,20 @@ class RenderableViewExceptionTest extends TestCase
 
 class RenderableException extends Exception
 {
+    public function render(Request $request): string
+    {
+        return 'This is a renderable exception.';
+    }
+}
+
+class ResponseRenderableException extends Exception
+{
     public function render(Request $request): Response
     {
-        return new Response('This is a renderable exception.');
+        return new Response(
+            'This is a response renderable exception.',
+            418,
+            ['X-View-Exception' => 'handled']
+        );
     }
 }

--- a/tests/Integration/View/templates/renderable-exception.blade.php
+++ b/tests/Integration/View/templates/renderable-exception.blade.php
@@ -1,3 +1,3 @@
 @php
-    throw new Hypervel\Tests\Integration\View\RenderableException;
+    throw $exception ?? new Hypervel\Tests\Integration\View\RenderableException;
 @endphp

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -9,34 +9,86 @@ use Hypervel\Tests\TestCase;
 
 class SupportNamespacedItemResolverTest extends TestCase
 {
-    public function testResolution()
+    public function testResolution(): void
     {
-        $r = new NamespacedItemResolver;
+        $resolver = new NamespacedItemResolver;
 
-        $this->assertEquals(['foo', 'bar', 'baz'], $r->parseKey('foo::bar.baz'));
-        $this->assertEquals(['foo', 'bar', null], $r->parseKey('foo::bar'));
-        $this->assertEquals([null, 'bar', 'baz'], $r->parseKey('bar.baz'));
-        $this->assertEquals([null, 'bar', null], $r->parseKey('bar'));
+        $this->assertSame(['foo', 'bar', 'baz'], $resolver->parseKey('foo::bar.baz'));
+        $this->assertSame(['foo', 'bar', null], $resolver->parseKey('foo::bar'));
+        $this->assertSame([null, 'bar', 'baz'], $resolver->parseKey('bar.baz'));
+        $this->assertSame([null, 'bar', null], $resolver->parseKey('bar'));
     }
 
-    public function testParsedItemsAreCached()
+    public function testParsedItemsAreNotAutomaticallyCached(): void
     {
-        $r = $this->getMockBuilder(NamespacedItemResolver::class)->onlyMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
-        $r->setParsedKey('foo.bar', ['foo']);
-        $r->expects($this->never())->method('parseBasicSegments');
-        $r->expects($this->never())->method('parseNamespacedSegments');
+        $resolver = new SupportNamespacedItemResolverStub;
 
-        $this->assertEquals(['foo'], $r->parseKey('foo.bar'));
+        $this->assertSame([null, 'foo', 'bar'], $resolver->parseKey('foo.bar'));
+        $this->assertSame([null, 'foo', 'bar'], $resolver->parseKey('foo.bar'));
+        $this->assertSame(['vendor', 'foo', 'bar'], $resolver->parseKey('vendor::foo.bar'));
+        $this->assertSame(['vendor', 'foo', 'bar'], $resolver->parseKey('vendor::foo.bar'));
+        $this->assertSame(4, $resolver->basicParseCount);
+        $this->assertSame(2, $resolver->namespacedParseCount);
+        $this->assertSame([], $resolver->parsedItems());
     }
 
-    public function testParsedItemsMayBeFlushed()
+    public function testArbitraryKeysDoNotAccumulate(): void
     {
-        $r = $this->getMockBuilder(NamespacedItemResolver::class)->onlyMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
-        $r->expects($this->once())->method('parseBasicSegments')->willReturn(['bar']);
+        $resolver = new SupportNamespacedItemResolverStub;
 
-        $r->setParsedKey('foo.bar', ['foo']);
-        $r->flushParsedKeys();
+        for ($index = 0; $index < 1000; ++$index) {
+            $resolver->parseKey("validation.attribute.{$index}");
+        }
 
-        $this->assertEquals(['bar'], $r->parseKey('foo.bar'));
+        $this->assertSame([], $resolver->parsedItems());
+    }
+
+    public function testExplicitlyParsedItemsAreCached(): void
+    {
+        $resolver = $this->getMockBuilder(NamespacedItemResolver::class)->onlyMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
+        $resolver->setParsedKey('foo.bar', ['foo']);
+        $resolver->expects($this->never())->method('parseBasicSegments');
+        $resolver->expects($this->never())->method('parseNamespacedSegments');
+
+        $this->assertSame(['foo'], $resolver->parseKey('foo.bar'));
+    }
+
+    public function testExplicitlyParsedItemsMayBeFlushed(): void
+    {
+        $resolver = new SupportNamespacedItemResolverStub;
+
+        $resolver->setParsedKey('foo.bar', ['foo']);
+        $resolver->setParsedKey('vendor::foo.bar', ['vendor']);
+        $resolver->flushParsedKeys();
+
+        $this->assertSame([null, 'foo', 'bar'], $resolver->parseKey('foo.bar'));
+        $this->assertSame(['vendor', 'foo', 'bar'], $resolver->parseKey('vendor::foo.bar'));
+        $this->assertSame([], $resolver->parsedItems());
+    }
+}
+
+class SupportNamespacedItemResolverStub extends NamespacedItemResolver
+{
+    public int $basicParseCount = 0;
+
+    public int $namespacedParseCount = 0;
+
+    public function parsedItems(): array
+    {
+        return $this->parsed;
+    }
+
+    protected function parseBasicSegments(array $segments): array
+    {
+        ++$this->basicParseCount;
+
+        return parent::parseBasicSegments($segments);
+    }
+
+    protected function parseNamespacedSegments(string $key): array
+    {
+        ++$this->namespacedParseCount;
+
+        return parent::parseNamespacedSegments($key);
     }
 }

--- a/tests/Translation/CoroutineIsolationTest.php
+++ b/tests/Translation/CoroutineIsolationTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Translation;
 
+use Hypervel\Context\CoroutineContext;
 use Hypervel\Tests\TestCase;
 use Hypervel\Translation\ArrayLoader;
+use Hypervel\Translation\MissingTranslationGroups;
 use Hypervel\Translation\Translator;
 
 use function Hypervel\Coroutine\parallel;
+use function Hypervel\Coroutine\wait;
 
 class CoroutineIsolationTest extends TestCase
 {
@@ -61,6 +64,78 @@ class CoroutineIsolationTest extends TestCase
         $this->assertSame('de', $secondLocale);
         $this->assertSame('es', $translator->getLocale());
     }
+
+    public function testMissingGroupsAreRecheckedInLaterExecutions(): void
+    {
+        $loader = new MutableTranslationLoader;
+        $translator = new Translator($loader, 'en');
+
+        $this->assertSame(
+            'messages.value',
+            wait(fn (): string => $translator->string('messages.value'))
+        );
+
+        $loader->messages = ['value' => 'translated'];
+
+        $this->assertSame(
+            'translated',
+            wait(fn (): string => $translator->string('messages.value'))
+        );
+        $this->assertSame(2, $loader->messageLoadCount);
+    }
+
+    public function testPositiveGroupsRemainCachedAcrossExecutions(): void
+    {
+        $loader = new MutableTranslationLoader;
+        $loader->messages = ['value' => 'translated'];
+        $translator = new Translator($loader, 'en');
+
+        $this->assertSame(
+            'translated',
+            wait(fn (): string => $translator->string('messages.value'))
+        );
+        $this->assertSame(
+            'translated',
+            wait(fn (): string => $translator->string('messages.value'))
+        );
+        $this->assertSame(1, $loader->messageLoadCount);
+    }
+
+    public function testTranslatorInstancesDoNotShareMissingGroups(): void
+    {
+        $loader = new MutableTranslationLoader;
+        $first = new Translator($loader, 'en');
+        $second = new Translator($loader, 'en');
+
+        $this->assertSame('messages.value', $first->get('messages.value'));
+        $this->assertSame('messages.value', $second->get('messages.value'));
+        $this->assertSame(2, $loader->messageLoadCount);
+    }
+
+    public function testCopiedMissingGroupsAreIndependent(): void
+    {
+        $contextKey = '__translation.test_missing_groups';
+        $missingGroups = new MissingTranslationGroups;
+        $missingGroups->mark('*', 'messages', 'en');
+        CoroutineContext::set($contextKey, $missingGroups);
+
+        [$isIndependent, $wasPresent, $wasForgotten] = wait(
+            function () use ($contextKey, $missingGroups): array {
+                /** @var MissingTranslationGroups $copy */
+                $copy = CoroutineContext::get($contextKey);
+                $wasPresent = $copy->has('*', 'messages', 'en');
+                $copy->forget('*', 'messages', 'en');
+
+                return [$copy !== $missingGroups, $wasPresent, ! $copy->has('*', 'messages', 'en')];
+            },
+            copyContext: [$contextKey]
+        );
+
+        $this->assertTrue($isIndependent);
+        $this->assertTrue($wasPresent);
+        $this->assertTrue($wasForgotten);
+        $this->assertTrue($missingGroups->has('*', 'messages', 'en'));
+    }
 }
 
 class YieldingTranslationLoader extends ArrayLoader
@@ -69,6 +144,24 @@ class YieldingTranslationLoader extends ArrayLoader
     {
         if ($locale === 'en' && $group === '*') {
             usleep(5000);
+        }
+
+        return parent::load($locale, $group, $namespace);
+    }
+}
+
+class MutableTranslationLoader extends ArrayLoader
+{
+    public array $messages = [];
+
+    public int $messageLoadCount = 0;
+
+    public function load(string $locale, string $group, ?string $namespace = null): array
+    {
+        if ($group === 'messages') {
+            ++$this->messageLoadCount;
+
+            return $this->messages;
         }
 
         return parent::load($locale, $group, $namespace);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -14,10 +14,11 @@ use Hypervel\Tests\Translation\Fixtures\Enums\Baz;
 use Hypervel\Tests\Translation\Fixtures\Enums\Foo;
 use Hypervel\Translation\ArrayLoader;
 use Hypervel\Translation\FileLoader;
-use Hypervel\Translation\MessageSelector;
+use Hypervel\Translation\MissingTranslationGroups;
 use Hypervel\Translation\Translator;
 use InvalidArgumentException;
 use Mockery as m;
+use ReflectionProperty;
 use RuntimeException;
 use stdClass;
 use TypeError;
@@ -51,6 +52,20 @@ class TranslationTranslatorTest extends TestCase
         $translator->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $translator->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
         $this->assertFalse($translator->hasForLocale('foo'));
+    }
+
+    public function testHasSuppressesMissingKeyCallbacks(): void
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $calls = 0;
+        $translator->handleMissingKeysUsing(function () use (&$calls): string {
+            ++$calls;
+
+            return 'handled';
+        });
+
+        $this->assertFalse($translator->has('messages.missing'));
+        $this->assertSame(0, $calls);
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItem(): void
@@ -249,6 +264,58 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame(['child' => 'last'], $translator->array('messages.parent'));
     }
 
+    public function testEmptyGroupsAreLoadedOnceWithinAnExecution(): void
+    {
+        $translator = new Translator($this->getLoader(), 'en');
+        $translator->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $translator->getLoader()->shouldReceive('load')->once()->with('en', 'messages', '*')->andReturn([]);
+
+        $this->assertSame('messages.missing', $translator->get('messages.missing'));
+        $this->assertSame('messages.other', $translator->get('messages.other'));
+    }
+
+    public function testArbitraryMissingGroupsRemainExecutionScoped(): void
+    {
+        $loader = new CountingTranslationLoader;
+        $translator = new TranslationTranslatorStub($loader, 'en');
+
+        for ($index = 0; $index < 1000; ++$index) {
+            $translator->get("group{$index}.missing");
+        }
+
+        $this->assertSame([], $translator->loadedGroups());
+        $this->assertSame(1001, $loader->loadCount);
+        $this->assertSame(1001, $this->missingGroupCount($translator->missingGroups()));
+    }
+
+    public function testArbitraryMissingLocalesRemainExecutionScoped(): void
+    {
+        $loader = new CountingTranslationLoader;
+        $translator = new TranslationTranslatorStub($loader, 'en');
+
+        for ($index = 0; $index < 1000; ++$index) {
+            $translator->setLocale("locale{$index}");
+            $translator->get('messages.missing');
+        }
+
+        $this->assertSame([], $translator->loadedGroups());
+        $this->assertSame(2000, $loader->loadCount);
+        $this->assertSame(2000, $this->missingGroupCount($translator->missingGroups()));
+    }
+
+    public function testLinesAddedAfterAMissingGroupBecomeVisibleInCallOrder(): void
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+
+        $this->assertSame('messages.parent', $translator->get('messages.parent'));
+
+        $translator->addLines(['messages.parent.child' => 'first'], 'en');
+        $translator->addLines(['messages.parent' => 'replacement'], 'en');
+        $translator->addLines(['messages.parent.child' => 'last'], 'en');
+
+        $this->assertSame(['child' => 'last'], $translator->array('messages.parent'));
+    }
+
     public function testPendingLinesRemainWhenLoadingFails(): void
     {
         $exception = new RuntimeException('Unable to load translations.');
@@ -264,7 +331,7 @@ class TranslationTranslatorTest extends TestCase
                 return ['file' => 'from file'];
             }
         );
-        $translator = new Translator($loader, 'en');
+        $translator = new TranslationTranslatorStub($loader, 'en');
         $translator->addLines(['messages.added' => 'registered'], 'en');
 
         $thrown = null;
@@ -277,13 +344,16 @@ class TranslationTranslatorTest extends TestCase
         }
 
         $this->assertSame($exception, $thrown);
+        $this->assertFalse($translator->missingGroups()?->has('*', 'messages', 'en'));
         $this->assertSame('from file', $translator->get('messages.file'));
         $this->assertSame('registered', $translator->get('messages.added'));
     }
 
-    public function testSetLoadedClearsPendingLines(): void
+    public function testSetLoadedClearsPendingLinesAndMissingGroups(): void
     {
-        $translator = new Translator(new ArrayLoader, 'en');
+        $translator = new TranslationTranslatorStub(new ArrayLoader, 'en');
+
+        $translator->get('missing.value');
         $translator->addLines(['messages.added' => 'registered'], 'en');
         $translator->setLoaded([
             '*' => [
@@ -293,67 +363,100 @@ class TranslationTranslatorTest extends TestCase
             ],
         ]);
 
+        $this->assertNull($translator->missingGroups());
         $this->assertSame('messages.added', $translator->get('messages.added'));
     }
 
-    public function testChoiceMethodProperlyLoadsAndRetrievesItemForAnInt(): void
+    public function testChoicePassesCallerReplacementsToMissingKeyCallback(): void
     {
-        $translator = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $translator->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $translator->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
-        $translator->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
-
-        $translator->choice('foo', 10, ['replace']);
-    }
-
-    public function testChoiceMethodProperlyLoadsAndRetrievesItemForAFloat(): void
-    {
-        $translator = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $translator->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $translator->expects($this->once())->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
-        $translator->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->once()->with('line', 1.2, 'en')->andReturn('choiced');
-
-        $translator->choice('foo', 1.2, ['replace']);
-    }
-
-    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem(): void
-    {
-        $translator = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $translator->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $translator->expects($this->exactly(2))->method('localeForChoice')->with($this->equalTo('foo'), $this->equalTo(null))->willReturn('en');
-        $translator->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
-
-        $values = ['foo', 'bar', 'baz'];
-        $translator->choice('foo', $values, ['replace']);
-
-        $values = new Collection(['foo', 'bar', 'baz']);
-        $translator->choice('foo', $values, ['replace']);
-    }
-
-    public function testChoiceMethodProperlySelectsLocaleForChoose(): void
-    {
-        $translator = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'hasForLocale'])->setConstructorArgs([$this->getLoader(), 'cs'])->getMock();
+        $translator = new Translator(new ArrayLoader, 'en');
         $translator->setFallback('en');
-        $translator->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('en'))->willReturn('line');
-        $translator->expects($this->once())->method('hasForLocale')->with($this->equalTo('foo'), $this->equalTo('cs'))->willReturn(false);
-        $translator->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
+        $received = null;
+        $translator->handleMissingKeysUsing(function (string $key, array $replace, ?string $locale, bool $fallback) use (&$received): string {
+            $received = [$key, $replace, $locale, $fallback];
 
-        $translator->choice('foo', 10, ['replace']);
+            return '{1} Hello :name|[2,*] Hello :name, you have :count messages';
+        });
+
+        $this->assertSame(
+            'Hello Taylor, you have 3 messages',
+            $translator->choice('messages.greeting', 3, ['name' => 'Taylor'])
+        );
+        $this->assertSame(
+            ['messages.greeting', ['name' => 'Taylor'], 'en', true],
+            $received
+        );
     }
 
-    public function testChoiceMethodProperlyUsesCustomCountReplacement(): void
+    public function testChoicePreservesCallerCountForMissingKeyCallback(): void
     {
-        $translator = $this->getMockBuilder(Translator::class)->onlyMethods(['get', 'localeForChoice'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $translator->expects($this->once())->method('get')->with($this->equalTo(':count foos'), $this->equalTo([]), $this->equalTo('en'))->willReturn('{1} :count foos|[2,*] :count foos');
-        $translator->expects($this->once())->method('localeForChoice')->with($this->equalTo(':count foos'), $this->equalTo(null))->willReturn('en');
-        $translator->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->once()->with('{1} :count foos|[2,*] :count foos', 1234, 'en')->andReturn(':count foos');
+        $translator = new Translator(new ArrayLoader, 'en');
+        $translator->setFallback('en');
+        $received = null;
+        $translator->handleMissingKeysUsing(function (string $key, array $replace) use (&$received): string {
+            $received = $replace;
 
-        $this->assertEquals('1,234 foos', $translator->choice(':count foos', 1234, ['count' => '1,234']));
+            return ':count item|:count items';
+        });
+
+        $this->assertSame('many items', $translator->choice('messages.items', 2, ['count' => 'many']));
+        $this->assertSame(['count' => 'many'], $received);
+    }
+
+    public function testChoiceUsesTheCurrentLocaleWhenNoFallbackIsConfigured(): void
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $receivedLocale = null;
+        $translator->handleMissingKeysUsing(function (string $key, array $replace, ?string $locale) use (&$receivedLocale): string {
+            $receivedLocale = $locale;
+
+            return 'apple|apples';
+        });
+
+        $this->assertSame('apples', $translator->choice('messages.apples', 2));
+        $this->assertSame('en', $receivedLocale);
+    }
+
+    public function testChoiceHandlesNumericArrayAndCountableValues(): void
+    {
+        $loader = (new ArrayLoader)->addMessages('en', 'messages', [
+            'items' => '{0} none|{1} one|[2,*] :count items',
+        ]);
+        $translator = new Translator($loader, 'en');
+
+        $this->assertSame('one', $translator->choice('messages.items', 1));
+        $this->assertSame('2 items', $translator->choice('messages.items', 2.0));
+        $this->assertSame('3 items', $translator->choice('messages.items', ['a', 'b', 'c']));
+        $this->assertSame('3 items', $translator->choice('messages.items', new Collection(['a', 'b', 'c'])));
+    }
+
+    public function testChoiceUsesTheFallbackLocaleForSelection(): void
+    {
+        $loader = (new ArrayLoader)->addMessages('fr', 'messages', [
+            'items' => '{0} aucun|{1} un|[2,*] :count éléments',
+        ]);
+        $translator = new Translator($loader, 'en');
+        $translator->setFallback('fr');
+
+        $this->assertSame('2 éléments', $translator->choice('messages.items', 2));
+    }
+
+    public function testChoiceAppliesReplacementsOnceAfterSelectingThePluralForm(): void
+    {
+        $loader = (new ArrayLoader)->addMessages('en', 'messages', [
+            'greeting' => '{1} Hello :name|[2,*] Hello :name',
+            'replacement' => '{1} :first|[2,*] :first',
+        ]);
+        $translator = new Translator($loader, 'en');
+
+        $this->assertSame(
+            'Hello Taylor | Hypervel',
+            $translator->choice('messages.greeting', 2, ['name' => 'Taylor | Hypervel'])
+        );
+        $this->assertSame(
+            ':second',
+            $translator->choice('messages.replacement', 2, ['first' => ':second', 'second' => 'replaced twice'])
+        );
     }
 
     public function testChoiceRequiresAStringTranslation(): void
@@ -764,8 +867,27 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame(1, $calls);
     }
 
+    public function testGetPassesCallerReplacementsToMissingKeyCallback(): void
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $received = null;
+        $translator->handleMissingKeysUsing(function (string $key, array $replace, ?string $locale, bool $fallback) use (&$received): string {
+            $received = [$key, $replace, $locale, $fallback];
+
+            return 'Hello :name';
+        });
+
+        $this->assertSame('Hello Taylor', $translator->get('messages.greeting', ['name' => 'Taylor'], 'fr', false));
+        $this->assertSame(
+            ['messages.greeting', ['name' => 'Taylor'], 'fr', false],
+            $received
+        );
+    }
+
     public function testFlushStateClearsMacros(): void
     {
+        new TranslationTranslatorStub(new ArrayLoader, 'en');
+        $nextTranslatorId = TranslationTranslatorStub::nextTranslatorId();
         Translator::macro('translationStaticStateProbe', static fn (): string => 'ok');
 
         $this->assertTrue(Translator::hasMacro('translationStaticStateProbe'));
@@ -773,6 +895,7 @@ class TranslationTranslatorTest extends TestCase
         Translator::flushState();
 
         $this->assertFalse(Translator::hasMacro('translationStaticStateProbe'));
+        $this->assertSame($nextTranslatorId, TranslationTranslatorStub::nextTranslatorId());
     }
 
     public function testDoubleUnderscoreHelperReturnsNullWhenKeyIsNull(): void
@@ -783,5 +906,50 @@ class TranslationTranslatorTest extends TestCase
     protected function getLoader(): Loader
     {
         return m::mock(Loader::class);
+    }
+
+    protected function missingGroupCount(?MissingTranslationGroups $missingTranslationGroups): int
+    {
+        if ($missingTranslationGroups === null) {
+            return 0;
+        }
+
+        $groups = (new ReflectionProperty(MissingTranslationGroups::class, 'groups'))
+            ->getValue($missingTranslationGroups);
+
+        return array_sum(array_map(
+            static fn (array $namespaceGroups): int => array_sum(array_map('count', $namespaceGroups)),
+            $groups
+        ));
+    }
+}
+
+class TranslationTranslatorStub extends Translator
+{
+    public function loadedGroups(): array
+    {
+        return $this->loaded;
+    }
+
+    public function missingGroups(): ?MissingTranslationGroups
+    {
+        return $this->missingTranslationGroups();
+    }
+
+    public static function nextTranslatorId(): int
+    {
+        return self::$nextTranslatorId;
+    }
+}
+
+class CountingTranslationLoader extends ArrayLoader
+{
+    public int $loadCount = 0;
+
+    public function load(string $locale, string $group, ?string $namespace = null): array
+    {
+        ++$this->loadCount;
+
+        return parent::load($locale, $group, $namespace);
     }
 }

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -386,6 +386,40 @@ class ComponentTest extends TestCase
         $this->assertSame([], $cacheA);
     }
 
+    public function testBladeViewCacheCanForgetOneInlineViewWithoutFlushingOtherVariants(): void
+    {
+        $componentA = new TestInlineViewComponentWhereRenderDependsOnProps('A');
+        $componentB = new TestInlineViewComponentWhereRenderDependsOnProps('B');
+
+        $this->viewFactory->shouldReceive('exists')->times(3)->andReturn(false);
+        $this->config->shouldReceive('string')->times(3)->with('view.compiled')->andReturn($this->compiledPath);
+        $this->viewFactory->shouldReceive('replaceNamespace')
+            ->with('__components', $this->compiledPath)
+            ->times(3);
+
+        $compiledViewNameA = '__components::9b0498cbe3839becd0d496e05c553485';
+        $compiledViewNameB = '__components::9d1b9bc4078a3e7274d3766ca02423f3';
+        $cacheAKey = hash('xxh128', sprintf('%s::%s', $componentA::class, 'A'));
+        $cacheBKey = hash('xxh128', sprintf('%s::%s', $componentB::class, 'B'));
+
+        $this->assertSame($compiledViewNameA, $componentA->resolveView());
+        $this->assertSame($compiledViewNameB, $componentB->resolveView());
+
+        $componentA::forgetBladeView('A');
+
+        $cache = (fn () => $componentA::$bladeViewCache)->call($componentA);
+        $this->assertSame([$cacheBKey => $compiledViewNameB], $cache);
+
+        $this->assertSame($compiledViewNameB, $componentB->resolveView());
+        $this->assertSame($compiledViewNameA, $componentA->resolveView());
+
+        $cache = (fn () => $componentA::$bladeViewCache)->call($componentA);
+        $this->assertSame([
+            $cacheBKey => $compiledViewNameB,
+            $cacheAKey => $compiledViewNameA,
+        ], $cache);
+    }
+
     public function testFactoryGetsSharedBetweenComponents()
     {
         $regular = new TestRegularViewNameViewComponent;

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypervel\Tests\View;
 
 use Hypervel\Context\CoroutineContext;
+use Hypervel\Contracts\Filesystem\FileNotFoundException;
 use Hypervel\Engine\Channel;
 use Hypervel\Filesystem\Filesystem;
 use Hypervel\Testing\ParallelTesting;
@@ -41,6 +42,38 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__ . '/' . hash('xxh128', 'v3foo') . '.php')->andReturn(true);
         $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(100);
         $files->shouldReceive('lastModified')->once()->with(__DIR__ . '/' . hash('xxh128', 'v3foo') . '.php')->andReturn(0);
+        $this->assertTrue($compiler->isExpired('foo'));
+    }
+
+    public function testIsExpiredReturnsTrueWhenSourceFileDoesntExist(): void
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiled = __DIR__ . '/' . hash('xxh128', 'v3foo') . '.php';
+        $files->shouldReceive('exists')->once()->with($compiled)->andReturn(true);
+        $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(false);
+
+        $this->assertTrue($compiler->isExpired('foo'));
+    }
+
+    public function testIsExpiredReturnsTrueWhenCompiledFileDisappearsBeforeTimestampRead(): void
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiled = __DIR__ . '/' . hash('xxh128', 'v3foo') . '.php';
+        $files->shouldReceive('exists')->once()->with($compiled)->andReturn(true);
+        $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(100);
+        $files->shouldReceive('lastModified')->once()->with($compiled)->andReturn(false);
+
+        $this->assertTrue($compiler->isExpired('foo'));
+    }
+
+    public function testIsExpiredReturnsTrueWhenModificationTimesAreEqual(): void
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiled = __DIR__ . '/' . hash('xxh128', 'v3foo') . '.php';
+        $files->shouldReceive('exists')->once()->with($compiled)->andReturn(true);
+        $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(100);
+        $files->shouldReceive('lastModified')->once()->with($compiled)->andReturn(100);
+
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
@@ -82,6 +115,17 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->compile('foo');
     }
 
+    public function testCompileMissingSourceThrowsPreciseFilesystemException(): void
+    {
+        $source = ParallelTesting::tempDir('ViewBladeCompilerMissingSource') . '/missing.blade.php';
+        $compiler = new BladeCompiler(new Filesystem, __DIR__);
+
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage("File does not exist at path {$source}.");
+
+        $compiler->compile($source);
+    }
+
     public function testCompileCompilesFileAndReturnsContentsCreatingDirectory(): void
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
@@ -117,6 +161,45 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('lastModified')->once()->with($compiledPath)->andReturn(200);
         $files->shouldReceive('replace')->never();
         $compiler->compile('foo');
+    }
+
+    #[DataProvider('missingFileDuringTimestampReadProvider')]
+    public function testCompileHandlesFilesDisappearingBeforeTimestampRead(
+        int|false $sourceModified,
+        int|false $compiledModified,
+        bool $shouldRepublish
+    ): void {
+        $compiledPath = __DIR__ . '/' . hash('xxh128', 'v3foo') . '.php';
+        $contents = 'Hello World<?php /**PATH foo ENDPATH**/ ?>';
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
+        $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
+        $files->shouldReceive('exists')->once()->with($compiledPath)->andReturn(true);
+        $files->shouldReceive('hash')->once()->with($compiledPath, 'xxh128')->andReturn(hash('xxh128', $contents));
+        $files->shouldReceive('lastModified')->once()->with('foo')->andReturn($sourceModified);
+        $files->shouldReceive('lastModified')->once()->with($compiledPath)->andReturn($compiledModified);
+
+        $replaceExpectation = $files->shouldReceive('replace')->with($compiledPath, $contents);
+
+        if ($shouldRepublish) {
+            $replaceExpectation->once();
+        } else {
+            $replaceExpectation->never();
+        }
+
+        $compiler->compile('foo');
+    }
+
+    /**
+     * Provide file timestamps for compile races.
+     */
+    public static function missingFileDuringTimestampReadProvider(): array
+    {
+        return [
+            'source disappeared' => [false, 200, false],
+            'compiled file disappeared' => [100, false, true],
+            'source and compiled file disappeared' => [false, false, true],
+        ];
     }
 
     public function testCompileRefreshesCacheTimestampIfUnchangedButExpired(): void

--- a/tests/View/ViewEngineTest.php
+++ b/tests/View/ViewEngineTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\View;
+
+use Hypervel\Tests\TestCase;
+use Hypervel\View\Engines\Engine;
+
+class ViewEngineTest extends TestCase
+{
+    public function testLastRenderedIsNullUntilAViewIsRecorded(): void
+    {
+        $engine = new class extends Engine {
+            public function record(string $path): void
+            {
+                $this->lastRendered = $path;
+            }
+        };
+
+        $this->assertNull($engine->getLastRendered());
+
+        $engine->record('/views/welcome.php');
+
+        $this->assertSame('/views/welcome.php', $engine->getLastRendered());
+    }
+}

--- a/tests/View/ViewExceptionTest.php
+++ b/tests/View/ViewExceptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\View;
+
+use Exception;
+use Hypervel\Contracts\Support\Responsable;
+use Hypervel\Contracts\View\View as ViewContract;
+use Hypervel\Http\Request;
+use Hypervel\Http\Response;
+use Hypervel\Tests\TestCase;
+use Hypervel\View\ViewException;
+use Mockery as m;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class ViewExceptionTest extends TestCase
+{
+    public function testRenderForwardsThePreviousExceptionResult(): void
+    {
+        $request = Request::create('/');
+        $view = m::mock(ViewContract::class);
+        $responsable = new ViewExceptionResponsable;
+        $response = new Response('hypervel');
+        $symfonyResponse = new SymfonyResponse('symfony');
+
+        foreach (['rendered', ['message' => 'rendered'], $view, $responsable, $response, $symfonyResponse, false, null] as $result) {
+            $exception = $this->viewException(new RenderableViewExceptionPrevious($result));
+
+            $this->assertSame($result, $exception->render($request));
+        }
+    }
+
+    public function testRenderReturnsNullWhenThePreviousExceptionCannotRender(): void
+    {
+        $this->assertNull($this->viewException(new Exception)->render(Request::create('/')));
+    }
+
+    public function testReportForwardsThePreviousExceptionResult(): void
+    {
+        foreach ([true, false, null] as $result) {
+            $this->assertSame(
+                $result,
+                $this->viewException(new ReportableViewExceptionPrevious($result))->report()
+            );
+        }
+    }
+
+    public function testReportReturnsFalseWhenThePreviousExceptionCannotReport(): void
+    {
+        $this->assertFalse($this->viewException(new Exception)->report());
+    }
+
+    protected function viewException(Exception $previous): ViewException
+    {
+        return new ViewException('View failed.', 0, E_ERROR, __FILE__, __LINE__, $previous);
+    }
+}
+
+class RenderableViewExceptionPrevious extends Exception
+{
+    public function __construct(protected mixed $result)
+    {
+        parent::__construct();
+    }
+
+    public function render(Request $request): mixed
+    {
+        return $this->result;
+    }
+}
+
+class ReportableViewExceptionPrevious extends Exception
+{
+    public function __construct(protected ?bool $result)
+    {
+        parent::__construct();
+    }
+
+    public function report(): ?bool
+    {
+        return $this->result;
+    }
+}
+
+class ViewExceptionResponsable implements Responsable
+{
+    public function toResponse(Request $request): SymfonyResponse
+    {
+        return new SymfonyResponse;
+    }
+}


### PR DESCRIPTION
## Summary

This fixes worker-lifetime state retention in translation and inline view rendering. It also closes the related pluralization, cache invalidation, compiler race, and type issues found while tracing those lifecycles.

The public Laravel-shaped APIs remain intact. Positive translation groups and stable inline templates keep their worker-level cache paths, while request-derived misses and explicit deletion now have the correct ownership.

## Translation

`NamespacedItemResolver` no longer retains every parsed key automatically. Explicitly seeded parsed keys still use the existing fast path, but arbitrary validation and translation keys can no longer grow a worker-lifetime map.

The Translator now keeps successful groups in its shared cache and stores empty loader results only for the current execution. The execution state is isolated per Translator, copied safely into child coroutines, and discarded with the execution. This allows later requests to discover translation files that were missing earlier without repeatedly loading the same missing group within one request.

`choice()` now keeps lookup substitutions separate from missing-key callback input. Plural selection happens before caller replacements, automatic `count` is applied afterward, and an unset fallback uses the current locale instead of probing an empty locale or selecting the wrong implicit plural form.

## Views

Inline Blade views retain content-addressed reuse for stable templates. `deleteCachedView` now forgets only the exact anonymous view mapping, so subsequent renders can recreate the source without clearing unrelated reflection, finder, or compiler caches.

`Blade::render()` now treats its input strictly as raw Blade source. A literal template that matches an application view name no longer renders or deletes that application view.

`view:clear` invalidates Component and compiler worker caches after deletion attempts, including failure paths. This keeps in-process cache state aligned with the files it removed while leaving cross-process reload ownership unchanged.

Compiler timestamp checks now handle `filemtime()` failures explicitly. Missing sources and compiled files are treated as expired, and an unchanged compiled file removed during a concurrent clear is atomically republished instead of being recreated as an empty file by `touch()`.

`ViewException::render()` forwards the full result shape accepted by the exception handler and router. The base view engine also exposes its real nullable initial rendered path.

## Performance and compatibility

No request-time filesystem polling, arbitrary cache limit, background cleanup, or cross-process coordination was added. Warm positive translations and warm inline views retain their existing fast paths. The only extra translation work is a small execution-context miss lookup after the positive cache check.

No public Laravel APIs were removed or renamed. Normal Components still support returning named views, while the private component used by `Blade::render()` follows that method's documented raw-source contract.

The Blade documentation now recommends stable inline templates with changing values passed as data or slots. The completed findings were removed from the master audit plan and are captured in the dedicated implementation plan.

## Verification

`composer fix` passes, including formatting, static analysis, the parallel test suite, Testbench, and the package dogfood checks. Focused translation, view, exception-pipeline, and cache-lifecycle coverage also passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved translation fallback, pluralization, replacement handling, and missing-key callback behavior.
  - Prevented stale or unbounded translation and inline view cache entries.
  - Improved Blade recompilation when source or compiled files are missing or changed.
  - Ensured `view:clear` fully resets relevant inline and compiled view caches.
  - Improved view exception handling and support for varied rendered response types.
- **Documentation**
  - Added guidance to keep inline Blade templates stable to avoid unnecessary stored artifacts.
- **Tests**
  - Expanded coverage for translation isolation, cache invalidation, compilation edge cases, and exception rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->