### PR TITLE
Optimize Container and Telescope coroutine state

### DIFF
--- a/src/container/README.md
+++ b/src/container/README.md
@@ -9,4 +9,6 @@ Documentation: https://hypervel.org/docs/container
 
 Hypervel supports Laravel's named container APIs, but not container ArrayAccess or dynamic service properties. Use `make()` / `get()`, `bound()` / `has()`, `bind()`, and `instance()`. For temporary instance overrides, use `forgetInstance()` to restore the original binding. Hypervel does not expose arbitrary binding removal because registrations are worker-wide boot-time state.
 
+Hypervel does not expose Laravel's protected per-parameter override helpers. Container subclasses that customize parameter override resolution should override `resolveRecipeParameters()`, which receives the current coroutine's resolution state and resolves the complete parameter list in one pass.
+
 Ported from: https://github.com/laravel/framework/tree/13.x/src/Illuminate/Container

--- a/src/container/src/Container.php
+++ b/src/container/src/Container.php
@@ -37,25 +37,9 @@ class Container implements ContainerContract
     use ReflectsClosures;
 
     /**
-     * Context key for the coroutine-local build stack.
+     * Context key for coroutine-local resolution state.
      */
-    protected const string BUILD_STACK_CONTEXT_KEY = '__container.build_stack';
-
-    /**
-     * Context key for the coroutine-local resolution depth counter.
-     */
-    public const string DEPTH_CONTEXT_KEY = '__container.depth';
-
-    /**
-     * Context key for the coroutine-local resolving stack.
-     *
-     * Tracks abstracts currently being resolved, used exclusively for circular
-     * dependency detection. Separate from BUILD_STACK_CONTEXT_KEY (which is
-     * also used by call() for contextual binding lookup) to avoid false
-     * positives when call() pushes a class name that is then re-resolved
-     * inside the method body.
-     */
-    protected const string RESOLVING_STACK_CONTEXT_KEY = '__container.resolving_stack';
+    protected const string RESOLUTION_STATE_CONTEXT_KEY = '__container.resolution_state';
 
     /**
      * Maximum resolution depth before assuming a circular dependency.
@@ -65,11 +49,6 @@ class Container implements ContainerContract
      * the direct in_array check insufficient.
      */
     protected const int MAX_RESOLUTION_DEPTH = 500;
-
-    /**
-     * Context key for the coroutine-local parameter override stack.
-     */
-    protected const string PARAMETER_OVERRIDES_CONTEXT_KEY = '__container.parameter_overrides';
 
     /**
      * Context key prefix for coroutine-local scoped instances.
@@ -983,16 +962,19 @@ class Container implements ContainerContract
                 return $callback();
             }
 
-            // First-class callables ($obj->method(...)) are Closure instances
-            // but not anonymous — they need the build stack for contextual
-            // bindings. Anonymous closures never have a class context.
-            $pushedToBuildStack = false;
+            // Anonymous closures do not contribute their scope class to contextual bindings,
+            // even when declared in a method or rebound. First-class callables do, matching Laravel.
+            if ($reflection->isAnonymous()) {
+                return BoundMethod::call($this, $callback, $parameters, null, $reflection);
+            }
 
-            if (! $reflection->isAnonymous()
-                && ($className = $reflection->getClosureScopeClass()?->name)
-                && ! in_array($className, $this->getBuildStack(), true)
+            $pushedToBuildStack = false;
+            $resolutionState = $this->getOrCreateResolutionState();
+
+            if (($className = $reflection->getClosureScopeClass()?->name)
+                && ! in_array($className, $resolutionState->buildStack, true)
             ) {
-                $this->pushBuildStack($className);
+                $resolutionState->buildStack[] = $className;
                 $pushedToBuildStack = true;
             }
 
@@ -1000,17 +982,18 @@ class Container implements ContainerContract
                 return BoundMethod::call($this, $callback, $parameters, null, $reflection);
             } finally {
                 if ($pushedToBuildStack) {
-                    $this->popBuildStack();
+                    array_pop($resolutionState->buildStack);
                 }
             }
         }
 
         // Non-closure path: shape-based class extraction, no reflection.
         $pushedToBuildStack = false;
+        $resolutionState = $this->getOrCreateResolutionState();
 
         if (($className = $this->getClassForCallable($callback))
-            && ! in_array($className, $this->getBuildStack(), true)) {
-            $this->pushBuildStack($className);
+            && ! in_array($className, $resolutionState->buildStack, true)) {
+            $resolutionState->buildStack[] = $className;
 
             $pushedToBuildStack = true;
         }
@@ -1019,7 +1002,7 @@ class Container implements ContainerContract
             return BoundMethod::call($this, $callback, $parameters, $defaultMethod);
         } finally {
             if ($pushedToBuildStack) {
-                $this->popBuildStack();
+                array_pop($resolutionState->buildStack);
             }
         }
     }
@@ -1226,7 +1209,8 @@ class Container implements ContainerContract
 
         // Depth guard — safety net for indirect cycles (e.g., through interfaces)
         // where the abstract names differ from the concretes in the resolving stack.
-        $depth = CoroutineContext::get(self::DEPTH_CONTEXT_KEY, 0);
+        $resolutionState = $this->getOrCreateResolutionState();
+        $depth = $resolutionState->depth;
 
         if ($depth >= static::MAX_RESOLUTION_DEPTH) {
             throw new CircularDependencyException(
@@ -1244,19 +1228,19 @@ class Container implements ContainerContract
         $pushedToResolvingStack = false;
 
         if (! $needsContextualBuild) {
-            if (in_array($abstract, $this->getResolvingStack(), true)) {
+            if (in_array($abstract, $resolutionState->resolvingStack, true)) {
                 $e = new CircularDependencyException;
                 $e->addDefinitionName($abstract);
 
                 throw $e;
             }
 
-            $this->pushResolvingStack($abstract);
+            $resolutionState->resolvingStack[] = $abstract;
             $pushedToResolvingStack = true;
         }
 
-        $this->pushParameterOverrides($parameters);
-        CoroutineContext::set(self::DEPTH_CONTEXT_KEY, $depth + 1);
+        $resolutionState->parameterOverrides[] = $parameters;
+        $resolutionState->depth = $depth + 1;
         $sharedResolution = null;
         $publishedCache = null;
         $publishedValue = null;
@@ -1389,11 +1373,11 @@ class Container implements ContainerContract
             throw $e;
         } finally {
             if ($pushedToResolvingStack) {
-                $this->popResolvingStack();
+                array_pop($resolutionState->resolvingStack);
             }
 
-            $this->popParameterOverrides();
-            CoroutineContext::set(self::DEPTH_CONTEXT_KEY, $depth);
+            array_pop($resolutionState->parameterOverrides);
+            $resolutionState->depth = $depth;
         }
     }
 
@@ -1590,116 +1574,40 @@ class Container implements ContainerContract
     }
 
     /**
-     * Get the current build stack from coroutine-local context.
+     * Get the resolution state for the current coroutine.
+     */
+    protected function getResolutionState(): ?ContainerResolutionState
+    {
+        $resolutionState = CoroutineContext::get(self::RESOLUTION_STATE_CONTEXT_KEY);
+
+        return $resolutionState instanceof ContainerResolutionState ? $resolutionState : null;
+    }
+
+    /**
+     * Get or create the mutable resolution state for the current coroutine.
+     */
+    protected function getOrCreateResolutionState(): ContainerResolutionState
+    {
+        if (($resolutionState = $this->getResolutionState()) !== null) {
+            return $resolutionState;
+        }
+
+        $resolutionState = new ContainerResolutionState;
+        CoroutineContext::set(self::RESOLUTION_STATE_CONTEXT_KEY, $resolutionState);
+
+        return $resolutionState;
+    }
+
+    /**
+     * Get the current build stack without creating resolution state.
      *
-     * @return string[]
+     * @return list<string>
      */
