### PR TITLE
Improve runtime contracts and regression coverage

### DIFF
--- a/src/console/src/Events/AfterExecute.php
+++ b/src/console/src/Events/AfterExecute.php
@@ -14,17 +14,15 @@ use Throwable;
  * Always fires regardless of success or failure. When the command threw an exception,
  * the throwable is available for inspection. Unlike CommandFinished, this event fires
  * within the command's execution boundary. Commands may disable coroutine execution,
- * so listeners must check before using coroutine-only APIs. Framework dispatches
- * always include the input and exit code; they remain nullable only for compatibility
- * with existing manual event construction.
+ * so listeners must check before using coroutine-only APIs.
  */
 class AfterExecute
 {
     public function __construct(
         public readonly Command $command,
-        public readonly ?Throwable $throwable = null,
-        public readonly ?InputInterface $input = null,
-        public readonly ?int $exitCode = null,
+        public readonly ?Throwable $throwable,
+        public readonly InputInterface $input,
+        public readonly int $exitCode,
     ) {
     }
 }

--- a/src/console/src/Events/BeforeHandle.php
+++ b/src/console/src/Events/BeforeHandle.php
@@ -13,14 +13,13 @@ use Symfony\Component\Console\Input\InputInterface;
  * Fires after all Symfony/run() setup is complete but before business logic executes.
  * Unlike CommandStarting, this event fires within the command's execution boundary.
  * Commands may disable coroutine execution, so listeners must check before using
- * coroutine-only APIs. Framework dispatches always include the input; it remains
- * nullable only for compatibility with existing manual event construction.
+ * coroutine-only APIs.
  */
 class BeforeHandle
 {
     public function __construct(
         public readonly Command $command,
-        public readonly ?InputInterface $input = null,
+        public readonly InputInterface $input,
     ) {
     }
 }

--- a/src/database/src/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/database/src/Eloquent/Concerns/QueriesRelationships.php
@@ -872,7 +872,7 @@ trait QueriesRelationships
                 )
             );
 
