### PR TITLE
Complete scheduler and WebSocket lifecycle cleanup

### DIFF
--- a/src/console/src/Commands/ScheduleRunCommand.php
+++ b/src/console/src/Commands/ScheduleRunCommand.php
@@ -15,6 +15,8 @@ use Hypervel\Console\Events\ScheduledTaskStarting;
 use Hypervel\Console\Scheduling\CallbackEvent;
 use Hypervel\Console\Scheduling\Event;
 use Hypervel\Console\Scheduling\Schedule;
+use Hypervel\Container\Container;
+use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Cache\Repository as Cache;
 use Hypervel\Contracts\Debug\ExceptionHandler;
 use Hypervel\Contracts\Events\Dispatcher;
@@ -23,10 +25,13 @@ use Hypervel\Coroutine\Waiter;
 use Hypervel\Log\Context\Repository as ContextRepository;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Support\Collection;
+use Hypervel\Support\Defer\DeferredCallback;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Support\Facades\Date;
 use Hypervel\Support\InteractsWithTime;
 use Hypervel\Support\Sleep;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
@@ -34,6 +39,11 @@ use Throwable;
 class ScheduleRunCommand extends Command
 {
     use InteractsWithTime;
+
+    /**
+     * The handled failure state for the current task coroutine.
+     */
+    private const string TASK_FAILED_CONTEXT_KEY = '__console.scheduled_task_failed';
 
     /**
      * The console command signature.
@@ -248,14 +258,14 @@ class ScheduleRunCommand extends Command
                     continue;
                 }
 
-                if ($paused && ! $event->runsWhenPaused()) {
-                    $event->lastChecked = Date::now();
-                    $this->dispatchTaskSkipped($event);
+                $this->runTaskInCoroutine(function () use ($event, $paused): void {
+                    if ($paused && ! $event->runsWhenPaused()) {
+                        $event->lastChecked = Date::now();
+                        $this->dispatchTaskSkipped($event);
 
-                    continue;
-                }
+                        return;
+                    }
 
-                $this->runTaskInCoroutine(function () use ($event): void {
                     if (! $event->filtersPass($this->hypervel)) {
                         $this->dispatchTaskSkipped($event);
 
@@ -285,14 +295,14 @@ class ScheduleRunCommand extends Command
                 continue;
             }
 
-            if ($paused && ! $event->runsWhenPaused()) {
-                $event->lastChecked = Date::now();
-                $this->dispatchTaskSkipped($event);
+            $this->runTaskInCoroutine(function () use ($event, $startedAt, $paused): void {
+                if ($paused && ! $event->runsWhenPaused()) {
+                    $event->lastChecked = Date::now();
+                    $this->dispatchTaskSkipped($event);
 
-                continue;
-            }
+                    return;
+                }
 
-            $this->runTaskInCoroutine(function () use ($event, $startedAt): void {
                 if (! $event->filtersPass($this->hypervel)) {
                     $this->dispatchTaskSkipped($event);
 
@@ -312,9 +322,56 @@ class ScheduleRunCommand extends Command
     protected function runTaskInCoroutine(Closure $callback): void
     {
         (new Waiter(-1))->wait(
-            $callback,
+            fn () => $this->runTask($callback),
             copyContext: [ContextRepository::CONTEXT_KEY],
         );
+    }
+
+    /**
+     * Run a task and its deferred callbacks in the owning coroutine.
+     *
+     * @throws Throwable
+     */
+    private function runTask(Closure $callback): void
+    {
+        $exception = null;
+
+        try {
+            $callback();
+        } catch (Throwable $throwable) {
+            $exception = $throwable;
+        }
+
+        // Nested commands leave deferred work to this boundary. Drain only once,
+        // after task listeners, so callbacks cannot run early or recursively.
+        if (! $exception instanceof CanceledException) {
+            try {
+                $this->invokeDeferredCallbacks(
+                    $exception === null && ! CoroutineContext::get(self::TASK_FAILED_CONTEXT_KEY, false)
+                );
+            } catch (CanceledException $cancellation) {
+                $exception = $cancellation;
+            } catch (Throwable $throwable) {
+                $exception ??= $throwable;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Invoke deferred callbacks allowed by the task's outcome.
+     */
+    private function invokeDeferredCallbacks(bool $successful): void
+    {
+        $container = Container::getInstance();
+
+        if ($container->resolvedScoped(DeferredCallbackCollection::class)) {
+            $container->make(DeferredCallbackCollection::class)
+                ->invokeWhen(fn (DeferredCallback $callback): bool => $successful || $callback->always);
+        }
     }
 
     /**
@@ -327,13 +384,10 @@ class ScheduleRunCommand extends Command
             : $this->runEvent($event);
 
         if ($event->runInBackground) {
-            $this->concurrent->fork(function () use ($runEvent, $event): void {
-                $runEvent();
-
-                if ($this->dispatcher->hasListeners(ScheduledBackgroundTaskFinished::class)) {
-                    $this->dispatcher->dispatch(new ScheduledBackgroundTaskFinished($event));
-                }
-            }, [ContextRepository::CONTEXT_KEY]);
+            $this->concurrent->fork(
+                fn () => $this->runTask($runEvent),
+                [ContextRepository::CONTEXT_KEY],
+            );
 
             return;
         }
@@ -440,8 +494,13 @@ class ScheduleRunCommand extends Command
                     "Scheduled command [{$command}] failed with exit code [{$exitCode}]."
                 );
             }
+        } catch (CanceledException $e) {
+            throw $e;
         } catch (Throwable $e) {
             $failed = true;
+            // runEvent reports ordinary failures instead of throwing them to
+            // runTask; keep that outcome local to this task's deferred work.
+            CoroutineContext::set(self::TASK_FAILED_CONTEXT_KEY, true);
 
             if ($this->dispatcher->hasListeners(ScheduledTaskFailed::class)) {
                 $this->dispatcher->dispatch(new ScheduledTaskFailed($event, $e));
@@ -468,6 +527,13 @@ class ScheduleRunCommand extends Command
         );
 
         $this->line($finishDescription);
+
+        if ($event->runInBackground
+            && ! $skippedBecauseOverlapping
+            && $this->dispatcher->hasListeners(ScheduledBackgroundTaskFinished::class)
+        ) {
+            $this->dispatcher->dispatch(new ScheduledBackgroundTaskFinished($event));
+        }
     }
 
     /**

--- a/src/console/src/Scheduling/CallbackEvent.php
+++ b/src/console/src/Scheduling/CallbackEvent.php
@@ -11,6 +11,7 @@ use Hypervel\Support\Reflector;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 use Throwable;
 
 class CallbackEvent extends Event
@@ -126,6 +127,9 @@ class CallbackEvent extends Event
             ]);
 
             return $result === false ? 1 : 0;
+        } catch (CanceledException $e) {
+            // Cancellation must unwind the mutex without running failure callbacks.
+            throw $e;
         } catch (Throwable $e) {
             CoroutineContext::set($this->callbackContextKey(), [
                 'result' => null,

--- a/src/docs/helpers.md
+++ b/src/docs/helpers.md
@@ -3522,7 +3522,7 @@ Route::post('/orders', function (Request $request) {
 });
 ```
 
-By default, deferred functions will only be executed if the HTTP response, Artisan command, scheduled task, or queued job from which `Hypervel\Support\defer` is invoked completes successfully. This means that deferred functions will not be executed if a request results in a `4xx` or `5xx` HTTP response. If you would like a deferred function to always execute, you may chain the `always` method onto your deferred function:
+By default, deferred functions will only be executed if the HTTP response, Artisan command, scheduled task, WebSocket callback, or queued job from which `Hypervel\Support\defer` is invoked completes successfully. This means that deferred functions will not be executed if a request results in a `4xx` or `5xx` HTTP response. If you would like a deferred function to always execute, you may chain the `always` method onto your deferred function:
 
 ```php
 defer(fn () => Metrics::reportOrder($order))->always();

--- a/src/docs/helpers.md
+++ b/src/docs/helpers.md
@@ -3522,7 +3522,7 @@ Route::post('/orders', function (Request $request) {
 });
 ```
 
-By default, deferred functions will only be executed if the HTTP response, Artisan command, or queued job from which `Hypervel\Support\defer` is invoked completes successfully. This means that deferred functions will not be executed if a request results in a `4xx` or `5xx` HTTP response. If you would like a deferred function to always execute, you may chain the `always` method onto your deferred function:
+By default, deferred functions will only be executed if the HTTP response, Artisan command, scheduled task, or queued job from which `Hypervel\Support\defer` is invoked completes successfully. This means that deferred functions will not be executed if a request results in a `4xx` or `5xx` HTTP response. If you would like a deferred function to always execute, you may chain the `always` method onto your deferred function:
 
 ```php
 defer(fn () => Metrics::reportOrder($order))->always();

--- a/src/docs/porting-from-laravel.md
+++ b/src/docs/porting-from-laravel.md
@@ -21,6 +21,7 @@
     - [Coroutine-Aware Dependencies](#coroutine-aware-dependencies)
 - [Configuration](#configuration)
 - [Other API Differences](#other-api-differences)
+    - [Scheduling](#scheduling)
     - [HTTP Client and Concurrency](#http-client-and-concurrency)
     - [CSRF Protection](#csrf-protection)
     - [Scout](#scout)
@@ -467,6 +468,11 @@ Application code should keep request-specific values in the request, session, co
 ## Other API Differences
 
 Many Laravel APIs have direct Hypervel equivalents under the `Hypervel` namespace. The following differences commonly require more than a namespace replacement.
+
+<a name="scheduling"></a>
+### Scheduling
+
+Scheduled Artisan commands share the scheduler process instead of starting a fresh process for each invocation. Use `exec('php artisan ...')` for commands that rely on process isolation. See [Scheduling Artisan Commands](/docs/{{version}}/scheduling#scheduling-artisan-commands).
 
 <a name="http-client-and-concurrency"></a>
 ### HTTP Client and Concurrency

--- a/src/docs/scheduling.md
+++ b/src/docs/scheduling.md
@@ -91,6 +91,8 @@ Schedule::command('emails:send Taylor --force')->daily();
 Schedule::command(SendEmailsCommand::class, ['Taylor', '--force'])->daily();
 ```
 
+Scheduled commands and closures run within the scheduler process, so static and singleton state persists between tasks. If a command needs a separate process, schedule it with `Schedule::exec('php artisan emails:send Taylor --force')` instead.
+
 <a name="scheduling-artisan-closure-commands"></a>
 #### Scheduling Artisan Closure Commands
 

--- a/src/docs/websockets.md
+++ b/src/docs/websockets.md
@@ -122,6 +122,8 @@ class ChatSocket implements OnOpenInterface, OnMessageInterface, OnCloseInterfac
 
 The handler's `__invoke` method handles ordinary HTTP requests because the route is also visible to your application's HTTP server. WebSocket handshakes run the route's middleware but use the handler's lifecycle methods instead of invoking the controller.
 
+Terminable route middleware runs after `onOpen`, or after a rejected handshake response has been sent. [Deferred functions](/docs/{{version}}/helpers#deferred-functions) registered during the handshake or `onOpen` run after this cleanup. Functions deferred by `onMessage` or `onClose` run after the callback and its lifecycle events finish. They follow the usual success and `always()` rules; coroutine cancellation skips deferred work.
+
 Handlers are resolved through the service container and normally live for the lifetime of a worker. Do not store connection-specific data on handler properties.
 
 <a name="connection-context"></a>

--- a/src/reverb/src/Protocols/Pusher/Channels/Channel.php
+++ b/src/reverb/src/Protocols/Pusher/Channels/Channel.php
@@ -16,6 +16,7 @@ use Hypervel\Reverb\Servers\Hypervel\Contracts\SharedState;
 use Hypervel\Reverb\Servers\Hypervel\Scaling\SubscriptionResult;
 use Hypervel\Reverb\Webhooks\Contracts\WebhookDispatcher;
 use Hypervel\Reverb\Webhooks\DeferredWebhookManager;
+use Swoole\Coroutine\CanceledException;
 use Throwable;
 
 class Channel
@@ -387,6 +388,8 @@ class Channel
 
             try {
                 $connection->send($message);
+            } catch (CanceledException $throwable) {
+                throw $throwable;
             } catch (Throwable $throwable) {
                 $exception ??= $throwable;
             }

--- a/src/reverb/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/reverb/src/Protocols/Pusher/EventDispatcher.php
@@ -16,6 +16,7 @@ use Hypervel\Reverb\Servers\Hypervel\Contracts\PubSubProvider;
 use Hypervel\Reverb\Servers\Hypervel\Contracts\SharedState;
 use Hypervel\Support\Arr;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 use Swoole\Server;
 use Throwable;
 
@@ -86,6 +87,8 @@ class EventDispatcher
                 if ($channel instanceof CacheChannel) {
                     app(SharedState::class)->clearCacheMissLock($app->id(), $channel->name());
                 }
+            } catch (CanceledException $throwable) {
+                throw $throwable;
             } catch (Throwable $throwable) {
                 $exception ??= $throwable;
             }
@@ -130,6 +133,8 @@ class EventDispatcher
                 $payload['channel'] = $channel->name();
 
                 $channel->broadcastInternally($payload, $connection);
+            } catch (CanceledException $throwable) {
+                throw $throwable;
             } catch (Throwable $throwable) {
                 $exception ??= $throwable;
             }
@@ -173,6 +178,8 @@ class EventDispatcher
 
             try {
                 $channel->broadcastInternally($payload, $connection);
+            } catch (CanceledException $throwable) {
+                throw $throwable;
             } catch (Throwable $throwable) {
                 $exception = $throwable;
             }
@@ -197,6 +204,8 @@ class EventDispatcher
 
             try {
                 app(PubSubProvider::class)->publish($data);
+            } catch (CanceledException $throwable) {
+                throw $throwable;
             } catch (Throwable $throwable) {
                 $exception = $throwable;
             }

--- a/src/reverb/src/Protocols/Pusher/EventDispatcher.php
+++ b/src/reverb/src/Protocols/Pusher/EventDispatcher.php
@@ -244,6 +244,8 @@ class EventDispatcher
         );
         $exception = null;
 
+        // Unlike channel delivery, sendMessage() never yields for these payloads,
+        // so it cannot be canceled.
         for ($workerId = 0; $workerId < $workerNum; ++$workerId) {
             if ($workerId === $currentWorkerId) {
                 continue;

--- a/src/reverb/src/Protocols/Pusher/Managers/ArrayChannelManager.php
+++ b/src/reverb/src/Protocols/Pusher/Managers/ArrayChannelManager.php
@@ -11,6 +11,7 @@ use Hypervel\Reverb\Protocols\Pusher\Channels\ChannelBroker;
 use Hypervel\Reverb\Protocols\Pusher\Channels\ChannelConnection;
 use Hypervel\Reverb\Protocols\Pusher\Contracts\ChannelManager as ChannelManagerInterface;
 use Hypervel\Support\Arr;
+use Throwable;
 
 class ArrayChannelManager implements ChannelManagerInterface
 {
@@ -116,8 +117,19 @@ class ArrayChannelManager implements ChannelManagerInterface
      */
     public function unsubscribeFromAllChannels(string $appId, Connection $connection): void
     {
+        $exception = null;
+
+        // A failed unsubscription must not leave the connection in later channels.
         foreach ($this->channels($appId) as $channel) {
-            $channel->unsubscribe($connection);
+            try {
+                $channel->unsubscribe($connection);
+            } catch (Throwable $throwable) {
+                $exception ??= $throwable;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
         }
     }
 

--- a/src/reverb/src/Protocols/Pusher/Server.php
+++ b/src/reverb/src/Protocols/Pusher/Server.php
@@ -21,6 +21,7 @@ use Hypervel\Reverb\Protocols\Pusher\Exceptions\RateLimitExceeded;
 use Hypervel\Reverb\Servers\Hypervel\Contracts\SharedState;
 use Hypervel\Support\Str;
 use JsonException;
+use Swoole\Coroutine\CanceledException;
 use Throwable;
 
 class Server
@@ -65,6 +66,10 @@ class Server
                 } catch (Throwable $throwable) {
                     $cleanupFailure = $throwable;
                 }
+            }
+
+            if ($e instanceof CanceledException) {
+                throw $e;
             }
 
             try {
@@ -136,6 +141,8 @@ class Server
             if (app('events')->hasListeners(MessageReceived::class)) {
                 MessageReceived::dispatch($from, $message);
             }
+        } catch (CanceledException $exception) {
+            throw $exception;
         } catch (Throwable $e) {
             $terminateOnLimit = $e instanceof RateLimitExceeded
                 && $from->app()->rateLimiting()['terminate_on_limit'];

--- a/src/telescope/src/Telescope.php
+++ b/src/telescope/src/Telescope.php
@@ -273,7 +273,7 @@ class Telescope
         if (Coroutine::inCoroutine()
             && ! $state->storeScheduled
         ) {
-            Coroutine::defer(function () {
+            Coroutine::defer(function (): void {
                 static::store(static::$store);
             });
             $state->storeScheduled = true;

--- a/src/websocket-server/composer.json
+++ b/src/websocket-server/composer.json
@@ -32,6 +32,7 @@
         "php": "^8.4",
         "ext-swoole": "^6.2.2",
         "hypervel/collections": "^0.4",
+        "hypervel/container": "^0.4",
         "hypervel/context": "^0.4",
         "hypervel/contracts": "^0.4",
         "hypervel/coordinator": "^0.4",

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\WebSocketServer;
 
+use Hypervel\Container\Container as BaseContainer;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Context\RequestContext;
 use Hypervel\Contracts\Container\Container;
@@ -27,6 +28,8 @@ use Hypervel\HttpServer\Events\ResponseSent;
 use Hypervel\HttpServer\RequestBridge;
 use Hypervel\HttpServer\ResponseBridge;
 use Hypervel\Routing\Router;
+use Hypervel\Support\Defer\DeferredCallback;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Support\SafeCaller;
 use Hypervel\WebSocketServer\Collector\FdCollector;
 use Hypervel\WebSocketServer\Context as WebSocketContext;
@@ -210,25 +213,38 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
                 }
             }
 
+            if ($terminalException === null && $handshake !== null) {
+                [$fd, $class, $instance, $server] = $handshake;
+
+                if ($server->isEstablished($fd)) {
+                    // No yield may occur between the native liveness check and
+                    // publication, or onClose could miss the committed connection.
+                    $this->deferOnOpen($request, $instance, $server, $fd, $httpRequest, $httpResponse);
+                    FdCollector::set($fd, $class);
+                    $committed = true;
+
+                    return;
+                }
+            }
+
+            if ($httpRequest !== null) {
+                try {
+                    $this->terminateRouteMiddleware($httpRequest, $httpResponse);
+                } catch (CanceledException $exception) {
+                    throw $exception;
+                } catch (Throwable $throwable) {
+                    $terminalException ??= $throwable;
+                }
+            }
+
+            $this->invokeDeferredCallbacks(
+                $terminalException === null
+                    && $httpResponse->getStatusCode() < Response::HTTP_BAD_REQUEST
+            );
+
             if ($terminalException !== null) {
                 throw $terminalException;
             }
-
-            if ($handshake === null) {
-                return;
-            }
-
-            [$fd, $class, $instance, $server] = $handshake;
-
-            if (! $server->isEstablished($fd)) {
-                return;
-            }
-
-            // No yield may occur between the native liveness check and
-            // publication, or onClose could miss the committed connection.
-            $this->deferOnOpen($request, $instance, $server, $fd);
-            FdCollector::set($fd, $class);
-            $committed = true;
         } finally {
             if ($fd !== null && ! $committed) {
                 FdCollector::del($fd);
@@ -305,8 +321,11 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
         } catch (CanceledException) {
             return;
         } catch (Throwable $throwable) {
+            $exception ??= $throwable;
             $this->reportCallbackFailure($throwable);
         }
+
+        $this->invokeDeferredCallbacks($exception === null);
     }
 
     /**
@@ -315,6 +334,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
     public function onClose(SwooleServer $server, int $fd, int $reactorId): void
     {
         CoroutineContext::set(WebSocketContext::FD, $fd);
+        $failed = false;
 
         try {
             $class = FdCollector::get($fd);
@@ -329,6 +349,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
             } catch (CanceledException) {
                 return;
             } catch (Throwable $throwable) {
+                $failed = true;
                 $this->reportCallbackFailure($throwable);
             }
 
@@ -337,6 +358,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
             } catch (CanceledException) {
                 return;
             } catch (Throwable $throwable) {
+                $failed = true;
                 $this->reportCallbackFailure($throwable);
             }
 
@@ -345,6 +367,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
             } catch (CanceledException) {
                 return;
             } catch (Throwable $throwable) {
+                $failed = true;
                 $this->reportCallbackFailure($throwable);
                 $instance = null;
             }
@@ -355,6 +378,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
                 } catch (CanceledException) {
                     return;
                 } catch (Throwable $throwable) {
+                    $failed = true;
                     $this->reportCallbackFailure($throwable);
                 }
             }
@@ -366,8 +390,11 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
             } catch (CanceledException) {
                 return;
             } catch (Throwable $throwable) {
+                $failed = true;
                 $this->reportCallbackFailure($throwable);
             }
+
+            $this->invokeDeferredCallbacks(! $failed);
         } finally {
             FdCollector::del($fd);
             WebSocketContext::release($fd);
@@ -457,11 +484,19 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
     }
 
     /**
-     * Defer the onOpen callback after handshake completes.
+     * Defer connection opening and cleanup until the handshake coroutine exits.
      */
-    protected function deferOnOpen(Request $request, object $instance, WebSocketServer $server, int $fd): void
-    {
-        Coroutine::defer(function () use ($request, $instance, $server, $fd) {
+    protected function deferOnOpen(
+        Request $request,
+        object $instance,
+        WebSocketServer $server,
+        int $fd,
+        HttpRequest $httpRequest,
+        Response $httpResponse,
+    ): void {
+        Coroutine::defer(function () use ($request, $instance, $server, $fd, $httpRequest, $httpResponse) {
+            $failed = false;
+
             try {
                 if ($this->event?->hasListeners(ConnectionOpened::class)) {
                     $this->event->dispatch(new ConnectionOpened($fd, $request, $this->serverName));
@@ -469,6 +504,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
             } catch (CanceledException) {
                 return;
             } catch (Throwable $throwable) {
+                $failed = true;
                 $this->reportCallbackFailure($throwable);
             }
 
@@ -478,10 +514,81 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
                 } catch (CanceledException) {
                     return;
                 } catch (Throwable $throwable) {
+                    $failed = true;
                     $this->reportCallbackFailure($throwable);
                 }
             }
+
+            // Termination may yield and let onClose run, so run it after onOpen
+            // has initialized the connection. Drain handshake defers afterward.
+            try {
+                $this->terminateRouteMiddleware($httpRequest, $httpResponse);
+            } catch (CanceledException) {
+                return;
+            } catch (Throwable $throwable) {
+                $failed = true;
+                $this->reportCallbackFailure($throwable);
+            }
+
+            $this->invokeDeferredCallbacks(! $failed);
         });
+    }
+
+    /**
+     * Terminate the middleware used by the handshake route.
+     */
+    private function terminateRouteMiddleware(HttpRequest $request, Response $response): void
+    {
+        $route = $request->route();
+
+        if ($route === null
+            || ($this->container->bound('middleware.disable')
+                && $this->container->make('middleware.disable') === true)) {
+            return;
+        }
+
+        $exception = null;
+
+        foreach ($this->getRouter()->gatherRouteMiddleware($route) as $middleware) {
+            if (! is_string($middleware)) {
+                continue;
+            }
+
+            try {
+                $instance = $this->container->make(explode(':', $middleware, 2)[0]);
+
+                if (method_exists($instance, 'terminate')) {
+                    $instance->terminate($request, $response);
+                }
+            } catch (CanceledException $throwable) {
+                throw $throwable;
+            } catch (Throwable $throwable) {
+                $exception ??= $throwable;
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Run deferred work without escaping the native callback boundary.
+     */
+    private function invokeDeferredCallbacks(bool $successful): void
+    {
+        try {
+            $container = BaseContainer::getInstance();
+
+            if ($container->resolvedScoped(DeferredCallbackCollection::class)) {
+                $container->make(DeferredCallbackCollection::class)->invokeWhen(
+                    fn (DeferredCallback $callback): bool => $successful || $callback->always
+                );
+            }
+        } catch (CanceledException) {
+        } catch (Throwable $throwable) {
+            $this->reportCallbackFailure($throwable);
+        }
     }
 
     /**

--- a/src/websocket-server/src/Server.php
+++ b/src/websocket-server/src/Server.php
@@ -494,7 +494,7 @@ class Server implements BootstrapsForServer, OnHandshakeInterface, OnCloseInterf
         HttpRequest $httpRequest,
         Response $httpResponse,
     ): void {
-        Coroutine::defer(function () use ($request, $instance, $server, $fd, $httpRequest, $httpResponse) {
+        Coroutine::defer(function () use ($request, $instance, $server, $fd, $httpRequest, $httpResponse): void {
             $failed = false;
 
             try {

--- a/tests/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleRunCommandTest.php
@@ -18,11 +18,13 @@ use Hypervel\Console\Scheduling\EventMutex;
 use Hypervel\Console\Scheduling\Schedule;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Cache\Repository as Cache;
+use Hypervel\Contracts\Console\Kernel;
 use Hypervel\Contracts\Container\Container as ContainerContract;
 use Hypervel\Contracts\Debug\ExceptionHandler;
 use Hypervel\Contracts\Events\Dispatcher;
 use Hypervel\Coroutine\Concurrent;
 use Hypervel\Coroutine\Coroutine as HypervelCoroutine;
+use Hypervel\Coroutine\Exceptions\ChildCancellationException;
 use Hypervel\Engine\Channel;
 use Hypervel\Log\Context\Repository as ContextRepository;
 use Hypervel\Support\Carbon;
@@ -38,11 +40,13 @@ use ReflectionMethod;
 use ReflectionProperty;
 use RuntimeException;
 use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Throwable;
 
 use function Hypervel\Coroutine\parallel;
+use function Hypervel\Support\defer;
 
 class ScheduleRunCommandTest extends TestCase
 {
@@ -89,6 +93,242 @@ class ScheduleRunCommandTest extends TestCase
         $this->assertSame($callbackEvent, $this->dispatched[0]->task);
         $this->assertSame($callbackEvent, $this->dispatched[1]->task);
         $this->assertIsFloat($this->dispatched[1]->runtime);
+    }
+
+    public function testScheduledCommandDefersNestedCommandWorkUntilTheTaskFinishes(): void
+    {
+        $calls = [];
+        $kernel = $this->app->make(Kernel::class);
+        $kernel->command('test:deferred-child', function () use (&$calls): void {
+            $calls[] = 'child';
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred child';
+            });
+        });
+        $kernel->command('test:deferred-parent', function () use (&$calls): void {
+            $calls[] = 'parent';
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred parent';
+                defer(function () use (&$calls): void {
+                    $calls[] = 'deferred during cleanup';
+                });
+            });
+            $this->call('test:deferred-child');
+            $calls[] = 'parent finished';
+        });
+        $event = new Event(m::mock(EventMutex::class), 'test:deferred-parent');
+        $event->after(function () use (&$calls): void {
+            $calls[] = 'after';
+        });
+
+        $this->invokeRunEvents($this->makeCommand(), [$event]);
+
+        $this->assertSame(['parent', 'child', 'parent finished', 'after', 'deferred parent', 'deferred child'], $calls);
+    }
+
+    #[DataProvider('deferredTaskOutcomes')]
+    public function testDeferredCallbacksRespectTheWholeTaskOutcome(string $outcome, array $expected): void
+    {
+        $calls = [];
+        $exception = new RuntimeException('Task failed');
+        $event = new CallbackEvent(m::mock(EventMutex::class), function () use (&$calls, $outcome, $exception): bool {
+            defer(function () use (&$calls): void {
+                $calls[] = 'ordinary';
+            });
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            })->always();
+
+            if ($outcome === 'throw') {
+                throw $exception;
+            }
+
+            return $outcome !== 'false';
+        });
+        if ($outcome === 'after') {
+            $event->after(function () use ($exception): void {
+                throw $exception;
+            });
+        }
+        if ($outcome !== 'success') {
+            $this->handler->shouldReceive('report')->once();
+        }
+        $nextEvent = new CallbackEvent(m::mock(EventMutex::class), function () use (&$calls): void {
+            defer(function () use (&$calls): void {
+                $calls[] = 'next task';
+            });
+        });
+
+        $this->invokeRunEvents($this->makeCommand(), [$event, $nextEvent]);
+
+        $this->assertSame([...$expected, 'next task'], $calls);
+    }
+
+    /**
+     * Provide successful and handled task failures.
+     */
+    public static function deferredTaskOutcomes(): array
+    {
+        return [
+            'success' => ['success', ['ordinary', 'always']],
+            'false return' => ['false', ['always']],
+            'thrown callback' => ['throw', ['always']],
+            'after callback failure' => ['after', ['always']],
+        ];
+    }
+
+    public function testCanceledCallbackReleasesItsMutexWithoutRunningFailureOrDeferredCallbacks(): void
+    {
+        $calls = [];
+        $cancellation = new CanceledException('Task canceled');
+        $mutex = m::mock(EventMutex::class);
+        $mutex->shouldReceive('exists')->once()->andReturnFalse();
+        $mutex->shouldReceive('create')->once()->andReturnTrue();
+        $mutex->shouldReceive('forget')->once();
+        $event = new CallbackEvent($mutex, function () use (&$calls, $cancellation): void {
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            })->always();
+
+            throw $cancellation;
+        });
+        $event->name('canceled')->withoutOverlapping()->onFailure(function () use (&$calls): void {
+            $calls[] = 'failure';
+        });
+        $this->handler->shouldNotReceive('report');
+
+        try {
+            $this->invokeRunEvents($this->makeCommand(), [$event]);
+            $this->fail('Expected the owned task to report cancellation.');
+        } catch (ChildCancellationException $exception) {
+            $this->assertSame($cancellation, $exception->getPrevious());
+        }
+
+        $this->assertSame([], $calls);
+        $this->assertCount(1, $this->dispatched);
+        $this->assertInstanceOf(ScheduledTaskStarting::class, $this->dispatched[0]);
+    }
+
+    public function testStartingListenerFailureRunsOnlyAlwaysCallbacksAndPreservesTheException(): void
+    {
+        $calls = [];
+        $exception = new RuntimeException('Starting listener failed');
+        $this->dispatcher = $this->app->make(Dispatcher::class);
+        $this->dispatcher->listen(ScheduledTaskStarting::class, function () use (&$calls, $exception): void {
+            defer(function () use (&$calls): void {
+                $calls[] = 'ordinary';
+            });
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            })->always();
+
+            throw $exception;
+        });
+        $event = new CallbackEvent(m::mock(EventMutex::class), static fn (): bool => true);
+        $caught = null;
+
+        try {
+            $this->invokeRunEvents($this->makeCommand(), [$event]);
+        } catch (RuntimeException $throwable) {
+            $caught = $throwable;
+        }
+
+        $this->assertSame($exception, $caught);
+        $this->assertSame(['always'], $calls);
+    }
+
+    public function testCancellationDuringDeferredWorkStopsTheRemainingCallbacks(): void
+    {
+        $calls = [];
+        $cancellation = new CanceledException('Deferred work canceled');
+        $event = new CallbackEvent(m::mock(EventMutex::class), function () use (&$calls, $cancellation): void {
+            defer(function () use ($cancellation): void {
+                throw $cancellation;
+            });
+            defer(function () use (&$calls): void {
+                $calls[] = 'always';
+            })->always();
+        });
+
+        try {
+            $this->invokeRunEvents($this->makeCommand(), [$event]);
+            $this->fail('Expected cancellation from deferred work.');
+        } catch (ChildCancellationException $exception) {
+            $this->assertSame($cancellation, $exception->getPrevious());
+        }
+
+        $this->assertSame([], $calls);
+    }
+
+    public function testBackgroundTaskDrainsItsCallbacksAfterBackgroundFinishedListeners(): void
+    {
+        $calls = [];
+        $this->app->make(Kernel::class)->command('test:background-defer', function () use (&$calls): void {
+            $calls[] = 'command';
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred command';
+            });
+        });
+        $this->dispatcher = $this->app->make(Dispatcher::class);
+        $this->dispatcher->listen(ScheduledBackgroundTaskFinished::class, function () use (&$calls): void {
+            $calls[] = 'background finished';
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred listener';
+            });
+        });
+        $event = new Event(m::mock(EventMutex::class), 'test:background-defer');
+        $event->runInBackground();
+        $command = $this->makeCommand();
+        $concurrent = new Concurrent(1);
+        (new ReflectionProperty($command, 'concurrent'))->setValue($command, $concurrent);
+
+        try {
+            $this->invokeRunEvents($command, [$event]);
+        } finally {
+            $this->waitForConcurrent($concurrent);
+        }
+
+        $this->assertSame(['command', 'background finished', 'deferred command', 'deferred listener'], $calls);
+    }
+
+    #[DataProvider('skippedBackgroundTasks')]
+    public function testSkippedBackgroundTaskDoesNotDispatchCompletion(bool $onAnotherServer): void
+    {
+        $mutex = m::mock(EventMutex::class);
+        $event = new Event($mutex, 'test:skipped-background');
+        $event->runInBackground();
+        $command = $this->makeCommand();
+        if ($onAnotherServer) {
+            $event->onOneServer();
+            $schedule = m::mock(Schedule::class);
+            $schedule->shouldReceive('serverShouldRun')->once()->with($event, m::type(CarbonInterface::class))->andReturnFalse();
+            (new ReflectionProperty($command, 'schedule'))->setValue($command, $schedule);
+        } else {
+            $event->withoutOverlapping();
+            $mutex->shouldReceive('exists')->once()->andReturnFalse();
+            $mutex->shouldReceive('create')->once()->andReturnFalse();
+        }
+        $concurrent = new Concurrent(1);
+        (new ReflectionProperty($command, 'concurrent'))->setValue($command, $concurrent);
+
+        try {
+            $this->invokeRunEvents($command, [$event]);
+        } finally {
+            $this->waitForConcurrent($concurrent);
+        }
+
+        $this->assertSame([], array_values(array_filter(
+            $this->dispatched,
+            static fn (object $event): bool => $event instanceof ScheduledBackgroundTaskFinished,
+        )));
+    }
+
+    /**
+     * Provide the two background dispatch skips.
+     */
+    public static function skippedBackgroundTasks(): array
+    {
+        return ['overlapping' => [false], 'another server' => [true]];
     }
 
     public function testFinishedOutputUsesTheSharedRuntimeFormatterWithoutAppendingUnits(): void
@@ -500,12 +740,19 @@ class ScheduleRunCommandTest extends TestCase
 
     public function testSkippedNonRepeatableTaskIsOnlyEvaluatedOncePerMinute(): void
     {
+        $deferred = [];
         $eventMutex = m::mock(EventMutex::class);
 
         $callbackEvent = new CallbackEvent($eventMutex, function () {
             return 0;
         });
-        $callbackEvent->when(false);
+        $callbackEvent->when(function () use (&$deferred): bool {
+            defer(function () use (&$deferred): void {
+                $deferred[] = 'filter';
+            });
+
+            return false;
+        });
 
         $command = $this->makeCommand();
         $startedAt = CarbonImmutable::parse('2026-05-28 12:34:00');
@@ -516,6 +763,7 @@ class ScheduleRunCommandTest extends TestCase
         $this->assertCount(1, $this->dispatched);
         $this->assertInstanceOf(ScheduledTaskSkipped::class, $this->dispatched[0]);
         $this->assertSame($callbackEvent, $this->dispatched[0]->task);
+        $this->assertSame(['filter'], $deferred);
     }
 
     public function testSkippedTaskEventIsGuardedByRegisteredListeners(): void
@@ -559,6 +807,28 @@ class ScheduleRunCommandTest extends TestCase
         $this->assertCount(1, $this->dispatched);
         $this->assertInstanceOf(ScheduledTaskSkipped::class, $this->dispatched[0]);
         $this->assertSame($callbackEvent, $this->dispatched[0]->task);
+    }
+
+    public function testPausedTaskListenerDefersWorkWithinItsOwnCoroutine(): void
+    {
+        $calls = [];
+        $parentCoroutine = Coroutine::getCid();
+        $this->dispatcher = $this->app->make(Dispatcher::class);
+        $this->dispatcher->listen(ScheduledTaskSkipped::class, function () use (&$calls): void {
+            $calls[] = Coroutine::getCid();
+            defer(function () use (&$calls): void {
+                $calls[] = 'deferred';
+            });
+        });
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('hypervel:schedule:paused', false)->andReturnTrue();
+        $event = new CallbackEvent(m::mock(EventMutex::class), static fn (): bool => true);
+
+        $this->invokeRunEvents($this->makeCommand($cache), [$event]);
+
+        $this->assertCount(2, $calls);
+        $this->assertNotSame($parentCoroutine, $calls[0]);
+        $this->assertSame('deferred', $calls[1]);
     }
 
     public function testTaskMarkedEvenWhenPausedRunsWhileSchedulerIsPaused(): void

