### PR TITLE
Fix correctness issues across existing packages

### DIFF
--- a/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
+++ b/docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md
@@ -1,6 +1,6 @@
 # Hypervel Components 0.4 Audit Remediation Plan
 
-Status: Signed off by `claude-fixes` on 2026-08-22; ready for implementation
+Status: Findings #21, #23, #26, #30–32, #34–35, and #82 are implemented in a separate slice; #160 (Vonage channel port plus Horizon wiring) is the only remaining work
 
 ## Objective
 
@@ -28,25 +28,6 @@ Resolve every genuine issue retained in this master plan against the current 0.4
 
 Each row is an implementation requirement. Test names are descriptive; use the repository's established test file for that component or create the narrowly corresponding file.
 
-### Mail, notifications, collections, and support
-
-| ID | Proposed implementation | Required tests |
-|---:|---|---|
-| 21 | Widen Mailable metadata values and storage shapes to int\|string\|null, matching Envelope. Cast consistently only where a downstream header API requires a string. | Integer and string metadata through send, render, and assertion helpers; null/absent metadata; strict-types regression. |
-| 23 | In hasEnvelopeAttachment, call attachments only when the mailable defines it; otherwise use an empty list. | Envelope-only mailable, mailable that also defines attachments, attachment match/no-match, and no method fatal. |
-| 26 | Keep AnonymousNotifiable::getKey returning null for Laravel fake/assertion parity, but make BroadcastNotificationCreated throw a descriptive exception when no explicit broadcast route exists instead of constructing a trailing-dot private channel. | Anonymous broadcast without route fails loudly; explicit broadcast route works; normal model notifiable fallback unchanged; getKey remains null. |
-| 30 | Add symfony/polyfill-php86 as a direct collections dependency because SortDirection is used by that split package. | Package metadata assertion and a standalone collections install/autoload smoke test without database. |
-| 31 | Cast the single-item Arr::join result to string, matching the multi-item path and native return type. | One integer, float, stringable object, string, and multi-item list. |
-| 32 | Use first() when guessing a resource collection class instead of reading items[0]. | keyBy, filtered/gapped keys, ordinary list, empty collection failure, and paginator/resource conversion. |
-| 34 | Port current Laravel's array-capable multibyte Str::substrReplace implementation, including array offset/length/replacement behavior and key preservation. Correct the scalar negative-length calculation as part of the port: the current Str::substrReplace('Hello', 'X', 2, -1) produces HeXello instead of HeXo. | Scalar parity including the explicit negative-length example; arrays with scalar and array replacements; offset/length arrays; associative keys; negative offsets and lengths; multibyte strings; mismatched replacement lengths. |
-| 35 | For built-in UUID/ULID codecs, identify binary values by the unambiguous 16-byte storage length and validate textual 36/26-byte forms separately. Leave the generic public BinaryCodec heuristic available to custom codecs. Runtime sampling confirmed that roughly one in sixteen thousand random v4-shaped UUID payloads can be valid UTF-8 and NUL-free, so this is ordinary data loss at scale rather than a purely theoretical collision. | Deterministic valid-UTF-8, NUL-free 16-byte UUID/ULID payloads round-trip through casts and database bindings; a fixed previously misclassified v4 payload; textual forms; invalid lengths; custom codec behavior unchanged. |
-
-### Database, image, and pagination
-
-| ID | Proposed implementation | Required tests |
-|---:|---|---|
-| 82 | Apply incrementEach's strict string-column and numeric-amount validation to decrementEach before constructing raw SQL. | Malicious SQL fragment and nonnumeric amount rejected before query; non-string/associative shape failures; valid ints, floats, and numeric strings update correctly. |
-
 ### Vonage notifications and Horizon
 
 | ID | Proposed implementation | Required tests |
@@ -55,10 +36,9 @@ Each row is an implementation requirement. Test names are descriptive; use the r
 
 ## Commit and dependency structure
 
-Use package-sized commits that remain reviewable and bisectable. The following order avoids building fixes on obsolete primitives:
+Use package-sized commits that remain reviewable and bisectable:
 
-1. Mail, notifications, and data representation: 21, 23, 26, 30-32, 34-35, 82.
-2. Vonage notification channel port followed by Horizon wiring: 160.
+1. Vonage notification channel port followed by Horizon wiring: 160.
 
 Do not combine unrelated packages merely because their findings have the same severity.
 

--- a/docs/plans/2026-09-02-0457-components-existing-package-correctness-remediation-plan.md
+++ b/docs/plans/2026-09-02-0457-components-existing-package-correctness-remediation-plan.md
@@ -1,6 +1,6 @@
 # Existing-Package Correctness Remediation Plan
 
-Status: Implementation, repository checks, and code review complete; ready to commit and open a pull request
+Status: Complete; pull request open with all follow-up corrections
 
 ## Objective
 
@@ -174,7 +174,7 @@ Extend `tests/Notifications/NotificationBroadcastChannelTest.php` to cover:
 
 - anonymous notification without an explicit or notification-defined channel throws the exact `LogicException`;
 - explicit anonymous `broadcast` route works;
-- `receivesBroadcastNotificationsOn()` still wins;
+- `receivesBroadcastNotificationsOn()` derives its expected channel from the event's own notification instance, proving exact forwarding as well as precedence;
 - an ordinary keyed notifiable retains the class-and-key fallback.
 
 Keep the existing `AnonymousNotifiable::getKey()` null assertion in `NotificationRoutesNotificationsTest`. Do not add a queued-broadcast integration test: serialization leaves the anonymous routes unchanged, so queueing changes only when this exact method executes and would otherwise retest unrelated queue/broadcast infrastructure.
@@ -246,6 +246,7 @@ Port the current Laravel default-branch implementation while preserving Hypervel
 
 - Delegate scalar-subject/array-offset-or-length combinations to native `substr_replace()` so PHP retains its native error behavior.
 - Use a local multibyte replacement closure whose suffix is `mb_substr(mb_substr($string, $offset), $length)`.
+- Type the closure's `$string`, `$offset`, `$length`, and return natively. Invalid inner values already fail inside strict `mb_substr()`, so these types move the same failure to the owning closure. Leave `$replace` untyped: typing it would reject numeric and `Stringable` array elements accepted by weak-mode scalar calls, creating a new scalar/array mismatch.
 - Normalize replacement, offset, and length arrays with `array_values()` so they are consumed positionally.
 - Preserve every original subject key in the result.
 - Use Laravel's defaults for missing positional replacement (`''`), offset (`0`), and length (`null`).