-    protected function getBuildStack(): array
+    protected function currentBuildStack(): array
     {
-        return CoroutineContext::get(self::BUILD_STACK_CONTEXT_KEY, []);
-    }
+        $resolutionState = $this->getResolutionState();
 
-    /**
-     * Set the build stack in coroutine-local context.
-     *
-     * @param string[] $stack
-     */
-    protected function setBuildStack(array $stack): void
-    {
-        CoroutineContext::set(self::BUILD_STACK_CONTEXT_KEY, $stack);
-    }
-
-    /**
-     * Push an abstract onto the coroutine-local build stack.
-     */
-    protected function pushBuildStack(string $abstract): void
-    {
-        $stack = $this->getBuildStack();
-        $stack[] = $abstract;
-        $this->setBuildStack($stack);
-    }
-
-    /**
-     * Pop the last entry from the coroutine-local build stack.
-     */
-    protected function popBuildStack(): void
-    {
-        $stack = $this->getBuildStack();
-        array_pop($stack);
-        $this->setBuildStack($stack);
-    }
-
-    /**
-     * Get the resolving stack from coroutine-local context.
-     *
-     * Used exclusively for circular dependency detection. Separate from the
-     * build stack so that call()'s contextual-binding pushes don't trigger
-     * false positives.
-     *
-     * @return string[]
-     */
-    protected function getResolvingStack(): array
-    {
-        return CoroutineContext::get(self::RESOLVING_STACK_CONTEXT_KEY, []);
-    }
-
-    /**
-     * Push an abstract onto the coroutine-local resolving stack.
-     */
-    protected function pushResolvingStack(string $abstract): void
-    {
-        $stack = $this->getResolvingStack();
-        $stack[] = $abstract;
-        CoroutineContext::set(self::RESOLVING_STACK_CONTEXT_KEY, $stack);
-    }
-
-    /**
-     * Pop the last entry from the coroutine-local resolving stack.
-     */
-    protected function popResolvingStack(): void
-    {
-        $stack = $this->getResolvingStack();
-        array_pop($stack);
-        CoroutineContext::set(self::RESOLVING_STACK_CONTEXT_KEY, $stack);
-    }
-
-    /**
-     * Get the parameter override stack from coroutine-local context.
-     *
-     * @return array[]
-     */
-    protected function getParameterOverrideStack(): array
-    {
-        return CoroutineContext::get(self::PARAMETER_OVERRIDES_CONTEXT_KEY, []);
-    }
-
-    /**
-     * Push parameter overrides onto the coroutine-local stack.
-     */
-    protected function pushParameterOverrides(array $parameters): void
-    {
-        $stack = $this->getParameterOverrideStack();
-        $stack[] = $parameters;
-        CoroutineContext::set(self::PARAMETER_OVERRIDES_CONTEXT_KEY, $stack);
-    }
-
-    /**
-     * Pop the last parameter overrides from the coroutine-local stack.
-     */
-    protected function popParameterOverrides(): void
-    {
-        $stack = $this->getParameterOverrideStack();
-        array_pop($stack);
-        CoroutineContext::set(self::PARAMETER_OVERRIDES_CONTEXT_KEY, $stack);
-    }
-
-    /**
-     * Get the last parameter override from the coroutine-local stack.
-     */
-    protected function getLastParameterOverride(): array
-    {
-        $stack = $this->getParameterOverrideStack();
-        return end($stack) ?: [];
+        return $resolutionState === null ? [] : $resolutionState->buildStack;
     }
 
     /**
@@ -1707,7 +1615,11 @@ class Container implements ContainerContract
      */
     protected function findInContextualBindings(string $abstract): mixed
     {
-        $buildStack = $this->getBuildStack();
+        if ($this->contextual === []) {
+            return null;
+        }
+
+        $buildStack = $this->currentBuildStack();
 
         return $this->contextual[end($buildStack)][$abstract] ?? null;
     }
@@ -1817,12 +1729,13 @@ class Container implements ContainerContract
      */
     public function buildWith(Closure|string $concrete, array $parameters = []): mixed
     {
-        $this->pushParameterOverrides($parameters);
+        $resolutionState = $this->getOrCreateResolutionState();
+        $resolutionState->parameterOverrides[] = $parameters;
 
         try {
             return $this->build($concrete);
         } finally {
-            $this->popParameterOverrides();
+            array_pop($resolutionState->parameterOverrides);
         }
     }
 