--- a/tests/Reverb/EventDispatcherTest.php
+++ b/tests/Reverb/EventDispatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Reverb;
 
+use Hypervel\Contracts\Debug\ExceptionHandler;
 use Hypervel\Reverb\Contracts\ApplicationProvider;
 use Hypervel\Reverb\Protocols\Pusher\Channels\CacheChannel;
 use Hypervel\Reverb\Protocols\Pusher\Channels\Channel;
@@ -18,7 +19,9 @@ use Hypervel\Reverb\Servers\Hypervel\Contracts\SharedState;
 use Hypervel\Reverb\Webhooks\Jobs\WebhookDeliveryJob;
 use Hypervel\Support\Facades\Queue;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 use Swoole\Server;
 
 class EventDispatcherTest extends ReverbTestCase
@@ -137,6 +140,91 @@ class EventDispatcherTest extends ReverbTestCase
         $this->channels()->findOrCreate('test-channel-two');
 
         EventDispatcher::dispatch(app(ApplicationProvider::class)->findByKey('reverb-key'), ['channels' => ['test-channel-one', 'test-channel-two']]);
+    }
+
+    #[DataProvider('synchronousDispatchMethods')]
+    public function testCanceledDispatchStopsBeforeLaterChannelsAndWorkers(string $method, string $broadcast): void
+    {
+        $app = app(ApplicationProvider::class)->findByKey('reverb-key');
+        $cancellation = new CanceledException;
+        $channel = m::mock(Channel::class);
+        $channel->allows('name')->andReturn('first');
+        $channel->expects($broadcast)->andThrow($cancellation);
+        $channels = m::mock(ScopedChannelManager::class);
+        $channels->expects('find')->with('first')->andReturn($channel);
+        $channels->shouldNotReceive('find')->with('later');
+        $manager = m::mock(ChannelManager::class);
+        $manager->expects('for')->with($app)->andReturn($channels);
+        $this->app->instance(ChannelManager::class, $manager);
+        $server = m::mock(Server::class);
+        $server->setting = ['worker_num' => 2];
+        $server->worker_id = 0;
+        $server->shouldNotReceive('sendMessage');
+        $this->app->instance(Server::class, $server);
+        $caught = null;
+
+        try {
+            EventDispatcher::{$method}($app, ['channels' => ['first', 'later']]);
+        } catch (CanceledException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertSame($cancellation, $caught);
+    }
+
+    /**
+     * Supply the public and internal channel delivery methods.
+     */
+    public static function synchronousDispatchMethods(): array
+    {
+        return [
+            ['dispatchSynchronously', 'broadcast'],
+            ['dispatchInternallySynchronously', 'broadcastInternally'],
+        ];
+    }
+
+    #[DataProvider('internalPublishingModes')]
+    public function testInternalChannelCancellationIsNotReported(bool $publish): void
+    {
+        $app = app(ApplicationProvider::class)->findByKey('reverb-key');
+        $cancellation = new CanceledException;
+        $channel = m::mock(Channel::class);
+        $channel->allows('name')->andReturn('presence-test');
+        $handler = m::mock(ExceptionHandler::class);
+        $handler->shouldNotReceive('report');
+        $this->app->instance(ExceptionHandler::class, $handler);
+        $server = m::mock(Server::class);
+        $server->setting = ['worker_num' => 2];
+        $server->worker_id = 0;
+        $server->shouldNotReceive('sendMessage');
+        $this->app->instance(Server::class, $server);
+
+        if ($publish) {
+            app(ServerProviderManager::class)->withPublishing();
+            $provider = m::mock(PubSubProvider::class);
+            $provider->expects('publish')->andThrow($cancellation);
+            $this->app->instance(PubSubProvider::class, $provider);
+        } else {
+            $channel->expects('broadcastInternally')->andThrow($cancellation);
+        }
+
+        $caught = null;
+
+        try {
+            EventDispatcher::dispatchInternalToChannel($app, $channel, ['event' => 'pusher_internal:member_added']);
+        } catch (CanceledException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertSame($cancellation, $caught);
+    }
+
+    /**
+     * Supply local and Redis-backed internal delivery.
+     */
+    public static function internalPublishingModes(): array
+    {
+        return [[false], [true]];
     }
 
     public function testSynchronousDispatchAttemptsEveryChannelAndFanOutBeforeThrowing(): void

--- a/tests/Reverb/Protocols/Pusher/Channels/ChannelTest.php
+++ b/tests/Reverb/Protocols/Pusher/Channels/ChannelTest.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace Hypervel\Tests\Reverb\Protocols\Pusher\Channels;
 
 use Hypervel\Contracts\Debug\ExceptionHandler;
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
+use Hypervel\Coroutine\Waiter;
+use Hypervel\Reverb\Connection;
+use Hypervel\Reverb\Contracts\ApplicationProvider;
+use Hypervel\Reverb\Contracts\WebSocketConnection;
+use Hypervel\Reverb\Events\MessageSent;
 use Hypervel\Reverb\Protocols\Pusher\Channels\Channel;
 use Hypervel\Reverb\Protocols\Pusher\Contracts\ChannelConnectionManager;
 use Hypervel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
@@ -220,6 +227,35 @@ class ChannelTest extends ReverbTestCase
         $channel->broadcast(['foo' => 'bar']);
 
         collect($connections)->each(fn ($connection) => $connection->assertReceived(['foo' => 'bar']));
+    }
+
+    public function testTimedOutSendListenerStopsDeliveryToLaterConnections(): void
+    {
+        $app = $this->app->make(ApplicationProvider::class)->findByKey('reverb-key');
+        $transport = m::mock(WebSocketConnection::class);
+        $transport->shouldReceive('id')->andReturn(42);
+        $transport->expects('send')->with('{"foo":"bar"}');
+        $first = new Connection($transport, $app, null);
+        $second = new FakeConnection;
+        $this->channelConnectionManager->add($first, []);
+        $this->channelConnectionManager->add($second, []);
+        $handler = m::mock(ExceptionHandler::class);
+        $handler->shouldNotReceive('report');
+        $this->app->instance(ExceptionHandler::class, $handler);
+        $this->app->make('events')->listen(MessageSent::class, static function (): void {
+            Coroutine::sleep(1);
+        });
+        $channel = new Channel('test-channel');
+        $caught = null;
+
+        try {
+            (new Waiter(0.01))->wait(fn () => $channel->broadcast(['foo' => 'bar']));
+        } catch (WaitTimeoutException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(WaitTimeoutException::class, $caught);
+        $second->assertNothingReceived();
     }
 
     public function testBroadcastAttemptsEveryConnectionAndReportsTheFirstFailure(): void

--- a/tests/Reverb/Protocols/Pusher/Managers/ChannelManagerTest.php
+++ b/tests/Reverb/Protocols/Pusher/Managers/ChannelManagerTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\Reverb\Protocols\Pusher\Managers;
 
+use Hypervel\Reverb\Events\ChannelRemoved;
 use Hypervel\Reverb\Protocols\Pusher\Channels\Channel;
 use Hypervel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
 use Hypervel\Reverb\Protocols\Pusher\Contracts\ScopedChannelManager;
 use Hypervel\Tests\Reverb\Fixtures\FakeConnection;
 use Hypervel\Tests\Reverb\ReverbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+use Swoole\Coroutine\CanceledException;
+use Throwable;
 
 class ChannelManagerTest extends ReverbTestCase
 {
@@ -88,6 +93,39 @@ class ChannelManagerTest extends ReverbTestCase
         $this->channelManager->unsubscribeFromAll($this->connection);
 
         collect($this->channelManager->all())->each(fn ($channel) => $this->assertCount(0, $channel->connections()));
+    }
+
+    #[DataProvider('unsubscribeFailures')]
+    public function testUnsubscribeFailureDoesNotLeaveMembershipInLaterChannels(bool $cancel): void
+    {
+        $first = $this->channel;
+        $second = $this->channelManager->findOrCreate('second');
+        $first->subscribe($this->connection);
+        $second->subscribe($this->connection);
+        $failure = $cancel ? new CanceledException : new RuntimeException('listener failed');
+        $laterFailure = new RuntimeException('later listener failed');
+        $this->app->make('events')->listen(ChannelRemoved::class, static function (ChannelRemoved $event) use ($first, $failure, $laterFailure): never {
+            throw $event->channel === $first ? $failure : $laterFailure;
+        });
+        $caught = null;
+
+        try {
+            $this->channelManager->unsubscribeFromAll($this->connection);
+        } catch (Throwable $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertSame($failure, $caught);
+        $this->assertFalse($first->subscribed($this->connection));
+        $this->assertFalse($second->subscribed($this->connection));
+    }
+
+    /**
+     * Supply ordinary failure and cancellation during channel cleanup.
+     */
+    public static function unsubscribeFailures(): array
+    {
+        return [[false], [true]];
     }
 
     public function testCanGetTheDataForAConnectionSubscribedToAChannel(): void

--- a/tests/Reverb/Protocols/Pusher/ServerTest.php
+++ b/tests/Reverb/Protocols/Pusher/ServerTest.php
@@ -6,11 +6,15 @@ namespace Hypervel\Tests\Reverb\Protocols\Pusher;
 
 use Hypervel\Contracts\Debug\ExceptionHandler;
 use Hypervel\Contracts\Foundation\Application as ApplicationContract;
+use Hypervel\Coroutine\Coroutine;
+use Hypervel\Coroutine\Exceptions\WaitTimeoutException;
+use Hypervel\Coroutine\Waiter;
 use Hypervel\Reverb\Connection;
 use Hypervel\Reverb\Contracts\ApplicationProvider;
 use Hypervel\Reverb\Contracts\WebSocketConnection;
 use Hypervel\Reverb\Events\ConnectionClosed;
 use Hypervel\Reverb\Events\ConnectionEstablished;
+use Hypervel\Reverb\Events\MessageReceived;
 use Hypervel\Reverb\Protocols\Pusher\Contracts\ChannelManager;
 use Hypervel\Reverb\Protocols\Pusher\EventHandler;
 use Hypervel\Reverb\Protocols\Pusher\Exceptions\RateLimitExceeded;
@@ -24,6 +28,7 @@ use Hypervel\Tests\Reverb\ReverbTestCase;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
+use Swoole\Coroutine\CanceledException;
 
 class ServerTest extends ReverbTestCase
 {
@@ -50,6 +55,55 @@ class ServerTest extends ReverbTestCase
                 'activity_timeout' => 30,
             ]),
         ]);