--- a/docs/plans/2026-09-02-0457-components-existing-package-correctness-remediation-plan.md
+++ b/docs/plans/2026-09-02-0457-components-existing-package-correctness-remediation-plan.md
@@ -1,0 +1,420 @@
+# Existing-Package Correctness Remediation Plan
+
+Status: Implementation, repository checks, and code review complete; ready to commit and open a pull request
+
+## Objective
+
+Resolve audit findings #21, #23, #26, #30–32, #34–35, and #82 against the current `0.4` branch. The work spans mail and notification metadata, declared attachments, anonymous broadcast routing, Collections package metadata, `Arr::join()`, resource collection guessing, multibyte substring replacement, identifier codecs, and `decrementEach()` validation.
+
+These are framework bug fixes and one missing split-package dependency. Preserve Laravel's public API where it is correct, port current Laravel source and tests where applicable, and fix verified upstream defects locally rather than copying them. Do not add compatibility shims, new abstractions, worker-lifetime state, or defensive behavior for unsupported calls.
+
+## Confirmed baseline
+
+- The branch was created from `0.4`, including the clarified dependency-ownership rule in `AGENTS.md`.
+- Current Laravel reference code is under `examples/laravel/framework` on its checked-out default branch.
+- Finding #35 is already complete in `0.4`: built-in UUID and ULID codecs classify the unambiguous 16-byte representation by length before the generic content heuristic, while custom codecs retain the public `BinaryCodec::isBinary()` behavior. Existing unit and database-binding coverage includes UTF-8-safe, NUL-free binary identifiers. This slice will verify that state but will not reimplement it.
+- No related `docs/todo.md` item belongs in this slice. The Foundation/Testing dependency cycle is an architectural change, and the GMP identifier-conversion investigation is a separate measured optimization proposal.
+
+## Design decisions
+
+### 1. Mail and notification metadata (#21)
+
+#### Problem
+
+`Envelope` accepts integer metadata and compares its wire-equivalent values as strings. `Mailable::metadata()` and `assertHasMetadata()` still narrow scalar values to strings, while direct mailable metadata uses strict unnormalized comparison. The same strict-types mismatch exists in `MailMessage`; passing an integer through `MailChannel` reaches Symfony's string-only `MetadataHeader` constructor unchanged.
+
+The two adjacent mailable assertion helpers also retain older failure messages that omit actual values. Laravel's current messages provide useful expected/actual output, but Laravel needlessly invokes the user-defined `envelope()` method again after `renderForAssertions()` has already hydrated envelope tags and metadata into the mailable.
+
+#### Implementation
+
+In `src/mail/src/Mailable.php`:
+
+- Document `$metadata` as `array<string, int|string|null>`.
+- Widen only the scalar value of `metadata()` to `int|string|null`; retain `null` as the overload's existing default for array-form calls.
+- Keep `hasMetadata()` at `int|string`. Continue using `isset()` so null entries do not become matchable values, and compare the stored and requested values after string normalization, matching `Envelope::hasMetadata()` and the emitted header representation.
+- Widen `assertHasMetadata()` to `int|string`.
+- Port Laravel's expected/actual diagnostics for `assertHasMetadata()` and `assertHasTag()`, but derive actual values from the already-hydrated `$this->metadata` and `$this->tags` arrays. This avoids an extra invocation of arbitrary application `envelope()` code solely to format a failure.
+- Use strict tag membership checks so numeric-looking strings such as `01` and `1` remain distinct.
+- Keep the existing cast in `buildMetadata()`, which is the Symfony header boundary. Do not filter nulls or add a guard for a scalar call that omits its value.
+
+Use strict named-key membership in `SesV2Transport::listManagementOptions()` as the adjacent mail-package comparison cleanup. The parsed named keys are strings, so this changes no supported behavior.
+
+Representative shape:
+
+```php
+/** @var array<string, int|string|null> */
+protected array $metadata = [];
+
+public function metadata(array|string $key, int|string|null $value = null): static
+{
+    // Existing array/scalar storage logic stays unchanged.
+}
+
+public function hasMetadata(string $key, int|string $value): bool
+{
+    return (isset($this->metadata[$key])
+            && (string) $this->metadata[$key] === (string) $value)
+        || (method_exists($this, 'envelope')
+            && $this->envelope()->hasMetadata($key, $value));
+}
+```
+
+In `src/notifications/src/Messages/MailMessage.php` and `src/notifications/src/Channels/MailChannel.php`:
+
+- Document notification metadata as `array<string, int|string>`.
+- Widen `MailMessage::metadata()` to `int|string`.
+- Cast each metadata value only when constructing `MetadataHeader`.
+
+These changes widen accepted valid input and preserve all existing string behavior. String normalization is constant-time and header casting occurs only while a message is being built.
+
+#### Tests
+
+- Extend `tests/Mail/MailMailableTest.php` with integer metadata supplied directly, in an array, and through an `Envelope`; verify rendering/sending, string-equivalent lookup, absent/null lookup behavior, integer assertions, missing and mismatched metadata diagnostics, empty and populated tag diagnostics, and strict numeric-looking tag comparison. Update the existing exact-message assertions in `testMailableMetadataGetsSent()` and `testMailableTagGetsSent()` rather than leaving their resulting failures unexplained.
+- Use the hydrated arrays in the diagnostic implementation and prove failure-message formatting does not invoke `envelope()`. Use a fresh envelope-backed mailable and exactly one failing assertion in this focused case: hydration contributes one call and the failed `hasMetadata()` or `hasTag()` predicate contributes its existing fallback call, for two calls in total and never a third call to build the message.
+- Extend `tests/Notifications/NotificationMailMessageTest.php` to prove integer metadata is retained without coercion before delivery.
+- Add the Hypervel-specific `tests/Notifications/NotificationMailChannelTest.php` at the channel boundary. Prove integer metadata becomes a valid string-valued Symfony header rather than raising a strict-types `TypeError`, and cover the adjacent tag-header loop in the same focused test file. Laravel has no corresponding channel test to port.
+
+### 2. Declared attachment lookup and resolver-time equivalence (#23 plus adjacent defect)
+
+#### Problem
+
+`Mailable::hasEnvelopeAttachment()` guards on `envelope()` but unconditionally calls `attachments()`. An envelope-only mailable therefore fails with an undefined-method error, while an attachments-only mailable is skipped and reports a false negative. Current Laravel has the same incorrect guard. The helper name also describes the old guard rather than the behavior it owns.
+
+Investigation exposed a second correctness defect in `Attachment::isEquivalent()`, shared by current Laravel. It snapshots the comparison attachment's `as` and `mime` values before either resolver runs. `fromStorage()`, `fromStorageDisk()`, and `fromUploadedFile()` populate those values during resolution, so two identical late-resolving attachments compare unequal. The documented `hasAttachment(Attachment::fromStorageDisk(...))` path therefore returns false.
+
+#### Implementation
+
+In `src/mail/src/Mailable.php`:
+
+- Rename the private helper to `hasDeclaredAttachment()`.
+- Guard only on `method_exists($this, 'attachments')`.
+- Preserve the existing `Attachable` conversion, object/list normalization, equivalence check, and fallback to legacy hydrated attachments.
+
+```php
+private function hasDeclaredAttachment(Attachment $attachment, array $options = []): bool
+{
+    if (! method_exists($this, 'attachments')) {
+        return false;
+    }
+
+    $attachments = $this->attachments();
+
+    return Collection::make(is_object($attachments) ? [$attachments] : $attachments)
+        ->map(fn ($attached) => $attached instanceof Attachable
+            ? $attached->toMailAttachment()
+            : $attached)
+        ->contains(fn ($attached) => $attached->isEquivalent($attachment, $options));
+}
+```
+
+In `src/mail/src/Attachment.php`:
+
+- Remove the early `with()` snapshot and its now-unused function import.
+- Build each side's two-key comparison metadata inside that attachment's existing resolver callbacks, after any resolver-owned metadata mutation.
+- Preserve caller-supplied `$options` precedence on the comparison attachment.
+- Resolve each attachment exactly once; do not introduce a normalized value object or another abstraction.
+
+```php
+return $this->attachWith(
+    fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
+    fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
+) === $attachment->attachWith(
+    fn ($path) => [$path, [
+        'as' => $options['as'] ?? $attachment->as,
+        'mime' => $options['mime'] ?? $attachment->mime,
+    ]],
+    fn ($data) => [$data(), [
+        'as' => $options['as'] ?? $attachment->as,
+        'mime' => $options['mime'] ?? $attachment->mime,
+    ]],
+);
+```
+
+Checking a declared data or storage attachment evaluates its resolver. That is required to compare its content and late-resolved metadata, and matches the cost already paid by Laravel and by envelope-style declared attachments. No I/O is added to unrelated mail operations.
+
+`Hypervel\Mail\Mailables\Attachment` remains the existing namespace-consistency subclass of `Hypervel\Mail\Attachment`; no documentation or stub correction is needed.
+
+#### Tests
+
+- In `tests/Mail/MailMailableTest.php`, cover an envelope-only mailable without `attachments()` and an attachments-only mailable whose storage attachment matches before rendering; include a non-match. Retain the existing both-method/data-attachment coverage rather than duplicating path/data variants.
+- In `tests/Mail/AttachmentTest.php`, prove equivalence for two identical `fromStorageDisk()` attachments and for two distinct `fromUploadedFile()` attachments created from the same `Hypervel\Http\Testing\File::createWithContent('example.pdf', 'content')->mimeType('application/pdf')` instance, matching the deterministic fixture already used in `AttachableTest`. These are the two public factory paths whose metadata is populated during resolution; existing path/data tests cannot expose the defect.
+- Bind the existing filesystem contracts and assert the real resolver operations. Do not create a second storage fixture system.
+
+### 3. Anonymous broadcast routing (#26)
+
+#### Problem
+
+When an on-demand notification has neither an explicit `broadcast` route nor a notification-defined channel, `BroadcastNotificationCreated::channelName()` falls back to the notifiable class and `getKey()`. `AnonymousNotifiable::getKey()` correctly returns null for notification fake/assertion compatibility, so the fallback silently constructs a malformed trailing-dot private channel.
+
+#### Implementation
+
+Keep route resolution at its current owner:
+
+1. `broadcastOn()` continues to honor an explicit anonymous broadcast route.
+2. A non-empty notification `broadcastOn()` result continues to win.
+3. `channelName()` continues to honor `receivesBroadcastNotificationsOn()` before fallback.
+4. Only when the remaining fallback notifiable is `AnonymousNotifiable`, throw `LogicException` with an actionable message requiring an explicit broadcast route or a notification-defined broadcast channel.
+5. Preserve ordinary model/class fallback behavior, including unsaved models with null keys. Do not generalize the guard.
+
+Document the new `LogicException` on the protected `channelName()` method that owns it.
+
+```php
+if ($this->notifiable instanceof AnonymousNotifiable) {
+    throw new LogicException(
+        'Anonymous notifiables must define an explicit broadcast route or the notification must define a broadcast channel.'
+    );
+}
+```
+
+For asynchronously handled broadcasts, this configuration error is reported by the worker when it resolves the channel rather than by the initiating request. Moving the check earlier would duplicate route and notification-channel resolution.
+
+#### Tests
+
+Extend `tests/Notifications/NotificationBroadcastChannelTest.php` to cover:
+
+- anonymous notification without an explicit or notification-defined channel throws the exact `LogicException`;
+- explicit anonymous `broadcast` route works;
+- `receivesBroadcastNotificationsOn()` still wins;
+- an ordinary keyed notifiable retains the class-and-key fallback.
+
+Keep the existing `AnonymousNotifiable::getKey()` null assertion in `NotificationRoutesNotificationsTest`. Do not add a queued-broadcast integration test: serialization leaves the anonymous routes unchanged, so queueing changes only when this exact method executes and would otherwise retest unrelated queue/broadcast infrastructure.
+
+### 4. Collections PHP 8.6 polyfill dependency (#30)
+
+#### Problem
+
+The Collections split package directly uses PHP 8.6's global `SortDirection` enum while supporting PHP 8.4. The monorepo root and Database package require `symfony/polyfill-php86`, but `hypervel/collections` does not, and none of its existing requirements guarantees the enum. A standalone supported Collections installation can therefore fail while loading or using sorting APIs.
+
+#### Implementation
+
+- Add `"symfony/polyfill-php86": "^1.36"` to `src/collections/composer.json`.
+- Do not add a PHP 8.5 polyfill sweep to downstream packages: every identified consumer already requires Collections, which guarantees the functions it uses.
+- Do not remove existing redundant declarations elsewhere; only repair the proven standalone installation gap.
+
+#### Tests and verification
+
+- Extend `tests/Support/PackageMetadataTest.php`, whose namespace already owns Support and Collections tests, to compare both Collections polyfill constraints with the root manifest. Widen the method description so it accurately covers both packages.
+- Before editing the manifest, use an isolated temporary directory and Composer path repository with no monorepo autoloading to record that the current Collections package fails to provide `SortDirection`. After adding the dependency, repeat the same install and execute a sorting call using `SortDirection` successfully. This is a one-off discriminating verification step, not a network-dependent PHPUnit test.
+
+### 5. `Arr::join()` one-item return type (#31)
+
+#### Problem and implementation
+
+With a non-empty final glue and exactly one item, `Arr::join()` returns the raw item despite its native `string` return type. Numeric and stringable values can therefore raise a `TypeError`, unlike the `implode()` and multi-item paths. Current Laravel retains the same raw return against its documented string result; Hypervel should fix the underlying defect rather than copy it.
+
+Cast only the one-item result:
+
+```php
+if (count($array) === 1) {
+    return (string) array_last($array);
+}
+```
+
+This preserves strings byte-for-byte and applies the same normal PHP string conversion already used by adjacent join paths.
+
+#### Tests
+
+Extend `tests/Support/SupportArrTest.php` with one-item integer, float, stringable object, and string cases, while retaining the existing empty and multi-item cases.
+
+### 6. Resource collection guessing with preserved keys (#32)
+
+#### Problem and implementation
+
+`TransformsToResourceCollection::guessResourceCollection()` reads `$this->items[0]`, so a valid collection keyed by an identifier has no index zero and fails as if it contained no model. Read the first value through the collection API instead:
+
+```php
+$model = $this->first();
+```
+
+Remove the nearby inaccurate `class-string<Model>` assertion, the now-unused `Model` import, and the resulting `function.alreadyNarrowedType` suppression; the natural `is_object()` plus `method_exists()` control flow analyzes cleanly. Normalize the `toResourceCollection()` parameter docblock to the already-imported short `JsonResource` name. Do not add an interface, callable wrapper, or runtime guard solely for static analysis.
+
+#### Tests
+
+- Add one keyed Eloquent collection case to `tests/Support/Traits/TransformsToResourceCollectionTest.php`.
+- Add symmetric keyed-item cases to `tests/Pagination/PaginatorResourceTest.php` and `tests/Pagination/CursorResourceTest.php`.
+- Retain existing ordinary-list, empty, non-object, missing-resource, and explicit-resource coverage. Do not add a second keyed base-Support case because Eloquent Collection inherits the same `first()` and trait implementation unchanged.
+
+### 7. Multibyte `Str::substrReplace()` parity (#34)
+
+#### Problem
+
+Hypervel's simplified scalar implementation cannot accept its declared array forms and computes the suffix as `mb_substr($string, $offset + $length)`. That calculation is wrong for negative lengths; for example, replacing at offset 2 with length -1 inserts before the wrong suffix. Current Laravel has the complete array-capable implementation and uses a nested multibyte substring to match native negative offset/length semantics without byte corruption.
+
+#### Implementation
+
+Port the current Laravel default-branch implementation while preserving Hypervel's native signature and formatting:
+
+- Delegate scalar-subject/array-offset-or-length combinations to native `substr_replace()` so PHP retains its native error behavior.
+- Use a local multibyte replacement closure whose suffix is `mb_substr(mb_substr($string, $offset), $length)`.
+- Normalize replacement, offset, and length arrays with `array_values()` so they are consumed positionally.
+- Preserve every original subject key in the result.
+- Use Laravel's defaults for missing positional replacement (`''`), offset (`0`), and length (`null`).
+
+Do not replace this with native `substr_replace()` generally; that function is byte-based and corrupts multibyte offsets.
+
+#### Tests
+
+Port the current Laravel cases into `tests/Support/SupportStrTest.php`, adapted only for Hypervel strings and typing:
+
+- negative offsets and negative lengths;
+- multibyte scalar input;
+- scalar and array replacements;
+- array offset/length inputs;
+- associative subject keys and positionally keyed option arrays;
+- mismatched replacement/offset/length lengths;
+- scalar subjects with array offset or length raising native `TypeError`.
+
+Retain all existing Hypervel assertions. Run `tests/Support/SupportStringableTest.php` as wrapper coverage; no Stringable source change or duplicate array matrix is needed because Stringable delegates directly to `Str::substrReplace()` and owns only scalar string state.
+
+### 8. UUID/ULID binary handling (#35)
+
+No files change. Re-run the focused `SupportBinaryCodecTest` and existing database binary-binding coverage to confirm the completed implementation remains green. The generic public binary-content heuristic remains available to custom codecs; built-in UUID/ULID routing continues to use exact 16-byte storage length.
+
+### 9. `decrementEach()` validation (#82)
+
+#### Problem and implementation
+
+Base `Query\Builder::incrementEach()` validates every amount before interpolating it into a raw arithmetic expression and rejects numeric array keys. `decrementEach()` interpolates without either guard. A nonnumeric amount can therefore reach raw SQL construction, and the two paired APIs accept different shapes.
+
+Mirror the two local checks with decrement-specific wording before constructing each expression:
+
+```php
+foreach ($columns as $column => $amount) {
+    if (! is_numeric($amount)) {
+        throw new InvalidArgumentException(
+            "Non-numeric value passed as decrement amount for column: '{$column}'."
+        );
+    }
+
+    if (! is_string($column)) {
+        throw new InvalidArgumentException(
+            'Non-associative array passed to decrementEach method.'
+        );
+    }
+
+    $columns[$column] = $this->raw("{$this->grammar->wrap($column)} - {$amount}");
+}
+```
+
+Keep the checks local. A shared validator would add indirection to two short loops whose operation names and error messages differ. Eloquent Builder and Model already forward to this base method, so they need no production changes.
+
+#### Tests
+
+- Extend `tests/Database/DatabaseQueryBuilderTest.php` with decrement-specific nonnumeric/malicious amount and numeric-key failures using the same bare-builder shape as the adjacent increment validation tests. The unconfigured connection already proves validation occurs before update execution; do not add mock expectations. Give the two new tests and the two adjacent increment tests explicit `: void` return types without sweeping the rest of this legacy test file.
+- Extend the existing `tests/Integration/Database/QueryBuilderTest.php` accounting scenario with valid decrement values covering integer, float, and numeric-string input without creating another schema fixture. Remove that scenario's arbitrary `string('name', 20)` test-only length while touching the schema, matching the repository's normal semantic-column rule.
+- Retain existing Eloquent Builder and Model forwarding tests. Do not repeat the same validation at every forwarding layer; the base builder is the single owner.
+
+## Documentation and compatibility
+
+- No package README or `src/docs/porting-from-laravel.md` entry is warranted. These changes repair bugs, align existing accepted values, or restore a missing dependency; they do not create a lasting Laravel migration difference.
+- Do not change `AnonymousNotifiable::getKey()`, add attachment-resolution configuration, or expose new public helper APIs.
+- The deliberate structural improvements over current Laravel are limited to using already-hydrated mailable state for assertion diagnostics and fixing resolver-time attachment equivalence. Both preserve the public contract while avoiding an unnecessary callback and a verified false negative.
+
+## Expected file changes
+
+Production and metadata:
+
+- `src/mail/src/Attachment.php`
+- `src/mail/src/Mailable.php`
+- `src/mail/src/Transport/SesV2Transport.php`
+- `src/notifications/src/Channels/MailChannel.php`
+- `src/notifications/src/Events/BroadcastNotificationCreated.php`
+- `src/notifications/src/Messages/MailMessage.php`
+- `src/collections/composer.json`
+- `src/collections/src/Arr.php`
+- `src/collections/src/Traits/TransformsToResourceCollection.php`
+- `src/support/src/Str.php`
+- `src/database/src/Query/Builder.php`
+
+Remediation ledger:
+
+- `docs/plans/2026-08-22-0604-components-04-audit-remediation-plan-codex.md`
+
+Tests:
+
+- `tests/Mail/AttachmentTest.php`
+- `tests/Mail/MailMailableTest.php`
+- `tests/Notifications/NotificationBroadcastChannelTest.php`
+- `tests/Notifications/NotificationMailChannelTest.php` (new)
+- `tests/Notifications/NotificationMailMessageTest.php`
+- `tests/Support/PackageMetadataTest.php`
+- `tests/Support/SupportArrTest.php`
+- `tests/Support/SupportStrTest.php`
+- `tests/Support/Traits/TransformsToResourceCollectionTest.php`
+- `tests/Pagination/PaginatorResourceTest.php`
+- `tests/Pagination/CursorResourceTest.php`
+- `tests/Database/DatabaseQueryBuilderTest.php`
+- `tests/Integration/Database/QueryBuilderTest.php`
+
+No user-facing documentation changes. This plan and the master remediation ledger are the only documentation files; finding #35 should produce no source or test diff.
+
+## Implementation order
+
+1. Correct mailable/notification metadata types, header conversion, diagnostics, and focused tests.
+2. Correct declared attachment discovery and resolver-time equivalence, then run mail tests.
+3. Add the anonymous broadcast fallback error and routing tests.
+4. Repair Collections package metadata and perform the standalone installation smoke test.
+5. Correct `Arr::join()` and resource collection first-item lookup with their focused tests.
+6. Port the current Laravel `Str::substrReplace()` implementation and tests.
+7. Add base `decrementEach()` validation and extend the existing cross-driver integration scenario.
+8. Reconfirm the already-complete identifier codec behavior.
+9. Remove findings #21, #23, #26, #30–32, #34–35, and #82 from the master remediation ledger, leaving #160 as its only remaining implementation slice.
+10. Run affected package suites, static analysis through the repository checkpoint, then self-review all callers, error paths, and final diffs.
+
+## Verification plan
+
+Run each changed test file immediately after its source/test edit:
+
+```text
+./vendor/bin/phpunit --no-progress tests/Mail/AttachmentTest.php
+./vendor/bin/phpunit --no-progress tests/Mail/MailMailableTest.php
+./vendor/bin/phpunit --no-progress tests/Mail/MailSesV2TransportTest.php
+./vendor/bin/phpunit --no-progress tests/Notifications/NotificationMailMessageTest.php
+./vendor/bin/phpunit --no-progress tests/Notifications/NotificationMailChannelTest.php
+./vendor/bin/phpunit --no-progress tests/Notifications/NotificationBroadcastChannelTest.php
+./vendor/bin/phpunit --no-progress tests/Support/PackageMetadataTest.php
+./vendor/bin/phpunit --no-progress tests/Support/SupportArrTest.php
+./vendor/bin/phpunit --no-progress tests/Support/Traits/TransformsToResourceCollectionTest.php
+./vendor/bin/phpunit --no-progress tests/Pagination/PaginatorResourceTest.php
+./vendor/bin/phpunit --no-progress tests/Pagination/CursorResourceTest.php
+./vendor/bin/phpunit --no-progress tests/Support/SupportStrTest.php
+./vendor/bin/phpunit --no-progress tests/Support/SupportStringableTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseQueryBuilderTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/QueryBuilderTest.php
+./vendor/bin/phpunit --no-progress tests/Support/SupportBinaryCodecTest.php
+./vendor/bin/phpunit --no-progress tests/Database/DatabaseEloquentAsBinaryCastTest.php
+./vendor/bin/phpunit --no-progress tests/Integration/Database/DatabaseEloquentAsBinaryIntegrationTest.php
+```
+
+Then run the affected package directories where practical, followed by the repository checkpoint once:
+
+```text
+./vendor/bin/phpunit --no-progress tests/Mail
+./vendor/bin/phpunit --no-progress tests/Notifications
+./vendor/bin/phpunit --no-progress tests/Support tests/Pagination
+./vendor/bin/phpunit --no-progress tests/Database
+composer fix
+```
+
+The database workflow must exercise the changed integration test across MySQL, MariaDB, PostgreSQL, and SQLite. The final `composer fix` owns formatting, both PHPStan configurations, the full parallel suite, Testbench package tests, and dogfood tests; do not duplicate those full checks at the same checkpoint.
+
+Finally:
+
+- inspect the complete diff and status for generated files, temporary Composer files, and unrelated changes;
+- trace every changed method through direct callers and relevant Symfony/Laravel boundaries;
+- verify no new static/singleton state, cache, lock, avoidable network round trip, or repeated hot-path work was introduced; declared storage-attachment comparison may perform its one existing resolver read per side, but must not resolve either attachment more than once;
+- confirm the standalone Collections installation loaded `SortDirection` through its own declared dependency;
+- confirm the attachment fix resolves each attachment exactly once and still honors explicit comparison options;
+- confirm all exact failure messages and exception types match the final implementation.
+
+## Completion criteria
+
+- Every genuine retained finding in this slice is implemented or, for #35, reconfirmed as already complete.
+- Two equivalent storage/upload attachments compare equal after their own metadata resolves.
+- Envelope-only and attachments-only mailables can query declared attachments without a fatal or false negative.
+- Integer metadata reaches both mailable and notification Symfony headers safely, and lookup semantics are consistent.
+- Anonymous broadcasts cannot silently create a malformed fallback channel.
+- Collections is independently installable on Hypervel's PHP floor with `SortDirection` available.
+- One-item joins always satisfy their string return type; keyed collections and paginators guess resources correctly; substring replacement matches current multibyte Laravel behavior.
+- `decrementEach()` rejects invalid raw-expression input before query construction and accepts valid numeric forms across supported databases.
+- Focused checks and `composer fix` are green, and the final diff contains no workaround, stale code, unnecessary abstraction, or unrelated change.

