### PR TITLE
Reduce Hypervel Data transformation overhead

### DIFF
--- a/src/data/src/Concerns/IncludeableData.php
+++ b/src/data/src/Concerns/IncludeableData.php
@@ -42,11 +42,19 @@ trait IncludeableData
             return false;
         }
 
-        $this->partialDefinitions = new PartialsDefinition;
-        $this->partialDefinitions->addDefaults('include', $includes);
-        $this->partialDefinitions->addDefaults('exclude', $excludes);
-        $this->partialDefinitions->addDefaults('only', $only);
-        $this->partialDefinitions->addDefaults('except', $except);
+        $partialDefinitions = new PartialsDefinition;
+        $partialDefinitions->addDefaults('include', $includes);
+        $partialDefinitions->addDefaults('exclude', $excludes);
+        $partialDefinitions->addDefaults('only', $only);
+        $partialDefinitions->addDefaults('except', $except);
+
+        if ($partialDefinitions->isEmpty()) {
+            $this->partialDefinitions = false;
+
+            return false;
+        }
+
+        $this->partialDefinitions = $partialDefinitions;
 
         return true;
     }

--- a/src/data/src/Concerns/IncludeableData.php
+++ b/src/data/src/Concerns/IncludeableData.php
@@ -11,22 +11,65 @@ trait IncludeableData
 {
     use ForwardsToPartialsDefinition;
 
-    protected ?PartialsDefinition $partialDefinitions = null;
+    /**
+     * Null before defaults are inspected, false when they are empty, or the mutable definition store.
+     */
+    protected PartialsDefinition|false|null $partialDefinitions = null;
+
+    /**
+     * Determine whether this object has partial definitions.
+     *
+     * @phpstan-impure
+     */
+    public function hasPartialsDefinition(): bool
+    {
+        if ($this->partialDefinitions instanceof PartialsDefinition) {
+            return ! $this->partialDefinitions->isEmpty();
+        }
+
+        if ($this->partialDefinitions === false) {
+            return false;
+        }
+
+        $includes = $this->includeProperties();
+        $excludes = $this->excludeProperties();
+        $only = $this->onlyProperties();
+        $except = $this->exceptProperties();
+
+        if ($includes === [] && $excludes === [] && $only === [] && $except === []) {
+            $this->partialDefinitions = false;
+
+            return false;
+        }
+
+        $this->partialDefinitions = new PartialsDefinition;
+        $this->partialDefinitions->addDefaults('include', $includes);
+        $this->partialDefinitions->addDefaults('exclude', $excludes);
+        $this->partialDefinitions->addDefaults('only', $only);
+        $this->partialDefinitions->addDefaults('except', $except);
+
+        return true;
+    }
 
     /**
      * Get the current partial definitions.
      */
     public function getPartialsDefinition(): PartialsDefinition
     {
-        if ($this->partialDefinitions !== null) {
+        if ($this->partialDefinitions instanceof PartialsDefinition) {
             return $this->partialDefinitions;
         }
 
+        if ($this->partialDefinitions === null) {
+            // Initialize class-owned defaults before creating an empty store for explicit writes.
+            $this->hasPartialsDefinition();
+
+            if ($this->partialDefinitions instanceof PartialsDefinition) {
+                return $this->partialDefinitions;
+            }
+        }
+
         $this->partialDefinitions = new PartialsDefinition;
-        $this->partialDefinitions->addDefaults('include', $this->includeProperties());
-        $this->partialDefinitions->addDefaults('exclude', $this->excludeProperties());
-        $this->partialDefinitions->addDefaults('only', $this->onlyProperties());
-        $this->partialDefinitions->addDefaults('except', $this->exceptProperties());
 
         return $this->partialDefinitions;
     }

--- a/src/data/src/Contracts/IncludeableData.php
+++ b/src/data/src/Contracts/IncludeableData.php
@@ -70,6 +70,11 @@ interface IncludeableData
     public function exceptWhen(string $except, bool|Closure $condition, bool $permanent = false): object;
 
     /**
+     * Determine whether this object has partial definitions.
+     */
+    public function hasPartialsDefinition(): bool;
+
+    /**
      * Get the current partial definitions.
      */
     public function getPartialsDefinition(): PartialsDefinition;

--- a/src/data/src/Support/Factories/DataClassFactory.php
+++ b/src/data/src/Support/Factories/DataClassFactory.php
@@ -118,7 +118,10 @@ class DataClassFactory
         $redirectRoute = $attributes->first(RedirectToRoute::class)?->newInstance();
         $lifecycleMethods = $this->resolveLifecycleMethods($reflectionClass);
         $propertyMorphable = $reflectionClass->implementsInterface(PropertyMorphableData::class);
-        $transformationRecipe = $this->resolveTransformationRecipe($properties);
+        $transformable = $reflectionClass->implementsInterface(TransformableData::class);
+        $transformationRecipe = $transformable
+            ? $this->resolveTransformationRecipe($properties)
+            : null;
         $bulkCopyTransformation = $transformationRecipe !== null
             && $this->supportsBulkCopyTransformation($properties);
 
@@ -136,7 +139,7 @@ class DataClassFactory
             appendable: $reflectionClass->implementsInterface(AppendableData::class),
             includeable: $reflectionClass->implementsInterface(IncludeableData::class),
             responsable: $reflectionClass->implementsInterface(ResponsableData::class),
-            transformable: $reflectionClass->implementsInterface(TransformableData::class),
+            transformable: $transformable,
             validateable: $reflectionClass->implementsInterface(ValidateableData::class),
             wrappable: $reflectionClass->implementsInterface(WrappableData::class),
             emptyData: $reflectionClass->implementsInterface(EmptyData::class),

--- a/src/data/src/Support/Transformation/DataTransformer.php
+++ b/src/data/src/Support/Transformation/DataTransformer.php
@@ -31,6 +31,7 @@ use Hypervel\Data\Support\DataClassRepository;
 use Hypervel\Data\Support\DataConfig;
 use Hypervel\Data\Support\DataProperty;
 use Hypervel\Data\Support\Lazy\DefaultLazy;
+use Hypervel\Data\Support\Partials\PartialDefinition;
 use Hypervel\Data\Support\Types\Type;
 use Hypervel\Data\Support\Wrapping\WrapExecutionType;
 use Hypervel\Data\Transformers\Transformer;
@@ -78,7 +79,7 @@ class DataTransformer
      */
     public function defaultContext(object $data): TransformationContext
     {
-        if (! $data instanceof IncludeableData || $data->getPartialsDefinition()->isEmpty()) {
+        if (! $data instanceof IncludeableData || ! $data->hasPartialsDefinition()) {
             return $this->defaultContext;
         }
 
@@ -92,7 +93,7 @@ class DataTransformer
      */
     public function allContext(object $data): TransformationContext
     {
-        if (! $data instanceof IncludeableData || $data->getPartialsDefinition()->isEmpty()) {
+        if (! $data instanceof IncludeableData || ! $data->hasPartialsDefinition()) {
             return $this->allContext;
         }
 
@@ -191,7 +192,7 @@ class DataTransformer
         }
 
         // Raw storage keeps excluded property hooks from running as a side effect.
-        $values = get_mangled_object_vars($data);
+        $values = (array) $data;
         $transformed = [];
 
         foreach ($dataClass->properties as $property) {
@@ -268,6 +269,7 @@ class DataTransformer
         foreach ($rootItems ?? $this->collectableItems($data) as $key => $item) {
             if (! $context->transformValues) {
                 if ($context->hasPartials() && $item instanceof IncludeableData) {
+                    // Non-transforming root contexts compile their selections from these same definitions.
                     $item->getPartialsDefinition()->addResolved($context->partialDefinitions);
                 }
 
@@ -430,7 +432,7 @@ class DataTransformer
         array &$extensions,
     ): array {
         // Raw storage keeps uninitialized properties from invoking public access.
-        $values = get_mangled_object_vars($data);
+        $values = (array) $data;
         $transformed = [];
 
         foreach ($recipe->properties as $property) {
@@ -605,17 +607,14 @@ class DataTransformer
         BaseData|BaseDataCollectable $value,
         TransformationContext $context,
     ): TransformationContext {
-        if ($context->constructable || ! $value instanceof IncludeableData) {
+        if ($context->constructable
+            || ! $value instanceof IncludeableData
+            || ! $value->hasPartialsDefinition()
+        ) {
             return $context;
         }
 
-        $partialDefinitions = $value->getPartialsDefinition();
-
-        if ($partialDefinitions->isEmpty()) {
-            return $context;
-        }
-
-        return $context->withMergedPartials($partialDefinitions->resolve(
+        return $context->withMergedPartials($value->getPartialsDefinition()->resolve(
             $value,
             consumeTemporary: true,
         ));
@@ -834,9 +833,13 @@ class DataTransformer
             return;
         }
 
-        $value->getPartialsDefinition()->addResolved(
-            $context->partialsForNestedProperty($property),
-        );
+        $definitions = $context->partialsForNestedProperty($property);
+
+        if (! self::hasResolvedPartials($definitions)) {
+            return;
+        }
+
+        $value->getPartialsDefinition()->addResolved($definitions);
     }
 
     /**
@@ -853,11 +856,28 @@ class DataTransformer
 
         $definitions = $context->partialsForNestedProperty($property);
 
+        if (! self::hasResolvedPartials($definitions)) {
+            return;
+        }
+
         foreach ($items as $item) {
             if ($item instanceof IncludeableData) {
                 $item->getPartialsDefinition()->addResolved($definitions);
             }
         }
+    }
+
+    /**
+     * Determine whether a resolved partial set contains any definitions.
+     *
+     * @param array{include: list<PartialDefinition>, exclude: list<PartialDefinition>, only: list<PartialDefinition>, except: list<PartialDefinition>} $definitions
+     */
+    private static function hasResolvedPartials(array $definitions): bool
+    {
+        return $definitions['include'] !== []
+            || $definitions['exclude'] !== []
+            || $definitions['only'] !== []
+            || $definitions['except'] !== [];
     }
 
     /**

--- a/src/data/src/Support/Transformation/TransformationContextFactory.php
+++ b/src/data/src/Support/Transformation/TransformationContextFactory.php
@@ -89,7 +89,7 @@ class TransformationContextFactory implements Transient
             return static::persistenceContext($this->configuredMaxDepth);
         }
 
-        $dataPartials = $data instanceof IncludeableData
+        $dataPartials = $data instanceof IncludeableData && $data->hasPartialsDefinition()
             ? $data->getPartialsDefinition()
             : null;
 

--- a/src/docs/data-objects.md
+++ b/src/docs/data-objects.md
@@ -569,7 +569,7 @@ Use `withValidator(Validator $validator)` and `after(): array` like a FormReques
 <a name="creation-factories"></a>
 ### Creation Factories
 
-The `factory` method returns a fluent factory for a single creation:
+The `factory` method returns a fluent factory for creating data objects:
 
 ```php
 $user = UserData::factory()
@@ -581,6 +581,19 @@ $user = UserData::factory()
     ->withValidator(fn (Validator $validator) => $validator->after($check))
     ->from($payload);
 ```
+
+Within one operation, you may reuse a factory to avoid repeating creation setup for every payload:
+
+```php
+$factory = UserData::factory();
+
+$users = array_map(
+    fn (array $payload): UserData => $factory->from($payload),
+    $payloads,
+);
+```
+
+Use `collect()` instead when the payloads form one collection. In addition to preserving supported collection shapes and keys, `collect()` allows collection validation rules and hooks to inspect the complete payload.
 
 Factories may change the validation strategy, enable or disable name mapping and named factories, ignore selected named methods, and add casts or normalizers. They also provide the following hooks, which run in this order:
 
@@ -595,7 +608,7 @@ Factories may change the validation strategy, enable or disable name mapping and
 
 The `prepareData`, `beforeCreation`, and `afterCreation` hooks run even when validation is skipped. The other hooks run while generating rules or validating, as appropriate. Call `alwaysValidate()` when validation hooks should also apply to an array, model, JSON value, or another non-request source.
 
-Each call to `factory()` returns a new factory. Configure and use the factory where it is created instead of storing one and reusing it across requests.
+Each call to `factory()` returns a new factory. Keep a reused factory scoped to the current operation instead of storing it across requests.
 
 <a name="transformation"></a>
 ## Transformation

--- a/tests/Benchmarks/Data/compare-data-object.php
+++ b/tests/Benchmarks/Data/compare-data-object.php
@@ -422,16 +422,21 @@ function measureCold(string $mode): array
 /**
  * Measure retained instance bytes over a large held set.
  *
- * @param Closure(int): object $factory
+ * @template TInstance of object
+ *
+ * @param Closure(int): TInstance $factory
+ * @param null|Closure(TInstance): void $prepare
  */
-function retainedInstanceBytes(Closure $factory): float
+function retainedInstanceBytes(Closure $factory, ?Closure $prepare = null): float
 {
     gc_collect_cycles();
     $baseline = memory_get_usage(false);
     $instances = [];
 
     for ($index = 1; $index <= 20_000; ++$index) {
-        $instances[] = $factory($index);
+        $instance = $factory($index);
+        $prepare?->__invoke($instance);
+        $instances[] = $instance;
     }
 
     $bytes = (memory_get_usage(false) - $baseline) / count($instances);
@@ -666,8 +671,31 @@ function execute(): void
             }
 
             printf("\nRetained instance bytes\n");
-            printf("%-38s %12.1f %12.1f\n", 'flat', retainedInstanceBytes(fn (int $id): OldFlat => OldFlat::from([...$flat, 'id' => $id])), retainedInstanceBytes(fn (int $id): NewFlat => NewFlat::from([...$flat, 'id' => $id])));
-            printf("%-38s %12.1f %12.1f\n", 'wide', retainedInstanceBytes(fn (int $id): OldWide => OldWide::from([...$wide, 'one' => $id])), retainedInstanceBytes(fn (int $id): NewWide => NewWide::from([...$wide, 'one' => $id])));
+            printf("%-38s %12s %12s\n", 'scenario', 'old', 'data');
+            printf("%-38s %12.1f %12.1f\n", 'flat, untransformed', retainedInstanceBytes(fn (int $id): OldFlat => OldFlat::from([...$flat, 'id' => $id])), retainedInstanceBytes(fn (int $id): NewFlat => NewFlat::from([...$flat, 'id' => $id])));
+            printf("%-38s %12.1f %12.1f\n", 'flat, transformed', retainedInstanceBytes(
+                fn (int $id): OldFlat => OldFlat::from([...$flat, 'id' => $id]),
+                static function (OldFlat $data): void {
+                    $data->toArray();
+                },
+            ), retainedInstanceBytes(
+                fn (int $id): NewFlat => NewFlat::from([...$flat, 'id' => $id]),
+                static function (NewFlat $data): void {
+                    $data->toArray();
+                },
+            ));
+            printf("%-38s %12.1f %12.1f\n", 'wide, untransformed', retainedInstanceBytes(fn (int $id): OldWide => OldWide::from([...$wide, 'one' => $id])), retainedInstanceBytes(fn (int $id): NewWide => NewWide::from([...$wide, 'one' => $id])));
+            printf("%-38s %12.1f %12.1f\n", 'wide, transformed', retainedInstanceBytes(
+                fn (int $id): OldWide => OldWide::from([...$wide, 'one' => $id]),
+                static function (OldWide $data): void {
+                    $data->toArray();
+                },
+            ), retainedInstanceBytes(
+                fn (int $id): NewWide => NewWide::from([...$wide, 'one' => $id]),
+                static function (NewWide $data): void {
+                    $data->toArray();
+                },
+            ));
 
             $repository = $application->make(DataClassRepository::class);
             $repository->get(NewWarm::class);

--- a/tests/Data/Support/DataClassTest.php
+++ b/tests/Data/Support/DataClassTest.php
@@ -24,6 +24,7 @@ use Hypervel\Data\Casts\Cast;
 use Hypervel\Data\Contracts\PropertyMorphableData;
 use Hypervel\Data\Data;
 use Hypervel\Data\DataCollection;
+use Hypervel\Data\Dto;
 use Hypervel\Data\Enums\DataPropertyOperation;
 use Hypervel\Data\Exceptions\InvalidDataDeclaration;
 use Hypervel\Data\Lazy;
@@ -189,6 +190,19 @@ class DataClassTest extends TestCase
         $this->assertNull($transformed->transformationRecipe);
         $this->assertFalse($annotated->bulkCopyTransformation);
         $this->assertNull($annotated->transformationRecipe);
+    }
+
+    /**
+     * Test non-transformable data does not retain unreachable transformation metadata.
+     */
+    public function testNonTransformableDataSkipsTransformationMetadata(): void
+    {
+        $class = $this->factory()->build(new ReflectionClass(NonTransformableDtoFixture::class));
+
+        $this->assertFalse($class->transformable);
+        $this->assertFalse($class->bulkCopyTransformation);
+        $this->assertNull($class->transformationRecipe);
+        $this->assertNotNull($class->creationRecipe);
     }
 
     /**
@@ -470,7 +484,7 @@ class DataClassTest extends TestCase
 #[ErrorBag('metadata')]
 #[RedirectTo('/metadata')]
 #[RedirectToRoute('metadata.store')]
-class DataClassMetadataFixture
+class DataClassMetadataFixture extends Data
 {
     /**
      * Create a new metadata fixture.
@@ -506,7 +520,7 @@ class DataClassMetadataFixture
     }
 }
 
-class ConstructorBindingDataFixture
+class ConstructorBindingDataFixture extends Data
 {
     public readonly string $readonlyName;
 
@@ -595,6 +609,13 @@ class ArbitraryObjectDataFixture extends Data
 class PlainArrayTransformationFixture extends Data
 {
     public array $values = [];
+}
+
+class NonTransformableDtoFixture extends Dto
+{
+    public function __construct(public int $id)
+    {
+    }
 }
 
 class PropertyTransformerDataFixture extends Data

--- a/tests/Data/Support/Transformation/DataTransformerTest.php
+++ b/tests/Data/Support/Transformation/DataTransformerTest.php
@@ -426,6 +426,22 @@ class DataTransformerTest extends TestCase
     }
 
     /**
+     * Test disabled class-owned defaults retain the empty sentinel.
+     */
+    public function testDisabledClassOwnedPartialDefaultsRemainEmpty(): void
+    {
+        $data = new DisabledDefaultPartialsData('first', 'second');
+
+        $this->assertFalse($data->hasPartialsDefinition());
+        $this->assertFalse($this->partialDefinitionsState($data));
+        $this->assertSame([
+            'first' => 'first',
+            'second' => 'second',
+        ], $data->toArray());
+        $this->assertFalse($this->partialDefinitionsState($data));
+    }
+
+    /**
      * Test plain collections and their items do not retain empty partial stores.
      */
     public function testPlainCollectionsDoNotRetainEmptyPartials(): void
@@ -1096,6 +1112,23 @@ class DefaultPartialsData extends Data
     protected function onlyProperties(): array
     {
         return ['first'];
+    }
+}
+
+class DisabledDefaultPartialsData extends Data
+{
+    public function __construct(
+        public string $first,
+        public string $second,
+    ) {
+    }
+
+    /**
+     * Disable the conditional default selection.
+     */
+    protected function onlyProperties(): array
+    {
+        return ['first' => false];
     }
 }
 

--- a/tests/Data/Support/Transformation/DataTransformerTest.php
+++ b/tests/Data/Support/Transformation/DataTransformerTest.php
@@ -30,6 +30,7 @@ use Hypervel\Data\Normalizers\Normalized\Normalized;
 use Hypervel\Data\Normalizers\Normalizer;
 use Hypervel\Data\Support\DataClass;
 use Hypervel\Data\Support\DataProperty;
+use Hypervel\Data\Support\Partials\PartialsDefinition;
 use Hypervel\Data\Support\Transformation\DataTransformer;
 use Hypervel\Data\Support\Transformation\TransformationContext;
 use Hypervel\Data\Support\Transformation\TransformationContextFactory;
@@ -40,6 +41,7 @@ use Hypervel\Inertia\OptionalProp;
 use Hypervel\Pagination\CursorPaginator;
 use Hypervel\Pagination\LengthAwarePaginator;
 use Hypervel\Testbench\TestCase;
+use ReflectionProperty;
 use RuntimeException;
 use Traversable;
 
@@ -383,6 +385,105 @@ class DataTransformerTest extends TestCase
         $this->assertSame($closure, $transformed['closure']);
         $this->assertArrayNotHasKey('default', $transformed);
         $this->assertArrayNotHasKey('excluded', $transformed);
+    }
+
+    /**
+     * Test plain transformations do not retain an empty partial definition store.
+     */
+    public function testPlainTransformationsDoNotRetainEmptyPartials(): void
+    {
+        $data = new SimpleData('value');
+
+        $this->assertNull($this->partialDefinitionsState($data));
+        $this->assertSame(['value' => 'value'], $data->toArray());
+        $this->assertFalse($this->partialDefinitionsState($data));
+        $this->assertSame(['value' => 'value'], $data->all());
+        $this->assertFalse($this->partialDefinitionsState($data));
+
+        TransformationContextFactory::create()->get($data);
+
+        $this->assertFalse($this->partialDefinitionsState($data));
+
+        $data->only('value');
+
+        $this->assertInstanceOf(PartialsDefinition::class, $this->partialDefinitionsState($data));
+        $this->assertSame(['value' => 'value'], $data->toArray());
+        $this->assertFalse($data->hasPartialsDefinition());
+    }
+
+    /**
+     * Test class-owned partial defaults still initialize once and remain active.
+     */
+    public function testClassOwnedPartialDefaultsStillInitialize(): void
+    {
+        $data = new DefaultPartialsData('first', 'second');
+
+        $this->assertNull($this->partialDefinitionsState($data));
+        $this->assertTrue($data->hasPartialsDefinition());
+        $this->assertInstanceOf(PartialsDefinition::class, $this->partialDefinitionsState($data));
+        $this->assertSame(['first' => 'first'], $data->toArray());
+        $this->assertTrue($data->hasPartialsDefinition());
+    }
+
+    /**
+     * Test plain collections and their items do not retain empty partial stores.
+     */
+    public function testPlainCollectionsDoNotRetainEmptyPartials(): void
+    {
+        $first = new SimpleData('first');
+        $second = new SimpleData('second');
+        $collection = new DataCollection(SimpleData::class, [$first, $second]);
+
+        $this->assertSame([
+            ['value' => 'first'],
+            ['value' => 'second'],
+        ], $collection->toArray());
+        $this->assertFalse($this->partialDefinitionsState($collection));
+        $this->assertFalse($this->partialDefinitionsState($first));
+        $this->assertFalse($this->partialDefinitionsState($second));
+    }
+
+    /**
+     * Test unrelated parent partials do not allocate stores on nested values or iterable items.
+     */
+    public function testUnrelatedParentPartialsDoNotAllocateNestedStores(): void
+    {
+        $nested = new NestedLazyData(
+            Lazy::create(static fn (): string => 'temporary'),
+            Lazy::create(static fn (): string => 'permanent'),
+        );
+        $first = new NestedLazyData(
+            Lazy::create(static fn (): string => 'first'),
+            Lazy::create(static fn (): string => 'ignored'),
+        );
+        $second = new NestedLazyData(
+            Lazy::create(static fn (): string => 'second'),
+            Lazy::create(static fn (): string => 'ignored'),
+        );
+
+        (new PartialOwnerData($nested))->include('enabled')->all();
+        (new DataArrayOwner([$first, $second]))->include('items')->all();
+
+        $this->assertNull($this->partialDefinitionsState($nested));
+        $this->assertNull($this->partialDefinitionsState($first));
+        $this->assertNull($this->partialDefinitionsState($second));
+    }
+
+    /**
+     * Test root collection partials still propagate to unchanged items.
+     */
+    public function testRootCollectionPartialsPropagateToUnchangedItems(): void
+    {
+        $item = new NestedLazyData(
+            Lazy::create(static fn (): string => 'temporary'),
+            Lazy::create(static fn (): string => 'ignored'),
+        );
+        $collection = (new DataCollection(NestedLazyData::class, [$item]))
+            ->include('temporary');
+
+        $this->assertSame([$item], $collection->all());
+        $this->assertInstanceOf(PartialsDefinition::class, $this->partialDefinitionsState($item));
+        $this->assertSame(['temporary' => 'temporary'], $item->toArray());
     }
 
     /**
@@ -937,6 +1038,17 @@ class DataTransformerTest extends TestCase
         ], $data->transform(TransformationContextFactory::forPersistence()));
         $this->assertSame(1, $model->relationReads);
     }
+
+    /**
+     * Get the internal partial definition state without initializing it.
+     */
+    private function partialDefinitionsState(object $data): PartialsDefinition|false|null
+    {
+        /** @var null|false|PartialsDefinition $state */
+        $state = (new ReflectionProperty($data, 'partialDefinitions'))->getValue($data);
+
+        return $state;
+    }
 }
 
 class BulkCopyRecordingDataTransformer extends DataTransformer
@@ -967,6 +1079,23 @@ class SimpleData extends Data
 {
     public function __construct(public string $value)
     {
+    }
+}
+
+class DefaultPartialsData extends Data
+{
+    public function __construct(
+        public string $first,
+        public string $second,
+    ) {
+    }
+
+    /**
+     * Keep the first property by default.
+     */
+    protected function onlyProperties(): array
+    {
+        return ['first'];
     }
 }
 


### PR DESCRIPTION
## Summary

This change reduces per-object transformation overhead in `hypervel/data` without adding a new execution mode or changing its public creation and transformation APIs.

- avoid retaining an empty partial-definition store on ordinary data objects
- skip empty partial propagation into nested data and collection items
- avoid persistent PHP object-property tables on raw-storage transformation paths
- skip unreachable transformation recipes for non-transformable `Dto` classes
- document safe operation-scoped factory reuse
- report transformed and untransformed instance retention in the comparison harness

## Motivation

Every includeable object previously allocated a mutable `PartialsDefinition` when its transformation context was first requested, even when the class and instance had no partial selections. That cost was retained for the lifetime of every transformed object. Nested traversal could also create empty stores while propagating a selection that did not apply to the child.

The general and fixed-recipe transformation paths also used `get_mangled_object_vars()`. PHP retains an expanded property table after that call. Those paths need raw storage, not the public hook-aware view, so an object-to-array cast provides the same values without retaining the table.

## Design

The existing partial-definition field now has three explicit states:

- `null`: class defaults have not been inspected
- `false`: defaults were inspected and no definitions exist
- `PartialsDefinition`: a mutable store is required

Explicit partial methods upgrade the empty sentinel transparently. Class-owned defaults are still evaluated once, temporary definitions are still consumed at the same boundary, and populated stores retain their existing behavior. Resolved nested selections are checked once before any child store is allocated.

The raw-storage change is intentionally limited to the general and fixed-recipe paths. Bulk copy continues to use `get_object_vars()` because public property hooks own the logical output there. Source-object normalization also remains hook-aware.

`DataClassFactory` now compiles transformation recipes only when a class implements `TransformableData`. This removes metadata that a `Dto` can never execute while leaving creation metadata unchanged.

## Performance

Measurements were taken in repeated isolated runs on PHP 8.4. The focused medians were stable across three runs.

| Measurement | Before | After | Result |
| --- | ---: | ---: | ---: |
| Default transformation context | 153-164 ns | 84-87 ns | about 45% faster |
| Fresh flat `toArray()` | 2.26-2.31 us | 2.00-2.02 us | about 11-13% faster |
| Empty partial store retained | about 125 B/object | 0 B/object | removed |
| General raw transform table retention | 376 B/object | 0 B/object | removed |

The comparison harness now reports retained memory on equivalent transformed states:

| Scenario | Removed `DataObject` fixture | Current `Data` |
| --- | ---: | ---: |
| Flat, untransformed | 197.9 B | 218.4 B |
| Flat, transformed | 562.4 B | 594.4 B |
| Wide, untransformed | 474.4 B | 474.4 B |
| Wide, transformed | 1810.4 B | 1810.4 B |

The hook-aware bulk path still pays the PHP property-table cost because replacing it would change property-hook semantics. This PR does not add a classifier, cache, alternate transformer, or mode switch to avoid that correct behavior.

## Documentation

The creation factory section now explains that one factory may be reused within a single operation to avoid repeating setup for every payload. It recommends `collect()` when inputs form one collection so shape preservation, keys, collection validation rules, and hooks retain their intended semantics. Mutable factories should not be stored across requests.

## Verification

- Data package test suite
- focused transformation and metadata tests
- PHPStan
- PHP CS Fixer
- comparison benchmark and focused memory profiles
- whitespace and diff validation