+    }
+
+    public function testCanceledOpenReleasesItsSlotWithoutSendingAProtocolError(): void
+    {
+        config()->set('reverb.apps.apps.0.max_connections', 1);
+        $state = m::mock(SharedState::class);
+        $state->expects('acquireConnectionSlot')->with('123456', 1)->andReturnTrue();
+        $state->expects('releaseConnectionSlot')->with('123456');
+        $this->app->instance(SharedState::class, $state);
+        $handler = m::mock(ExceptionHandler::class);
+        $handler->shouldNotReceive('report');
+        $this->app->instance(ExceptionHandler::class, $handler);
+        $cancellation = new CanceledException;
+        Event::listen(ConnectionEstablished::class, static fn () => throw $cancellation);
+        $connection = new FakeConnection;
+        $caught = null;
+
+        try {
+            $this->server->open($connection);
+        } catch (CanceledException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertSame($cancellation, $caught);
+        $this->assertFalse($connection->hasAcquiredConnectionSlot());
+        $this->assertFalse($connection->isEstablished());
+        $connection->assertReceivedCount(1);
+        $this->assertSame('pusher:connection_established', json_decode($connection->messages[0], true)['event']);
+    }
+
+    public function testTimedOutMessageDoesNotSendOrReportAProtocolError(): void
+    {
+        $handler = m::mock(ExceptionHandler::class);
+        $handler->shouldNotReceive('report');
+        $this->app->instance(ExceptionHandler::class, $handler);
+        Event::listen(MessageReceived::class, static function (): void {
+            Coroutine::sleep(1);
+        });
+        $connection = new FakeConnection;
+        $caught = null;
+
+        try {
+            (new Waiter(0.01))->wait(fn () => $this->server->message($connection, '{"event":"pusher:ping"}'));
+        } catch (WaitTimeoutException $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(WaitTimeoutException::class, $caught);
+        $this->assertSame(['{"event":"pusher:pong"}'], $connection->messages);
     }
 
     public function testCanHandleADisconnection(): void

--- a/tests/WebSocketServer/ServerHandshakeTest.php
+++ b/tests/WebSocketServer/ServerHandshakeTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Hypervel\Tests\WebSocketServer;
 
 use Closure;
+use Hypervel\Container\Container as BaseContainer;
 use Hypervel\Contracts\Container\Container;
+use Hypervel\Contracts\Debug\ExceptionHandler;
 use Hypervel\Contracts\Log\StdoutLoggerInterface;
+use Hypervel\Contracts\Server\OnOpenInterface;
 use Hypervel\Coordinator\Constants;
 use Hypervel\Coordinator\CoordinatorManager;
+use Hypervel\Coroutine\Waiter;
 use Hypervel\Events\Dispatcher;
 use Hypervel\Http\Request as HttpRequest;
 use Hypervel\HttpServer\Events\RequestHandled;
@@ -16,15 +20,18 @@ use Hypervel\HttpServer\Events\RequestReceived;
 use Hypervel\HttpServer\Events\ResponseSent;
 use Hypervel\Routing\Route;
 use Hypervel\Routing\Router;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Support\SafeCaller;
 use Hypervel\Tests\TestCase;
 use Hypervel\Tests\WebSocketServer\Fixtures\WebSocketStub;
 use Hypervel\WebSocketServer\Collector\FdCollector;
 use Hypervel\WebSocketServer\Context as WebSocketContext;
 use Hypervel\WebSocketServer\Events\ConnectionOpening;
+use Hypervel\WebSocketServer\Exceptions\Handler\WebSocketExceptionHandler;
 use Hypervel\WebSocketServer\Security;
 use Hypervel\WebSocketServer\Server;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Swoole\Coroutine\CanceledException;
 use Swoole\Http\Request as SwooleRequest;
@@ -33,8 +40,163 @@ use Swoole\WebSocket\Server as SwooleWebSocketServer;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
+use function Hypervel\Support\defer;
+
 class ServerHandshakeTest extends TestCase
 {
+    #[DataProvider('acceptedTerminationOutcomes')]
+    public function testAcceptedHandshakeTerminatesAfterOpenAndDrainsOnce(string $outcome, array $expected): void
+    {
+        $calls = [];
+        $exception = $outcome === 'canceled' ? new CanceledException : new RuntimeException('termination failed');
+        $events = new Dispatcher;
+        $events->listen(RequestReceived::class, function () use (&$calls): void {
+            defer(function () use (&$calls): void { $calls[] = 'handshake deferred'; });
+        });
+        $container = $this->container($events);
+        $reporter = m::mock(ExceptionHandler::class);
+        if ($outcome === 'failed') {
+            $reporter->expects('report')->with($exception);
+        } else {
+            $reporter->shouldNotReceive('report');
+        }
+        $container->shouldReceive('make')->with(ExceptionHandler::class)->andReturn($reporter);
+        $container->shouldReceive('make')->with(Security::class)->andReturn(new Security);
+        $handler = m::mock(OnOpenInterface::class);
+        $handler->expects('onOpen')->andReturnUsing(function () use (&$calls): void {
+            $calls[] = 'open';
+            defer(function () use (&$calls): void { $calls[] = 'open deferred'; });
+        });
+        $container->shouldReceive('make')->with(WebSocketStub::class)->andReturn($handler);
+        $middleware = new HandshakeTerminationStub(function () use (&$calls, $outcome, $exception): void {
+            $calls[] = FdCollector::get(42);
+            $calls[] = 'terminated';
+            defer(function () use (&$calls): void { $calls[] = 'termination deferred'; })->always();
+            if ($outcome !== 'success') {
+                throw $exception;
+            }
+        });
+        $container->shouldReceive('make')->with(HandshakeTerminationStub::class)->andReturn($middleware);
+        $native = m::mock(SwooleWebSocketServer::class);
+        $native->expects('isEstablished')->with(42)->andReturnTrue();
+        $server = new HandshakeLifecycleServer($container, $this->router(101, [HandshakeTerminationStub::class . ':value']), $native);
+        $response = $this->response(101, onEnd: function () use (&$calls): bool {
+            $calls[] = 'sent';
+            return true;
+        });
+
+        (new Waiter(1))->wait(fn () => $server->onHandshake($this->request(), $response));
+
+        $this->assertSame(['sent', 'open', WebSocketStub::class, 'terminated', ...$expected], $calls);
+    }
+
+    /**
+     * Supply termination outcomes after the connection opens.
+     */
+    public static function acceptedTerminationOutcomes(): array
+    {
+        return [
+            ['success', ['handshake deferred', 'open deferred', 'termination deferred']],
+            ['failed', ['termination deferred']],
+            ['canceled', []],
+        ];
+    }
+
+    #[DataProvider('uncommittedTerminationOutcomes')]
+    public function testUncommittedHandshakeTerminatesBeforeDrainingAndReleasesContext(int $status, string $outcome, array $expected): void
+    {
+        $calls = [];
+        $exception = $outcome === 'canceled' ? new CanceledException : new RuntimeException('termination failed');
+        $events = new Dispatcher;
+        $events->listen(RequestReceived::class, function () use (&$calls): void {
+            defer(function () use (&$calls): void { $calls[] = 'normal'; });
+            defer(function () use (&$calls): void { $calls[] = WebSocketContext::get('middleware.value'); })->always();
+        });
+        $container = $this->container($events);
+        $container->shouldReceive('make')->with(Security::class)->andReturn(new Security);
+        $container->shouldReceive('make')->with(HandshakeTerminationStub::class)->andReturn(
+            new HandshakeTerminationStub(function () use (&$calls, $outcome, $exception): void {
+                $calls[] = 'first';
+                if ($outcome !== 'success') {
+                    throw $exception;
+                }
+            }),
+        );
+        $container->shouldReceive('make')->with('second.middleware')->andReturn(
+            new HandshakeTerminationStub(function () use (&$calls): void { $calls[] = 'second'; }),
+        );
+        $server = new HandshakeLifecycleServer(
+            $container,
+            $this->router($status, [HandshakeTerminationStub::class, 'second.middleware']),
+            m::mock(SwooleWebSocketServer::class),
+        );
+        $caught = null;
+
+        try {
+            $server->onHandshake($this->request(), $this->response($status, $status === 403 ? 'Forbidden' : ''));
+        } catch (Throwable $throwable) {
+            $caught = $throwable;
+        }
+
+        $this->assertSame($outcome === 'success' ? null : $exception, $caught);
+        $this->assertSame($expected, $calls);
+        $this->assertNull(FdCollector::get(42));
+        $this->assertArrayNotHasKey(42, WebSocketContext::getStorage());
+    }
+
+    /**
+     * Supply response statuses and termination outcomes without an upgrade.
+     */
+    public static function uncommittedTerminationOutcomes(): array
+    {
+        return [
+            [302, 'success', ['first', 'second', 'normal', 'preserved']],
+            [302, 'failed', ['first', 'second', 'preserved']],
+            [302, 'canceled', ['first']],
+            [403, 'success', ['first', 'second', 'preserved']],
+        ];
+    }
+
+    public function testHandledHandshakeExceptionUsesTheRenderedStatusForDeferredWork(): void
+    {
+        $calls = [];
+        $exception = new RuntimeException('rendered as a redirect');
+        $events = new Dispatcher;
+        $events->listen(RequestReceived::class, function () use (&$calls, $exception): void {
+            defer(function () use (&$calls): void { $calls[] = 'deferred'; });
+
+            throw $exception;
+        });
+        $container = $this->container($events);
+        $container->expects('make')->with(SafeCaller::class)->andReturn(new SafeCaller($container));
+        $handler = m::mock(WebSocketExceptionHandler::class);
+        $handler->expects('handle')->with($exception, m::type(Response::class))->andReturn(new Response('', 302));
+        $container->expects('make')->with(WebSocketExceptionHandler::class)->andReturn($handler);
+        $server = new HandshakeLifecycleServer($container, m::mock(Router::class), m::mock(SwooleWebSocketServer::class));
+
+        $server->onHandshake($this->request(), $this->response(302));
+
+        $this->assertSame(['deferred'], $calls);
+    }
+
+    public function testDisabledHandshakeMiddlewareIsNotTerminated(): void
+    {
+        $container = $this->container();
+        $container->shouldReceive('bound')->with('middleware.disable')->andReturnTrue();
+        $container->shouldReceive('make')->with('middleware.disable')->andReturnTrue();
+        $container->shouldReceive('make')->with(Security::class)->andReturn(new Security);
+        $container->shouldNotReceive('make')->with(HandshakeTerminationStub::class);
+        $server = new HandshakeLifecycleServer(
+            $container,
+            $this->router(403, [HandshakeTerminationStub::class]),
+            m::mock(SwooleWebSocketServer::class),
+        );
+
+        $server->onHandshake($this->request(), $this->response(403, 'Forbidden'));
+
+        $this->assertNull(FdCollector::get(42));
+    }
+
     public function testDispatchesHttpLifecycleAroundNativeHandshakeEmission(): void
     {
         $order = [];
@@ -289,6 +451,7 @@ class ServerHandshakeTest extends TestCase
         $container->shouldReceive('make')->once()->with(StdoutLoggerInterface::class)
             ->andReturn(m::mock(StdoutLoggerInterface::class)->shouldIgnoreMissing());
         $container->shouldReceive('bound')->once()->with('events')->andReturn($events !== null);
+        $container->shouldReceive('bound')->with('middleware.disable')->andReturnFalse()->byDefault();
 
         if ($events !== null) {
             $container->shouldReceive('make')->once()->with('events')->andReturn($events);
@@ -300,12 +463,13 @@ class ServerHandshakeTest extends TestCase
     /**
      * Create a router returning the requested handshake status.
      */
-    protected function router(int $status): Router
+    protected function router(int $status, array $middleware = []): Router
     {
         $route = m::mock(Route::class);
         $route->shouldReceive('getControllerClass')->andReturn(WebSocketStub::class);
 
         $router = m::mock(Router::class);
+        $router->shouldReceive('gatherRouteMiddleware')->with($route)->andReturn($middleware);
         $router->shouldReceive('dispatchToCallback')->once()
             ->with(m::type(HttpRequest::class), m::type(Closure::class))
             ->andReturnUsing(function (HttpRequest $request) use ($route, $status): Response {
@@ -368,6 +532,25 @@ class ServerHandshakeTest extends TestCase
         parent::setUp();
 
         CoordinatorManager::until(Constants::WORKER_START)->resume();
+        BaseContainer::getInstance()->scoped(DeferredCallbackCollection::class);
+    }
+}
+
+class HandshakeTerminationStub
+{
+    /**
+     * Create middleware with an observable termination callback.
+     */
+    public function __construct(private Closure $callback)
+    {
+    }
+
+    /**
+     * Run the termination callback.
+     */
+    public function terminate(HttpRequest $request, Response $response): void
+    {
+        ($this->callback)();
     }
 }
 

--- a/tests/WebSocketServer/ServerTest.php
+++ b/tests/WebSocketServer/ServerTest.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace Hypervel\Tests\WebSocketServer;
 
+use Hypervel\Container\Container as BaseContainer;
 use Hypervel\Context\CoroutineContext;
 use Hypervel\Contracts\Container\Container;
 use Hypervel\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Hypervel\Contracts\Events\Dispatcher as EventDispatcherContract;
 use Hypervel\Contracts\Log\StdoutLoggerInterface;
+use Hypervel\Contracts\Server\OnCloseInterface;
+use Hypervel\Contracts\Server\OnMessageInterface;
+use Hypervel\Contracts\Server\OnOpenInterface;
 use Hypervel\Coroutine\Coroutine;
+use Hypervel\Coroutine\Waiter;
+use Hypervel\Http\Request as HttpRequest;
 use Hypervel\Support\ClassInvoker;
+use Hypervel\Support\Defer\DeferredCallbackCollection;
 use Hypervel\Tests\TestCase;
 use Hypervel\Tests\WebSocketServer\Fixtures\WebSocketMessageStub;
 use Hypervel\Tests\WebSocketServer\Fixtures\WebSocketStub;
@@ -25,6 +32,7 @@ use Hypervel\WebSocketServer\Events\MessageReceived;
 use Hypervel\WebSocketServer\Exceptions\Handler\WebSocketExceptionHandler;
 use Hypervel\WebSocketServer\Server;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Swoole\Coroutine\CanceledException;
 use Swoole\Http\Request as SwooleRequest;
@@ -34,8 +42,17 @@ use Swoole\WebSocket\Server as WebSocketSwooleServer;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
+use function Hypervel\Support\defer;
+
 class ServerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        BaseContainer::getInstance()->scoped(DeferredCallbackCollection::class);
+    }
+
     protected function tearDown(): void
     {
         WebSocketMessageStub::flushState();
@@ -62,7 +79,7 @@ class ServerTest extends TestCase
         // Run deferOnOpen inside a child coroutine so that defer() fires
         // when that coroutine exits, before we make our assertions.
         $coroutineId = Coroutine::create(function () use ($invoker, $swooleServer) {
-            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1);
+            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1, new HttpRequest, new Response('', 101));
         });
         $this->waitForCoroutine($coroutineId);
 
@@ -89,7 +106,7 @@ class ServerTest extends TestCase
         $swooleServer = m::mock(WebSocketSwooleServer::class);
 
         $coroutineId = Coroutine::create(function () use ($invoker, $swooleServer) {
-            $invoker->deferOnOpen(new SwooleRequest, new WebSocketThrowingStub, $swooleServer, 1);
+            $invoker->deferOnOpen(new SwooleRequest, new WebSocketThrowingStub, $swooleServer, 1, new HttpRequest, new Response('', 101));
         });
         $this->waitForCoroutine($coroutineId);
 
@@ -115,7 +132,7 @@ class ServerTest extends TestCase
         $swooleServer = m::mock(WebSocketSwooleServer::class);
 
         $coroutineId = Coroutine::create(function () use ($invoker, $swooleServer) {
-            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1);
+            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1, new HttpRequest, new Response('', 101));
         });
         $this->waitForCoroutine($coroutineId);
 
@@ -142,7 +159,7 @@ class ServerTest extends TestCase
         $swooleServer = m::mock(WebSocketSwooleServer::class);
 
         $coroutineId = Coroutine::create(function () use ($invoker, $swooleServer) {
-            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1);
+            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1, new HttpRequest, new Response('', 101));
         });
         $this->waitForCoroutine($coroutineId);
 