-            $this->assertNoTimeoutOnRelationshipConstraint($query);
+            $this->ensureNoTimeoutOnRelationshipConstraint($query);
 
             if (is_null($this->query->columns)) {
                 $this->query->select([$this->query->from . '.*']);
@@ -969,7 +969,7 @@ trait QueriesRelationships
         $hasQuery->mergeConstraintsFrom($relation->getQuery());
         $query = $hasQuery->toBase();
 
-        $this->assertNoTimeoutOnRelationshipConstraint($query);
+        $this->ensureNoTimeoutOnRelationshipConstraint($query);
 
         return $this->canUseExistsForExistenceCheck($operator, $count)
             ? $this->addWhereExistsQuery($query, $boolean, $operator === '<' && $count === 1)
@@ -1039,7 +1039,7 @@ trait QueriesRelationships
      *
      * @throws InvalidArgumentException
      */
-    protected function assertNoTimeoutOnRelationshipConstraint(QueryBuilder $query): void
+    protected function ensureNoTimeoutOnRelationshipConstraint(QueryBuilder $query): void
     {
         if ($query->timeout !== null) {
             throw new InvalidArgumentException(

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -389,7 +389,7 @@ class Builder implements BuilderContract
         }
 
         if ($query instanceof self) {
-            $this->assertNoTimeoutOnEmbeddedQuery($query);
+            $this->ensureNoTimeoutOnEmbeddedQuery($query);
 
             $query = $this->prependDatabaseNameIfCrossDatabaseQuery($query);
 
@@ -1744,7 +1744,7 @@ class Builder implements BuilderContract
             $query = $callback instanceof self ? $callback : $callback->toBase();
         }
 
-        $this->assertNoTimeoutOnEmbeddedQuery($query);
+        $this->ensureNoTimeoutOnEmbeddedQuery($query);
 
         $this->wheres[] = compact(
             'type',
@@ -1825,7 +1825,7 @@ class Builder implements BuilderContract
      */
     public function addWhereExistsQuery(self $query, string $boolean = 'and', bool $not = false): static
     {
-        $this->assertNoTimeoutOnEmbeddedQuery($query);
+        $this->ensureNoTimeoutOnEmbeddedQuery($query);
 
         $type = $not ? 'NotExists' : 'Exists';
 
@@ -2728,7 +2728,7 @@ class Builder implements BuilderContract
             $query = $query->toBase();
         }
 
-        $this->assertNoTimeoutOnEmbeddedQuery($query);
+        $this->ensureNoTimeoutOnEmbeddedQuery($query);
 
         $this->unions[] = compact('query', 'all');
 
@@ -4206,7 +4206,7 @@ class Builder implements BuilderContract
      *
      * @throws InvalidArgumentException
      */
-    protected function assertNoTimeoutOnEmbeddedQuery(self $query): void
+    protected function ensureNoTimeoutOnEmbeddedQuery(self $query): void
     {
         if ($query->timeout !== null) {
             throw new InvalidArgumentException(

--- a/src/grpc/src/Client/BaseClient.php
+++ b/src/grpc/src/Client/BaseClient.php
@@ -130,7 +130,7 @@ abstract class BaseClient
      */
     public function __construct(private readonly string $target, array $options = [])
     {
-        $this->assertKnownOptions($options, self::OPTION_KEYS, 'client');
+        $this->ensureKnownOptions($options, self::OPTION_KEYS, 'client');
 
         $connectionCount = $this->positiveIntegerOption($options, 'connections', 1);
         $this->connectTimeout = $this->positiveSecondsOption($options, 'connect_timeout', 3.0);
@@ -715,7 +715,7 @@ abstract class BaseClient
      */
     private function normalizeCallOptions(array $options, bool $retryable): array
     {
-        $this->assertKnownOptions($options, self::CALL_OPTION_KEYS, 'call');
+        $this->ensureKnownOptions($options, self::CALL_OPTION_KEYS, 'call');
 
         if (! $retryable && array_key_exists('retry', $options)) {
             throw new InvalidArgumentException(
@@ -763,7 +763,7 @@ abstract class BaseClient
             throw new InvalidArgumentException('The gRPC TLS option must be an array.');
         }
 
-        $this->assertKnownOptions($rawTls, self::TLS_OPTION_KEYS, 'TLS');
+        $this->ensureKnownOptions($rawTls, self::TLS_OPTION_KEYS, 'TLS');
         $suppliedKeys = array_keys($rawTls);
 
         foreach ($suppliedKeys as $key) {
@@ -909,7 +909,7 @@ abstract class BaseClient
      * @param array<array-key, mixed> $options
      * @param list<string> $allowedKeys
      */
-    private function assertKnownOptions(array $options, array $allowedKeys, string $scope): void
+    private function ensureKnownOptions(array $options, array $allowedKeys, string $scope): void
     {
         foreach (array_keys($options) as $key) {
             if (! is_string($key) || ! in_array($key, $allowedKeys, true)) {

--- a/src/grpc/src/GrpcServiceProvider.php
+++ b/src/grpc/src/GrpcServiceProvider.php
@@ -294,12 +294,12 @@ class GrpcServiceProvider extends ServiceProvider
                 );
             }
         } else {
-            $this->assertReadableFile($certificate, 'certificate');
-            $this->assertReadableFile($privateKey, 'private key');
+            $this->ensureReadableFile($certificate, 'certificate');
+            $this->ensureReadableFile($privateKey, 'private key');
         }
 
         if ($clientCa !== null) {
-            $this->assertReadableFile($clientCa, 'client CA');
+            $this->ensureReadableFile($clientCa, 'client CA');
         }
 
         return [
@@ -376,7 +376,7 @@ class GrpcServiceProvider extends ServiceProvider
     /**
      * Require a readable TLS file.
      */
-    private function assertReadableFile(string $path, string $description): void
+    private function ensureReadableFile(string $path, string $description): void
     {
         if (! is_file($path) || ! is_readable($path)) {
             throw new InvalidArgumentException(

--- a/src/horizon/src/Lock.php
+++ b/src/horizon/src/Lock.php
@@ -27,7 +27,7 @@ class Lock
      */
     public function with(string $key, Closure $callback, int $seconds = 60): void
     {
-        $this->assertPositiveLifetime($key, $seconds);
+        $this->ensurePositiveLifetime($key, $seconds);
 
         (new RedisLock($this->connection(), $key, $seconds))->get($callback);
     }
@@ -45,7 +45,7 @@ class Lock
      */
     public function get(string $key, int $seconds = 60): bool
     {
-        $this->assertPositiveLifetime($key, $seconds);
+        $this->ensurePositiveLifetime($key, $seconds);
 
         return $this->connection()->set($key, '1', 'EX', $seconds, 'NX') === true;
     }
@@ -61,7 +61,7 @@ class Lock
     /**
      * Ensure the lock lifetime is positive.
      */
-    private function assertPositiveLifetime(string $key, int $seconds): void
+    private function ensurePositiveLifetime(string $key, int $seconds): void
     {
         if ($seconds <= 0) {
             throw new InvalidArgumentException(

--- a/src/nested-set/src/Eloquent/QueryBuilder.php
+++ b/src/nested-set/src/Eloquent/QueryBuilder.php
@@ -75,7 +75,7 @@ class QueryBuilder extends EloquentBuilder
 
         if ($id instanceof Model) {
             $model = $id;
-            $this->assertUsableNodeForPositionalQuery($model);
+            $this->ensureUsableNodeForPositionalQuery($model);
             $value = '?';
             $bindings = [$id->getRgt()]; /* @phpstan-ignore method.notFound */
         } else {
@@ -180,7 +180,7 @@ class QueryBuilder extends EloquentBuilder
     {
         $this->query->whereNested(function (BaseQueryBuilder $inner) use ($id, $andSelf, $not) {
             if ($id instanceof Model) {
-                $this->assertUsableNodeForPositionalQuery($id);
+                $this->ensureUsableNodeForPositionalQuery($id);
                 $id->applyNestedSetScope($inner); /* @phpstan-ignore method.notFound */
                 $data = $id->getBounds(); /* @phpstan-ignore method.notFound */
             } else {
@@ -263,7 +263,7 @@ class QueryBuilder extends EloquentBuilder
 
         if ($id instanceof Model) {
             $model = $id;
-            $this->assertUsableNodeForPositionalQuery($model);
+            $this->ensureUsableNodeForPositionalQuery($model);
             $value = '?';
             $bindings = [$id->getLft()]; /* @phpstan-ignore method.notFound */
         } else {
@@ -982,9 +982,9 @@ class QueryBuilder extends EloquentBuilder
     }
 
     /**
-     * Assert that a node can supply coordinates to this query.
+     * Ensure that a node can supply coordinates to this query.
      */
-    protected function assertUsableNodeForPositionalQuery(Model $node): void
+    protected function ensureUsableNodeForPositionalQuery(Model $node): void
     {
         if (! NestedSet::isNode($node)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/nested-set/src/HasNode.php
+++ b/src/nested-set/src/HasNode.php
@@ -241,9 +241,9 @@ trait HasNode
      */
     protected function actionAppendOrPrependPrepared(self $parent, bool $prepend = false): bool
     {
-        $this->assertNodeInTree($parent)
+        $this->ensureNodeInTree($parent)
             ->assertNotDescendant($parent)
-            ->assertSameTree($parent)
+            ->ensureSameTree($parent)
             ->setParent($parent)
             ->dirtyBounds();
 
@@ -295,9 +295,9 @@ trait HasNode
     {
         $node->prepareForNestedSetMutation();
 
-        $this->assertNodeInTree($node)
+        $this->ensureNodeInTree($node)
             ->assertNotDescendant($node)
-            ->assertSameTree($node)
+            ->ensureSameTree($node)
             ->setParentFromSibling($node)
             ->dirtyBounds();
 
@@ -459,7 +459,7 @@ trait HasNode
      */
     public function nextSiblings(): QueryBuilder
     {
-        $this->assertParentageLoaded();
+        $this->ensureParentageLoaded();
 
         return $this->nextNodes()
             ->where(
@@ -474,7 +474,7 @@ trait HasNode
      */
     public function prevSiblings(): QueryBuilder
     {
-        $this->assertParentageLoaded();
+        $this->ensureParentageLoaded();
 
         return $this->prevNodes()
             ->where(
@@ -489,8 +489,8 @@ trait HasNode
      */
     public function nextNodes(): QueryBuilder
     {
-        $this->assertBoundsLoaded();
-        $this->assertScopeLoaded();
+        $this->ensureBoundsLoaded();
+        $this->ensureScopeLoaded();
 
         return $this->newScopedQuery()
             ->where(
@@ -505,8 +505,8 @@ trait HasNode
      */
     public function prevNodes(): QueryBuilder
     {
-        $this->assertBoundsLoaded();
-        $this->assertScopeLoaded();
+        $this->ensureBoundsLoaded();
+        $this->ensureScopeLoaded();
 
         return $this->newScopedQuery()
             ->where(
@@ -1165,7 +1165,7 @@ trait HasNode
             return 2;
         }
 
-        $this->assertBoundsLoaded();
+        $this->ensureBoundsLoaded();
 
         return $this->getRgt() - $this->getLft() + 1;
     }
@@ -1610,6 +1610,7 @@ trait HasNode
         $this->assertNotDescendant($node);
     }
 
+    // Keep NodeTrait::assertNotDescendant() so upstream subclasses remain compatible.
     /**
      * Assert that a node is not this node's descendant.
      */
@@ -1623,9 +1624,9 @@ trait HasNode
     }
 
     /**
-     * Assert that a node has persisted tree bounds.
+     * Ensure that a node has persisted tree bounds.
      */
-    protected function assertNodeInTree(self $node): static
+    protected function ensureNodeInTree(self $node): static
     {
         if (($node->getLft() ?? 0) < 1 || ($node->getRgt() ?? 0) < 1) {
             throw new LogicException('Node must be part of a tree.');
@@ -1635,9 +1636,9 @@ trait HasNode
     }
 
     /**
-     * Assert that this node has loaded bounds.
+     * Ensure that this node has loaded bounds.
      */
-    protected function assertBoundsLoaded(): void
+    protected function ensureBoundsLoaded(): void
     {
         if ($this->getLft() === null || $this->getRgt() === null) {
             throw new LogicException(sprintf(
@@ -1648,9 +1649,9 @@ trait HasNode
     }
 
     /**
-     * Assert that this node has loaded parentage.
+     * Ensure that this node has loaded parentage.
      */
-    protected function assertParentageLoaded(): void
+    protected function ensureParentageLoaded(): void
     {
         if (! array_key_exists($this->getParentIdName(), $this->attributes)) {
             throw new LogicException(sprintf(
@@ -1661,9 +1662,9 @@ trait HasNode
     }
 
     /**
-     * Assert that this node has loaded scope attributes.
+     * Ensure that this node has loaded scope attributes.
      */
-    protected function assertScopeLoaded(): void
+    protected function ensureScopeLoaded(): void
     {
         foreach ($this->getScopeAttributes() as $attribute) {
             if (! array_key_exists($attribute, $this->attributes)) {
@@ -1677,9 +1678,9 @@ trait HasNode
     }
 
     /**
-     * Assert that a node belongs to the same nested set tree.
+     * Ensure that a node belongs to the same nested set tree.
      */
-    protected function assertSameTree(self $node): static
+    protected function ensureSameTree(self $node): static
     {
         if (! $this->isSameTree($node)) {
             throw new LogicException('Nodes must be in the same tree.');

--- a/src/object-pool/src/ObjectPool.php
+++ b/src/object-pool/src/ObjectPool.php
@@ -82,7 +82,7 @@ abstract class ObjectPool implements ObjectPoolContract
      */
     public function release(object $object): void
     {
-        $id = $this->assertBorrowed($object);
+        $id = $this->ensureBorrowed($object);
         unset($this->borrowed[$id]);
 
         if ($this->closed) {
@@ -103,7 +103,7 @@ abstract class ObjectPool implements ObjectPoolContract
      */
     public function discard(object $object): void
     {
-        $id = $this->assertBorrowed($object);
+        $id = $this->ensureBorrowed($object);
         unset($this->borrowed[$id]);
 
         $this->destroyObject($object);
@@ -269,9 +269,9 @@ abstract class ObjectPool implements ObjectPoolContract
     abstract protected function createObject(): object;
 
     /**
-     * Assert an object is currently checked out from this pool.
+     * Ensure an object is currently checked out from this pool.
      */
-    protected function assertBorrowed(object $object): int
+    protected function ensureBorrowed(object $object): int
     {
         $id = spl_object_id($object);
 

--- a/src/opentelemetry/src/Instrumentation/ConsoleInstrumentation.php
+++ b/src/opentelemetry/src/Instrumentation/ConsoleInstrumentation.php
@@ -187,13 +187,12 @@ class ConsoleInstrumentation extends AbstractInstrumentation
         }
 
         $finishedAt = $this->clock->now();
-        $failed = $event->throwable !== null || ($event->exitCode !== null && $event->exitCode !== 0);
+        $failed = $event->throwable !== null || $event->exitCode !== 0;
         $result = $failed ? 'failure' : 'success';
-        $attributes = $state->attributes + ['result' => $result];
-
-        if ($event->exitCode !== null) {
-            $attributes[self::EXIT_CODE_ATTRIBUTE] = $event->exitCode;
-        }
+        $attributes = $state->attributes + [
+            'result' => $result,
+            self::EXIT_CODE_ATTRIBUTE => $event->exitCode,
+        ];
 
         if ($event->throwable !== null) {
             $attributes[ErrorAttributes::ERROR_TYPE] = $event->throwable::class;
@@ -202,10 +201,7 @@ class ConsoleInstrumentation extends AbstractInstrumentation
         try {
             if ($state->span?->isRecording()) {
                 $state->span->setAttribute('result', $result);
-
-                if ($event->exitCode !== null) {
-                    $state->span->setAttribute(self::EXIT_CODE_ATTRIBUTE, $event->exitCode);
-                }
+                $state->span->setAttribute(self::EXIT_CODE_ATTRIBUTE, $event->exitCode);
 
                 if ($event->throwable !== null) {
                     $state->span->recordException($event->throwable);

--- a/src/pool/src/Pool.php
+++ b/src/pool/src/Pool.php
@@ -101,7 +101,7 @@ abstract class Pool implements PoolInterface
      */
     public function release(ConnectionInterface $connection): void
     {
-        $connectionId = $this->assertBorrowed($connection, 'release');
+        $connectionId = $this->ensureBorrowed($connection, 'release');
         unset($this->borrowedConnections[$connectionId]);
 
         if ($this->closed) {
@@ -118,7 +118,7 @@ abstract class Pool implements PoolInterface
      */
     public function discard(ConnectionInterface $connection): void
     {
-        $this->assertBorrowed($connection, 'discard');
+        $this->ensureBorrowed($connection, 'discard');
         $this->destroyConnection($connection);
     }
 
@@ -478,9 +478,9 @@ abstract class Pool implements PoolInterface
     }
 
     /**
-     * Assert that a connection is currently borrowed from this pool.
+     * Ensure that a connection is currently borrowed from this pool.
      */
-    private function assertBorrowed(ConnectionInterface $connection, string $operation): int
+    private function ensureBorrowed(ConnectionInterface $connection, string $operation): int
     {
         $connectionId = spl_object_id($connection);
 

--- a/src/sentry/src/Features/ConsoleIntegration.php
+++ b/src/sentry/src/Features/ConsoleIntegration.php
@@ -129,7 +129,7 @@ class ConsoleIntegration extends Feature
     /**
      * Resolve the command exit code represented by the terminal event.
      */
-    private function resolveExitCode(AfterExecute $event): ?int
+    private function resolveExitCode(AfterExecute $event): int
     {
         if ($event->throwable === null) {
             return $event->exitCode;
@@ -145,7 +145,7 @@ class ConsoleIntegration extends Feature
      *
      * @return array{input?: string}
      */
-    private function commandInputMetadata(?InputInterface $input): array
+    private function commandInputMetadata(InputInterface $input): array
     {
         if (! $this->shouldSendDefaultPii() || ! $input instanceof ArgvInput) {
             return [];

--- a/src/telescope/src/Watchers/CommandWatcher.php
+++ b/src/telescope/src/Watchers/CommandWatcher.php
@@ -48,12 +48,8 @@ class CommandWatcher extends Watcher
      *
      * @return array{arguments: array<string, mixed>, options: array<string, mixed>}
      */
-    private function redactInput(Command $command, ?InputInterface $input): array
+    private function redactInput(Command $command, InputInterface $input): array
     {
-        if ($input === null) {
-            return ['arguments' => [], 'options' => []];
-        }
-
         $arguments = array_map(
             static fn (mixed $value): mixed => $value === null ? null : Telescope::REDACTED_VALUE,
             $input->getArguments(),

--- a/src/translation/src/FileLoader.php
+++ b/src/translation/src/FileLoader.php
@@ -45,7 +45,7 @@ class FileLoader implements Loader
      */
     public function load(string $locale, string $group, ?string $namespace = null): array
     {
-        // Mirrors Translator::assertValidLocale(); keep both predicates identical.
+        // Mirrors Translator::ensureValidLocale(); keep both predicates identical.
         if (Str::contains($locale, ['/', '\\']) || $locale === '.' || $locale === '..') {
             throw new InvalidArgumentException('Invalid characters present in locale.');
         }

--- a/src/translation/src/Translator.php
+++ b/src/translation/src/Translator.php
@@ -645,7 +645,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function setLocale(string $locale): void
     {
-        $this->assertValidLocale($locale);
+        $this->ensureValidLocale($locale);
 
         CoroutineContext::set(self::LOCALE_CONTEXT_KEY, $locale);
     }
@@ -660,7 +660,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function setBaseLocale(string $locale): void
     {
-        $this->assertValidLocale($locale);
+        $this->ensureValidLocale($locale);
 
         $this->locale = $locale;
     }
@@ -670,7 +670,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      *
      * @throws InvalidArgumentException
      */
-    protected function assertValidLocale(string $locale): void
+    protected function ensureValidLocale(string $locale): void
     {
         // Mirrors the trust-boundary check in FileLoader::load(); keep both predicates identical.
         if (Str::contains($locale, ['/', '\\']) || $locale === '.' || $locale === '..') {
@@ -695,7 +695,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function setFallback(string $fallback): void
     {
-        $this->assertValidLocale($fallback);
+        $this->ensureValidLocale($fallback);
 
         $this->fallback = $fallback;
     }

--- a/tests/Console/CommandEventContextTest.php
+++ b/tests/Console/CommandEventContextTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Console;
+
+use Hypervel\Console\Command;
+use Hypervel\Console\Events\AfterExecute;
+use Hypervel\Console\Events\AfterHandle;
+use Hypervel\Console\Events\BeforeHandle;
+use Hypervel\Contracts\Events\Dispatcher;
+use Hypervel\Engine\Coroutine;
+use Hypervel\Testbench\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+use function Hypervel\Coroutine\run;
+
+class CommandEventContextTest extends TestCase
+{
+    protected bool $runTestsInCoroutine = false;
+
+    public function testLifecycleEventsShareTheCommandExecutionContext(): void
+    {
+        $eventCoroutineIds = [];
+        $eventInputs = [];
+        $this->app->make(Dispatcher::class)->listen(
+            static function (BeforeHandle|AfterHandle|AfterExecute $event) use (&$eventCoroutineIds, &$eventInputs): void {
+                $commandId = spl_object_id($event->command);
+                $eventCoroutineIds[$commandId][] = Coroutine::id();
+
+                if ($event instanceof BeforeHandle || $event instanceof AfterExecute) {
+                    $eventInputs[$commandId][] = $event->input;
+                }
+            },
+        );
+
+        $ownCoroutine = new CommandEventContextTestCommand;
+        $ownCoroutine->setHypervel($this->app);
+        $ownInput = new ArrayInput([]);
+
+        $this->assertSame(-1, Coroutine::id());
+        $this->assertNull($ownCoroutine->handleCoroutineId);
+        $this->assertSame(Command::SUCCESS, $ownCoroutine->run($ownInput, new NullOutput));
+        $this->assertGreaterThan(0, $ownCoroutine->handleCoroutineId);
+        $this->assertSame(
+            array_fill(0, 3, $ownCoroutine->handleCoroutineId),
+            $eventCoroutineIds[spl_object_id($ownCoroutine)],
+        );
+        $this->assertSame([$ownInput, $ownInput], $eventInputs[spl_object_id($ownCoroutine)]);
+
+        $inline = new CommandEventContextTestCommand(coroutine: false);
+        $inline->setHypervel($this->app);
+        $inlineInput = new ArrayInput([]);
+
+        $this->assertSame(Command::SUCCESS, $inline->run($inlineInput, new NullOutput));
+        $this->assertSame(-1, $inline->handleCoroutineId);
+        $this->assertSame(
+            [-1, -1, -1],
+            $eventCoroutineIds[spl_object_id($inline)],
+        );
+        $this->assertSame([$inlineInput, $inlineInput], $eventInputs[spl_object_id($inline)]);
+
+        $nested = new CommandEventContextTestCommand;
+        $nested->setHypervel($this->app);
+        $nestedInput = new ArrayInput([]);
+        $invocationCoroutineId = null;
+
+        run(function () use ($nested, $nestedInput, &$invocationCoroutineId): void {
+            $invocationCoroutineId = Coroutine::id();
+            $nested->run($nestedInput, new NullOutput);
+        });
+
+        $this->assertGreaterThan(0, $invocationCoroutineId);
+        $this->assertSame($invocationCoroutineId, $nested->handleCoroutineId);
+        $this->assertSame(
+            array_fill(0, 3, $invocationCoroutineId),
+            $eventCoroutineIds[spl_object_id($nested)],
+        );
+        $this->assertSame([$nestedInput, $nestedInput], $eventInputs[spl_object_id($nested)]);
+    }
+}
+
+class CommandEventContextTestCommand extends Command
+{
+    public ?int $handleCoroutineId = null;
+
+    public function __construct(bool $coroutine = true)
+    {
+        parent::__construct();
+
+        $this->coroutine = $coroutine;
+    }
+
+    public function handle(): int
+    {
+        $this->handleCoroutineId = Coroutine::id();
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -11,10 +11,12 @@ use Hypervel\Console\Attributes\Signature;
 use Hypervel\Console\Attributes\Usage;
 use Hypervel\Console\Command;
 use Hypervel\Console\CommandInput;
+use Hypervel\Console\Events\AfterExecute;
 use Hypervel\Console\ManuallyFailedException;
 use Hypervel\Console\OutputStyle;
 use Hypervel\Console\SignalRegistry;
 use Hypervel\Console\View\Components\Factory;
+use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Support\ClassInvoker;
 use Hypervel\Testbench\TestCase;
@@ -139,6 +141,93 @@ class CommandTest extends TestCase
     public function testExitCodeFromExitExceptionAndNormalCommandInCoroutine()
     {
         $this->testExitCodeFromExitExceptionAndNormalCommand();
+    }
+
+    public function testAfterExecuteCarriesTheFinalExitCodeAndExecutionThrowable(): void
+    {
+        $events = [];
+        $this->app->make(Dispatcher::class)->listen(
+            AfterExecute::class,
+            static function (AfterExecute $event) use (&$events): void {
+                $events[] = $event;
+            },
+        );
+
+        $success = new class extends Command {
+            public function handle(): int
+            {
+                return self::SUCCESS;
+            }
+        };
+        $nonZero = new class extends Command {
+            public function handle(): int
+            {
+                return 11;
+            }
+        };
+        $manualFailure = new class extends Command {
+            public function handle(): never
+            {
+                $this->fail('command failed manually');
+            }
+        };
+        $outOfRange = new class extends Command {
+            public function handle(): int
+            {
+                return 300;
+            }
+        };
+        $failure = new RuntimeException('command failed');
+        $throwing = new class($failure) extends Command {
+            public function __construct(private readonly RuntimeException $failure)
+            {
+                parent::__construct();
+            }
+
+            public function handle(): never
+            {
+                throw $this->failure;
+            }
+        };
+
+        foreach ([$success, $nonZero, $manualFailure, $outOfRange, $throwing] as $command) {
+            $command->setHypervel($this->app);
+        }
+
+        $successInput = new ArrayInput([]);
+        $nonZeroInput = new ArrayInput([]);
+        $manualFailureInput = new ArrayInput([]);
+        $outOfRangeInput = new ArrayInput([]);
+        $throwingInput = new ArrayInput([]);
+
+        $this->assertSame(Command::SUCCESS, $success->run($successInput, new NullOutput));
+        $this->assertSame(11, $nonZero->run($nonZeroInput, new NullOutput));
+        $this->assertSame(Command::FAILURE, $manualFailure->run($manualFailureInput, new NullOutput));
+        $this->assertSame(Command::INVALID, $outOfRange->run($outOfRangeInput, new NullOutput));
+
+        try {
+            $throwing->run($throwingInput, new NullOutput);
+            $this->fail('Expected the command exception to propagate.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($failure, $exception);
+        }
+
+        $this->assertCount(5, $events);
+        $this->assertSame(Command::SUCCESS, $events[0]->exitCode);
+        $this->assertNull($events[0]->throwable);
+        $this->assertSame($successInput, $events[0]->input);
+        $this->assertSame(11, $events[1]->exitCode);
+        $this->assertNull($events[1]->throwable);
+        $this->assertSame($nonZeroInput, $events[1]->input);
+        $this->assertSame(Command::FAILURE, $events[2]->exitCode);
+        $this->assertNull($events[2]->throwable);
+        $this->assertSame($manualFailureInput, $events[2]->input);
+        $this->assertSame(Command::INVALID, $events[3]->exitCode);
+        $this->assertNull($events[3]->throwable);
+        $this->assertSame($outOfRangeInput, $events[3]->input);
+        $this->assertSame(Command::FAILURE, $events[4]->exitCode);
+        $this->assertSame($failure, $events[4]->throwable);
+        $this->assertSame($throwingInput, $events[4]->input);
     }
 
     public function testProhibitableCommand()

--- a/tests/Console/Events/EventsTest.php
+++ b/tests/Console/Events/EventsTest.php
@@ -68,19 +68,15 @@ class EventsTest extends TestCase
         $this->assertSame(1, $event->exitCode);
     }
 
-    public function testBeforeHandleCarriesCommandAndOptionalInput(): void
+    public function testBeforeHandleCarriesCommandAndInput(): void
     {
         $command = m::mock(Command::class);
         $input = new ArrayInput([]);
 
-        $event = new BeforeHandle($command);
+        $event = new BeforeHandle($command, $input);
 
         $this->assertSame($command, $event->command);
-        $this->assertNull($event->input);
-
-        $eventWithInput = new BeforeHandle($command, $input);
-
-        $this->assertSame($input, $eventWithInput->input);
+        $this->assertSame($input, $event->input);
     }
 
     public function testAfterHandleCarriesCommand()
@@ -92,22 +88,17 @@ class EventsTest extends TestCase
         $this->assertSame($command, $event->command);
     }
 
-    public function testAfterExecuteCarriesCommandAndOptionalExecutionData(): void
+    public function testAfterExecuteCarriesExecutionData(): void
     {
         $command = m::mock(Command::class);
-
-        $event = new AfterExecute($command);
-        $this->assertSame($command, $event->command);
-        $this->assertNull($event->throwable);
-        $this->assertNull($event->input);
-        $this->assertNull($event->exitCode);
-
         $throwable = new RuntimeException('Execute failed');
         $input = new ArrayInput([]);
-        $eventWithThrowable = new AfterExecute($command, $throwable, $input, 1);
-        $this->assertSame($throwable, $eventWithThrowable->throwable);
-        $this->assertSame($input, $eventWithThrowable->input);
-        $this->assertSame(1, $eventWithThrowable->exitCode);
+        $event = new AfterExecute($command, $throwable, $input, 1);
+
+        $this->assertSame($command, $event->command);
+        $this->assertSame($throwable, $event->throwable);
+        $this->assertSame($input, $event->input);
+        $this->assertSame(1, $event->exitCode);
     }
 
     public function testScheduledTaskStartingCarriesTask()

--- a/tests/Foundation/Http/HealthCheckControllerTest.php
+++ b/tests/Foundation/Http/HealthCheckControllerTest.php
@@ -11,13 +11,76 @@ use Hypervel\Contracts\Routing\ResponseFactory;
 use Hypervel\Contracts\View\Factory as ViewFactory;
 use Hypervel\Foundation\Events\DiagnosingHealth;
 use Hypervel\Foundation\Http\HealthCheckController;
+use Hypervel\Http\JsonResponse;
 use Hypervel\Http\Request;
 use Hypervel\Tests\TestCase;
 use Mockery as m;
+use RuntimeException;
 use Swoole\Coroutine\CanceledException;
 
 class HealthCheckControllerTest extends TestCase
 {
+    public function testDiagnosisFailureIsReportedAndReturnsTheDownResponse(): void
+    {
+        $failure = new RuntimeException('Database connection refused.');
+        $application = m::mock(Application::class);
+        $application->expects('hasDebugModeEnabled')->andReturnFalse();
+        $events = m::mock(Dispatcher::class);
+        $events->expects('dispatch')
+            ->with(m::type(DiagnosingHealth::class))
+            ->andThrow($failure);
+        $exceptions = m::mock(ExceptionHandler::class);
+        $exceptions->expects('report')->with($failure);
+        $response = new JsonResponse(['status' => 'down'], 500);
+        $responses = m::mock(ResponseFactory::class);
+        $responses->expects('json')->with(['status' => 'down'], 500)->andReturn($response);
+        $responses->shouldNotReceive('make');
+        $views = m::mock(ViewFactory::class);
+        $views->shouldNotReceive('file');
+        $controller = new HealthCheckController(
+            $application,
+            $events,
+            $exceptions,
+            $responses,
+            $views,
+        );
+
+        $this->assertSame($response, $controller(Request::create('/up', server: [
+            'HTTP_ACCEPT' => 'application/json',
+        ])));
+    }
+
+    public function testDiagnosisFailureEscapesWithoutReportingOrRenderingInDebugMode(): void
+    {
+        $failure = new RuntimeException('Database connection refused.');
+        $application = m::mock(Application::class);
+        $application->expects('hasDebugModeEnabled')->andReturnTrue();
+        $events = m::mock(Dispatcher::class);
+        $events->expects('dispatch')
+            ->with(m::type(DiagnosingHealth::class))
+            ->andThrow($failure);
+        $exceptions = m::mock(ExceptionHandler::class);
+        $exceptions->shouldNotReceive('report');
+        $responses = m::mock(ResponseFactory::class);
+        $responses->shouldNotReceive('make', 'json');
+        $views = m::mock(ViewFactory::class);
+        $views->shouldNotReceive('file');
+        $controller = new HealthCheckController(
+            $application,
+            $events,
+            $exceptions,
+            $responses,
+            $views,
+        );
+
+        try {
+            $controller(Request::create('/up'));
+            $this->fail('Expected the health diagnosis failure to escape in debug mode.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame($failure, $exception);
+        }
+    }
+
     public function testDiagnosisCancellationEscapesWithoutReportingOrRendering(): void
     {
         $cancellation = new CanceledException('cancelled');

--- a/tests/OpenTelemetry/Instrumentation/ConsoleInstrumentationNonCoroutineTest.php
+++ b/tests/OpenTelemetry/Instrumentation/ConsoleInstrumentationNonCoroutineTest.php
@@ -26,6 +26,7 @@ use OpenTelemetry\Context\ExecutionContextAwareInterface;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
+use Symfony\Component\Console\Input\ArrayInput;
 
 class ConsoleInstrumentationNonCoroutineTest extends TestCase
 {
@@ -81,10 +82,11 @@ class ConsoleInstrumentationNonCoroutineTest extends TestCase
             'metrics' => false,
         ]);
         $command = new ConsoleInstrumentationNonCoroutineCommand('package:discover');
+        $input = new ArrayInput([]);
 
-        $this->events->dispatch(new BeforeHandle($command));
+        $this->events->dispatch(new BeforeHandle($command, $input));
         $this->assertTrue(Span::getCurrent()->getContext()->isValid());
-        $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+        $this->events->dispatch(new AfterExecute($command, null, $input, 0));
 
         $this->assertFalse(Span::getCurrent()->getContext()->isValid());
         $this->assertCount(1, $this->spanExporter->getSpans());

--- a/tests/OpenTelemetry/Instrumentation/ConsoleInstrumentationTest.php
+++ b/tests/OpenTelemetry/Instrumentation/ConsoleInstrumentationTest.php
@@ -40,6 +40,8 @@ use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 use OpenTelemetry\SemConv\Attributes\ExceptionAttributes;
 use RuntimeException;
 use Swoole\Coroutine\CanceledException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Throwable;
 
 use function Hypervel\Coroutine\parallel;
 
@@ -132,12 +134,12 @@ class ConsoleInstrumentationTest extends TestCase
 
         try {
             $this->clock->timestamp = 1_000_000_000;
-            $this->events->dispatch(new BeforeHandle($command));
+            $input = $this->startCommand($command);
             $commandSpan = Span::getCurrent()->getContext();
             $this->assertNotSame($ambient->getContext()->getSpanId(), $commandSpan->getSpanId());
 
             $this->clock->timestamp = 4_000_000_000;
-            $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+            $this->finishCommand($command, $input);
             $this->assertSame($ambient->getContext()->getSpanId(), Span::getCurrent()->getContext()->getSpanId());
         } finally {
             $ambientScope->detach();
@@ -170,16 +172,16 @@ class ConsoleInstrumentationTest extends TestCase
 
         foreach (['reports:secret', 'cache:clear', ''] as $name) {
             $command = new ConsoleInstrumentationCommand($name === '' ? null : $name);
-            $this->events->dispatch(new BeforeHandle($command));
-            $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+            $input = $this->startCommand($command);
+            $this->finishCommand($command, $input);
         }
 
         $this->assertSame(0, $this->clock->calls);
         $this->assertFalse(Span::getCurrent()->getContext()->isValid());
 
         $allowed = new ConsoleInstrumentationCommand('reports:daily');
-        $this->events->dispatch(new BeforeHandle($allowed));
-        $this->events->dispatch(new AfterExecute($allowed, exitCode: 0));
+        $input = $this->startCommand($allowed);
+        $this->finishCommand($allowed, $input);
 
         $this->assertSame(2, $this->clock->calls);
         $this->assertCount(1, $this->spanExporter->getSpans());
@@ -190,8 +192,8 @@ class ConsoleInstrumentationTest extends TestCase
         $this->instrumentation()->register($this->options());
         $command = new ConsoleInstrumentationCommand('reports:daily');
 
-        $this->events->dispatch(new BeforeHandle($command));
-        $this->events->dispatch(new AfterExecute($command, exitCode: 7));
+        $input = $this->startCommand($command);
+        $this->finishCommand($command, $input, exitCode: 7);
 
         $span = $this->exportedSpan('reports:daily');
         $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
@@ -212,8 +214,8 @@ class ConsoleInstrumentationTest extends TestCase
         $command = new ConsoleInstrumentationCommand('reports:daily');
         $exception = new RuntimeException('Command failed.');
 
-        $this->events->dispatch(new BeforeHandle($command));
-        $this->events->dispatch(new AfterExecute($command, $exception, exitCode: 1));
+        $input = $this->startCommand($command);
+        $this->finishCommand($command, $input, $exception, 1);
 
         $span = $this->exportedSpan('reports:daily');
         $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
@@ -238,9 +240,9 @@ class ConsoleInstrumentationTest extends TestCase
         $this->instrumentation()->register($this->options());
         $command = new ConsoleInstrumentationCommand('reports:daily');
 
-        $this->events->dispatch(new BeforeHandle($command));
+        $input = $this->startCommand($command);
         $active = Span::getCurrent()->getContext();
-        $this->events->dispatch(new AfterExecute($command, new CanceledException, exitCode: 1));
+        $this->finishCommand($command, $input, new CanceledException, 1);
 
         $this->assertTrue($active->isValid());
         $this->assertSame($active->getSpanId(), Span::getCurrent()->getContext()->getSpanId());
@@ -255,17 +257,17 @@ class ConsoleInstrumentationTest extends TestCase
         $outer = new ConsoleInstrumentationCommand('outer');
         $inner = new ConsoleInstrumentationCommand('inner');
 
-        $this->events->dispatch(new BeforeHandle($outer));
+        $outerInput = $this->startCommand($outer);
         $outerSpan = Span::getCurrent()->getContext();
-        $this->events->dispatch(new BeforeHandle($inner));
+        $innerInput = $this->startCommand($inner);
         $innerSpan = Span::getCurrent()->getContext();
 
-        $this->events->dispatch(new AfterExecute($outer, exitCode: 0));
+        $this->finishCommand($outer, $outerInput);
         $this->assertSame($innerSpan->getSpanId(), Span::getCurrent()->getContext()->getSpanId());
 
-        $this->events->dispatch(new AfterExecute($inner, exitCode: 0));
+        $this->finishCommand($inner, $innerInput);
         $this->assertSame($outerSpan->getSpanId(), Span::getCurrent()->getContext()->getSpanId());
-        $this->events->dispatch(new AfterExecute($outer, exitCode: 0));
+        $this->finishCommand($outer, $outerInput);
         $this->assertFalse(Span::getCurrent()->getContext()->isValid());
         $this->assertCount(2, $this->spanExporter->getSpans());
     }
@@ -277,19 +279,19 @@ class ConsoleInstrumentationTest extends TestCase
 
         $spanIds = parallel([
             function () use ($command): string {
-                $this->events->dispatch(new BeforeHandle($command));
+                $input = $this->startCommand($command);
                 $spanId = Span::getCurrent()->getContext()->getSpanId();
                 usleep(10_000);
-                $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+                $this->finishCommand($command, $input);
                 $this->assertFalse(Span::getCurrent()->getContext()->isValid());
 
                 return $spanId;
             },
             function () use ($command): string {
-                $this->events->dispatch(new BeforeHandle($command));
+                $input = $this->startCommand($command);
                 $spanId = Span::getCurrent()->getContext()->getSpanId();
                 usleep(5_000);
-                $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+                $this->finishCommand($command, $input);
                 $this->assertFalse(Span::getCurrent()->getContext()->isValid());
 
                 return $spanId;
@@ -306,9 +308,9 @@ class ConsoleInstrumentationTest extends TestCase
         $command = new ConsoleInstrumentationCommand('reports:daily');
 
         $this->clock->timestamp = 1_000_000_000;
-        $this->events->dispatch(new BeforeHandle($command));
+        $input = $this->startCommand($command);
         $this->clock->timestamp = 2_000_000_000;
-        $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+        $this->finishCommand($command, $input);
 
         $this->assertSame([], $this->spanExporter->getSpans());
         $this->metricReader->collect();
@@ -320,8 +322,8 @@ class ConsoleInstrumentationTest extends TestCase
         $this->instrumentation()->register($this->options(duration: false));
         $command = new ConsoleInstrumentationCommand('reports:daily');
 
-        $this->events->dispatch(new BeforeHandle($command));
-        $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+        $input = $this->startCommand($command);
+        $this->finishCommand($command, $input);
 
         $this->assertCount(1, $this->spanExporter->getSpans());
         $this->metricReader->collect();
@@ -338,8 +340,8 @@ class ConsoleInstrumentationTest extends TestCase
         $this->instrumentation()->register($this->options(duration: false));
         $command = new ConsoleInstrumentationCommand('reports:daily');
 
-        $this->events->dispatch(new BeforeHandle($command));
-        $this->events->dispatch(new AfterExecute($command, exitCode: 0));
+        $input = $this->startCommand($command);
+        $this->finishCommand($command, $input);
 
         $this->assertCount(1, $sampler->samples);
         $this->assertSame(
@@ -347,6 +349,29 @@ class ConsoleInstrumentationTest extends TestCase
             $sampler->samples[0]['attributes']['hypervel.console.command'],
         );
         $this->assertSame([], $this->spanExporter->getSpans());
+    }
+
+    /**
+     * Dispatch a command-start event with its input.
+     */
+    private function startCommand(Command $command): ArrayInput
+    {
+        $input = new ArrayInput([]);
+        $this->events->dispatch(new BeforeHandle($command, $input));
+
+        return $input;
+    }
+
+    /**
+     * Dispatch a command-completion event with its input.
+     */
+    private function finishCommand(
+        Command $command,
+        ArrayInput $input,
+        ?Throwable $throwable = null,
+        int $exitCode = 0,
+    ): void {
+        $this->events->dispatch(new AfterExecute($command, $throwable, $input, $exitCode));
     }
 
     /**

--- a/tests/Redis/RedisCancellationLifecycleTest.php
+++ b/tests/Redis/RedisCancellationLifecycleTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Tests\Redis;
+
+use Hypervel\Engine\Channel;
+use Hypervel\Engine\Coroutine;
+use Hypervel\Pool\Exceptions\ConnectionException;
+use Hypervel\Redis\Events\CommandExecuted;
+use Hypervel\Redis\Events\CommandFailed;
+use Hypervel\Redis\Pool\PoolFactory;
+use Hypervel\Redis\RedisConnection;
+use Hypervel\Support\Facades\Redis as RedisFacade;
+use Hypervel\Testbench\TestCase;
+use Hypervel\Tests\Redis\Fixtures\RespServer;
+use RedisException;
+use Swoole\Coroutine\CanceledException;
+use Throwable;
+
+class RedisCancellationLifecycleTest extends TestCase
+{
+    public function testBlockedCommandCancellationInvalidatesAndReturnsTheLeaseWithoutEvents(): void
+    {
+        $server = new RespServer;
+        $commandReceived = new Channel(1);
+        $releaseServer = new Channel(1);
+        $server->start(function ($client) use ($commandReceived, $releaseServer): void {
+            $command = fread($client, 4096);
+
+            $this->assertIsString($command);
+            $this->assertStringContainsString('BLPOP', $command);
+            $commandReceived->push(true);
+            $releaseServer->pop(2.0);
+        });
+
+        [$host, $port] = $server->hostAndPort();
+        $connectionName = 'canceled_command';
+        $this->configureConnection($connectionName, $host, $port);
+        $executed = 0;
+        $failed = 0;
+        RedisFacade::listen(static function (CommandExecuted $event) use (&$executed): void {
+            ++$executed;
+        });
+        RedisFacade::listenForFailures(static function (CommandFailed $event) use (&$failed): void {
+            ++$failed;
+        });
+        $connection = RedisFacade::connection($connectionName);
+        $pool = $this->app->make(PoolFactory::class)->getPool($connectionName);
+        // The one-connection pool establishes the only socket accepted by the test server,
+        // then the canceled command reuses it.
+        $eventConnection = $pool->get();
+
+        try {
+            $this->assertInstanceOf(RedisConnection::class, $eventConnection);
+            $this->assertNotNull($eventConnection->getEventDispatcher());
+        } finally {
+            $pool->release($eventConnection);
+        }
+
+        try {
+            $exception = $this->cancelAfter(
+                static fn () => $connection->blpop('blocked', 0),
+                $commandReceived,
+            );
+
+            $this->assertInstanceOf(CanceledException::class, $exception);
+            $this->assertSame('Executing Redis command [blpop] was canceled.', $exception->getMessage());
+            $this->assertInstanceOf(RedisException::class, $exception->getPrevious());
+            $this->assertSame(0, $executed);
+            $this->assertSame(0, $failed);
+
+            // The pool already owns this lease, so cancellation returns it invalidated.
+            $this->assertSame(1, $pool->getCurrentConnections());
+            $this->assertSame(1, $pool->getConnectionsInChannel());
+            $pooledConnection = $pool->get();
+
+            try {
+                $this->assertInstanceOf(RedisConnection::class, $pooledConnection);
+                $this->assertFalse($pooledConnection->check());
+            } finally {
+                $pool->release($pooledConnection);
+            }
+        } finally {
+            $releaseServer->push(true);
+
+            try {
+                $server->wait();
+            } finally {
+                $this->app->make(PoolFactory::class)->flushPool($connectionName);
+            }
+        }
+    }
+
+    public function testBlockedSelectCancellationRepairsPoolCapacity(): void
+    {
+        $server = new RespServer;
+        $selectReceived = new Channel(1);
+        $releaseServer = new Channel(1);
+        $server->start(function ($client) use ($selectReceived, $releaseServer): void {
+            $command = fread($client, 4096);
+
+            $this->assertIsString($command);
+            $this->assertStringContainsString('SELECT', $command);
+            $selectReceived->push(true);
+            $releaseServer->pop(2.0);
+        });
+
+        [$host, $port] = $server->hostAndPort();
+        $connectionName = 'canceled_select';
+        $this->configureConnection($connectionName, $host, $port, ['database' => 1]);
+        $connection = RedisFacade::connection($connectionName);
+        $pool = $this->app->make(PoolFactory::class)->getPool($connectionName);
+
+        try {
+            try {
+                $exception = $this->cancelAfter(
+                    static fn () => $connection->get('blocked'),
+                    $selectReceived,
+                );
+
+                $this->assertInstanceOf(CanceledException::class, $exception);
+                $this->assertSame('Connecting to Redis was canceled.', $exception->getMessage());
+                $this->assertInstanceOf(RedisException::class, $exception->getPrevious());
+
+                // Initial SELECT was canceled before admission, so the pool discards the lease.
+                $this->assertSame(0, $pool->getCurrentConnections());
+                $this->assertSame(0, $pool->getConnectionsInChannel());
+            } finally {
+                $releaseServer->push(true);
+                $server->wait();
+            }
+
+            $capacityFailure = null;
+
+            try {
+                $pool->get();
+            } catch (Throwable $throwable) {
+                $capacityFailure = $throwable;
+            }
+
+            $this->assertTrue(
+                $capacityFailure instanceof RedisException || $capacityFailure instanceof ConnectionException,
+                sprintf(
+                    'Expected the next checkout to reach the Redis transport, got [%s].',
+                    $capacityFailure === null ? 'no exception' : $capacityFailure::class,
+                ),
+            );
+        } finally {
+            $this->app->make(PoolFactory::class)->flushPool($connectionName);
+        }
+    }
+
+    /**
+     * Configure shared Redis options and one connection for a local test server.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function configureConnection(string $name, string $host, int $port, array $overrides = []): void
+    {
+        $config = $this->app->make('config');
+        $config->set('database.redis.options', []);
+        $connection = [
+            'url' => null,
+            'host' => $host,
+            'port' => $port,
+            'username' => null,
+            'password' => null,
+            'database' => 0,
+            'timeout' => 0.5,
+            'read_timeout' => 5.0,
+            'events' => true,
+            'max_retries' => 0,
+            'options' => ['prefix' => ''],
+            'pool' => [
+                'min_connections' => 0,
+                'max_connections' => 1,
+                'connect_timeout' => 0.5,
+                'wait_timeout' => 0.1,
+                'heartbeat' => -1.0,
+                'heartbeat_timeout' => 0.1,
+                'max_idle_time' => 60.0,
+                'max_lifetime' => -1.0,
+            ],
+        ];
+
+        $config->set("database.redis.{$name}", array_replace($connection, $overrides));
+    }
+
+    /**
+     * Cancel an operation after its native I/O boundary has been reached.
+     */
+    private function cancelAfter(callable $operation, Channel $entered): Throwable
+    {
+        $result = new Channel(1);
+        $coroutine = Coroutine::create(static function () use ($operation, $result): void {
+            try {
+                $operation();
+                $result->push(true);
+            } catch (Throwable $exception) {
+                $result->push($exception);
+            }
+        });
+        $enteredOperation = false;
+        $cancellationRequested = false;
+
+        try {
+            $enteredOperation = $entered->pop(2.0);
+
+            if ($enteredOperation) {
+                $cancellationRequested = Coroutine::cancelById($coroutine->getId(), throwException: true);
+            }
+        } finally {
+            try {
+                if (! $cancellationRequested && Coroutine::exists($coroutine->getId())) {
+                    Coroutine::cancelById($coroutine->getId(), throwException: true);
+                }
+            } finally {
+                Coroutine::join([$coroutine->getId()], 2.0);
+            }
+        }
+
+        $this->assertTrue($enteredOperation);
+        $this->assertTrue($cancellationRequested);
+        $this->assertFalse(Coroutine::exists($coroutine->getId()));
+        $outcome = $result->pop(2.0);
+        $this->assertInstanceOf(Throwable::class, $outcome);
+
+        return $outcome;
+    }
+}

--- a/tests/Sentry/Features/ConsoleIntegrationNonCoroutineTest.php
+++ b/tests/Sentry/Features/ConsoleIntegrationNonCoroutineTest.php
@@ -26,7 +26,7 @@ class ConsoleIntegrationNonCoroutineTest extends SentryTestCase
         $this->dispatchHypervelEvent(new BeforeHandle($command, $input));
         $this->assertNotSame($scope, $this->getCurrentSentryScope());
 
-        $this->dispatchHypervelEvent(new AfterExecute($command, input: $input, exitCode: 0));
+        $this->dispatchHypervelEvent(new AfterExecute($command, null, $input, 0));
         $this->assertSame($scope, $this->getCurrentSentryScope());
     }
 
@@ -44,11 +44,11 @@ class ConsoleIntegrationNonCoroutineTest extends SentryTestCase
         $outerScope = $this->getCurrentSentryScope();
 
         $this->dispatchHypervelEvent(new BeforeHandle($inner, $input));
-        $this->dispatchHypervelEvent(new AfterExecute($inner, input: $input, exitCode: 0));
+        $this->dispatchHypervelEvent(new AfterExecute($inner, null, $input, 0));
 
         $this->assertSame($outerScope, $this->getCurrentSentryScope());
 
-        $this->dispatchHypervelEvent(new AfterExecute($outer, input: $input, exitCode: 0));
+        $this->dispatchHypervelEvent(new AfterExecute($outer, null, $input, 0));
         $this->assertSame($baselineScope, $this->getCurrentSentryScope());
     }
 }

--- a/tests/Sentry/Features/ConsoleIntegrationTest.php
+++ b/tests/Sentry/Features/ConsoleIntegrationTest.php
@@ -39,8 +39,9 @@ class ConsoleIntegrationTest extends SentryTestCase
         $unmatchedCommand = new ConsoleIntegrationCommand;
         $this->app->make(ConsoleIntegration::class)->afterExecute(new AfterExecute(
             $unmatchedCommand,
-            input: $this->commandInput($unmatchedCommand, true),
-            exitCode: 12,
+            null,
+            $this->commandInput($unmatchedCommand, true),
+            12,
         ));
         $lastBreadcrumb = $this->getLastSentryBreadcrumb();
 
@@ -70,8 +71,9 @@ class ConsoleIntegrationTest extends SentryTestCase
         $unmatchedCommand = new ConsoleIntegrationCommand;
         $this->app->make(ConsoleIntegration::class)->afterExecute(new AfterExecute(
             $unmatchedCommand,
-            input: $this->commandInput($unmatchedCommand, true),
-            exitCode: 12,
+            null,
+            $this->commandInput($unmatchedCommand, true),
+            12,
         ));
         $metadata = $this->getLastSentryBreadcrumb()->getMetadata();
 
@@ -195,13 +197,13 @@ class ConsoleIntegrationTest extends SentryTestCase
         $dispatcher->dispatch(new BeforeHandle($inner, $input));
         $innerScope = $this->getCurrentSentryScope();
 
-        $dispatcher->dispatch(new AfterExecute($inner, input: $input, exitCode: 0));
-        $dispatcher->dispatch(new AfterExecute($outer, input: $input, exitCode: 0));
+        $dispatcher->dispatch(new AfterExecute($inner, null, $input, 0));
+        $dispatcher->dispatch(new AfterExecute($outer, null, $input, 0));
 
         $this->assertSame($innerScope, $this->getCurrentSentryScope());
 
-        $integration->afterExecute(new AfterExecute($inner, input: $input, exitCode: 0));
-        $integration->afterExecute(new AfterExecute($outer, input: $input, exitCode: 0));
+        $integration->afterExecute(new AfterExecute($inner, null, $input, 0));
+        $integration->afterExecute(new AfterExecute($outer, null, $input, 0));
         $this->assertSame($baselineScope, $this->getCurrentSentryScope());
     }
 
@@ -257,11 +259,11 @@ class ConsoleIntegrationTest extends SentryTestCase
         $dispatcher->listen(BeforeHandle::class, [$integration, 'beforeHandle']);
         $dispatcher->dispatch(new BeforeHandle($inner, $input));
 
-        $integration->afterExecute(new AfterExecute($inner, input: $input, exitCode: 0));
+        $integration->afterExecute(new AfterExecute($inner, null, $input, 0));
 
         $this->assertSame($outerScope, $this->getCurrentSentryScope());
 
-        $integration->afterExecute(new AfterExecute($outer, input: $input, exitCode: 0));
+        $integration->afterExecute(new AfterExecute($outer, null, $input, 0));
         $this->assertSame($baselineScope, $this->getCurrentSentryScope());
     }
 
@@ -274,7 +276,7 @@ class ConsoleIntegrationTest extends SentryTestCase
         $integration = $this->app->make(ConsoleIntegration::class);
         $input = new ArgvInput(['artisan', '--foo=bar']);
 
-        $integration->afterExecute(new AfterExecute($command, input: $input, exitCode: 12));
+        $integration->afterExecute(new AfterExecute($command, null, $input, 12));
         $this->assertSame(12, $this->getLastSentryBreadcrumb()?->getMetadata()['exit']);
 
         $integration->afterExecute(new AfterExecute($command, new RuntimeException('failed', 17), $input, 0));
@@ -296,7 +298,7 @@ class ConsoleIntegrationTest extends SentryTestCase
     private function dispatchCommandFinishEvent(
         Command $command,
         ?RuntimeException $throwable = null,
-        ?int $exitCode = 0,
+        int $exitCode = 0,
         bool $withValue = false,
     ): void {
         $this->dispatchHypervelEvent(new AfterExecute(

--- a/tests/Sentry/FlushLifecycleTest.php
+++ b/tests/Sentry/FlushLifecycleTest.php
@@ -193,7 +193,7 @@ class FlushLifecycleTest extends TestCase
             $input = new ArrayInput([]);
 
             $feature->beforeHandle(new BeforeHandle($command, $input));
-            $feature->afterExecute(new AfterExecute($command, input: $input, exitCode: 0));
+            $feature->afterExecute(new AfterExecute($command, null, $input, 0));
         });
     }
 

--- a/tests/Telescope/Telescope/TelescopeTest.php
+++ b/tests/Telescope/Telescope/TelescopeTest.php
@@ -25,6 +25,7 @@ use Hypervel\Tests\Telescope\FeatureTestCase;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
 
 #[WithConfig('telescope.watchers', [
     QueryWatcher::class => [
@@ -219,7 +220,7 @@ class TelescopeTest extends FeatureTestCase
         Telescope::stopRecording();
 
         $this->app->make(EventDispatcher::class)
-            ->dispatch(new BeforeHandle(new RecordingStateCommand('telescope:test-command')));
+            ->dispatch(new BeforeHandle(new RecordingStateCommand('telescope:test-command'), new ArrayInput([])));
 
         $this->assertTrue(Telescope::isRecording());
     }
@@ -230,7 +231,7 @@ class TelescopeTest extends FeatureTestCase
         Telescope::stopRecording();
 
         $this->app->make(EventDispatcher::class)
-            ->dispatch(new BeforeHandle(new RecordingStateCommand($command)));
+            ->dispatch(new BeforeHandle(new RecordingStateCommand($command), new ArrayInput([])));
 
         $this->assertFalse(Telescope::isRecording());
     }
@@ -249,7 +250,7 @@ class TelescopeTest extends FeatureTestCase
         Telescope::stopRecording();
 
         $this->app->make(EventDispatcher::class)
-            ->dispatch(new BeforeHandle(new RecordingStateCommand('custom:ignored')));
+            ->dispatch(new BeforeHandle(new RecordingStateCommand('custom:ignored'), new ArrayInput([])));
 
         $this->assertFalse(Telescope::isRecording());
     }
@@ -269,7 +270,7 @@ class TelescopeTest extends FeatureTestCase
 
         Telescope::stopRecording();
         $this->app->make(EventDispatcher::class)
-            ->dispatch(new BeforeHandle(new RecordingStateCommand('custom:command')));
+            ->dispatch(new BeforeHandle(new RecordingStateCommand('custom:command'), new ArrayInput([])));
 
         $this->assertTrue(Telescope::isRecording());
     }
@@ -279,7 +280,7 @@ class TelescopeTest extends FeatureTestCase
         Telescope::stopRecording();
 
         $this->app->make(EventDispatcher::class)
-            ->dispatch(new BeforeHandle(new RecordingStateCommand('schedule:run')));
+            ->dispatch(new BeforeHandle(new RecordingStateCommand('schedule:run'), new ArrayInput([])));
 
         $this->assertFalse(Telescope::isRecording());
 

--- a/tests/Telescope/Watchers/CommandWatcherTest.php
+++ b/tests/Telescope/Watchers/CommandWatcherTest.php
@@ -95,25 +95,22 @@ class CommandWatcherTest extends FeatureTestCase
         }
     }
 
-    public function testCommandWatcherFailsClosedForMissingAndUnknownInput(): void
+    public function testCommandWatcherRedactsUnknownInput(): void
     {
         $command = new SensitiveInputCommand;
         $watcher = $this->app->make(CommandWatcher::class);
-
-        $watcher->recordCommand(new AfterExecute($command));
 
         $input = m::mock(InputInterface::class);
         $input->shouldReceive('getArguments')->once()->andReturn([]);
         $input->shouldReceive('getOptions')->once()->andReturn(['unknown' => 'unknown-secret']);
 
-        $watcher->recordCommand(new AfterExecute($command, input: $input));
+        $watcher->recordCommand(new AfterExecute($command, null, $input, 0));
 
         $entries = Telescope::getEntriesQueue();
 
-        $this->assertCount(2, $entries);
+        $this->assertCount(1, $entries);
         $this->assertSame([], $entries[0]->content['arguments']);
-        $this->assertSame([], $entries[0]->content['options']);
-        $this->assertSame(Telescope::REDACTED_VALUE, $entries[1]->content['options']['unknown']);
+        $this->assertSame(Telescope::REDACTED_VALUE, $entries[0]->content['options']['unknown']);
     }
 
     public function testNestedCommandsStoreOnceAfterTheOuterCommandEntryIsRecorded(): void


### PR DESCRIPTION
## Summary

This PR tightens Hypervel's inner command lifecycle contracts, restores focused regression coverage, and aligns runtime guard naming with the framework's conventions.

The changes are intentionally narrow. They remove impossible states, preserve the existing runtime behavior, and test failure paths that are difficult to cover through mocks alone.

## Command lifecycle contracts

`BeforeHandle` and `AfterExecute` now require the input and final exit code that `Command` already supplies on every dispatch. The throwable stays nullable because successful commands do not have one.

This removes nullable handling that could never run from the Sentry, Telescope, and OpenTelemetry consumers. It also makes manually constructed events match the real framework contract instead of allowing incomplete payloads.

The command tests now cover:

- execution in a new coroutine, inline execution, and execution inside an existing coroutine;
- exact input identity across the inner lifecycle events;
- successful, non-zero, manually failed, out-of-range, and throwing command outcomes;
- normalized exit codes and the original throwable instance.

These events are Hypervel-specific and do not change a Laravel API.

## Runtime regression coverage

The health-check tests now pin both failure modes: production reports a failed diagnosis and returns the down response, while debug mode rethrows the original exception without reporting or rendering.

The Redis cancellation tests use a local RESP server to reach the real native I/O boundaries. They verify that:

- command cancellation is preserved without emitting success or failure events;
- canceled leases return to the pool as invalid;
- cancellation during initial database selection repairs pool bookkeeping;
- the next checkout reaches connection creation instead of failing from exhausted capacity;
- child coroutines, sockets, leases, and pools are cleaned up even when an assertion or teardown step fails.

## Runtime guard naming

Hypervel-owned production guards now use `ensure*` instead of the testing-oriented `assert*` prefix. Every caller was updated without changing visibility, exceptions, or behavior.

The protected `NodeTrait::assertNotDescendant()` name from the nested-set package remains unchanged so existing upstream subclasses stay compatible. A short source comment records why this one method keeps the upstream name.

## Verification

The full `composer fix` workflow passes, including formatting, both static-analysis configurations, the parallel suite, Testbench, and dogfood checks. Focused Console, Foundation, Redis, Sentry, Telescope, OpenTelemetry, Pool, ObjectPool, Database, gRPC, Horizon, Translation, and Nested Set tests also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Command lifecycle events now require command input and a final exit code when constructed.

- **Bug Fixes**
  - Console telemetry consistently records exit codes and treats every nonzero exit code as a failure.
  - Improved handling of canceled Redis operations to preserve pool integrity and prevent incorrect command events.

- **Refactor**
  - Internal validation terminology was standardized for clearer consistency across database, networking, pooling, translation, and nested-set features.

- **Tests**
  - Expanded coverage for command event context, exit-code reporting, health-check failures, Redis cancellation, and input redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->