### PR TITLE
Support reusable pipelines and detached background coroutines

### DIFF
--- a/src/coroutine/src/Concurrent.php
+++ b/src/coroutine/src/Concurrent.php
@@ -104,8 +104,9 @@ class Concurrent
     /**
      * Start a coroutine that owns one concurrency slot.
      *
-     * The optional wrapper runs at native child entry. It must not suspend
-     * outside the supplied runner and must invoke that runner exactly once.
+     * The optional wrapper runs at native child entry and must invoke the supplied
+     * runner exactly once. Outside the runner it must not wait for I/O or other work.
+     * Finalize ownership before notifying waiters, which may run immediately.
      *
      * @param array<string>|false $copyContext
      * @param null|Closure(Closure(): void): void $wrapper

--- a/src/coroutine/src/Coroutine.php
+++ b/src/coroutine/src/Coroutine.php
@@ -127,6 +127,9 @@ class Coroutine
     {
         $context = CoroutineContext::captureFrom($keys);
 
+        // Forks created by startup hooks must not inherit the parent's detachment instruction.
+        unset($context[self::DETACHED_CONTEXT_KEY]);
+
         return self::createWithContext($callable, $context, null);
     }
 
@@ -144,6 +147,7 @@ class Coroutine
     public static function forkOwned(callable $callable, Closure $wrapper, array $keys = [], bool $detached = false): int
     {
         $context = CoroutineContext::captureFrom($keys);
+        unset($context[self::DETACHED_CONTEXT_KEY]);
 
         if ($detached) {
             $context[self::DETACHED_CONTEXT_KEY] = true;

--- a/src/coroutine/src/Coroutine.php
+++ b/src/coroutine/src/Coroutine.php
@@ -16,6 +16,8 @@ use Throwable;
 
 class Coroutine
 {
+    public const string DETACHED_CONTEXT_KEY = '__coroutine.detached';
+
     protected static bool $enableReportException = true;
 
     /**
@@ -39,6 +41,8 @@ class Coroutine
      * Boot-only. The callback persists in a static property for the worker
      * lifetime and runs for every subsequently created coroutine. Callbacks
      * run synchronously during child startup and must not suspend.
+     * Hooks that inherit parent context must honor DETACHED_CONTEXT_KEY while
+     * preserving values explicitly installed in the child.
      */
     public static function afterCreated(callable $callback): void
     {
@@ -100,18 +104,18 @@ class Coroutine
     }
 
     /**
-     * Create a coroutine whose lifecycle is owned by a framework wrapper.
+     * Create a coroutine whose lifecycle is owned by a wrapper.
      *
-     * The wrapper runs at native child entry. It must not suspend outside the
-     * supplied runner and must invoke that runner exactly once.
+     * The wrapper runs at native child entry and must invoke the supplied runner
+     * exactly once. Outside the runner it must not wait for I/O or other work.
+     * Finalize ownership before notifying waiters, which may run immediately.
+     * Detachment prevents implicit parent-context propagation during startup.
      *
      * @param Closure(Closure(): void): void $wrapper
-     *
-     * @internal
      */
-    public static function createOwned(callable $callable, Closure $wrapper): int
+    public static function createOwned(callable $callable, Closure $wrapper, bool $detached = false): int
     {
-        return self::createWithContext($callable, [], $wrapper);
+        return self::createWithContext($callable, $detached ? [self::DETACHED_CONTEXT_KEY => true] : [], $wrapper);
     }
 
     /**
@@ -129,17 +133,21 @@ class Coroutine
     /**
      * Create an owned coroutine with a copy of the parent coroutine context.
      *
-     * The wrapper runs at native child entry. It must not suspend outside the
-     * supplied runner and must invoke that runner exactly once.
+     * The wrapper runs at native child entry and must invoke the supplied runner
+     * exactly once. Outside the runner it must not wait for I/O or other work.
+     * Finalize ownership before notifying waiters, which may run immediately.
+     * Detachment prevents parent fallback without discarding the copied context.
      *
      * @param Closure(Closure(): void): void $wrapper
      * @param array<string> $keys Context keys to copy (empty = all keys)
-     *
-     * @internal
      */
-    public static function forkOwned(callable $callable, Closure $wrapper, array $keys = []): int
+    public static function forkOwned(callable $callable, Closure $wrapper, array $keys = [], bool $detached = false): int
     {
         $context = CoroutineContext::captureFrom($keys);
+
+        if ($detached) {
+            $context[self::DETACHED_CONTEXT_KEY] = true;
+        }
 
         return self::createWithContext($callable, $context, $wrapper);
     }
@@ -184,6 +192,9 @@ class Coroutine
                 static::printLog($throwable);
             }
         }
+
+        // Detachment affects startup inheritance, not the child's own descendants.
+        CoroutineContext::forget(self::DETACHED_CONTEXT_KEY);
 
         $callable();
     }