@@ -171,7 +188,7 @@ class ServerTest extends TestCase
         $swooleServer = m::mock(WebSocketSwooleServer::class);
 
         $coroutineId = Coroutine::create(function () use ($invoker, $swooleServer) {
-            $invoker->deferOnOpen(new SwooleRequest, new WebSocketThrowingStub, $swooleServer, 1);
+            $invoker->deferOnOpen(new SwooleRequest, new WebSocketThrowingStub, $swooleServer, 1, new HttpRequest, new Response('', 101));
         });
         $this->waitForCoroutine($coroutineId);
 
@@ -194,11 +211,157 @@ class ServerTest extends TestCase
         $swooleServer = m::mock(WebSocketSwooleServer::class);
 
         $coroutineId = Coroutine::create(function () use ($invoker, $swooleServer) {
-            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1);
+            $invoker->deferOnOpen(new SwooleRequest, new WebSocketStub, $swooleServer, 1, new HttpRequest, new Response('', 101));
         });
         $this->waitForCoroutine($coroutineId);
 
         $this->assertNotSame(0, WebSocketStub::$coroutineId);
+    }
+
+    #[DataProvider('messageDeferredOutcomes')]
+    public function testMessageDeferredWorkFollowsTheCallbackOutcome(?string $failureAt, bool $cancel, array $expected): void
+    {
+        $calls = [];
+        $exception = $cancel ? new CanceledException : new RuntimeException('message failed');
+        $dispatcher = m::mock(EventDispatcherContract::class);
+        $dispatcher->shouldReceive('hasListeners')->andReturnTrue();
+        $dispatcher->shouldReceive('dispatch')->andReturnUsing(function (object $event) use (&$calls, $failureAt, $exception): void {
+            $phase = $event instanceof MessageReceived ? 'received' : 'handled';
+            $calls[] = $phase;
+
+            if ($phase === 'received') {
+                defer(function () use (&$calls): void { $calls[] = 'deferred'; });
+                defer(function () use (&$calls): void { $calls[] = 'always'; })->always();
+            }
+
+            if ($failureAt === $phase) {
+                throw $exception;
+            }
+        });
+        $handler = m::mock(OnMessageInterface::class);
+        $handler->shouldReceive('onMessage')->andReturnUsing(function () use (&$calls, $failureAt, $exception): void {
+            $calls[] = 'handler';
+            if ($failureAt === 'handler') {
+                throw $exception;
+            }
+        });
+        $container = $this->createContainer(dispatcher: $dispatcher);
+        $container->shouldReceive('make')->with(OnMessageInterface::class)->andReturn($handler);
+        FdCollector::set(1, OnMessageInterface::class);
+        $frame = new Frame;
+        $frame->fd = 1;
+
+        (new Server($container))->onMessage(m::mock(WebSocketSwooleServer::class), $frame);
+
+        $this->assertSame($expected, $calls);
+    }
+
+    /**
+     * Supply successful, failed and canceled message phases.
+     */
+    public static function messageDeferredOutcomes(): array
+    {
+        return [
+            'success' => [null, false, ['received', 'handler', 'handled', 'deferred', 'always']],
+            'received failure' => ['received', false, ['received', 'handler', 'handled', 'always']],
+            'handler failure' => ['handler', false, ['received', 'handler', 'handled', 'always']],
+            'handled failure' => ['handled', false, ['received', 'handler', 'handled', 'always']],
+            'received cancellation' => ['received', true, ['received']],
+            'handler cancellation' => ['handler', true, ['received', 'handler']],
+            'handled cancellation' => ['handled', true, ['received', 'handler', 'handled']],
+        ];
+    }
+
+    #[DataProvider('callbackFailures')]
+    public function testOpenDeferredWorkRunsAfterTheHandler(bool $fail): void
+    {
+        $calls = [];
+        $dispatcher = m::mock(EventDispatcherContract::class);
+        $dispatcher->shouldReceive('hasListeners')->with(ConnectionOpened::class)->andReturnTrue();
+        $dispatcher->expects('dispatch')->andReturnUsing(function () use (&$calls): void {
+            $calls[] = 'opened';
+            defer(function () use (&$calls): void { $calls[] = 'event deferred'; })->always();
+        });
+        $handler = m::mock(OnOpenInterface::class);
+        $handler->expects('onOpen')->andReturnUsing(function () use (&$calls, $fail): void {
+            $calls[] = 'handler';
+            defer(function () use (&$calls): void { $calls[] = 'handler deferred'; });
+            if ($fail) {
+                throw new RuntimeException('open failed');
+            }
+        });
+        $server = new Server($this->createContainer(dispatcher: $dispatcher));
+        $native = m::mock(WebSocketSwooleServer::class);
+
+        (new Waiter(1))->wait(fn () => (new ClassInvoker($server))->deferOnOpen(
+            new SwooleRequest,
+            $handler,
+            $native,
+            1,
+            new HttpRequest,
+            new Response('', 101)
+        ));
+
+        $this->assertSame($fail
+            ? ['opened', 'handler', 'event deferred']
+            : ['opened', 'handler', 'event deferred', 'handler deferred'], $calls);
+    }
+
+    #[DataProvider('callbackFailures')]
+    public function testCloseDeferredWorkRunsBeforeConnectionContextIsReleased(bool $fail): void
+    {
+        $calls = [];
+        $dispatcher = m::mock(EventDispatcherContract::class);
+        $dispatcher->shouldReceive('hasListeners')->with(ConnectionClosed::class)->andReturnTrue();
+        $dispatcher->expects('dispatch')->andReturnUsing(function () use (&$calls): void { $calls[] = 'closed'; });
+        $handler = m::mock(OnCloseInterface::class);
+        $handler->expects('onClose')->andReturnUsing(function () use (&$calls, $fail): void {
+            defer(function () use (&$calls): void { $calls[] = 'deferred'; });
+            defer(function () use (&$calls): void { $calls[] = WebSocketContext::get('value'); })->always();
+            if ($fail) {
+                throw new RuntimeException('close failed');
+            }
+        });
+        $container = $this->createContainer(dispatcher: $dispatcher);
+        $container->shouldReceive('make')->with(OnCloseInterface::class)->andReturn($handler);
+        FdCollector::set(1, OnCloseInterface::class);
+        CoroutineContext::set(WebSocketContext::FD, 1);
+        WebSocketContext::set('value', 'context');
+
+        (new Server($container))->onClose(m::mock(SwooleServer::class), 1, 0);
+
+        $this->assertSame($fail ? ['closed', 'context'] : ['closed', 'deferred', 'context'], $calls);
+        $this->assertNull(WebSocketContext::get('value', fd: 1));
+        $this->assertNull(FdCollector::get(1));
+    }
+
+    /**
+     * Supply ordinary callback outcomes.
+     */
+    public static function callbackFailures(): array
+    {
+        return [[false], [true]];
+    }
+
+    public function testCancellationDuringDeferredWorkStillReleasesConnectionContext(): void
+    {
+        $calls = [];
+        $handler = m::mock(OnCloseInterface::class);
+        $handler->expects('onClose')->andReturnUsing(function () use (&$calls): void {
+            defer(static fn () => throw new CanceledException);
+            defer(function () use (&$calls): void { $calls[] = 'later'; })->always();
+        });
+        $container = $this->createContainer();
+        $container->shouldReceive('make')->with(OnCloseInterface::class)->andReturn($handler);
+        FdCollector::set(1, OnCloseInterface::class);
+        CoroutineContext::set(WebSocketContext::FD, 1);
+        WebSocketContext::set('value', 'context');
+
+        (new Server($container))->onClose(m::mock(SwooleServer::class), 1, 0);
+
+        $this->assertSame([], $calls);
+        $this->assertNull(WebSocketContext::get('value', fd: 1));
+        $this->assertNull(FdCollector::get(1));
     }
 
     public function testMessageLifecycleEventsAreDispatchedInOrder(): void