@@ -1839,16 +1752,18 @@ class Container implements ContainerContract
      */
     public function build(Closure|string $concrete): mixed
     {
+        $resolutionState = $this->getOrCreateResolutionState();
+
         // If the concrete type is actually a Closure, we will just execute it and
         // hand back the results of the functions, which allows functions to be
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
-            $this->pushBuildStack(spl_object_hash($concrete));
+            $resolutionState->buildStack[] = spl_object_hash($concrete);
 
             try {
-                return $concrete($this, $this->getLastParameterOverride());
+                return $concrete($this, end($resolutionState->parameterOverrides) ?: []);
             } finally {
-                $this->popBuildStack();
+                array_pop($resolutionState->buildStack);
             }
         }
 
@@ -1866,11 +1781,11 @@ class Container implements ContainerContract
         }
 
         if (is_a($concrete, SelfBuilding::class, true)
-            && ! in_array($concrete, $this->getBuildStack(), true)) {
-            return $this->buildSelfBuildingInstance($concrete, $recipe);
+            && ! in_array($concrete, $resolutionState->buildStack, true)) {
+            return $this->buildSelfBuildingInstance($concrete, $recipe, $resolutionState);
         }
 
-        $this->pushBuildStack($concrete);
+        $resolutionState->buildStack[] = $concrete;
 
         try {
             // If there are no constructors, that means there are no dependencies then
@@ -1892,9 +1807,9 @@ class Container implements ContainerContract
             // Once we have all the constructor's parameters we can create each of the
             // dependency instances and then use them to make a new instance of this
             // class, injecting the created dependencies in.
-            $instances = $this->resolveRecipeParameters($recipe);
+            $instances = $this->resolveRecipeParameters($recipe, $resolutionState);
         } finally {
-            $this->popBuildStack();
+            array_pop($resolutionState->buildStack);
         }
 
         $instance = new $concrete(...$instances);
@@ -1916,18 +1831,21 @@ class Container implements ContainerContract
      *
      * @throws BindingResolutionException
      */