--- a/src/docs/coroutines.md
+++ b/src/docs/coroutines.md
@@ -290,7 +290,7 @@ $coroutineId = Coroutine::createOwned($callable, $wrapper, detached: true);
 
 Startup hooks still run. The framework installs `Coroutine::DETACHED_CONTEXT_KEY` before the hooks run. Hooks that propagate parent context honor this marker by leaving explicitly installed child values intact and avoiding parent fallback. Detachment does not erase values explicitly copied by `forkOwned`. See the [Sentry](/docs/{{version}}/sentry#introduction) and [Telescope](/docs/{{version}}/telescope#controlling-recording) documentation for their behavior in detached children.
 
-The framework removes the marker after startup hooks and before the callable runs. A detached child may establish its own context, and children it later creates follow normal inheritance rules. Detachment controls context propagation; the caller still owns cancellation, joining, and resource cleanup.
+The framework removes the marker after startup hooks and before the callable runs. A detached child may establish its own context, and children it creates, including from startup hooks, follow normal inheritance rules unless explicitly detached. Detachment controls context propagation; the caller still owns cancellation, joining, and resource cleanup.
 
 <a name="nested-coroutines"></a>
 ### Nested Coroutines

--- a/src/docs/coroutines.md
+++ b/src/docs/coroutines.md
@@ -9,6 +9,8 @@
     - [Determining if Code is Running in a Coroutine](#determining-if-code-is-running-in-a-coroutine)
     - [Creating a Child Coroutine](#creating-a-child-coroutine)
     - [Copying Coroutine Context](#copying-coroutine-context)
+    - [Owning Child Startup](#owning-child-startup)
+    - [Detached Background Work](#detached-background-work)
     - [Nested Coroutines](#nested-coroutines)
 - [Error Handling](#error-handling)
     - [Coroutine Cancellation](#coroutine-cancellation)
@@ -234,6 +236,62 @@ go(function () {
 
 Objects stored directly as context values are shared by default. Values that implement `Hypervel\Context\ReplicableContext` are copied independently, while values that implement `Hypervel\Context\NonCopyableContext` are omitted. Hypervel does not inspect objects nested within arrays or other objects. See the [coroutine context](/docs/{{version}}/coroutine-context) documentation for more information.
 
+Package startup hooks may also propagate their own context into a fresh child. For example, Sentry and Telescope associate ordinary children with the parent's execution. Use [detached background work](#detached-background-work) when that association is unwanted.
+
+<a name="owning-child-startup"></a>
+### Owning Child Startup
+
+Package infrastructure may need to record ownership before a child's startup hooks run. The `createOwned` method accepts a wrapper that runs inside the child before its initial context is installed and before any startup hooks run. For example, count a child before creating it, then release that count even if the child is canceled during startup:
+
+```php
+use Closure;
+use Hypervel\Coroutine\Coroutine;
+use Throwable;
+
+$activeChildren = 0;
+++$activeChildren;
+
+try {
+    $coroutineId = Coroutine::createOwned(
+        function () {
+            // Perform the child work...
+        },
+        function (Closure $run) use (&$activeChildren): void {
+            try {
+                $run();
+            } finally {
+                --$activeChildren;
+            }
+        },
+    );
+} catch (Throwable $exception) {
+    --$activeChildren;
+
+    throw $exception;
+}
+```
+
+The wrapper must invoke `$run` exactly once. Outside that call it must not wait for I/O, channel data or capacity, or other work. Releases that cannot wait are allowed. Finalize the relevant ownership state before notifying waiters, since a notification can immediately run another coroutine. Keep work and cleanup that may wait inside the child callable. The wrapper's `finally` also runs if the child is canceled during startup, before the callable begins.
+
+`forkOwned` accepts the same wrapper plus the context keys to copy, following the [normal copying rules](#copying-coroutine-context). Both methods return the child ID. If either method throws, including `CoroutineCreateException` or a context-copy failure from `forkOwned`, the wrapper has not run, so the caller still owns any resources it reserved.
+
+Returning from the wrapper is not proof that the child has exited: deferred callbacks run afterward and may wait. Use `Coroutine::join()` or `Coroutine::exists()` when resource ownership depends on physical exit. A timed-out join does not terminate a child. For ordinary application tasks, prefer the `wait`, `parallel`, and `WaitConcurrent` APIs, which manage child ownership for you.
+
+<a name="detached-background-work"></a>
+### Detached Background Work
+
+Background services can start without inheriting the request or tracing state of the caller that starts them. Pass `detached: true` to `createOwned` or `forkOwned`, using a callable and ownership wrapper as shown in the [previous example](#owning-child-startup):
+
+```php
+use Hypervel\Coroutine\Coroutine;
+
+$coroutineId = Coroutine::createOwned($callable, $wrapper, detached: true);
+```
+
+Startup hooks still run. The framework installs `Coroutine::DETACHED_CONTEXT_KEY` before the hooks run. Hooks that propagate parent context honor this marker by leaving explicitly installed child values intact and avoiding parent fallback. Detachment does not erase values explicitly copied by `forkOwned`. See the [Sentry](/docs/{{version}}/sentry#introduction) and [Telescope](/docs/{{version}}/telescope#controlling-recording) documentation for their behavior in detached children.
+
+The framework removes the marker after startup hooks and before the callable runs. A detached child may establish its own context, and children it later creates follow normal inheritance rules. Detachment controls context propagation; the caller still owns cancellation, joining, and resource cleanup.
+
 <a name="nested-coroutines"></a>
 ### Nested Coroutines
 
@@ -257,7 +315,7 @@ go(function () {
 echo 'Main process' . PHP_EOL;
 ```
 
-Each nested coroutine has its own coroutine ID and its own coroutine context. Context values are isolated unless you explicitly copy them into the child coroutine.
+Each nested coroutine has its own coroutine ID and its own coroutine context. Application values are isolated unless explicitly copied; package startup hooks may also propagate execution context as described above.
 
 <a name="error-handling"></a>
 ## Error Handling
@@ -314,7 +372,7 @@ try {
 }
 ```
 
-Cleanup that does not pause should remain in `finally` as usual. Code that owns child coroutines should use `wait`, `parallel`, or `WaitConcurrent` so Hypervel can cancel active children when their parent is canceled.
+Cleanup that does not wait should remain in `finally` as usual. Code that owns child coroutines should use `wait`, `parallel`, or `WaitConcurrent` so Hypervel can cancel active children when their parent is canceled.
 
 <a name="reporting-unhandled-exceptions"></a>
 ### Reporting Unhandled Exceptions
@@ -870,7 +928,7 @@ if (! Coroutine::join($coroutineIds) && EngineCoroutine::isCanceled()) {
 
 This state is not durable. Read it only at the failed native operation boundary.
 
-The `afterCreated` method registers a callback that runs whenever `Coroutine::create` creates a coroutine. APIs built on `Coroutine::create`, including `go`, `co`, and `Coroutine::fork`, also run the callback:
+The `afterCreated` method registers a callback that runs during child startup for `Coroutine::create`, `fork`, `createOwned`, and `forkOwned`, as well as helpers such as `go` and `co`:
 
 ```php
 Coroutine::afterCreated(function () {
@@ -880,6 +938,8 @@ Coroutine::afterCreated(function () {
 
 > [!WARNING]
 > These callbacks remain registered for the lifetime of the Swoole worker. Register them during application boot or tests only. They run synchronously during child startup and must not perform work that suspends the coroutine.
+
+Hooks that copy state from the parent must check `CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY)` and skip parent fallback when it is present. Preserve explicitly installed child values and any isolation they need. The marker remains available to every startup hook and is removed before the application callable runs. See [detached background work](#detached-background-work).
 
 The `flushState` method clears coroutine settings and callbacks stored for the current worker:
 

--- a/src/docs/helpers.md
+++ b/src/docs/helpers.md
@@ -3692,6 +3692,29 @@ $user = Pipeline::send($user)
     ->thenReturn();
 ```
 
+#### Reusing a Pipeline
+
+When processing many values through the same middleware, you may build a reusable closure with `toClosure`. The closure receives a new input on each call, so the middleware structure only needs to be built once:
+
+```php
+use App\Pipes\NormalizeRecord;
+use App\Pipes\ValidateRecord;
+use Hypervel\Support\Facades\Pipeline;
+
+$process = Pipeline::through([
+    NormalizeRecord::class,
+    ValidateRecord::class,
+])->toClosure(fn (array $record): array => $record);
+
+foreach ($records as $record) {
+    $processed = $process($record);
+}
+```
+
+Class middleware is resolved when each invocation reaches it, using its normal [container lifetime](/docs/{{version}}/container). Middleware bound with `scoped` is resolved once per coroutine; `bind` creates a fresh instance each time it is resolved. Unbound classes are shared by default, and singleton bindings are shared for the worker's lifetime. Shared middleware, supplied middleware objects, and state captured by closures must not retain invocation-specific values when the closure is used concurrently. Transaction and `finally` behavior applies separately to each invocation.
+
+Configure the pipeline before calling `toClosure` and leave that pipeline's configuration unchanged while using the returned closure. Each invocation receives its own input, but the closure still uses the pipeline's container, method, transaction, and `finally` settings.
+
 <a name="sleep"></a>
 ### Sleep
 

--- a/src/docs/helpers.md
+++ b/src/docs/helpers.md
@@ -3711,7 +3711,7 @@ foreach ($records as $record) {
 }
 ```
 
-Class middleware is resolved when each invocation reaches it, using its normal [container lifetime](/docs/{{version}}/container). Middleware bound with `scoped` is resolved once per coroutine; `bind` creates a fresh instance each time it is resolved. Unbound classes are shared by default, and singleton bindings are shared for the worker's lifetime. Shared middleware, supplied middleware objects, and state captured by closures must not retain invocation-specific values when the closure is used concurrently. Transaction and `finally` behavior applies separately to each invocation.
+Class middleware is resolved when each invocation reaches it, using its normal [container lifetime](/docs/{{version}}/container). Scoped middleware is resolved once per coroutine. Bindings and class lifetime rules decide whether other middleware is shared or fresh; ordinary unbound classes are shared by default. Shared middleware, supplied middleware objects, and state captured by closures must not retain invocation-specific values when the closure is used concurrently. Transaction and `finally` behavior applies separately to each invocation.
 
 Configure the pipeline before calling `toClosure` and leave that pipeline's configuration unchanged while using the returned closure. Each invocation receives its own input, but the closure still uses the pipeline's container, method, transaction, and `finally` settings.
 

--- a/src/docs/sentry.md
+++ b/src/docs/sentry.md
@@ -25,7 +25,9 @@
 
 [Sentry](https://sentry.io) provides error tracking and performance monitoring for your Hypervel application. Hypervel's Sentry integration captures exceptions, logs, requests, database queries, cache operations, queued jobs, notifications, Redis commands, scheduled tasks, and filesystem operations.
 
-The integration is designed for Hypervel's long-running Swoole workers. Sentry state is isolated across requests, queued jobs, scheduled tasks, and WebSocket callbacks, while HTTP connections are pooled and reused across executions. An execution remains active until any application child coroutines it starts have finished.
+The integration is designed for Hypervel's long-running Swoole workers. Sentry state is isolated across requests, queued jobs, scheduled tasks, and WebSocket callbacks, while HTTP connections are pooled and reused across executions. An execution remains active until the child coroutines sharing its runtime context have finished.
+
+[Detached background coroutines](/docs/{{version}}/coroutines#detached-background-work) do not inherit the creator's scope, request, or runtime context. Explicitly copied scopes and requests are still cloned for isolation. Sentry starts an execution when a child handles an HTTP request, queued job, scheduled task, or WebSocket event through the usual framework lifecycle. Without an execution, logs and metrics use the SDK's shared global buffer, which is not automatically flushed when detached work finishes.
 
 <a name="installation"></a>
 ## Installation

--- a/src/docs/telescope.md
+++ b/src/docs/telescope.md
@@ -214,6 +214,8 @@ public function register(): void
 
 This callback controls whether recording begins. To choose which collected entries are stored, use Telescope's [entry and batch filters](#filtering).
 
+Ordinary child coroutines inherit the parent's recording state and batch. [Detached background coroutines](/docs/{{version}}/coroutines#detached-background-work) start with recording disabled and no parent batch, unless those values were explicitly copied into the child. Recording can then begin through the usual request, command, job, or scheduled-task lifecycle.
+
 <a name="deferred-storage"></a>
 ### Deferred Storage
 

--- a/src/pipeline/src/Pipeline.php
+++ b/src/pipeline/src/Pipeline.php
@@ -106,14 +106,12 @@ class Pipeline implements PipelineContract, Transient
     }
 
     /**
-     * Compile the pipeline structure without binding it to a passable value.
+     * Create a reusable closure that receives a value on each invocation.
      *
-     * The returned closure receives its passable per invocation. Immutable pipe
-     * descriptors stay in the onion while their middleware instances are resolved
-     * inside each call, allowing independent requests to reuse the same structure.
-     * Transaction and finally callbacks are also applied per invocation.
-     *
-     * @internal
+     * Class middleware resolves inside each call using its container lifetime.
+     * Supplied middleware objects and captured closure state remain shared.
+     * Transaction and finally callbacks are applied per invocation.
+     * Keep this pipeline's configuration unchanged while using the closure.
      */
     public function toClosure(Closure $destination): Closure
     {

--- a/src/sentry/src/SentryServiceProvider.php
+++ b/src/sentry/src/SentryServiceProvider.php
@@ -556,7 +556,9 @@ class SentryServiceProvider extends ServiceProvider
             }
 
             /** @var null|ArrayObject<string, mixed> $parentContext */
-            $parentContext = CoroutineContext::getContainer(Coroutine::parentId());
+            $parentContext = isset($context[Coroutine::DETACHED_CONTEXT_KEY])
+                ? null
+                : CoroutineContext::getContainer(Coroutine::parentId());
 
             /** @var null|list<Layer> $stack */
             $stack = $context[Hub::CONTEXT_STACK_KEY]

--- a/src/support/src/Facades/Pipeline.php
+++ b/src/support/src/Facades/Pipeline.php
@@ -17,6 +17,7 @@ namespace Hypervel\Support\Facades;
  * @method static mixed then(\Closure $destination)
  * @method static mixed thenReturn()
  * @method static \Hypervel\Pipeline\Pipeline through(mixed $pipes)
+ * @method static \Closure toClosure(\Closure $destination)
  * @method static mixed unless(mixed $value = null, null|callable $callback = null, null|callable $default = null)
  * @method static \Hypervel\Pipeline\Pipeline via(string $method)
  * @method static mixed when(mixed $value = null, null|callable $callback = null, null|callable $default = null)

--- a/src/telescope/src/TelescopeServiceProvider.php
+++ b/src/telescope/src/TelescopeServiceProvider.php
@@ -41,18 +41,21 @@ class TelescopeServiceProvider extends ServiceProvider
 
         Telescope::start($this->app);
         Telescope::listenForStorageOpportunities($this->app);
-        Coroutine::afterCreated(function () {
+        Coroutine::afterCreated(static function (): void {
+            $detached = CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY);
             $keys = [
                 Telescope::SHOULD_RECORD_CONTEXT_KEY => false,
                 Telescope::BATCH_ID_CONTEXT_KEY => null,
             ];
             foreach ($keys as $key => $default) {
-                // fork() installs its snapshot before callbacks run, so keep captured values.
+                // Keep explicit snapshots; detachment only prevents parent fallback.
                 if (CoroutineContext::has($key)) {
                     continue;
                 }
 
-                CoroutineContext::set($key, CoroutineContext::get($key, $default, Coroutine::parentId()));
+                CoroutineContext::set($key, $detached
+                    ? $default
+                    : CoroutineContext::get($key, $default, Coroutine::parentId()));
             }
         });
     }

--- a/tests/Coroutine/CoroutineTest.php
+++ b/tests/Coroutine/CoroutineTest.php
@@ -219,6 +219,50 @@ class CoroutineTest extends TestCase
         $this->assertFalse(CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY));
     }
 
+    public function testForksDuringDetachedStartupOnlyDetachWhenRequested(): void
+    {
+        $observed = [];
+        $coroutineIds = [];
+        $started = false;
+        $wrapper = static function (Closure $run): void {
+            $run();
+        };
+
+        Coroutine::afterCreated(static function () use (&$observed, &$coroutineIds, &$started, $wrapper): void {
+            if ($started) {
+                $observed[] = [
+                    CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY),
+                    CoroutineContext::get('request-id'),
+                ];
+
+                return;
+            }
+
+            $started = true;
+            CoroutineContext::set('request-id', 'child-request');
+            $callable = static function (): void {};
+            $coroutineIds = [
+                Coroutine::fork($callable),
+                Coroutine::forkOwned($callable, $wrapper),
+                Coroutine::forkOwned($callable, $wrapper, detached: true),
+            ];
+
+            $observed[] = ['parent', CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY)];
+        });
+
+        $coroutineId = Coroutine::createOwned(static function (): void {}, $wrapper, detached: true);
+        Coroutine::join([...$coroutineIds, $coroutineId]);
+
+        $this->assertSame([
+            [false, 'child-request'],
+            [false, 'child-request'],
+            [true, 'child-request'],
+            ['parent', true],
+        ], $observed);
+        $this->assertFalse(CoroutineContext::has('request-id'));
+        $this->assertFalse(CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY));
+    }
+
     public function testFlushStateRestoresExceptionReporting()
     {
         try {

--- a/tests/Coroutine/CoroutineTest.php
+++ b/tests/Coroutine/CoroutineTest.php
@@ -188,6 +188,37 @@ class CoroutineTest extends TestCase
         $this->assertSame(1, $count); // Should still be 1, callback was flushed
     }
 
+    public function testDetachmentMarkerIsOnlyAvailableDuringChildStartup(): void
+    {
+        $observed = [];
+        Coroutine::afterCreated(static function () use (&$observed): void {
+            $observed[] = ['startup', CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY)];
+        });
+
+        Coroutine::createOwned(
+            static function () use (&$observed): void {
+                $observed[] = ['callable', CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY)];
+                Coroutine::fork(static function () use (&$observed): void {
+                    $observed[] = ['descendant', CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY)];
+                });
+            },
+            static function (Closure $run) use (&$observed): void {
+                $run();
+                $observed[] = ['wrapper', CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY)];
+            },
+            detached: true,
+        );
+
+        $this->assertSame([
+            ['startup', true],
+            ['callable', false],
+            ['startup', false],
+            ['descendant', false],
+            ['wrapper', false],
+        ], $observed);
+        $this->assertFalse(CoroutineContext::has(Coroutine::DETACHED_CONTEXT_KEY));
+    }
+
     public function testFlushStateRestoresExceptionReporting()
     {
         try {

--- a/tests/Pipeline/CoroutineIsolationTest.php
+++ b/tests/Pipeline/CoroutineIsolationTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Pipeline;
 
+use Closure;
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Engine\Coroutine as EngineCoroutine;
 use Hypervel\Pipeline\Pipeline;
 use Hypervel\Testbench\TestCase;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 use Swoole\Coroutine\Channel;
 
 use function Hypervel\Coroutine\parallel;
@@ -73,5 +77,92 @@ class CoroutineIsolationTest extends TestCase
         sort($finalized);
 
         $this->assertSame(['first:first', 'second:second'], $finalized);
+    }
+
+    public function testReusablePipelineResolvesScopedMiddlewareInsideEachCoroutine(): void
+    {
+        $this->app->scoped(ReusablePipelineState::class);
+        $pipeline = $this->app->make(Pipeline::class)
+            ->through(ReusablePipelineState::class)
+            ->toClosure(static fn (string $value): string => $value);
+
+        $results = parallel([
+            static fn (): array => $pipeline('first'),
+            static fn (): array => $pipeline('second'),
+        ]);
+
+        $this->assertSame(['first', 'second'], array_column($results, 0));
+        $this->assertNotSame($results[0][1], $results[1][1]);
+    }
+
+    public function testReusablePipelinePreservesSharedAndFreshMiddlewareBindings(): void
+    {
+        $pipeline = $this->app->make(Pipeline::class)
+            ->through(ReusablePipelineState::class)
+            ->toClosure(static fn (string $value): string => $value);
+
+        $first = $pipeline('first');
+        $second = $pipeline('second');
+        $this->assertSame($first[1], $second[1]);
+
+        $this->app->bind(ReusablePipelineState::class);
+        $third = $pipeline('third');
+        $fourth = $pipeline('fourth');
+        $this->assertNotSame($first[1], $third[1]);
+        $this->assertNotSame($third[1], $fourth[1]);
+    }
+
+    public function testCancelingAnInvocationDoesNotDisturbAnotherInvocation(): void
+    {
+        $blocker = new Channel(1);
+        $finalized = [];
+        $canceled = null;
+        $pipeline = $this->app->make(Pipeline::class)
+            ->through([static function (string $value, Closure $next) use ($blocker): string {
+                if ($value === 'canceled') {
+                    $blocker->pop();
+                }
+
+                return $next($value);
+            }])
+            ->finally(static function (string $value) use (&$finalized): void {
+                $finalized[] = $value;
+            })
+            ->toClosure(static fn (string $value): string => $value);
+
+        $coroutineId = Coroutine::create(static function () use ($pipeline, &$canceled): void {
+            try {
+                $pipeline('canceled');
+            } catch (CanceledException $exception) {
+                $canceled = $exception;
+            }
+        });
+
+        try {
+            $this->assertSame('completed', $pipeline('completed'));
+            $this->assertTrue(EngineCoroutine::cancelById($coroutineId, throwException: true));
+            $this->assertInstanceOf(CanceledException::class, $canceled);
+            $this->assertSame('later', $pipeline('later'));
+            $this->assertSame(['completed', 'canceled', 'later'], $finalized);
+        } finally {
+            $blocker->close();
+            Coroutine::join([$coroutineId], 1);
+        }
+    }
+}
+
+class ReusablePipelineState
+{
+    protected string $value;
+
+    /**
+     * Retain the input across a suspension to exercise the binding's lifetime.
+     */
+    public function handle(string $value, Closure $next): array
+    {
+        $this->value = $value;
+        usleep(1000);
+
+        return [$next($this->value), $this];
     }
 }

--- a/tests/Sentry/CoroutineContextPropagationTest.php
+++ b/tests/Sentry/CoroutineContextPropagationTest.php
@@ -11,6 +11,7 @@ use Hypervel\Http\Request;
 use Hypervel\Sentry\Hub;
 use Hypervel\Sentry\State\CoroutineRuntimeContextStorage;
 use Hypervel\Sentry\Transport\HttpPoolTransport;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Sentry\Event;
 use Sentry\EventType;
 use Sentry\SentrySdk;
@@ -271,7 +272,8 @@ class CoroutineContextPropagationTest extends SentryTestCase
         $this->assertSame(1, $this->countCapturedEvents(EventType::metrics()));
     }
 
-    public function testDeliveryChildDoesNotInheritApplicationContext(): void
+    #[DataProvider('isolatedChildTypes')]
+    public function testDetachedAndDeliveryChildrenDoNotInheritApplicationContext(bool $detached): void
     {
         $hub = $this->getSentryHubFromContainer();
         $hub->pushScope();
@@ -287,10 +289,14 @@ class CoroutineContextPropagationTest extends SentryTestCase
                     app(CoroutineRuntimeContextStorage::class)->get(),
                 ]);
             },
-            static function (Closure $run): void {
-                CoroutineContext::set(HttpPoolTransport::DELIVERY_CONTEXT_KEY, true);
+            static function (Closure $run) use ($detached): void {
+                if (! $detached) {
+                    CoroutineContext::set(HttpPoolTransport::DELIVERY_CONTEXT_KEY, true);
+                }
+
                 $run();
             },
+            detached: $detached,
         );
 
         [$stack, $request, $runtimeContext] = $result->pop(1.0);
@@ -301,6 +307,112 @@ class CoroutineContextPropagationTest extends SentryTestCase
         Coroutine::join([$childId]);
 
         SentrySdk::endContext();
+    }
+
+    /**
+     * Provide child types that suppress implicit Sentry inheritance.
+     */
+    public static function isolatedChildTypes(): array
+    {
+        return [
+            'delivery' => [false],
+            'detached' => [true],
+        ];
+    }
+
+    public function testDetachedForkClonesExplicitScopesWithoutFillingOmittedContext(): void
+    {
+        $hub = $this->getSentryHubFromContainer();
+        $hub->pushScope();
+        $hub->configureScope(static function (Scope $scope): void {
+            $scope->setTag('owner', 'parent');
+        });
+        CoroutineContext::set(Request::class, Request::create('/parent'));
+        SentrySdk::startContext($hub);
+        $parentStack = CoroutineContext::get(Hub::CONTEXT_STACK_KEY);
+        $observed = [];
+        $childId = null;
+
+        try {
+            $childId = Coroutine::forkOwned(
+                static function () use ($hub, &$observed): void {
+                    $observed = [
+                        CoroutineContext::get(Hub::CONTEXT_STACK_KEY),
+                        CoroutineContext::get(Request::class),
+                        app(CoroutineRuntimeContextStorage::class)->get(),
+                    ];
+                    $hub->configureScope(static function (Scope $scope): void {
+                        $scope->setTag('owner', 'child');
+                    });
+                },
+                static function (Closure $run): void {
+                    $run();
+                },
+                [Hub::CONTEXT_STACK_KEY],
+                detached: true,
+            );
+
+            [$childStack, $request, $runtimeContext] = $observed;
+            $this->assertCount(count($parentStack), $childStack);
+
+            foreach ($childStack as $index => $layer) {
+                $this->assertNotSame($parentStack[$index], $layer);
+                $this->assertNotSame($parentStack[$index]->getScope(), $layer->getScope());
+                $this->assertSame($parentStack[$index]->getClient(), $layer->getClient());
+            }
+
+            $this->assertNull($request);
+            $this->assertNull($runtimeContext);
+            $this->assertSame(['owner' => 'parent'], $this->scopeTags($hub));
+        } finally {
+            if ($childId !== null) {
+                Coroutine::join([$childId], 1);
+            }
+
+            SentrySdk::endContext();
+        }
+    }
+
+    public function testDetachedChildCanEstablishScopeForItsOwnDescendants(): void
+    {
+        $hub = $this->getSentryHubFromContainer();
+        $hub->pushScope();
+        $hub->configureScope(static function (Scope $scope): void {
+            $scope->setTag('owner', 'parent');
+        });
+        $observed = [];
+
+        Coroutine::createOwned(
+            function () use ($hub, &$observed): void {
+                $observed['initial'] = $this->scopeTags($hub);
+                $hub->configureScope(static function (Scope $scope): void {
+                    $scope->setTag('owner', 'child');
+                });
+
+                Coroutine::create(function () use ($hub, &$observed): void {
+                    $observed['created'] = $this->scopeTags($hub);
+                    $hub->configureScope(static function (Scope $scope): void {
+                        $scope->setTag('owner', 'grandchild');
+                    });
+                });
+                Coroutine::fork(function () use ($hub, &$observed): void {
+                    $observed['forked'] = $this->scopeTags($hub);
+                });
+                $observed['child'] = $this->scopeTags($hub);
+            },
+            static function (Closure $run): void {
+                $run();
+            },
+            detached: true,
+        );
+
+        $this->assertSame([
+            'initial' => [],
+            'created' => ['owner' => 'child'],
+            'forked' => ['owner' => 'child'],
+            'child' => ['owner' => 'child'],
+        ], $observed);
+        $this->assertSame(['owner' => 'parent'], $this->scopeTags($hub));
     }
 
     /**

--- a/tests/Telescope/TelescopeServiceProviderTest.php
+++ b/tests/Telescope/TelescopeServiceProviderTest.php
@@ -127,7 +127,7 @@ class TelescopeServiceProviderTest extends FeatureTestCase
         CoroutineContext::set(Telescope::BATCH_ID_CONTEXT_KEY, 'parent-batch');
         $observed = [];
 
-        Coroutine::createOwned(
+        $coroutineId = Coroutine::createOwned(
             static function () use (&$observed): void {
                 $observed = [
                     Telescope::isRecording(),
@@ -139,6 +139,8 @@ class TelescopeServiceProviderTest extends FeatureTestCase
             },
             detached: true,
         );
+
+        Coroutine::join([$coroutineId]);
 
         $this->assertSame([false, null], $observed);
         $this->assertTrue(Telescope::isRecording());
@@ -151,7 +153,7 @@ class TelescopeServiceProviderTest extends FeatureTestCase
         CoroutineContext::set(Telescope::BATCH_ID_CONTEXT_KEY, 'parent-batch');
         $observed = [];
 
-        Coroutine::forkOwned(
+        $coroutineId = Coroutine::forkOwned(
             static function () use (&$observed): void {
                 $observed = [
                     Telescope::isRecording(),
@@ -164,6 +166,8 @@ class TelescopeServiceProviderTest extends FeatureTestCase
             [Telescope::SHOULD_RECORD_CONTEXT_KEY],
             detached: true,
         );
+
+        Coroutine::join([$coroutineId]);
 
         $this->assertSame([true, null], $observed);
         $this->assertSame('parent-batch', CoroutineContext::get(Telescope::BATCH_ID_CONTEXT_KEY));

--- a/tests/Telescope/TelescopeServiceProviderTest.php
+++ b/tests/Telescope/TelescopeServiceProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Telescope;
 
+use Closure;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
 use Hypervel\Coroutine\Coroutine;
@@ -118,6 +119,54 @@ class TelescopeServiceProviderTest extends FeatureTestCase
         $this->assertSame(['parent'], array_column($storedBatches[1], 'message'));
         $this->assertNotNull($storedBatches[0][0]['batch_id']);
         $this->assertSame($storedBatches[0][0]['batch_id'], $storedBatches[1][0]['batch_id']);
+    }
+
+    public function testDetachedChildStartsWithoutParentRecordingOrBatch(): void
+    {
+        CoroutineContext::set(Telescope::SHOULD_RECORD_CONTEXT_KEY, true);
+        CoroutineContext::set(Telescope::BATCH_ID_CONTEXT_KEY, 'parent-batch');
+        $observed = [];
+
+        Coroutine::createOwned(
+            static function () use (&$observed): void {
+                $observed = [
+                    Telescope::isRecording(),
+                    CoroutineContext::get(Telescope::BATCH_ID_CONTEXT_KEY),
+                ];
+            },
+            static function (Closure $run): void {
+                $run();
+            },
+            detached: true,
+        );
+
+        $this->assertSame([false, null], $observed);
+        $this->assertTrue(Telescope::isRecording());
+        $this->assertSame('parent-batch', CoroutineContext::get(Telescope::BATCH_ID_CONTEXT_KEY));
+    }
+
+    public function testDetachedForkKeepsSelectedRecordingWithoutInheritingBatch(): void
+    {
+        CoroutineContext::set(Telescope::SHOULD_RECORD_CONTEXT_KEY, true);
+        CoroutineContext::set(Telescope::BATCH_ID_CONTEXT_KEY, 'parent-batch');
+        $observed = [];
+
+        Coroutine::forkOwned(
+            static function () use (&$observed): void {
+                $observed = [
+                    Telescope::isRecording(),
+                    CoroutineContext::get(Telescope::BATCH_ID_CONTEXT_KEY),
+                ];
+            },
+            static function (Closure $run): void {
+                $run();
+            },
+            [Telescope::SHOULD_RECORD_CONTEXT_KEY],
+            detached: true,
+        );
+
+        $this->assertSame([true, null], $observed);
+        $this->assertSame('parent-batch', CoroutineContext::get(Telescope::BATCH_ID_CONTEXT_KEY));
     }
 
     public function testRouteRegistrationRequiresStringPath(): void


### PR DESCRIPTION
## Summary

Background work can outlive the request that starts it. It needs an explicit way to avoid inheriting that request's tracing and recording state, while still running the framework's normal startup hooks.

This adds that option to owned coroutine creation and makes reusable pipelines a supported public API. These are general framework capabilities for background services and repeated middleware execution.

## Changes

### Reusable pipelines

Support `Pipeline::toClosure()` as a public API, add it to the Pipeline facade's method annotations, and document reusable pipelines. The returned closure accepts a value on each invocation and reuses the middleware structure.

Middleware is resolved when each invocation reaches it, using its normal container lifetime. Scoped middleware is resolved once per coroutine, and other middleware follows its binding and class lifetime; ordinary unbound classes are shared by default. The documentation explains those lifetimes and why the pipeline's configuration must remain fixed while its closure is in use. The pipeline implementation stays unchanged.

### Owned coroutine creation

Support `Coroutine::createOwned()` and `forkOwned()` as public APIs, with an optional `detached: true` argument. Existing calls retain their default behavior, and `forkOwned()` still preserves the selected context snapshot.

The wrapper records ownership before startup hooks run. Its cleanup also runs when cancellation happens during startup, before the child callable begins. The documentation covers creation failures, releases that don't wait, and the difference between wrapper completion and the child's final exit.

### Detached context propagation

Detached creation installs a startup marker before the hooks run. Sentry avoids parent fallback while still cloning explicitly copied scopes and requests. Telescope preserves explicitly copied values and otherwise starts with recording disabled and no parent batch.

The marker is removed before the callable runs and excluded from fork snapshots. A detached child can establish its own context, and children it creates, including from startup hooks, follow normal inheritance rules unless explicitly detached. The hook contract is documented so other integrations can honor the same choice.

Sentry's existing delivery behavior remains intact. Its documentation also explains that logs and metrics emitted without an execution use the SDK's shared global buffer, which isn't automatically flushed when detached work finishes.

## Verification

Repository formatting, source and type-fixture analysis, the affected suites, and the full parallel framework suite pass locally. The full suite retains its configured skips.

Coverage includes concurrent pipeline reuse with scoped middleware, shared and fresh bindings, cancellation during one invocation, startup marker removal, preserved Sentry snapshots, detached Telescope defaults, and forks created during startup hooks. Existing transaction, cleanup, ordinary propagation, and delivery tests remain in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly detached background coroutines.
  - Detached coroutines no longer inherit parent request, recording, or monitoring context unless explicitly provided.
  - Added reusable pipeline closures for safely processing multiple inputs.

- **Bug Fixes**
  - Improved isolation between concurrent reusable pipeline executions.
  - Ensured coroutine ownership and context cleanup occur reliably.

- **Documentation**
  - Clarified detached coroutine behavior, monitoring lifetimes, and reusable pipeline usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->