--- a/src/collections/composer.json
+++ b/src/collections/composer.json
@@ -38,7 +38,8 @@
         "hypervel/conditionable": "^0.4",
         "hypervel/contracts": "^0.4",
         "hypervel/macroable": "^0.4",
-        "symfony/polyfill-php85": "^1.36"
+        "symfony/polyfill-php85": "^1.36",
+        "symfony/polyfill-php86": "^1.36"
     },
     "suggest": {
         "hypervel/http": "Required to convert collections to API resources (^0.4).",

--- a/src/collections/src/Arr.php
+++ b/src/collections/src/Arr.php
@@ -669,7 +669,7 @@ class Arr
         }
 
         if (count($array) === 1) {
-            return array_last($array);
+            return (string) array_last($array);
         }
 
         $finalItem = array_pop($array);

--- a/src/collections/src/Traits/TransformsToResourceCollection.php
+++ b/src/collections/src/Traits/TransformsToResourceCollection.php
@@ -6,7 +6,6 @@ namespace Hypervel\Support\Traits;
 
 use Hypervel\Database\Eloquent\Attributes\UseResource;
 use Hypervel\Database\Eloquent\Attributes\UseResourceCollection;
-use Hypervel\Database\Eloquent\Model;
 use Hypervel\Http\Resources\Json\JsonResource;
 use Hypervel\Http\Resources\Json\ResourceCollection;
 use LogicException;