-    protected function buildSelfBuildingInstance(string $concrete, BuildRecipe $recipe): mixed
-    {
+    protected function buildSelfBuildingInstance(
+        string $concrete,
+        BuildRecipe $recipe,
+        ContainerResolutionState $resolutionState,
+    ): mixed {
         if (! method_exists($concrete, 'newInstance')) {
             throw new BindingResolutionException("No newInstance method exists for [{$concrete}].");
         }
 
-        $this->pushBuildStack($concrete);
+        $resolutionState->buildStack[] = $concrete;
 
         try {
             $instance = $this->call([$concrete, 'newInstance']); // @phpstan-ignore argument.type
         } finally {
-            $this->popBuildStack();
+            array_pop($resolutionState->buildStack);
         }
 
         if ($recipe->classAttributes !== []) {
@@ -1945,16 +1863,19 @@ class Container implements ContainerContract
      *
      * @throws BindingResolutionException
      */
-    protected function resolveRecipeParameters(BuildRecipe $recipe): array
-    {
+    protected function resolveRecipeParameters(
+        BuildRecipe $recipe,
+        ContainerResolutionState $resolutionState,
+    ): array {
         $results = [];
+        $parameterOverrides = end($resolutionState->parameterOverrides) ?: [];
 
         foreach ($recipe->parameters as $paramRecipe) {
             // If the dependency has an override for this particular build we will use
             // that instead as the value. Otherwise, we will continue with this run
             // of resolutions and let the cached recipe metadata determine the result.
-            if ($this->hasParameterOverride($paramRecipe)) {
-                $results[] = $this->getParameterOverride($paramRecipe);
+            if (array_key_exists($paramRecipe->name, $parameterOverrides)) {
+                $results[] = $parameterOverrides[$paramRecipe->name];
 
                 continue;
             }
@@ -1991,24 +1912,8 @@ class Container implements ContainerContract
         return $results;
     }
 
-    /**
-     * Determine if the given dependency has a parameter override.
-     */
-    protected function hasParameterOverride(ParameterRecipe $param): bool
-    {
-        return array_key_exists(
-            $param->name,
-            $this->getLastParameterOverride()
-        );
-    }
-
-    /**
-     * Get a parameter override for a dependency.
-     */
-    protected function getParameterOverride(ParameterRecipe $param): mixed
-    {
-        return $this->getLastParameterOverride()[$param->name];
-    }
+    // REMOVED: Override resolveRecipeParameters() instead of Laravel's per-parameter
+    // override helpers, which repeat coroutine-state reads for every dependency.
 
     /**
      * Resolve a non-class hinted primitive dependency.
@@ -2113,7 +2018,7 @@ class Container implements ContainerContract
      */
     protected function notInstantiable(string $concrete): never
     {
-        $buildStack = $this->getBuildStack();
+        $buildStack = $this->currentBuildStack();
 
         if (! empty($buildStack)) {
             $previous = implode(', ', $buildStack);
@@ -2328,7 +2233,7 @@ class Container implements ContainerContract
      */
     public function currentlyResolving(): ?string
     {
-        $buildStack = $this->getBuildStack();
+        $buildStack = $this->currentBuildStack();
 
         return end($buildStack) ?: null;
     }

--- a/src/container/src/ContainerResolutionState.php
+++ b/src/container/src/ContainerResolutionState.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Container;
+
+use Hypervel\Context\ReplicableContext;
+
+/**
+ * Mutable state for one container resolution chain.
+ *
+ * The state is cloned when coroutine context is copied, so parent and child
+ * coroutines never share mutable stacks. Entries unwind through `finally`,
+ * while allocated capacity lives until the coroutine ends or non-coroutine
+ * context is explicitly flushed. Resolution depth is bounded by the Container;
+ * build-stack growth from `call()` remains bounded by the PHP call stack.
+ *
+ * @internal
+ */
+final class ContainerResolutionState implements ReplicableContext
+{
+    /**
+     * The current nested resolution depth.
+     */
+    public int $depth = 0;
+
+    /**
+     * The concrete types currently being built.
+     *
+     * @var list<string>
+     */
+    public array $buildStack = [];
+
+    /**
+     * The abstracts currently being resolved.
+     *
+     * Used exclusively for circular-dependency detection and kept separate
+     * from the build stack because call() contributes contextual scope without
+     * beginning another container resolution.
+     *
+     * @var list<string>
+     */
+    public array $resolvingStack = [];
+
+    /**
+     * The parameter overrides for nested builds.
+     *
+     * @var list<array<array-key, mixed>>
+     */
+    public array $parameterOverrides = [];
+
+    /**
+     * Copy the complete resolution state into an independent object.
+     */
+    public function replicate(): static
+    {
+        return clone $this;
+    }
+}

--- a/src/context/src/ReplicableContext.php
+++ b/src/context/src/ReplicableContext.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Hypervel\Context;
 
 /**
- * Marks objects stored in coroutine context that need deep-copying
- * when context is copied between coroutines.
+ * Marks objects that control what is installed when coroutine context is
+ * copied between coroutines.
  *
  * Without this, CoroutineContext::copyFrom() shares object references
  * between parent and child coroutines, causing mutations in one to
@@ -15,7 +15,10 @@ namespace Hypervel\Context;
 interface ReplicableContext
 {
     /**
-     * Create an independent copy with the same state.
+     * Create the value to install in the copied context.
+     *
+     * Implementations decide which state is inherited, projected, or reset
+     * and must document that choice on this method.
      */
     public function replicate(): static;
 }

--- a/src/inertia/src/InertiaState.php
+++ b/src/inertia/src/InertiaState.php
@@ -126,7 +126,7 @@ class InertiaState implements ReplicableContext
     }
 
     /**
-     * Create an independent copy with the same state.
+     * Copy all current configuration and request state into an independent object.
      */
     public function replicate(): static
     {

--- a/src/telescope/src/RecordingState.php
+++ b/src/telescope/src/RecordingState.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypervel\Telescope;
+
+use Hypervel\Context\NonCopyableContext;
+
+/**
+ * Coroutine-owned Telescope queues and deferred storage state.
+ *
+ * The state is omitted from copied context so each child that records entries
+ * owns its queue and schedules at most one independent deferred store.
+ */
+class RecordingState implements NonCopyableContext
+{
+    /**
+     * The entries awaiting deferred storage.
+     *
+     * @var list<IncomingEntry>
+     */
+    public array $entries = [];
+
+    /**
+     * The entry updates awaiting storage.
+     *
+     * @var list<EntryUpdate>
+     */
+    public array $updates = [];
+
+    /**
+     * Whether the entry-recording recursion guard is active.
+     */
+    public bool $processingEntry = false;
+
+    /**
+     * Whether deferred storage has been scheduled for this coroutine.
+     */
+    public bool $storeScheduled = false;
+}

--- a/src/telescope/src/Telescope.php
+++ b/src/telescope/src/Telescope.php
@@ -48,17 +48,11 @@ class Telescope
 
     public const string REDACTED_VALUE = '********';
 
-    public const string ENTRIES_QUEUE_CONTEXT_KEY = '__telescope.entries_queue';
-
-    public const string UPDATES_QUEUE_CONTEXT_KEY = '__telescope.updates_queue';
-
     public const string SHOULD_RECORD_CONTEXT_KEY = '__telescope.should_record';
 
-    public const string IS_RECORDING_CONTEXT_KEY = '__telescope.is_recording';
-
-    public const string HAS_STORED_CONTEXT_KEY = '__telescope.has_stored';
-
     public const string BATCH_ID_CONTEXT_KEY = '__telescope.batch_id';
+
+    protected const string RECORDING_STATE_CONTEXT_KEY = '__telescope.recording_state';
 
     protected const string CSP_NONCE_CONTEXT_KEY = '__telescope.csp_nonce';
 
@@ -271,20 +265,22 @@ class Telescope
             return;
         }
 
-        if (CoroutineContext::get(static::IS_RECORDING_CONTEXT_KEY, false)) {
+        $state = static::getOrCreateRecordingState();
+
+        if ($state->processingEntry) {
             return;
         }
 
         if (Coroutine::inCoroutine()
-            && ! CoroutineContext::get(static::HAS_STORED_CONTEXT_KEY, false)
+            && ! $state->storeScheduled
         ) {
             Coroutine::defer(function () {
                 static::store(static::$store);
             });
-            CoroutineContext::set(static::HAS_STORED_CONTEXT_KEY, true);
+            $state->storeScheduled = true;
         }
 
-        CoroutineContext::set(static::IS_RECORDING_CONTEXT_KEY, true);
+        $state->processingEntry = true;
 
         try {
             try {
@@ -299,11 +295,9 @@ class Telescope
                 return $tagCallback($entry);
             }, static::$tagUsing)));
 
-            static::withoutRecording(function () use ($entry) {
+            static::withoutRecording(function () use ($entry, $state) {
                 if (Collection::make(static::$filterUsing)->every->__invoke($entry)) {
-                    CoroutineContext::override(static::ENTRIES_QUEUE_CONTEXT_KEY, function ($entries) use ($entry) {
-                        return array_merge($entries ?? [], [$entry]);
-                    });
+                    $state->entries[] = $entry;
                 }
 
                 if (static::$afterRecordingHook) {
@@ -311,7 +305,7 @@ class Telescope
                 }
             });
         } finally {
-            CoroutineContext::set(static::IS_RECORDING_CONTEXT_KEY, false);
+            $state->processingEntry = false;
         }
     }
 
@@ -320,7 +314,9 @@ class Telescope
      */
     public static function getEntriesQueue(): array
     {
-        return CoroutineContext::get(static::ENTRIES_QUEUE_CONTEXT_KEY, []);
+        $state = static::getRecordingState();
+
+        return $state ? $state->entries : [];
     }
 
     /**
@@ -328,7 +324,35 @@ class Telescope
      */
     public static function getUpdatesQueue(): array
     {
-        return CoroutineContext::get(static::UPDATES_QUEUE_CONTEXT_KEY, []);
+        $state = static::getRecordingState();
+
+        return $state ? $state->updates : [];
+    }
+
+    /**
+     * Get the current recording state.
+     */
+    protected static function getRecordingState(): ?RecordingState
+    {
+        /** @var null|RecordingState $state */
+        $state = CoroutineContext::get(static::RECORDING_STATE_CONTEXT_KEY);
+
+        return $state;
+    }
+
+    /**
+     * Get or create the current recording state.
+     */
+    protected static function getOrCreateRecordingState(): RecordingState
+    {
+        if (($state = static::getRecordingState()) !== null) {
+            return $state;
+        }
+
+        $state = new RecordingState;
+        CoroutineContext::set(static::RECORDING_STATE_CONTEXT_KEY, $state);
+
+        return $state;
     }
 
     /**
@@ -340,9 +364,7 @@ class Telescope
             return;
         }
 
-        CoroutineContext::override(static::UPDATES_QUEUE_CONTEXT_KEY, function ($updates) use ($update) {
-            return array_merge($updates ?? [], [$update]);
-        });
+        static::getOrCreateRecordingState()->updates[] = $update;
     }
 
     /**
@@ -502,7 +524,9 @@ class Telescope
      */
     public static function flushEntries(): static
     {
-        CoroutineContext::set(static::ENTRIES_QUEUE_CONTEXT_KEY, []);
+        if (($state = static::getRecordingState()) !== null) {
+            $state->entries = [];
+        }
 
         return new static;
     }
@@ -512,7 +536,9 @@ class Telescope
      */
     public static function flushUpdates(): static
     {
-        CoroutineContext::set(static::UPDATES_QUEUE_CONTEXT_KEY, []);
+        if (($state = static::getRecordingState()) !== null) {
+            $state->updates = [];
+        }
 
         return new static;
     }

--- a/src/telescope/src/TelescopeServiceProvider.php
+++ b/src/telescope/src/TelescopeServiceProvider.php
@@ -44,7 +44,6 @@ class TelescopeServiceProvider extends ServiceProvider
         Coroutine::afterCreated(function () {
             $keys = [
                 Telescope::SHOULD_RECORD_CONTEXT_KEY => false,
-                Telescope::IS_RECORDING_CONTEXT_KEY => false,
                 Telescope::BATCH_ID_CONTEXT_KEY => null,
             ];
             foreach ($keys as $key => $default) {

--- a/src/telescope/src/Watchers/RequestWatcher.php
+++ b/src/telescope/src/Watchers/RequestWatcher.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hypervel\Telescope\Watchers;
 
-use Hypervel\Container\Container;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Contracts\Foundation\Application;
@@ -274,9 +273,6 @@ class RequestWatcher extends Watcher
     {
         $result = [];
         foreach (CoroutineContext::getContainer() as $key => $value) {
-            if ($key === Container::DEPTH_CONTEXT_KEY) {
-                continue;
-            }
             if (is_object($value)) {
                 $value = 'object(' . get_class($value) . ')';
             } elseif (is_array($value)) {

--- a/src/translation/src/MissingTranslationGroups.php
+++ b/src/translation/src/MissingTranslationGroups.php
@@ -48,7 +48,7 @@ final class MissingTranslationGroups implements ReplicableContext
     }
 
     /**
-     * Create an independent copy with the same state.
+     * Copy the missing translation groups into an independent snapshot.
      */
     public function replicate(): static
     {

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -11,6 +11,7 @@ use Hypervel\Container\Attributes\Give;
 use Hypervel\Container\BoundMethod;
 use Hypervel\Container\Container;
 use Hypervel\Container\ParameterRecipe;
+use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Container\BindingResolutionException;
 use Hypervel\Tests\TestCase;
 use ReflectionProperty;
@@ -517,6 +518,20 @@ class ContainerCallTest extends TestCase
         $this->assertSame('hello', $result);
     }
 
+    public function testParameterizedAnonymousClosureCallDoesNotCreateResolutionState(): void
+    {
+        $container = new ContainerCallStateInspectionStub;
+
+        $this->assertFalse($container->hasResolutionState());
+
+        $result = $container->call(static fn (string $value): string => $value, ['value' => 'hello']);
+
+        // Anonymous closures have no contextual build-stack role, so state access
+        // here would add coroutine-context overhead without affecting resolution.
+        $this->assertSame('hello', $result);
+        $this->assertFalse($container->hasResolutionState());
+    }
+
     public function testCallClosureWithOptionalTypedParameterStillInjectsBoundDependency()
     {
         $container = new Container;
@@ -626,6 +641,14 @@ class ContainerCallThrowingStub
     public function throwingMethod(): never
     {
         throw new RuntimeException('Intentional failure');
+    }
+}
+
+class ContainerCallStateInspectionStub extends Container
+{
+    public function hasResolutionState(): bool
+    {
+        return CoroutineContext::has(self::RESOLUTION_STATE_CONTEXT_KEY);
     }
 }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -933,6 +933,30 @@ class ContainerTest extends TestCase
         $this->assertEquals(ContainerCurrentResolvingConcrete::class, $resolved->currentlyResolving);
     }
 
+    public function testCurrentlyResolvingDoesNotCreateResolutionStateWhenIdle(): void
+    {
+        $container = new ContainerStateInspectionStub;
+
+        $this->assertFalse($container->hasResolutionState());
+        $this->assertNull($container->currentlyResolving());
+        $this->assertFalse($container->hasResolutionState());
+    }
+
+    public function testCachedSingletonDoesNotCreateResolutionStateWhenContextualBindingsExist(): void
+    {
+        $container = new ContainerStateInspectionStub;
+        $instance = new stdClass;
+
+        $container->when(ContainerCurrentResolvingConcrete::class)
+            ->needs('$currentlyResolving')
+            ->give('resolved');
+        $container->instance('cached', $instance);
+
+        $this->assertFalse($container->hasResolutionState());
+        $this->assertSame($instance, $container->make('cached'));
+        $this->assertFalse($container->hasResolutionState());
+    }
+
     public function testGetAliasRecursive()
     {
         $container = new Container;
@@ -1703,7 +1727,7 @@ class ContainerTest extends TestCase
     public function testDepthLimitFailureDoesNotMutateResolutionState(): void
     {
         $container = new ContainerStateInspectionStub;
-        CoroutineContext::set(Container::DEPTH_CONTEXT_KEY, $container->resolutionLimit());
+        $container->setResolutionDepth($container->resolutionLimit());
 
         try {
             $container->make(ContainerConcreteStub::class);
@@ -1712,11 +1736,11 @@ class ContainerTest extends TestCase
             $this->assertStringContainsString('Maximum resolution depth', $exception->getMessage());
         }
 
-        $this->assertSame($container->resolutionLimit(), CoroutineContext::get(Container::DEPTH_CONTEXT_KEY));
+        $this->assertSame($container->resolutionLimit(), $container->resolutionDepth());
         $this->assertSame([], $container->resolvingStack());
         $this->assertSame([], $container->parameterOverrideStack());
 
-        CoroutineContext::set(Container::DEPTH_CONTEXT_KEY, 0);
+        $container->setResolutionDepth(0);
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $container->make(ContainerConcreteStub::class));
     }
@@ -2564,6 +2588,11 @@ class ContainerVariadicDependencyConsumer
 
 class ContainerStateInspectionStub extends Container
 {
+    public function hasResolutionState(): bool
+    {
+        return CoroutineContext::has(self::RESOLUTION_STATE_CONTEXT_KEY);
+    }
+
     public function resolutionLimit(): int
     {
         return parent::MAX_RESOLUTION_DEPTH;
@@ -2571,11 +2600,21 @@ class ContainerStateInspectionStub extends Container
 
     public function resolvingStack(): array
     {
-        return $this->getResolvingStack();
+        return $this->getOrCreateResolutionState()->resolvingStack;
     }
 
     public function parameterOverrideStack(): array
     {
-        return $this->getParameterOverrideStack();
+        return $this->getOrCreateResolutionState()->parameterOverrides;
+    }
+
+    public function resolutionDepth(): int
+    {
+        return $this->getOrCreateResolutionState()->depth;
+    }
+
+    public function setResolutionDepth(int $depth): void
+    {
+        $this->getOrCreateResolutionState()->depth = $depth;
     }
 }

--- a/tests/Container/CoroutineSafetyTest.php
+++ b/tests/Container/CoroutineSafetyTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Container;
 
 use Hypervel\Container\Container;
+use Hypervel\Container\ContainerResolutionState;
 use Hypervel\Container\SharedResolution;
 use Hypervel\Contracts\Container\BindingResolutionException;
 use Hypervel\Contracts\Container\CircularDependencyException;
 use Hypervel\Contracts\Container\Transient;
+use Hypervel\Coroutine\Coroutine;
 use Hypervel\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
@@ -22,6 +24,64 @@ use function Hypervel\Coroutine\parallel;
 
 class CoroutineSafetyTest extends TestCase
 {
+    public function testResolutionStateIsReplicatedWhenContextIsForked(): void
+    {
+        $container = new CoroutineResolutionStateInspectionContainer;
+        $parent = $container->resolutionState();
+        $parent->depth = 2;
+        $parent->buildStack = ['parent-build'];
+        $parent->resolvingStack = ['parent-resolution'];
+        $parent->parameterOverrides = [['value' => 'parent']];
+        $result = new Channel(1);
+
+        $childId = Coroutine::fork(static function () use ($container, $result): void {
+            $child = $container->resolutionState();
+            $before = [
+                'depth' => $child->depth,
+                'build' => $child->buildStack,
+                'resolving' => $child->resolvingStack,
+                'overrides' => $child->parameterOverrides,
+            ];
+
+            ++$child->depth;
+            $child->buildStack[] = 'child-build';
+            $child->resolvingStack[] = 'child-resolution';
+            $child->parameterOverrides[] = ['value' => 'child'];
+
+            $result->push([
+                'id' => spl_object_id($child),
+                'before' => $before,
+                'after' => [
+                    'depth' => $child->depth,
+                    'build' => $child->buildStack,
+                    'resolving' => $child->resolvingStack,
+                    'overrides' => $child->parameterOverrides,
+                ],
+            ]);
+        });
+
+        $child = $result->pop(1.0);
+        Coroutine::join([$childId], 1.0);
+
+        $this->assertNotSame(spl_object_id($parent), $child['id']);
+        $this->assertSame([
+            'depth' => 2,
+            'build' => ['parent-build'],
+            'resolving' => ['parent-resolution'],
+            'overrides' => [['value' => 'parent']],
+        ], $child['before']);
+        $this->assertSame([
+            'depth' => 3,
+            'build' => ['parent-build', 'child-build'],
+            'resolving' => ['parent-resolution', 'child-resolution'],
+            'overrides' => [['value' => 'parent'], ['value' => 'child']],
+        ], $child['after']);
+        $this->assertSame(2, $parent->depth);
+        $this->assertSame(['parent-build'], $parent->buildStack);
+        $this->assertSame(['parent-resolution'], $parent->resolvingStack);
+        $this->assertSame([['value' => 'parent']], $parent->parameterOverrides);
+    }
+
     public function testScopedInstancesAreIsolatedPerCoroutine(): void
     {
         $container = new Container;
@@ -710,6 +770,14 @@ class CoroutineSafetyTest extends TestCase
         }
 
         $this->assertInstanceOf(stdClass::class, $ownerFinished->pop(1));
+    }
+}
+
+class CoroutineResolutionStateInspectionContainer extends Container
+{
+    public function resolutionState(): ContainerResolutionState
+    {
+        return $this->getOrCreateResolutionState();
     }
 }
 

--- a/tests/Telescope/FeatureTestCase.php
+++ b/tests/Telescope/FeatureTestCase.php
@@ -6,16 +6,20 @@ namespace Hypervel\Tests\Telescope;
 
 use Hypervel\Contracts\Cache\Factory as CacheFactoryContract;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
-use Hypervel\Database\Eloquent\Collection;
+use Hypervel\Database\Eloquent\Collection as EloquentCollection;
 use Hypervel\Foundation\Testing\RefreshDatabase;
 use Hypervel\Queue\Queue;
+use Hypervel\Support\Collection;
 use Hypervel\Telescope\Contracts\EntriesRepository;
 use Hypervel\Telescope\Http\Middleware\Authorize;
+use Hypervel\Telescope\IncomingEntry;
 use Hypervel\Telescope\Storage\EntryModel;
 use Hypervel\Telescope\Telescope;
 use Hypervel\Telescope\TelescopeServiceProvider;
 use Hypervel\Testbench\Attributes\WithMigration;
 use Hypervel\Testbench\TestCase;
+use Mockery as m;
+use ReflectionProperty;
 
 use function Hypervel\Testbench\load_migration_paths;
 
@@ -88,11 +92,38 @@ class FeatureTestCase extends TestCase
         parent::tearDown();
     }
 
-    protected function loadTelescopeEntries(): Collection
+    protected function loadTelescopeEntries(): EloquentCollection
     {
         $this->terminateTelescope();
 
         return EntryModel::all();
+    }
+
+    /**
+     * Create a recording store that captures stored batches.
+     *
+     * @param list<list<array{message: string, batch_id: null|string}>> $storedBatches
+     */
+    protected function fakeRecordingStore(array &$storedBatches): EntriesRepository
+    {
+        $store = m::mock(EntriesRepository::class);
+        $store->shouldReceive('store')
+            ->twice()
+            ->withArgs(function (Collection $entries) use (&$storedBatches): bool {
+                $storedBatches[] = $entries->map(fn (IncomingEntry $entry): array => [
+                    'message' => $entry->content['message'],
+                    'batch_id' => $entry->batchId,
+                ])->all();
+
+                return true;
+            });
+        $store->shouldReceive('update')
+            ->twice()
+            ->andReturn(Collection::make());
+
+        (new ReflectionProperty(Telescope::class, 'store'))->setValue($store);
+
+        return $store;
     }
 
     public function terminateTelescope(): void

--- a/tests/Telescope/Telescope/TelescopeTest.php
+++ b/tests/Telescope/Telescope/TelescopeTest.php
@@ -13,6 +13,7 @@ use Hypervel\Contracts\Bus\Dispatcher;
 use Hypervel\Contracts\Debug\ExceptionHandler;
 use Hypervel\Contracts\Events\Dispatcher as EventDispatcher;
 use Hypervel\Contracts\Queue\ShouldQueue;
+use Hypervel\Coroutine\Coroutine;
 use Hypervel\Http\Request;
 use Hypervel\HttpServer\Events\RequestReceived;
 use Hypervel\Telescope\Contracts\EntriesRepository;
@@ -120,6 +121,26 @@ class TelescopeTest extends FeatureTestCase
         Telescope::recordLog(IncomingEntry::make(['message' => 'second']));
 
         $this->assertSame('second', Telescope::getEntriesQueue()[1]->content['message']);
+    }
+
+    public function testForkedRecordingChildOwnsItsQueueAndDeferredStore(): void
+    {
+        $storedBatches = [];
+        $store = $this->fakeRecordingStore($storedBatches);
+
+        Telescope::recordLog(IncomingEntry::make(['message' => 'parent']));
+
+        $coroutineId = Coroutine::fork(function (): void {
+            Telescope::recordLog(IncomingEntry::make(['message' => 'child']));
+        });
+
+        Coroutine::join([$coroutineId]);
+        Telescope::store($store);
+
+        $this->assertSame(['child'], array_column($storedBatches[0], 'message'));
+        $this->assertSame(['parent'], array_column($storedBatches[1], 'message'));
+        $this->assertNotNull($storedBatches[0][0]['batch_id']);
+        $this->assertSame($storedBatches[0][0]['batch_id'], $storedBatches[1][0]['batch_id']);
     }
 
     public function testRunAfterStoreCallback()

--- a/tests/Telescope/TelescopeServiceProviderTest.php
+++ b/tests/Telescope/TelescopeServiceProviderTest.php
@@ -8,6 +8,7 @@ use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Coroutine\Coroutine;
 use Hypervel\Telescope\Contracts\EntriesRepository;
+use Hypervel\Telescope\IncomingEntry;
 use Hypervel\Telescope\Storage\DatabaseEntriesRepository;
 use Hypervel\Telescope\Telescope;
 use Hypervel\Telescope\TelescopeServiceProvider;
@@ -87,6 +88,36 @@ class TelescopeServiceProviderTest extends FeatureTestCase
         Coroutine::join([$coroutineId]);
 
         $this->assertSame([true, 'selected'], $observed);
+    }
+
+    public function testCreatedRecordingChildDoesNotInheritParentEntryGuard(): void
+    {
+        $storedBatches = [];
+        $store = $this->fakeRecordingStore($storedBatches);
+        $coroutineId = null;
+
+        Telescope::tag(function (IncomingEntry $entry) use (&$coroutineId): array {
+            if ($entry->content['message'] !== 'parent') {
+                return [];
+            }
+
+            $coroutineId = Coroutine::create(function (): void {
+                Telescope::recordLog(IncomingEntry::make(['message' => 'child']));
+            });
+
+            return [];
+        });
+
+        Telescope::recordLog(IncomingEntry::make(['message' => 'parent']));
+
+        $this->assertIsInt($coroutineId);
+        Coroutine::join([$coroutineId]);
+        Telescope::store($store);
+
+        $this->assertSame(['child'], array_column($storedBatches[0], 'message'));
+        $this->assertSame(['parent'], array_column($storedBatches[1], 'message'));
+        $this->assertNotNull($storedBatches[0][0]['batch_id']);
+        $this->assertSame($storedBatches[0][0]['batch_id'], $storedBatches[1][0]['batch_id']);
     }
 
     public function testRouteRegistrationRequiresStringPath(): void


### PR DESCRIPTION
## Summary

Container resolution kept depth, build-stack, resolving-stack, and parameter-override state in four coroutine-context values. Stack updates repeatedly read and rewrote arrays through `CoroutineContext`, adding measurable work to every transient build, nested resolution, parameter override, and method injection.

Telescope used the same pattern for its recording queues, with `array_merge()` rebuilding the complete queue for every entry. Its recording guard and deferred-store marker could also cross into a child coroutine even though the child must own its recording lifecycle.

This change gives each subsystem one coroutine-owned state object:

- `ContainerResolutionState` holds all mutable state for one resolution chain. It is cloned when coroutine context is copied, so parent and child stacks remain independent.
- Container stack operations mutate that state directly. Idle inspection, cached singleton hits, and anonymous closure calls avoid allocating it when resolution bookkeeping is unnecessary.
- Constructor recipes read parameter overrides once, and empty contextual-binding registries return before reading the build stack.
- `RecordingState` holds Telescope's queues, recursion guard, and deferred-store marker. It is non-copyable, so a child begins with its own recording lifecycle while retaining the separately managed batch ID.
- Telescope now appends to its queues directly instead of copying the growing arrays.
- `ReplicableContext` now documents that each implementation chooses whether copied context inherits, projects, or resets its state. Existing implementations document their concrete choice.

## Container extension point

Hypervel no longer exposes Laravel's protected per-parameter override helpers. Container subclasses that customize parameter resolution should override `resolveRecipeParameters()`, which receives the current `ContainerResolutionState` and resolves the complete parameter list in one pass. This deliberate difference is documented in the Container README.

All named Container APIs and their behavior remain unchanged.

## Benchmarks

Measurements compare `0.4` with this branch on the same machine. Results are medians from alternating baseline and candidate samples with OPcache disabled. The singleton-hit control remains flat, showing that the improvement comes from resolution bookkeeping rather than unrelated cache behavior.

| Scenario | Execution | `0.4` | This branch | Change |
| --- | --- | ---: | ---: | ---: |
| Build transient | Outside coroutine | 877.49 ns | 424.41 ns | -51.6% |
| Build transient | Inside coroutine | 906.29 ns | 396.89 ns | -56.2% |
| Singleton hit | Outside coroutine | 243.41 ns | 245.59 ns | noise |
| Singleton hit | Inside coroutine | 260.99 ns | 255.90 ns | noise |
| Make transient | Outside coroutine | 4,455.17 ns | 2,388.77 ns | -46.4% |
| Make transient | Inside coroutine | 5,352.63 ns | 3,260.84 ns | -39.1% |
| Bound closure | Outside coroutine | 3,971.58 ns | 1,658.78 ns | -58.2% |
| Bound closure | Inside coroutine | 4,077.94 ns | 2,000.79 ns | -50.9% |
| Nested resolution, 5 levels | Outside coroutine | 30.334 us | 16.719 us | -44.9% |
| Nested resolution, 5 levels | Inside coroutine | 36.240 us | 21.578 us | -40.5% |
| `makeWith()` primitive | Outside coroutine | 3.867 us | 2.283 us | -41.0% |
| `makeWith()` primitive | Inside coroutine | 3.847 us | 2.223 us | -42.2% |
| `buildWith()` primitive | Outside coroutine | 2.238 us | 0.970 us | -56.7% |
| `buildWith()` primitive | Inside coroutine | 2.217 us | 0.986 us | -55.5% |
| Method injection | Outside coroutine | 24.730 us | 14.043 us | -43.2% |
| Method injection | Inside coroutine | 29.218 us | 17.388 us | -40.5% |

OPcache-enabled runs confirmed the same direction, with measured resolution-path improvements between 38.3% and 65.7% and a flat singleton control.

The final anonymous-closure and empty-contextual-registry guards were measured separately against the state-object implementation before those guards:

| Scenario | Before guard | Final | Change |
| --- | ---: | ---: | ---: |
| Parameterized anonymous call, supplied scalar | 1,216.44 ns | 1,189.11 ns | -2.2% |
| Parameterized anonymous call, defaulted scalar | 1,448.87 ns | 1,362.16 ns | -6.0% |
| Parameterized anonymous call, injected class | 1,862.47 ns | 1,795.27 ns | -3.6% |
| Empty registry, defaulted primitive constructor | 4,952.65 ns | 4,715.73 ns | -4.8% |
| Empty registry, defaulted class constructor | 5,088.01 ns | 4,798.04 ns | -5.7% |
| Empty registry, variadic class constructor | 5,281.12 ns | 5,136.19 ns | -2.7% |

The state object adds a small bounded amount of memory while a resolving coroutine remains active:

| Measurement | `0.4` | This branch | Difference |
| --- | ---: | ---: | ---: |
| Active memory across 2,000 suspended coroutines | 21,116,440 B | 21,568,248 B | +451,808 B |
| Per active coroutine | 10,558.22 B | 10,784.12 B | +225.90 B (+2.1%) |
| Retained after exit | 76,440 B | 112,248 B | +35,808 B |

Telescope queue recording changes from repeated full-array copies to direct append:

| Entries | Previous queue append | Mutable state append | Change |
| ---: | ---: | ---: | ---: |
| 10 | 5.96 us | 1.30 us | -78.2% |
| 100 | 65.52 us | 10.96 us | -83.3% |
| 500 | 455.96 us | 54.43 us | -88.1% |
| 1,000 | 1,285.88 us | 121.25 us | -90.6% |

## Verification

- Ran `composer fix`, including formatting, both PHPStan configurations, parallel tests, Testbench, and dogfood tests.
- Ran the focused Container, Context, Telescope, Inertia, and Translation suites.
- Covered state-free Container paths, nested cleanup, copied-context isolation, Telescope child queue ownership, independent deferred storage, recursion-guard isolation, and inherited batch identity.
- Checked the final diff for stale context keys, removed helper references, formatting issues, and unintended API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coroutine isolation for dependency resolution state, preventing child coroutine changes from affecting the parent.
  * Anonymous closure calls no longer create unnecessary resolution state.
  * Improved Telescope recording isolation so forked coroutines maintain independent queues and deferred storage behavior.

* **Documentation**
  * Clarified guidance for customizing container parameter resolution.
  * Updated documentation describing how coroutine context state is copied and replicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->