### PR DESCRIPTION
## Summary

Deferred functions registered by scheduled tasks and WebSocket callbacks were never run by their owning lifecycle. WebSocket handshakes also ran route middleware without calling its termination methods. This completes that cleanup and fixes Reverb treating coroutine cancellation as a protocol error or continuing delivery after cancellation.

It also fixes a channel cleanup failure: if leaving one Reverb channel threw, later channels could retain a closed connection indefinitely.

## Changes

### Scheduled tasks

Run deferred functions once after each task and its lifecycle listeners. Nested Artisan calls leave that work to the task boundary. Ordinary deferred functions run after success; `always()` functions also run after ordinary failures. Cancellation skips remaining deferred work and preserves mutex cleanup.

Keep handled failure state local to the task coroutine. Give paused-task skip listeners their own finite execution scope, and send background-finished notifications only for tasks that were not skipped because of overlap or another server.

Scheduled commands continue to run inside the scheduler process. The documentation explains when to use `Schedule::exec('php artisan ...')` for commands that require a separate process. This does not change the scheduler's execution model or its public method signatures.

### WebSocket callbacks

Terminate handshake route middleware after `onOpen` for an accepted connection, or after sending an uncommitted handshake response. Keep connection publication atomic, and initialize the handler before termination can yield to a concurrent close callback.