@@ -18,7 +17,7 @@ trait TransformsToResourceCollection
     /**
      * Create a new resource collection instance for the given resource.
      *
-     * @param null|class-string<\Hypervel\Http\Resources\Json\JsonResource> $resourceClass
+     * @param null|class-string<JsonResource> $resourceClass
      *
      * @throws Throwable
      */
@@ -42,14 +41,12 @@ trait TransformsToResourceCollection
             return new ResourceCollection($this);
         }
 
-        $model = $this->items[0] ?? null;
+        $model = $this->first();
 
         throw_unless(is_object($model), LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
 
-        /** @var class-string<Model> $className */
         $className = get_class($model);
 
-        // @phpstan-ignore function.alreadyNarrowedType (defensive: validates model uses TransformsToResource trait)
         throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
 
         $useResourceCollection = $this->resolveResourceCollectionFromAttribute($className);

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -3888,6 +3888,13 @@ class Builder implements BuilderContract
     public function decrementEach(array $columns, array $extra = []): int
     {
         foreach ($columns as $column => $amount) {
+            if (! is_numeric($amount)) {
+                throw new InvalidArgumentException("Non-numeric value passed as decrement amount for column: '{$column}'.");
+            }
+            if (! is_string($column)) {
+                throw new InvalidArgumentException('Non-associative array passed to decrementEach method.');
+            }
+
             $columns[$column] = $this->raw("{$this->grammar->wrap($column)} - {$amount}");
         }
 

--- a/src/mail/src/Attachment.php
+++ b/src/mail/src/Attachment.php
@@ -15,8 +15,6 @@ use Hypervel\Support\Traits\Macroable;
 use InvalidArgumentException;
 use RuntimeException;
 
-use function with;
-
 class Attachment
 {
     use Macroable;
@@ -193,16 +191,20 @@ class Attachment
      */
     public function isEquivalent(Attachment $attachment, array $options = []): bool
     {
-        return with([
-            'as' => $options['as'] ?? $attachment->as,
-            'mime' => $options['mime'] ?? $attachment->mime,
-        ], fn ($options) => $this->attachWith(
+        // Storage and uploaded-file attachments populate metadata while their resolvers run.
+        return $this->attachWith(
             fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
             fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
         ) === $attachment->attachWith(
-            fn ($path) => [$path, $options],
-            fn ($data) => [$data(), $options],
-        ));
+            fn ($path) => [$path, [
+                'as' => $options['as'] ?? $attachment->as,
+                'mime' => $options['mime'] ?? $attachment->mime,
+            ]],
+            fn ($data) => [$data(), [
+                'as' => $options['as'] ?? $attachment->as,
+                'mime' => $options['mime'] ?? $attachment->mime,
+            ]],
+        );
     }
 
     /**

--- a/src/mail/src/Mailable.php
+++ b/src/mail/src/Mailable.php
@@ -128,6 +128,8 @@ class Mailable implements MailableContract, Renderable
 
     /**
      * The metadata for the message.
+     *
+     * @var array<string, null|int|string>
      */
     protected array $metadata = [];
 
@@ -885,7 +887,7 @@ class Mailable implements MailableContract, Renderable
             $file = $file->toMailAttachment();
         }
 
-        if ($file instanceof Attachment && $this->hasEnvelopeAttachment($file, $options)) {
+        if ($file instanceof Attachment && $this->hasDeclaredAttachment($file, $options)) {
             return true;
         }
 
@@ -913,15 +915,14 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Determine if the mailable has the given envelope attachment.
+     * Determine if the mailable has the given declared attachment.
      */
-    private function hasEnvelopeAttachment(Attachment $attachment, array $options = []): bool
+    private function hasDeclaredAttachment(Attachment $attachment, array $options = []): bool
     {
-        if (! method_exists($this, 'envelope')) {
+        if (! method_exists($this, 'attachments')) {
             return false;
         }
 
-        /* @phpstan-ignore-next-line */
         $attachments = $this->attachments();
 
         return Collection::make(is_object($attachments) ? [$attachments] : $attachments)
@@ -1016,14 +1017,14 @@ class Mailable implements MailableContract, Renderable
      */
     public function hasTag(string $value): bool
     {
-        return in_array($value, $this->tags)
-            || (method_exists($this, 'envelope') && in_array($value, $this->envelope()->tags));
+        return in_array($value, $this->tags, true)
+            || (method_exists($this, 'envelope') && in_array($value, $this->envelope()->tags, true));
     }
 
     /**
      * Add a metadata header to the message when supported by the underlying transport.
      */
-    public function metadata(array|string $key, ?string $value = null): static
+    public function metadata(array|string $key, int|string|null $value = null): static
     {
         if (is_array($key)) {
             $this->metadata = array_merge($this->metadata, $key);
@@ -1039,7 +1040,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function hasMetadata(string $key, int|string $value): bool
     {
-        return (isset($this->metadata[$key]) && $this->metadata[$key] === $value)
+        return (isset($this->metadata[$key]) && (string) $this->metadata[$key] === (string) $value)
             || (method_exists($this, 'envelope') && $this->envelope()->hasMetadata($key, $value));
     }
 
@@ -1383,9 +1384,11 @@ class Mailable implements MailableContract, Renderable
     {
         $this->renderForAssertions();
 
+        $actualTagsString = empty($this->tags) ? 'none' : implode(', ', $this->tags);
+
         PHPUnit::assertTrue(
             $this->hasTag($tag),
-            "Did not see expected tag [{$tag}] in email tags."
+            "Did not see expected tag in email tags.\nExpected: [{$tag}]\nActual: [{$actualTagsString}]"
         );
 
         return $this;
@@ -1394,13 +1397,16 @@ class Mailable implements MailableContract, Renderable
     /**
      * Assert that the mailable has the given metadata.
      */
-    public function assertHasMetadata(string $key, string $value): static
+    public function assertHasMetadata(string $key, int|string $value): static
     {
         $this->renderForAssertions();
 
+        $actualValue = $this->metadata[$key] ?? null;
+        $actualString = $actualValue !== null ? "[{$key}] => [{$actualValue}]" : "key [{$key}] not found";
+
         PHPUnit::assertTrue(
             $this->hasMetadata($key, $value),
-            "Did not see expected key [{$key}] and value [{$value}] in email metadata."
+            "Email metadata does not match expected value.\nExpected: [{$key}] => [{$value}]\nActual: {$actualString}"
         );
 
         return $this;

--- a/src/mail/src/Transport/SesV2Transport.php
+++ b/src/mail/src/Transport/SesV2Transport.php
@@ -95,7 +95,7 @@ class SesV2Transport extends AbstractTransport implements Stringable
         /* @phpstan-ignore-next-line */
         if ($header = $message->getOriginalMessage()->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
             if (preg_match('/^(contactListName=)*(?<ContactListName>[^;]+)(;\s?topicName=(?<TopicName>.+))?$/ix', $header->getBodyAsString(), $listManagementOptions)) {
-                return array_filter($listManagementOptions, fn ($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
+                return array_filter($listManagementOptions, fn ($e) => in_array($e, ['ContactListName', 'TopicName'], true), ARRAY_FILTER_USE_KEY);
             }
         }
 

--- a/src/notifications/src/Channels/MailChannel.php
+++ b/src/notifications/src/Channels/MailChannel.php
@@ -155,7 +155,7 @@ class MailChannel
 
         if ($message->metadata) {
             foreach ($message->metadata as $key => $value) {
-                $mailMessage->getHeaders()->add(new MetadataHeader($key, $value));
+                $mailMessage->getHeaders()->add(new MetadataHeader($key, (string) $value));
             }
         }
 

--- a/src/notifications/src/Events/BroadcastNotificationCreated.php
+++ b/src/notifications/src/Events/BroadcastNotificationCreated.php
@@ -12,6 +12,7 @@ use Hypervel\Notifications\Notification;
 use Hypervel\Queue\SerializesModels;
 use Hypervel\Support\Arr;
 use Hypervel\Support\Collection;
+use LogicException;
 
 class BroadcastNotificationCreated implements ShouldBroadcast
 {
@@ -60,11 +61,19 @@ class BroadcastNotificationCreated implements ShouldBroadcast
 
     /**
      * Get the broadcast channel name for the event.
+     *
+     * @throws LogicException
      */
     protected function channelName(): array|string
     {
         if (method_exists($this->notifiable, 'receivesBroadcastNotificationsOn')) {
             return $this->notifiable->receivesBroadcastNotificationsOn($this->notification);
+        }
+
+        if ($this->notifiable instanceof AnonymousNotifiable) {
+            throw new LogicException(
+                'Anonymous notifiables must define an explicit broadcast route or the notification must define a broadcast channel.'
+            );
         }
 
         $class = str_replace('\\', '.', get_class($this->notifiable));

--- a/src/notifications/src/Messages/MailMessage.php
+++ b/src/notifications/src/Messages/MailMessage.php
@@ -74,6 +74,8 @@ class MailMessage extends SimpleMessage implements Renderable
 
     /**
      * The metadata for the message.
+     *
+     * @var array<string, int|string>
      */
     public array $metadata = [];
 
@@ -288,7 +290,7 @@ class MailMessage extends SimpleMessage implements Renderable
     /**
      * Add a metadata header to the message when supported by the underlying transport.
      */
-    public function metadata(string $key, string $value): static
+    public function metadata(string $key, int|string $value): static
     {
         $this->metadata[$key] = $value;
 

--- a/src/support/src/Str.php
+++ b/src/support/src/Str.php
@@ -1498,7 +1498,8 @@ class Str
             return substr_replace($string, $replace, $offset, $length);
         }
 
-        $replaceSubstring = function ($string, $replace, $offset, $length) {
+        // $replace stays untyped: typing it would reject numeric and Stringable array values accepted by weak-mode scalar calls.
+        $replaceSubstring = function (string $string, $replace, int $offset, ?int $length): string {
             if ($length === null) {
                 $length = static::length($string);
             }

--- a/src/support/src/Str.php
+++ b/src/support/src/Str.php
@@ -1494,13 +1494,48 @@ class Str
      */
     public static function substrReplace(string|array $string, string|array $replace, int|array $offset = 0, int|array|null $length = null): string|array
     {
-        if ($length === null) {
-            $length = static::length($string);
+        if (! is_array($string) && (is_array($offset) || is_array($length))) {
+            return substr_replace($string, $replace, $offset, $length);
         }
 
-        return mb_substr($string, 0, $offset)
-            . $replace
-            . mb_substr($string, $offset + $length);
+        $replaceSubstring = function ($string, $replace, $offset, $length) {
+            if ($length === null) {
+                $length = static::length($string);
+            }
+
+            return mb_substr($string, 0, $offset)
+                . $replace
+                . mb_substr(mb_substr($string, $offset), $length);
+        };
+
+        $replacements = is_array($replace) ? array_values($replace) : null;
+
+        if (! is_array($string)) {
+            return $replaceSubstring(
+                $string,
+                $replacements === null ? $replace : ($replacements[0] ?? ''),
+                $offset,
+                $length,
+            );
+        }
+
+        $offsets = is_array($offset) ? array_values($offset) : null;
+        $lengths = is_array($length) ? array_values($length) : null;
+        $result = [];
+        $position = 0;
+
+        foreach ($string as $index => $value) {
+            $result[$index] = $replaceSubstring(
+                $value,
+                $replacements === null ? $replace : ($replacements[$position] ?? ''),
+                $offsets === null ? $offset : ($offsets[$position] ?? 0),
+                $lengths === null ? $length : ($lengths[$position] ?? null),
+            );
+
+            ++$position;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3432,7 +3432,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
     }
 
-    public function testIncrementManyArgumentValidation1()
+    public function testIncrementManyArgumentValidation1(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Non-numeric value passed as increment amount for column: \'col\'.');
@@ -3440,12 +3440,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->incrementEach(['col' => 'a']);
     }
 
-    public function testIncrementManyArgumentValidation2()
+    public function testIncrementManyArgumentValidation2(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Non-associative array passed to incrementEach method.');
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach([11 => 11]);
+    }
+
+    public function testDecrementManyArgumentValidation1(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-numeric value passed as decrement amount for column: \'col\'.');
+        $builder = $this->getBuilder();
+        $builder->from('users')->decrementEach(['col' => '1; DROP TABLE users']);
+    }
+
+    public function testDecrementManyArgumentValidation2(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-associative array passed to decrementEach method.');
+        $builder = $this->getBuilder();
+        $builder->from('users')->decrementEach([11 => 11]);
     }
 
     public function testWhereNotWithArrayConditions()

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -34,14 +34,14 @@ class QueryBuilderTest extends DatabaseTestCase
         ]);
     }
 
-    public function testIncrement()
+    public function testIncrement(): void
     {
         Schema::create('accounting', function (Blueprint $table) {
             $table->increments('id');
             $table->float('wallet_1');
             $table->float('wallet_2');
             $table->integer('user_id');
-            $table->string('name', 20);
+            $table->string('name');
         });
 
         DB::table('accounting')->insert([
@@ -143,6 +143,33 @@ class QueryBuilderTest extends DatabaseTestCase
 
         $this->assertEquals(1.5, $rows[0]->wallet_1);
         $this->assertEquals(1.5, $rows[1]->wallet_1);
+
+        // Decrement accepts integer, float, and numeric-string amounts.
+        $affectedRowsCount = DB::table('accounting')->decrementEach([
+            'wallet_1' => 1,
+            'wallet_2' => 0.5,
+            'user_id' => '1',
+        ]);
+
+        $this->assertEquals(2, $affectedRowsCount);
+
+        $rows = DB::table('accounting')->get();
+
+        $this->assertEquals([
+            'id' => 1,
+            'wallet_1' => 0.5,
+            'wallet_2' => 167,
+            'user_id' => 0,
+            'name' => 'Taylor',
+        ], (array) $rows[0]);
+
+        $this->assertEquals([
+            'id' => 2,
+            'wallet_1' => 0.5,
+            'wallet_2' => 267,
+            'user_id' => 1,
+            'name' => 'foo',
+        ], (array) $rows[1]);
 
         Schema::drop('accounting');
     }

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -7,6 +7,7 @@ namespace Hypervel\Tests\Mail;
 use Hypervel\Container\Container;
 use Hypervel\Contracts\Filesystem\Factory as FilesystemFactory;
 use Hypervel\Filesystem\FilesystemAdapter;
+use Hypervel\Http\Testing\File;
 use Hypervel\Mail\Attachment;
 use Hypervel\Tests\TestCase;
 use InvalidArgumentException;
@@ -115,6 +116,48 @@ class AttachmentTest extends TestCase
         $b = Attachment::fromPath('/path/to/b.pdf');
 
         $this->assertFalse($a->isEquivalent($b));
+    }
+
+    public function testIsEquivalentHonorsComparisonOptions(): void
+    {
+        $a = Attachment::fromPath('/path/to/file.pdf')
+            ->as('renamed.pdf')
+            ->withMime('application/pdf');
+        $b = Attachment::fromPath('/path/to/file.pdf');
+
+        $this->assertTrue($a->isEquivalent($b, [
+            'as' => 'renamed.pdf',
+            'mime' => 'application/pdf',
+        ]));
+    }
+
+    public function testIsEquivalentWithStorageAttachments(): void
+    {
+        $storage = m::mock(FilesystemAdapter::class);
+        $storage->shouldReceive('mimeType')->twice()->with('report.txt')->andReturn('text/plain');
+        $storage->shouldReceive('get')->twice()->with('report.txt')->andReturn('file content');
+
+        $factory = m::mock(FilesystemFactory::class);
+        $factory->shouldReceive('disk')->twice()->with('documents')->andReturn($storage);
+
+        $container = new Container;
+        $container->instance(FilesystemFactory::class, $factory);
+        Container::setInstance($container);
+
+        $a = Attachment::fromStorageDisk('documents', 'report.txt');
+        $b = Attachment::fromStorageDisk('documents', 'report.txt');
+
+        $this->assertTrue($a->isEquivalent($b));
+    }
+
+    public function testIsEquivalentWithUploadedFileAttachments(): void
+    {
+        $file = File::createWithContent('example.pdf', 'content')
+            ->mimeType('application/pdf');
+        $a = Attachment::fromUploadedFile($file);
+        $b = Attachment::fromUploadedFile($file);
+
+        $this->assertTrue($a->isEquivalent($b));
     }
 
     public function testFromDataCreatesAttachment(): void

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -660,6 +660,7 @@ class MailMailableTest extends TestCase
 
         $this->assertTrue($mailable->hasMetadata('template_id', 'external-template-id'));
         $this->assertTrue($mailable->hasMetadata('customer_id', 101));
+        $this->assertTrue($mailable->hasMetadata('customer_id', '101'));
         $this->assertTrue($mailable->hasMetadata('order_id', 1000));
         $this->assertTrue($mailable->hasMetadata('subtotal', 1500));
         $this->assertTrue($mailable->hasMetadata('gst', 150));
@@ -688,30 +689,40 @@ class MailMailableTest extends TestCase
 
         $mailer = new Mailer('array', $view, new ArrayTransport);
 
-        $mailable = new WelcomeMailableStub;
+        $mailable = new class extends WelcomeMailableStub {
+            public function envelope(): Envelope
+            {
+                return new Envelope(metadata: ['account_id' => 42]);
+            }
+        };
         $mailable->to('hello@laravel.com');
         $mailable->from('taylor@laravel.com');
         $mailable->html('test content');
 
         $mailable->metadata('origin', 'test-suite');
-        $mailable->metadata('user_id', '1');
+        $mailable->metadata('user_id', 1);
 
         $sentMessage = $mailer->send($mailable);
 
         $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
         $this->assertStringContainsString('X-Metadata-origin: test-suite', $sentMessage->toString());
         $this->assertStringContainsString('X-Metadata-user_id: 1', $sentMessage->toString());
+        $this->assertStringContainsString('X-Metadata-account_id: 42', $sentMessage->toString());
 
         $this->assertTrue($mailable->hasMetadata('origin', 'test-suite'));
         $this->assertTrue($mailable->hasMetadata('user_id', '1'));
+        $this->assertTrue($mailable->hasMetadata('user_id', 1));
+        $this->assertTrue($mailable->hasMetadata('account_id', 42));
+        $mailable->metadata(['nullable' => null]);
+        $this->assertFalse($mailable->hasMetadata('nullable', ''));
         $this->assertFalse($mailable->hasMetadata('test', 'test'));
         $mailable->assertHasMetadata('origin', 'test-suite');
-        $mailable->assertHasMetadata('user_id', '1');
+        $mailable->assertHasMetadata('user_id', 1);
         try {
             $mailable->assertHasMetadata('test', 'test');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected key [test] and value [test] in email metadata.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Email metadata does not match expected value.\nExpected: [test] => [test]\nActual: key [test] not found\nFailed asserting that false is true.", $e->getMessage());
         }
     }
 
@@ -746,8 +757,65 @@ class MailMailableTest extends TestCase
             $mailable->assertHasTag('bar');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected tag [bar] in email tags.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Did not see expected tag in email tags.\nExpected: [bar]\nActual: [test, foo]\nFailed asserting that false is true.", $e->getMessage());
         }
+
+        $mailable->tag('01');
+        $this->assertFalse($mailable->hasTag('1'));
+    }
+
+    public function testAssertionDiagnosticsDoNotInvokeEnvelopeAgain(): void
+    {
+        $this->mockContainer();
+
+        $mailable = new class extends Mailable {
+            public int $envelopeCalls = 0;
+
+            public function envelope(): Envelope
+            {
+                ++$this->envelopeCalls;
+
+                return new Envelope(metadata: ['attempts' => 3]);
+            }
+        };
+        $mailable->html('test content');
+
+        $failure = null;
+
+        try {
+            $mailable->assertHasMetadata('attempts', 4);
+        } catch (AssertionFailedError $exception) {
+            $failure = $exception;
+        }
+
+        $this->assertInstanceOf(AssertionFailedError::class, $failure);
+        $this->assertSame(
+            "Email metadata does not match expected value.\nExpected: [attempts] => [4]\nActual: [attempts] => [3]\nFailed asserting that false is true.",
+            $failure->getMessage()
+        );
+        $this->assertSame(2, $mailable->envelopeCalls);
+    }
+
+    public function testTagAssertionReportsWhenMailableHasNoTags(): void
+    {
+        $this->mockContainer();
+
+        $mailable = new Mailable;
+        $mailable->html('test content');
+
+        $failure = null;
+
+        try {
+            $mailable->assertHasTag('bar');
+        } catch (AssertionFailedError $exception) {
+            $failure = $exception;
+        }
+
+        $this->assertInstanceOf(AssertionFailedError::class, $failure);
+        $this->assertSame(
+            "Did not see expected tag in email tags.\nExpected: [bar]\nActual: [none]\nFailed asserting that false is true.",
+            $failure->getMessage()
+        );
     }
 
     public function testItCanAttachMultipleFiles(): void
@@ -893,6 +961,41 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachment($unnamedAttachable, ['as' => 'foo.jpg']));
         $this->assertFalse($mailable->hasAttachment($unnamedAttachable, ['mime' => 'image/png']));
         $this->assertTrue($mailable->hasAttachment($unnamedAttachable, ['as' => 'foo.jpg', 'mime' => 'image/png']));
+    }
+
+    public function testHasAttachmentWithEnvelopeAndNoDeclaredAttachments(): void
+    {
+        $mailable = new class extends Mailable {
+            public function envelope(): Envelope
+            {
+                return new Envelope;
+            }
+        };
+
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('/foo.jpg')));
+    }
+
+    public function testHasAttachmentWithDeclaredStorageAttachmentsAndNoEnvelope(): void
+    {
+        $storage = m::mock(FilesystemAdapter::class);
+        $storage->shouldReceive('mimeType')->with('report.txt')->andReturn('text/plain');
+        $storage->shouldReceive('mimeType')->with('other.txt')->andReturn('text/plain');
+        $storage->shouldReceive('get')->with('report.txt')->andReturn('report content');
+        $storage->shouldReceive('get')->with('other.txt')->andReturn('other content');
+
+        $factory = m::mock(FilesystemFactory::class);
+        $factory->shouldReceive('disk')->with('documents')->andReturn($storage);
+        $this->app->instance(FilesystemFactory::class, $factory);
+
+        $mailable = new class extends Mailable {
+            public function attachments(): array
+            {
+                return [Attachment::fromStorageDisk('documents', 'report.txt')];
+            }
+        };
+
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromStorageDisk('documents', 'report.txt')));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromStorageDisk('documents', 'other.txt')));
     }
 
     public function testItCanCheckForPathBasedAttachments(): void

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -6,11 +6,13 @@ namespace Hypervel\Tests\Notifications;
 
 use Hypervel\Broadcasting\PrivateChannel;
 use Hypervel\Contracts\Events\Dispatcher;
+use Hypervel\Notifications\AnonymousNotifiable;
 use Hypervel\Notifications\Channels\BroadcastChannel;
 use Hypervel\Notifications\Events\BroadcastNotificationCreated;
 use Hypervel\Notifications\Messages\BroadcastMessage;
 use Hypervel\Notifications\Notification;
 use Hypervel\Tests\TestCase;
+use LogicException;
 use Mockery as m;
 
 class NotificationBroadcastChannelTest extends TestCase
@@ -31,7 +33,7 @@ class NotificationBroadcastChannelTest extends TestCase
     {
         $notification = new CustomChannelsTestNotification;
         $notification->id = '1';
-        $notifiable = m::mock();
+        $notifiable = new AnonymousNotifiable;
 
         $event = new BroadcastNotificationCreated(
             $notifiable,
@@ -42,6 +44,50 @@ class NotificationBroadcastChannelTest extends TestCase
         $channels = $event->broadcastOn();
 
         $this->assertEquals(new PrivateChannel('custom-channel'), $channels[0]);
+    }
+
+    public function testAnonymousNotificationWithoutBroadcastRouteThrows(): void
+    {
+        $event = new BroadcastNotificationCreated(
+            new AnonymousNotifiable,
+            new Notification,
+        );
+
+        $this->expectExceptionObject(new LogicException(
+            'Anonymous notifiables must define an explicit broadcast route or the notification must define a broadcast channel.'
+        ));
+
+        $event->broadcastOn();
+    }
+
+    public function testAnonymousNotificationUsesExplicitBroadcastRoute(): void
+    {
+        $notifiable = (new AnonymousNotifiable)->route('broadcast', 'custom-route');
+        $event = new BroadcastNotificationCreated($notifiable, new Notification);
+
+        $this->assertSame(['custom-route'], $event->broadcastOn());
+    }
+
+    public function testNotificationUsesNotifiableBroadcastChannel(): void
+    {
+        $event = new BroadcastNotificationCreated(
+            new NotificationBroadcastChannelTestNotifiableWithChannel,
+            new Notification,
+        );
+
+        $this->assertEquals([new PrivateChannel('notifiable-channel')], $event->broadcastOn());
+    }
+
+    public function testNotificationUsesNotifiableClassAndKeyByDefault(): void
+    {
+        $event = new BroadcastNotificationCreated(
+            new NotificationBroadcastChannelTestNotifiable,
+            new Notification,
+        );
+
+        $this->assertEquals([
+            new PrivateChannel('Hypervel.Tests.Notifications.NotificationBroadcastChannelTestNotifiable.1'),
+        ], $event->broadcastOn());
     }
 
     public function testNotificationIsBroadcastedWithCustomEventName(): void
@@ -167,5 +213,21 @@ class CustomBroadcastWithTestNotification extends Notification
     public function broadcastWith(): array
     {
         return ['id' => 1, 'type' => 'custom', 'additional' => 'custom'];
+    }
+}
+
+class NotificationBroadcastChannelTestNotifiable
+{
+    public function getKey(): int
+    {
+        return 1;
+    }
+}
+
+class NotificationBroadcastChannelTestNotifiableWithChannel
+{
+    public function receivesBroadcastNotificationsOn(Notification $notification): string
+    {
+        return 'notifiable-channel';
     }
 }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -70,12 +70,15 @@ class NotificationBroadcastChannelTest extends TestCase
 
     public function testNotificationUsesNotifiableBroadcastChannel(): void
     {
+        $notification = new Notification;
+        $notification->id = '1';
+
         $event = new BroadcastNotificationCreated(
             new NotificationBroadcastChannelTestNotifiableWithChannel,
-            new Notification,
+            $notification,
         );
 
-        $this->assertEquals([new PrivateChannel('notifiable-channel')], $event->broadcastOn());
+        $this->assertEquals([new PrivateChannel('notifiable-channel.1')], $event->broadcastOn());
     }
 
     public function testNotificationUsesNotifiableClassAndKeyByDefault(): void
@@ -228,6 +231,6 @@ class NotificationBroadcastChannelTestNotifiableWithChannel
 {
     public function receivesBroadcastNotificationsOn(Notification $notification): string
     {
-        return 'notifiable-channel';
+        return 'notifiable-channel.' . $notification->id;
     }
 }

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Notifications;
+
+use Hypervel\Contracts\Mail\Factory as MailFactory;
+use Hypervel\Mail\Markdown;
+use Hypervel\Mail\Message;
+use Hypervel\Notifications\Channels\MailChannel;
+use Hypervel\Notifications\Messages\MailMessage;
+use Hypervel\Notifications\Notification;
+use Hypervel\Support\ClassInvoker;
+use Hypervel\Tests\TestCase;
+use Mockery as m;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Email;
+
+class NotificationMailChannelTest extends TestCase
+{
+    public function testBuildMessageAddsTagsAndStringifiesMetadata(): void
+    {
+        $channel = new MailChannel(
+            m::mock(MailFactory::class),
+            m::mock(Markdown::class),
+        );
+        $message = new Email;
+        $notifiable = new class {
+            public function routeNotificationFor(string $driver, Notification $notification): string
+            {
+                return 'taylor@hypervel.org';
+            }
+        };
+        $notification = new Notification;
+        $mailMessage = (new MailMessage)
+            ->tag('release')
+            ->metadata('attempts', 2);
+
+        (new ClassInvoker($channel))->buildMessage(
+            new Message($message),
+            $notifiable,
+            $notification,
+            $mailMessage,
+        );
+
+        $tagHeader = $message->getHeaders()->get('X-Tag');
+        $this->assertInstanceOf(TagHeader::class, $tagHeader);
+        $this->assertSame('release', $tagHeader->getBody());
+
+        $metadataHeader = $message->getHeaders()->get('X-Metadata-attempts');
+        $this->assertInstanceOf(MetadataHeader::class, $metadataHeader);
+        $this->assertSame('2', $metadataHeader->getBody());
+    }
+}

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -183,12 +183,12 @@ class NotificationMailMessageTest extends TestCase
     {
         $message = new MailMessage;
         $message->metadata('origin', 'test-suite');
-        $message->metadata('user_id', '1');
+        $message->metadata('user_id', 1);
 
         $this->assertArrayHasKey('origin', $message->metadata);
         $this->assertSame('test-suite', $message->metadata['origin']);
         $this->assertArrayHasKey('user_id', $message->metadata);
-        $this->assertSame('1', $message->metadata['user_id']);
+        $this->assertSame(1, $message->metadata['user_id']);
     }
 
     public function testTagIsSetCorrectly(): void

--- a/tests/Pagination/CursorResourceTest.php
+++ b/tests/Pagination/CursorResourceTest.php
@@ -46,6 +46,14 @@ class CursorResourceTest extends TestCase
         $resource = $paginator->toResourceCollection();
 
         $this->assertInstanceOf(JsonResource::class, $resource);
+
+        $keyedPaginator = new CursorResourceTestPaginator([
+            'model-key' => new CursorResourceTestModel,
+        ], 1);
+
+        $keyedResource = $keyedPaginator->toResourceCollection();
+
+        $this->assertInstanceOf(JsonResource::class, $keyedResource);
     }
 }
 

