### PR TITLE
Fix preserved scalar path restoration

### DIFF
--- a/src/data/src/Support/Validation/CompiledValidation.php
+++ b/src/data/src/Support/Validation/CompiledValidation.php
@@ -97,6 +97,14 @@ final readonly class CompiledValidation
             return;
         }
 
+        $value = $source[$segment];
+        $nextOffset = $offset + 1;
+
+        // A failed descent must not materialize an empty container in the validated payload.
+        if ($nextOffset !== count($segments) && ! is_array($value)) {
+            return;
+        }
+
         if (! is_array($target)) {
             $target = [];
         }
@@ -107,9 +115,9 @@ final readonly class CompiledValidation
 
         $this->restoreValueAtPath(
             $target[$segment],
-            $source[$segment],
+            $value,
             $segments,
-            $offset + 1,
+            $nextOffset,
         );
     }
 }

--- a/tests/Data/Support/Validation/CompiledValidationTest.php
+++ b/tests/Data/Support/Validation/CompiledValidationTest.php
@@ -35,6 +35,28 @@ class CompiledValidationTest extends TestCase
     }
 
     /**
+     * Test exact paths only create containers for descendable source values.
+     */
+    public function testExactPathsOnlyCreateDescendableSourceContainers(): void
+    {
+        $compiled = new CompiledValidation(
+            rules: [],
+            preservedPaths: [
+                ValidationPath::create('nested.value'),
+            ],
+        );
+
+        $this->assertSame([], $compiled->restorePreservedValues(
+            [],
+            ['nested' => 'scalar'],
+        ));
+        $this->assertSame(['nested' => []], $compiled->restorePreservedValues(
+            [],
+            ['nested' => []],
+        ));
+    }
+
+    /**
      * Test wildcard paths restore each existing source leaf without key collisions.
      */
     public function testRestoresPreservedValuesByWildcardPath(): void

--- a/tests/Data/Support/Validation/DataValidatorTest.php
+++ b/tests/Data/Support/Validation/DataValidatorTest.php
@@ -1429,6 +1429,24 @@ class DataValidatorTest extends TestCase
     }
 
     /**
+     * Test validation hooks do not replace scalar mapped ancestors with arrays.
+     */
+    public function testBeforeValidationDoesNotReplaceScalarMappedAncestorsWithArrays(): void
+    {
+        $payload = HookMappedUnvalidatedDataFixture::factory()
+            ->beforeValidation(static fn (array $payload): array => [
+                ...$payload,
+                'nested' => 'scalar',
+            ])
+            ->validate([
+                'id' => 1,
+                'nested' => ['value' => 'original'],
+            ]);
+
+        $this->assertSame(['id' => 1], $payload);
+    }
+
+    /**
      * Test validation hooks can replace filled data with a named-factory value.
      */
     public function testBeforeValidationReconcilesStructuredValuesThroughNamedFactories(): void
@@ -2820,6 +2838,16 @@ class HookMappedScalarDataFixture extends Data
     public function __construct(
         #[MapInputName('email_address')]
         public string $email,
+    ) {
+    }
+}
+
+class HookMappedUnvalidatedDataFixture extends Data
+{
+    public function __construct(
+        public int $id,
+        #[MapInputName('nested.value'), WithoutValidation]
+        public ?string $value = null,
     ) {
     }
 }


### PR DESCRIPTION
## Summary

Prevent preserved validation paths from replacing non-array source ancestors with invented empty arrays.

Reported by @albertcht in https://github.com/hypervel/components/pull/558#discussion_r3931046786.

## Problem

`CompiledValidation::restoreValueAtPath()` initialized a missing target slot before recursing into the corresponding source value. When an exact preserved path continued through a scalar, object, or null source child, recursion stopped because the child was not traversable, but the empty target array remained.

This is reachable when a mapped `#[WithoutValidation]` property has a nested input path and a `beforeValidation` hook replaces that path's ancestor with a scalar. Validator filtering correctly removes the malformed value, but restoration previously added an empty array in its place and passed it to the construction state.

## Fix

Resolve the exact source child and next offset before touching the target. When more path segments remain, return unless the source child is an array.

The check is intentionally limited to exact segments:

- scalar, object, and null leaves are still restored;
- genuine empty array ancestors remain available for Data construction;
- wildcard handling retains its existing fill-time shape guarantees;
- no source prewalk, rollback, copied tree, or additional abstraction is introduced.

The added branch only runs while restoring non-leaf exact preserved paths and allocates no additional containers.

## Tests

Add focused coverage for both walker invariants:

- non-array intermediate values do not create target containers;
- empty array intermediate values retain their structural container.

Add an end-to-end regression through a mapped `WithoutValidation` property, a `beforeValidation` hook, validator filtering, preserved-value restoration, and construction-state replacement.

## Verification

- `composer lint:fix`
- `composer analyse`
- focused Data validation tests
- `git diff --check`