Run handshake and opening deferred functions after middleware termination. Message and close callbacks drain their deferred functions after their lifecycle events; close retains connection context until cleanup finishes. Rendered response status determines handshake success, including handled redirects, while unhandled lifecycle failures suppress ordinary deferred work.

Honor disabled middleware and middleware parameters. Continue route termination after an ordinary failure and preserve its first exception. Cancellation skips remaining deferred work and stays contained at native callback boundaries. The callback collection is resolved only when the current coroutine already created one.

### Reverb delivery and cleanup

Pass cancellation through protocol opening, message handling, recipient delivery, channel delivery and internal presence publication. An application listener that times out no longer causes a false protocol error or sends the same event to later recipients. Opening still releases its acquired connection slot before rethrowing cancellation.

When a connection closes, attempt every channel unsubscription once and rethrow the first failure afterward. A listener or webhook failure after removing one membership no longer strands the remaining memberships. Existing behavior for an unsuccessful shared-state write remains intact; this adds no retry or recovery registry.

Ordinary delivery failures retain the existing attempt-all behavior. Mandatory cleanup continues after failures, including cancellation, while canceled ordinary delivery stops.

## Verification

Formatting, full source and type-fixture analysis, and the affected Console, Console integration, WebSocketServer and Reverb suites pass on the new branch. Earlier validation also covered the Sentry WebSocket context boundary and native Reverb integration.

Regression tests cover task and listener ordering, nested commands, success and failure eligibility, cancellation, middleware termination, context release, real listener deadlines and cleanup after a channel failure. The new cases fail against the previous implementations.

An isolated empty-message benchmark measured about 0.35 microseconds of additional callback work, with no deferred collection allocated when unused. This is a callback microbenchmark, not an end-to-end throughput measurement. CI runs the full framework suite and supported service matrix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hypervel/components/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of canceled or timed-out scheduled tasks and WebSocket operations, preventing cancellations from being incorrectly reported as application errors.
  - Ensured WebSocket broadcasts stop safely after delivery failures and clean up channel memberships reliably.
  - Improved scheduled-task failure handling and background-task completion behavior.

- **Documentation**
  - Clarified when deferred callbacks run across HTTP, scheduling, queued jobs, and WebSocket lifecycles.
  - Documented that scheduled commands share the scheduler process and how to run them in isolated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->