--- a/tests/Pagination/PaginatorResourceTest.php
+++ b/tests/Pagination/PaginatorResourceTest.php
@@ -46,6 +46,14 @@ class PaginatorResourceTest extends TestCase
         $resource = $paginator->toResourceCollection();
 
         $this->assertInstanceOf(JsonResource::class, $resource);
+
+        $keyedPaginator = new PaginatorResourceTestPaginator([
+            'model-key' => new PaginatorResourceTestModel,
+        ], 1, 1, 1);
+
+        $keyedResource = $keyedPaginator->toResourceCollection();
+
+        $this->assertInstanceOf(JsonResource::class, $keyedResource);
     }
 }
 

--- a/tests/Support/PackageMetadataTest.php
+++ b/tests/Support/PackageMetadataTest.php
@@ -10,14 +10,20 @@ use JsonException;
 class PackageMetadataTest extends TestCase
 {
     /**
-     * Ensure Support dependencies match the classes it imports directly.
+     * Ensure Support and Collections declare their direct runtime dependencies.
      *
      * @throws JsonException
      */
     public function testRuntimeDependenciesAreDeclared(): void
     {
-        $composer = json_decode(
+        $supportComposer = json_decode(
             file_get_contents(__DIR__ . '/../../src/support/composer.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+        $collectionsComposer = json_decode(
+            file_get_contents(__DIR__ . '/../../src/collections/composer.json'),
             true,
             512,
             JSON_THROW_ON_ERROR,
@@ -31,8 +37,14 @@ class PackageMetadataTest extends TestCase
 
         foreach (['guzzlehttp/promises', 'league/commonmark'] as $dependency) {
             $this->assertArrayHasKey($dependency, $rootComposer['require']);
-            $this->assertArrayHasKey($dependency, $composer['require']);
-            $this->assertSame($rootComposer['require'][$dependency], $composer['require'][$dependency]);
+            $this->assertArrayHasKey($dependency, $supportComposer['require']);
+            $this->assertSame($rootComposer['require'][$dependency], $supportComposer['require'][$dependency]);
+        }
+
+        foreach (['symfony/polyfill-php85', 'symfony/polyfill-php86'] as $dependency) {
+            $this->assertArrayHasKey($dependency, $rootComposer['require']);
+            $this->assertArrayHasKey($dependency, $collectionsComposer['require']);
+            $this->assertSame($rootComposer['require'][$dependency], $collectionsComposer['require'][$dependency]);
         }
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -495,6 +495,17 @@ class SupportArrTest extends TestCase
 
         $this->assertSame('a', Arr::join(['a'], ', ', ' and '));
 
+        $this->assertSame('1', Arr::join([1], ', ', ' and '));
+
+        $this->assertSame('1.5', Arr::join([1.5], ', ', ' and '));
+
+        $this->assertSame('value', Arr::join([new class {
+            public function __toString(): string
+            {
+                return 'value';
+            }
+        }], ', ', ' and '));
+
         $this->assertSame('', Arr::join([], ', ', ' and '));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Swoole\Coroutine\CanceledException;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
+use TypeError;
 use ValueError;
 
 class SupportStrTest extends TestCase
@@ -1539,12 +1540,72 @@ class SupportStrTest extends TestCase
         $this->assertSame('12:00', Str::substrReplace('1200', ':', 2, 0));
         $this->assertSame('The Hypervel Framework', Str::substrReplace('The Framework', 'Hypervel ', 4, 0));
         $this->assertSame('Hypervel – The PHP Framework for High-Performance Apps', Str::substrReplace('Hypervel Framework', '– The PHP Framework for High-Performance Apps', 9));
+        $this->assertSame('1567', Str::substrReplace('1234', '567', -3, 3));
+        $this->assertSame('125674', Str::substrReplace('1234', '567', 2, -1));
+        $this->assertSame('125674', Str::substrReplace('1234', '567', -2, -1));
+        $this->assertSame('HeXo', Str::substrReplace('Hello', 'X', 2, -1));
     }
 
     public function testSubstrReplaceWithMultibyte(): void
     {
         $this->assertSame('kengä', Str::substrReplace('kenkä', 'ng', -3, 2));
         $this->assertSame('kenga', Str::substrReplace('kenka', 'ng', -3, 2));
+    }
+
+    public function testSubstrReplaceWithArrays(): void
+    {
+        $this->assertSame(
+            ['INV-****', 'INV-****'],
+            Str::substrReplace(['INV-1234', 'INV-5678'], ['****', '****'], [4, 4], [4, 4])
+        );
+
+        $this->assertSame(
+            ['first' => 'aXc', 'second' => 'Yef', 'third' => ''],
+            Str::substrReplace(
+                ['first' => 'abc', 'second' => 'def', 'third' => 'ghi'],
+                ['X', 'Y'],
+                [1],
+                [1, 1]
+            )
+        );
+
+        $this->assertSame('kengä', Str::substrReplace('kenkä', ['ng'], -3, 2));
+        $this->assertSame('ac', Str::substrReplace('abc', [], 1, 1));
+        $this->assertSame(
+            ['kengä', 'БXДЖ'],
+            Str::substrReplace(['kenkä', 'БГДЖ'], ['ng', 'X'], [-3, 1], [2, 1])
+        );
+        $this->assertSame(
+            ['kXnkä', 'БXДЖ'],
+            Str::substrReplace(['kenkä', 'БГДЖ'], 'X', 1, 1)
+        );
+        $this->assertSame(
+            ['keX', 'БГX'],
+            Str::substrReplace(['kenkä', 'БГДЖ'], 'X', 2)
+        );
+        $this->assertSame(
+            ['first' => 'aXc', 'second' => 'deY'],
+            Str::substrReplace(
+                ['first' => 'abc', 'second' => 'def'],
+                ['second' => 'X', 'first' => 'Y'],
+                [10 => 1, 20 => 2],
+                [30 => 1, 40 => 1]
+            )
+        );
+    }
+
+    public function testSubstrReplaceWithArrayOffsetRequiresArraySubject(): void
+    {
+        $this->expectException(TypeError::class);
+
+        Str::substrReplace('abc', 'X', [1], 1);
+    }
+
+    public function testSubstrReplaceWithArrayLengthRequiresArraySubject(): void
+    {
+        $this->expectException(TypeError::class);
+
+        Str::substrReplace('abc', 'X', 1, [1]);
     }
 
     public function testTake(): void

--- a/tests/Support/Traits/TransformsToResourceCollectionTest.php
+++ b/tests/Support/Traits/TransformsToResourceCollectionTest.php
@@ -70,6 +70,16 @@ class TransformsToResourceCollectionTest extends TestCase
         $this->assertInstanceOf(ResourceCollectionTestResource::class, $resource[0]);
     }
 
+    public function testToResourceCollectionGuessesResourceForKeyedEloquentCollection(): void
+    {
+        $model = new ResourceCollectionTestModelWithResourceAttribute;
+        $collection = new EloquentCollection(['model-key' => $model]);
+
+        $resource = $collection->toResourceCollection();
+
+        $this->assertInstanceOf(AnonymousResourceCollection::class, $resource);
+    }
+
     public function testToResourceCollectionPrefersUseResourceCollectionOverUseResource(): void
     {
         $model = new ResourceCollectionTestModelWithBothAttributes;


### PR DESCRIPTION
This fixes a set of correctness issues in existing mail, notification, collection, support, pagination, and database APIs.

## Mail and notifications

Mailable metadata now accepts the same integer values as `Envelope`, compares values using their wire representation, and converts them to strings only at the Symfony header boundary. Assertion failures include the expected and actual values without invoking application `envelope()` code again.

Declared attachment lookup now checks `attachments()` directly. Storage and uploaded-file attachments compare their filename and MIME metadata after their resolvers have populated it, while explicit comparison options still win.

Anonymous broadcast notifications now fail with a clear exception when they have no usable broadcast route or notification-defined channel. Explicit routes, custom notification channels, custom notifiable channels, and normal keyed notifiables keep their existing behavior.

Tag membership and SES list-management key filtering now use strict comparisons.

## Collections, pagination, and strings

The Collections split package now declares the PHP 8.6 polyfill required by its `SortDirection` usage. The package metadata test keeps both PHP polyfill constraints aligned with the root package.

`Arr::join()` now returns a string for single numeric and stringable values, matching its native return type and multi-item behavior.

Resource collection guessing now reads the first collection value rather than assuming a numeric zero key. This fixes keyed Eloquent collections and paginators that preserve application keys.

`Str::substrReplace()` now supports the full scalar and array contract while preserving multibyte offsets, negative lengths, subject keys, positional option arrays, and native error behavior.

## Database

`decrementEach()` now validates column keys and amounts before constructing raw arithmetic expressions, matching `incrementEach()`. Valid integers, floats, and numeric strings continue through the existing query path.

## Compatibility

These changes preserve Laravel APIs. Accepted metadata input is widened, existing valid routing and collection behavior is unchanged, and invalid decrement input now fails before SQL construction. No new caches, shared state, locks, or runtime services are introduced.

The completed findings have also been removed from the master remediation plan and recorded in the focused implementation plan.

## Verification

- Ran each changed test file and the affected package suites.
- Exercised the database behavior through the integration suite used by all supported drivers.
- Verified the Collections dependency through an isolated split-package install and a real sorting call.
- Ran the full repository formatter, static analysis, parallel suite, Testbench checks, and dogfood tests with `composer fix`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mail attachment comparison across file, storage, and uploaded-file attachments.
  * Mail and notification metadata now supports numeric values and consistently formats them in email headers.
  * Added clearer diagnostics for missing mail tags and metadata.
  * Invalid database decrement inputs now produce clear exceptions.
  * Improved broadcast channel validation for anonymous notifications.
  * Fixed multibyte and array-based substring replacement behavior.
  * Improved resource collection detection for keyed model collections.
  * Corrected single-item array joining for non-string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->