### PR TITLE
Fix Eloquent query results and fresh builder operations

### DIFF
--- a/src/database/README.md
+++ b/src/database/README.md
@@ -18,5 +18,6 @@ Documentation: https://hypervel.org/docs/database
 - `Blueprint::dropForeign()` widens Laravel's method signature with an optional constraint name when columns are supplied, allowing explicitly named foreign keys to be dropped portably across SQLite and the server databases. Custom `Blueprint` subclasses that override this method must accept the optional second argument.
 - Eloquent models that override `CREATED_AT` or `UPDATED_AT` must declare the compatible `?string` constant type, such as `public const ?string UPDATED_AT = null;`. Laravel's constants are untyped, but omitting the type from an override in Hypervel causes a fatal error.
 - Eloquent expression plucks use `Query\Builder::pluckWithColumn()` to retain the returned field name for casts and accessors. Custom query builders overriding `pluck()` must also override `pluckWithColumn()` to customize this path. String-based Eloquent plucks still call `pluck()`.
+- Eloquent `updateFrom()` maintains the model's `updated_at` timestamp, like `update()`. Laravel forwards this method without adding a timestamp.
 
 Ported from: https://github.com/laravel/framework

--- a/src/database/src/Eloquent/Builder.php
+++ b/src/database/src/Eloquent/Builder.php
@@ -123,9 +123,11 @@ class Builder implements BuilderContract
         'existsor',
         'explain',
         'getbindings',
+        'getcolumns',
         'getconnection',
         'getcountforpagination',
         'getgrammar',
+        'getprocessor',
         'getrawbindings',
         'implode',
         'insert',
@@ -141,6 +143,7 @@ class Builder implements BuilderContract
         'sum',
         'tosql',
         'torawsql',
+        'updateorinsert',
     ];
 
     /**
@@ -1179,6 +1182,14 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Update records in a PostgreSQL database using the update from syntax.
+     */
+    public function updateFrom(array $values): int
+    {
+        return $this->toBase()->updateFrom($this->addUpdatedAtColumn($values));
+    }
+
+    /**
      * Insert new records or update the existing ones.
      */
     public function upsert(array $values, array|string $uniqueBy, ?array $update = null): int
@@ -1925,6 +1936,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a fresh query builder with the model's default scopes and eager loads.
+     *
+     * @return Builder<TModel>
+     */
+    public function newQuery(): Builder
+    {
+        return $this->getModel()->newQuery();
+    }
+
+    /**
      * Set a model instance for the model being queried.
      *
      * @template TModelNew of \Hypervel\Database\Eloquent\Model
@@ -2114,6 +2135,28 @@ class Builder implements BuilderContract
     public function clone(): static
     {
         return clone $this;
+    }
+
+    /**
+     * Clone the Eloquent query builder without the given query properties.
+     */
+    public function cloneWithout(array $properties): static
+    {
+        $clone = $this->clone();
+
+        return $clone->setQuery($clone->getQuery()->cloneWithout($properties));
+    }
+
+    /**
+     * Clone the Eloquent query builder without the given query bindings.
+     *
+     * @param list<string> $except
+     */
+    public function cloneWithoutBindings(array $except): static
+    {
+        $clone = $this->clone();
+
+        return $clone->setQuery($clone->getQuery()->cloneWithoutBindings($except));
     }
 
     /**

--- a/src/database/src/Eloquent/Builder.php
+++ b/src/database/src/Eloquent/Builder.php
@@ -126,6 +126,7 @@ class Builder implements BuilderContract
         'getcolumns',
         'getconnection',
         'getcountforpagination',
+        'getfromalias',
         'getgrammar',
         'getprocessor',
         'getrawbindings',
@@ -1301,6 +1302,13 @@ class Builder implements BuilderContract
 
         $column = $this->model->getUpdatedAtColumn();
 
+        $alias = $this->query->getFromAlias();
+
+        // Opaque raw sources cannot safely qualify an automatic timestamp.
+        if ($alias === null) {
+            return $values;
+        }
+
         if (! array_key_exists($column, $values)) {
             $timestamp = $this->model->freshTimestampString();
 
@@ -1317,9 +1325,7 @@ class Builder implements BuilderContract
             $values = array_merge([$column => $timestamp], $values);
         }
 
-        $segments = preg_split('/\s+as\s+/i', $this->query->from);
-
-        $qualifiedColumn = array_last($segments) . '.' . $column;
+        $qualifiedColumn = $alias . '.' . $column;
 
         $values[$qualifiedColumn] = Arr::get($values, $qualifiedColumn, $values[$column]);
 

--- a/src/database/src/Query/Builder.php
+++ b/src/database/src/Query/Builder.php
@@ -450,12 +450,20 @@ class Builder implements BuilderContract
 
     /**
      * Get the wildcard selection for the query's primary source.
+     *
+     * @throws InvalidArgumentException
      */
     public function getDefaultSelectColumn(): string
     {
         // Raw sources need an explicit alias or selection: an unqualified wildcard
         // can introduce duplicate columns into a joined pagination count subquery.
-        return ($this->fromAlias ?? last(preg_split('/\s+as\s+/i', $this->from))) . '.*';
+        $alias = $this->getFromAlias();
+
+        if ($alias === null) {
+            throw new InvalidArgumentException('Raw query sources need an explicit alias or selection.');
+        }
+
+        return $alias . '.*';
     }
 
     /**
@@ -529,6 +537,16 @@ class Builder implements BuilderContract
         $this->fromAlias = $as !== '' ? $as : null;
 
         return $this;
+    }
+
+    /**
+     * Get the alias or table name that qualifies the query's source columns.
+     *
+     * Raw sources without an explicit alias return null; raw SQL is not parsed.
+     */
+    public function getFromAlias(): ?string
+    {
+        return $this->fromAlias ?? (is_string($this->from) ? last(preg_split('/\s+as\s+/i', $this->from)) : null);
     }
 
     /**

--- a/src/database/src/Query/Grammars/Grammar.php
+++ b/src/database/src/Query/Grammars/Grammar.php
@@ -14,6 +14,7 @@ use Hypervel\Database\Query\JoinClause;
 use Hypervel\Database\Query\JoinLateralClause;
 use Hypervel\Support\Arr;
 use Hypervel\Support\Collection;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Grammar extends BaseGrammar
@@ -1210,6 +1211,28 @@ class Grammar extends BaseGrammar
         $joins = $this->compileJoins($query, $query->joins);
 
         return "delete {$alias} from {$table} {$joins} {$where}";
+    }
+
+    /**
+     * Qualify the row identifier selected by a limited or joined write rewrite.
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function qualifyRowIdentifier(Builder $query, string $identifier): string
+    {
+        $alias = $query->getFromAlias();
+
+        if ($alias !== null) {
+            return $alias . '.' . $identifier;
+        }
+
+        // In a join, an unqualified identifier can resolve to the outer query in
+        // PostgreSQL or a string literal in SQLite, silently affecting the wrong rows.
+        if ($query->joins) {
+            throw new InvalidArgumentException('Joined writes on a raw query source require an explicit alias set through from().');
+        }
+
+        return $identifier;
     }
 
     /**

--- a/src/database/src/Query/Grammars/PostgresGrammar.php
+++ b/src/database/src/Query/Grammars/PostgresGrammar.php
@@ -534,9 +534,9 @@ class PostgresGrammar extends Grammar
 
         $columns = $this->compileUpdateColumns($query, $values);
 
-        $alias = last(preg_split('/\s+as\s+/i', $query->from));
+        $alias = $query->getFromAlias();
 
-        $selectSql = $this->compileSelectQuery($query->select($alias . '.ctid'));
+        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'ctid' : $alias . '.ctid'));
 
         return "update {$table} set {$columns} where {$this->wrap('ctid')} in ({$selectSql})";
     }
@@ -581,9 +581,9 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
 
-        $alias = last(preg_split('/\s+as\s+/i', $query->from));
+        $alias = $query->getFromAlias();
 
-        $selectSql = $this->compileSelectQuery($query->select($alias . '.ctid'));
+        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'ctid' : $alias . '.ctid'));
 
         return "delete from {$table} where {$this->wrap('ctid')} in ({$selectSql})";
     }

--- a/src/database/src/Query/Grammars/PostgresGrammar.php
+++ b/src/database/src/Query/Grammars/PostgresGrammar.php
@@ -534,9 +534,7 @@ class PostgresGrammar extends Grammar
 
         $columns = $this->compileUpdateColumns($query, $values);
 
-        $alias = $query->getFromAlias();
-
-        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'ctid' : $alias . '.ctid'));
+        $selectSql = $this->compileSelectQuery($query->select($this->qualifyRowIdentifier($query, 'ctid')));
 
         return "update {$table} set {$columns} where {$this->wrap('ctid')} in ({$selectSql})";
     }
@@ -581,9 +579,7 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
 
-        $alias = $query->getFromAlias();
-
-        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'ctid' : $alias . '.ctid'));
+        $selectSql = $this->compileSelectQuery($query->select($this->qualifyRowIdentifier($query, 'ctid')));
 
         return "delete from {$table} where {$this->wrap('ctid')} in ({$selectSql})";
     }

--- a/src/database/src/Query/Grammars/SQLiteGrammar.php
+++ b/src/database/src/Query/Grammars/SQLiteGrammar.php
@@ -303,9 +303,9 @@ class SQLiteGrammar extends Grammar
 
         $columns = $this->compileUpdateColumns($query, $values);
 
-        $alias = last(preg_split('/\s+as\s+/i', $query->from));
+        $alias = $query->getFromAlias();
 
-        $selectSql = $this->compileSelectQuery($query->select($alias . '.rowid'));
+        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'rowid' : $alias . '.rowid'));
 
         return "update {$table} set {$columns} where {$this->wrap('rowid')} in ({$selectSql})";
     }
@@ -352,9 +352,9 @@ class SQLiteGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
 
-        $alias = last(preg_split('/\s+as\s+/i', $query->from));
+        $alias = $query->getFromAlias();
 
-        $selectSql = $this->compileSelectQuery($query->select($alias . '.rowid'));
+        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'rowid' : $alias . '.rowid'));
 
         return "delete from {$table} where {$this->wrap('rowid')} in ({$selectSql})";
     }

--- a/src/database/src/Query/Grammars/SQLiteGrammar.php
+++ b/src/database/src/Query/Grammars/SQLiteGrammar.php
@@ -303,9 +303,7 @@ class SQLiteGrammar extends Grammar
 
         $columns = $this->compileUpdateColumns($query, $values);
 
-        $alias = $query->getFromAlias();
-
-        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'rowid' : $alias . '.rowid'));
+        $selectSql = $this->compileSelectQuery($query->select($this->qualifyRowIdentifier($query, 'rowid')));
 
         return "update {$table} set {$columns} where {$this->wrap('rowid')} in ({$selectSql})";
     }
@@ -352,9 +350,7 @@ class SQLiteGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
 
-        $alias = $query->getFromAlias();
-
-        $selectSql = $this->compileSelectQuery($query->select($alias === null ? 'rowid' : $alias . '.rowid'));
+        $selectSql = $this->compileSelectQuery($query->select($this->qualifyRowIdentifier($query, 'rowid')));
 
         return "delete from {$table} where {$this->wrap('rowid')} in ({$selectSql})";
     }

--- a/src/docs/eloquent.md
+++ b/src/docs/eloquent.md
@@ -944,6 +944,8 @@ $affected = Invoice::join('customers', 'invoices.customer_id', '=', 'customers.i
 
 Like `update`, `updateFrom` applies the model's global scopes and returns the number of affected rows. It also updates the model's `updated_at` column unless timestamps are disabled or you supply that column explicitly.
 
+When using `fromRaw`, supply timestamps yourself or give the raw source an explicit alias with `from(DB::raw(...), 'alias')` to retain automatic timestamps.
+
 > [!WARNING]
 > When issuing a mass update via Eloquent, the `saving`, `saved`, `updating`, and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
 

--- a/src/docs/eloquent.md
+++ b/src/docs/eloquent.md
@@ -931,6 +931,19 @@ Flight::where('active', 1)
 
 The `update` method expects an array of column and value pairs representing the columns that should be updated. The `update` method returns the number of affected rows.
 
+When using PostgreSQL, the `updateFrom` method allows you to update columns using values from joined tables:
+
+```php
+use App\Models\Invoice;
+use Hypervel\Support\Facades\DB;
+
+$affected = Invoice::join('customers', 'invoices.customer_id', '=', 'customers.id')
+    ->whereNull('invoices.currency')
+    ->updateFrom(['currency' => DB::raw('customers.currency')]);
+```
+
+Like `update`, `updateFrom` applies the model's global scopes and returns the number of affected rows. It also updates the model's `updated_at` column unless timestamps are disabled or you supply that column explicitly.
+
 > [!WARNING]
 > When issuing a mass update via Eloquent, the `saving`, `saved`, `updating`, and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
 

--- a/src/docs/porting-from-laravel.md
+++ b/src/docs/porting-from-laravel.md
@@ -580,11 +580,13 @@ When a package constructs `DatabaseStore`, `DatabaseSessionHandler`, `DatabaseQu
 
 Laravel's base `Connection` class exposes PDO methods. Hypervel's base `Connection` is driver-neutral, while its built-in SQL connections extend `PdoConnection`. Ported code that calls `getPdo`, `getReadPdo`, or another PDO-specific method should accept or narrow to `PdoConnection`. See [extending database connections](/docs/{{version}}/database#extending-database-connections) when porting a custom driver.
 
-Custom query builders overriding `newQuery`, `forNestedWhere`, or `cloneForPaginationCount` must declare `static` returns and preserve the concrete builder class. Keep `forSubQuery` separate: join subqueries return the parent query builder. See the [database extension guide](/docs/{{version}}/database#extending-database-connections) for these return contracts.
+Custom base query builders overriding `newQuery`, `forNestedWhere`, or `cloneForPaginationCount` must declare `static` returns and preserve the concrete builder class. Keep `forSubQuery` separate: join subqueries return the parent query builder. See the [database extension guide](/docs/{{version}}/database#extending-database-connections) for these return contracts.
 
 Laravel's nested `direct` connection endpoint and `::direct` suffix are not available. Configure the direct endpoint as a normal named connection and point the pooled connection's `migrations_connection` option at it.
 
 Model casts are not applied to direct query builder operations or Eloquent key helpers. When ported code passes already-encoded binary strings to query builder `where`, bulk `update`, or `upsert` calls, or to Eloquent `find`, `whereKey`, or `whereKeyNot`, wrap them in `Hypervel\Database\BinaryParameter`. See [binding binary values](/docs/{{version}}/database#binding-binary-values) and [binary casting](/docs/{{version}}/eloquent-mutators#binary-casting).
+
+Eloquent `updateOrInsert` and `updateFrom` honor global scopes, including soft deletes. Review calls that rely on matching rows excluded by those scopes. Both methods return their write result, so do not chain another query onto them. Eloquent `updateFrom` also maintains `updated_at`, like `update`; supply that column explicitly if it must stay unchanged. See [mass updates](/docs/{{version}}/eloquent#mass-updates).
 
 Hypervel's `migrate:fresh` command discovers the connection declared by each migration and resets every resolved target before rebuilding the schema. Keep each migration's connection stable, and split manual cross-connection schema work into separate migrations with explicit connection declarations. See [drop all tables and migrate](/docs/{{version}}/migrations#drop-all-tables-migrate) for details.
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -23,6 +23,7 @@ use Hypervel\Database\PdoConnection;
 use Hypervel\Database\Query\Builder as BaseBuilder;
 use Hypervel\Database\Query\Expression;
 use Hypervel\Database\Query\Grammars\Grammar;
+use Hypervel\Database\Query\Grammars\MySqlGrammar;
 use Hypervel\Database\Query\Processors\Processor;
 use Hypervel\Support\CarbonImmutable;
 use Hypervel\Support\Collection as BaseCollection;
@@ -3220,6 +3221,25 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpdateWithAnExplicitRawSourceAliasAndPrefix(): void
+    {
+        CarbonImmutable::setTestNow('2017-10-10 10:10:10');
+
+        $connection = m::mock(Connection::class, ['getTablePrefix' => 'prefix_']);
+        $query = new BaseBuilder($connection, new MySqlGrammar($connection), m::mock(Processor::class));
+        $builder = (new Builder($query))->setModel((new Stub)->setDateFormat('Y-m-d H:i:s'));
+        $connection->shouldReceive('update')->once()->with(
+            'update `prefix_table` as `prefix_target` inner join `prefix_profiles` on `prefix_profiles`.`user_id` = `prefix_target`.`id` set `prefix_target`.`name` = ?, `prefix_target`.`updated_at` = ?',
+            ['new', '2017-10-10 10:10:10'],
+        )->andReturn(1);
+
+        $builder->from(new Expression('`prefix_table`'), 'target')
+            ->join('profiles', 'profiles.user_id', '=', 'target.id');
+
+        $this->assertSame(1, $builder->update(['target.name' => 'new']));
+        $this->assertSame('target', $builder->getFromAlias());
+    }
+
     public function testUpdateOrInsertReturnsTheQueryResult(): void
     {
         $builder = $this->getBuilder();
@@ -3281,6 +3301,33 @@ class DatabaseEloquentBuilderTest extends TestCase
                 'update "table" set "name" = ? from "profiles" where ("table"."active" = ?) and "profiles"."user_id" = "table"."id"',
                 ['new', 1],
             ],
+        ];
+    }
+
+    #[DataProvider('rawSourceUpdateValues')]
+    public function testUpdateFromWithAnOpaqueRawSourcePreservesSuppliedValues(array $values, string $columns, array $bindings): void
+    {
+        $model = new Stub;
+        $connection = $this->mockConnectionForModel($model, 'Postgres');
+        $connection->shouldReceive('update')->once()->with(
+            'update "table" as "target" set ' . $columns . ' from "profiles" where "profiles"."user_id" = "target"."id"',
+            $bindings,
+        )->andReturn(1);
+
+        $builder = $model->newQuery()->fromRaw('"table" as "target"')
+            ->join('profiles', 'profiles.user_id', '=', 'target.id');
+
+        $this->assertSame(1, $builder->updateFrom($values));
+    }
+
+    /**
+     * Provide writes with caller-owned timestamps for opaque raw sources.
+     */
+    public static function rawSourceUpdateValues(): array
+    {
+        return [
+            'no automatic timestamp' => [['name' => 'new'], '"name" = ?', ['new']],
+            'explicit qualified timestamp' => [['name' => 'new', 'target.updated_at' => null], '"name" = ?, "updated_at" = ?', ['new', null]],
         ];
     }
 
@@ -3590,7 +3637,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $query = m::mock(BaseBuilder::class);
         $query->shouldReceive('from')->with('foo_table');
-        $query->from = 'foo_table';
+        $query->shouldReceive('getFromAlias')->andReturn('foo_table');
         $query->shouldReceive('incrementEach')->once()->withArgs(function ($columns, $extra) {
             return $columns === ['votes' => 5]
                 && array_key_exists('foo_table.updated_at', $extra);
@@ -3615,7 +3662,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $query = m::mock(BaseBuilder::class);
         $query->shouldReceive('from')->with('foo_table');
-        $query->from = 'foo_table';
+        $query->shouldReceive('getFromAlias')->andReturn('foo_table');
         $query->shouldReceive('decrementEach')->once()->withArgs(function ($columns, $extra) {
             return $columns === ['votes' => 3]
                 && array_key_exists('foo_table.updated_at', $extra);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -3220,6 +3220,87 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpdateOrInsertReturnsTheQueryResult(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('updateOrInsert')->once()
+            ->with(['email' => 'user@example.com'], ['name' => 'Taylor'])->andReturn(false);
+
+        $this->assertFalse($builder->updateOrInsert(['email' => 'user@example.com'], ['name' => 'Taylor']));
+    }
+
+    public function testUpdateOrInsertAppliesGlobalScopes(): void
+    {
+        $connection = new PdoConnection(new PDO('sqlite::memory:'));
+        $connection->statement('create table items (id integer primary key, email text, name text, active integer)');
+        $connection->table('items')->insert(['email' => 'user@example.com', 'name' => 'old', 'active' => 0]);
+        $builder = (new Builder($connection->query()))->setModel((new Stub)->setTable('items'));
+        $builder->withGlobalScope('active', fn (Builder $query): Builder => $query->where('active', 1));
+
+        $this->assertTrue($builder->updateOrInsert(['email' => 'user@example.com'], ['name' => 'new', 'active' => 1]));
+        $this->assertSame(['old', 'new'], $connection->table('items')->orderBy('id')->pluck('name')->all());
+    }
+
+    #[DataProvider('updateFromTimestamps')]
+    public function testUpdateFromAppliesScopesAndModelTimestamps(bool $timestamps, array $values, string $sql, array $bindings): void
+    {
+        CarbonImmutable::setTestNow('2017-10-10 10:10:10');
+        $model = new Stub;
+        $model->timestamps = $timestamps;
+        $connection = $this->mockConnectionForModel($model, 'Postgres');
+        $connection->shouldReceive('update')->once()->with($sql, $bindings)->andReturn(2);
+
+        $builder = $model->newQuery()
+            ->withGlobalScope('active', fn (Builder $query): Builder => $query->where('table.active', 1))
+            ->join('profiles', 'profiles.user_id', '=', 'table.id');
+
+        $this->assertSame(2, $builder->updateFrom($values));
+    }
+
+    /**
+     * Provide timestamp configurations for PostgreSQL model updates.
+     */
+    public static function updateFromTimestamps(): array
+    {
+        return [
+            'automatic timestamp' => [
+                true,
+                ['name' => 'new'],
+                'update "table" set "name" = ?, "updated_at" = ? from "profiles" where ("table"."active" = ?) and "profiles"."user_id" = "table"."id"',
+                ['new', '2017-10-10 10:10:10', 1],
+            ],
+            'explicit timestamp' => [
+                true,
+                ['name' => 'new', 'updated_at' => null],
+                'update "table" set "name" = ?, "updated_at" = ? from "profiles" where ("table"."active" = ?) and "profiles"."user_id" = "table"."id"',
+                ['new', null, 1],
+            ],
+            'timestamps disabled' => [
+                false,
+                ['name' => 'new'],
+                'update "table" set "name" = ? from "profiles" where ("table"."active" = ?) and "profiles"."user_id" = "table"."id"',
+                ['new', 1],
+            ],
+        ];
+    }
+
+    public function testGetColumnsReturnsTheQueryColumns(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('getColumns')->once()->andReturn(['name']);
+
+        $this->assertSame(['name'], $builder->getColumns());
+    }
+
+    public function testGetProcessorReturnsTheQueryProcessor(): void
+    {
+        $builder = $this->getBuilder();
+        $processor = new Processor;
+        $builder->getQuery()->shouldReceive('getProcessor')->once()->andReturn($processor);
+
+        $this->assertSame($processor, $builder->getProcessor());
+    }
+
     public function testUpsert()
     {
         CarbonImmutable::setTestNow($now = '2017-10-10 10:10:10');
@@ -3342,6 +3423,63 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertNotSame($builder, $clone);
         $this->assertSame('select * from "users"', $builder->toSql());
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+    }
+
+    public function testCloneWithoutPreservesTheModelAndCloneCallbackChanges(): void
+    {
+        $model = new Stub;
+        $this->mockConnectionForModel($model, '');
+        $builder = $model->newQuery()->where('active', 1)->orderBy('name');
+        $clones = [];
+        $builder->onClone(function (Builder $clone) use (&$clones): void {
+            $clones[] = $clone;
+            $clone->where('verified', 1)->orderBy('id');
+        });
+
+        $clone = $builder->cloneWithout(['orders']);
+
+        $this->assertNotSame($builder, $clone);
+        $this->assertSame($model, $clone->getModel());
+        $this->assertSame([$clone], $clones);
+        $this->assertSame('select * from "table" where "active" = ? and "verified" = ?', $clone->toSql());
+        $this->assertSame('select * from "table" where "active" = ? order by "name" asc', $builder->toSql());
+    }
+
+    public function testCloneWithoutBindingsKeepsTheOriginalQueryIntact(): void
+    {
+        $model = new Stub;
+        $this->mockConnectionForModel($model, '');
+        $builder = $model->newQuery()->where('active', 1)->orderBy('name');
+
+        $withoutWheres = $builder->cloneWithout(['wheres']);
+        $clone = $withoutWheres->cloneWithoutBindings(['where']);
+
+        $this->assertNotSame($withoutWheres, $clone);
+        $this->assertSame($model, $clone->getModel());
+        $this->assertSame('select * from "table" order by "name" asc', $clone->toSql());
+        $this->assertSame([], $clone->getBindings());
+        $this->assertSame([1], $withoutWheres->getBindings());
+        $this->assertSame([1], $builder->getBindings());
+        $this->assertSame('select * from "table" where "active" = ? order by "name" asc', $builder->toSql());
+    }
+
+    public function testNewQueryRestoresTheModelDefaults(): void
+    {
+        $model = new FreshQueryModel;
+        $this->mockConnectionForModel($model, '');
+        FreshQueryModel::addGlobalScope('active', fn (Builder $query): Builder => $query->where('active', 1));
+        $builder = $model->newQuery()->withoutGlobalScopes()->withoutEagerLoads()->where('name', 'Taylor');
+        $builder->macro('customQuery', fn (Builder $query): Builder => $query);
+
+        $fresh = $builder->newQuery();
+
+        $this->assertNotSame($builder, $fresh);
+        $this->assertSame($model, $fresh->getModel());
+        $this->assertInstanceOf(FreshQueryBuilder::class, $fresh);
+        $this->assertSame(['related'], array_keys($fresh->getEagerLoads()));
+        $this->assertFalse($fresh->hasMacro('customQuery'));
+        $this->assertSame('select * from "table" where ("active" = ?)', $fresh->toSql());
+        $this->assertSame('select * from "table" where "name" = ?', $builder->toSql());
     }
 
     public function testCloneModelMakesAFreshCopyOfTheModel()
@@ -3584,6 +3722,17 @@ class DatabaseEloquentBuilderTest extends TestCase
 class Stub extends Model
 {
     protected ?string $table = 'table';
+}
+
+class FreshQueryBuilder extends Builder
+{
+}
+
+class FreshQueryModel extends Stub
+{
+    protected static string $builder = FreshQueryBuilder::class;
+
+    protected array $with = ['related'];
 }
 
 class ScopeStub extends Model

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5140,20 +5140,31 @@ class DatabaseQueryBuilderTest extends TestCase
     }
 
     #[DataProvider('rawSourcesForLimitedWrites')]
-    public function testUpdateWithRawSourceAndLimit(string $database, ?string $alias, string $source, string $rowIdentifier, string $selection): void
+    public function testUpdateWithRawSourceAndLimit(string $database, ?string $alias, string $source, string $rowIdentifier, string $selection, bool $withJoin = false): void
     {
         $builder = $database === 'Postgres' ? $this->getPostgresBuilder('prefix_') : $this->getSQLiteBuilder('prefix_');
         $builder->from(new Raw('"prefix_users"'), $alias);
-        $builder->getConnection()->shouldReceive('update')->once()->with(
-            'update ' . $source . ' set "email" = ? where ' . $rowIdentifier . ' in (select ' . $selection . ' from ' . $source . ' where "active" = ? limit 1)',
-            ['new@example.com', 1],
-        )->andReturn(1);
+        $join = '';
+
+        if ($withJoin) {
+            $builder->join('profiles', 'profiles.user_id', '=', ($alias ?? 'users') . '.id');
+            $join = ' inner join "prefix_profiles" on "prefix_profiles"."user_id" = "prefix_target"."id"';
+        }
+
+        if ($withJoin && $alias === null) {
+            $this->expectException(InvalidArgumentException::class);
+        } else {
+            $builder->getConnection()->shouldReceive('update')->once()->with(
+                'update ' . $source . ' set "email" = ? where ' . $rowIdentifier . ' in (select ' . $selection . ' from ' . $source . $join . ' where "active" = ? limit 1)',
+                ['new@example.com', 1],
+            )->andReturn(1);
+        }
 
         $this->assertSame(1, $builder->where('active', 1)->limit(1)->update(['email' => 'new@example.com']));
     }
 
     /**
-     * Provide opaque and explicitly aliased sources for limited writes.
+     * Provide opaque and explicitly aliased sources for limited writes with and without joins.
      */
     public static function rawSourcesForLimitedWrites(): array
     {
@@ -5162,6 +5173,10 @@ class DatabaseQueryBuilderTest extends TestCase
             'Postgres explicit alias' => ['Postgres', 'target', '"prefix_users" as "prefix_target"', '"ctid"', '"prefix_target"."ctid"'],
             'SQLite opaque source' => ['SQLite', null, '"prefix_users"', '"rowid"', '"rowid"'],
             'SQLite explicit alias' => ['SQLite', 'target', '"prefix_users" as "prefix_target"', '"rowid"', '"prefix_target"."rowid"'],
+            'Postgres opaque source with join' => ['Postgres', null, '"prefix_users"', '"ctid"', '"ctid"', true],
+            'Postgres explicit alias with join' => ['Postgres', 'target', '"prefix_users" as "prefix_target"', '"ctid"', '"prefix_target"."ctid"', true],
+            'SQLite opaque source with join' => ['SQLite', null, '"prefix_users"', '"rowid"', '"rowid"', true],
+            'SQLite explicit alias with join' => ['SQLite', 'target', '"prefix_users" as "prefix_target"', '"rowid"', '"prefix_target"."rowid"', true],
         ];
     }
 
@@ -5351,14 +5366,25 @@ class DatabaseQueryBuilderTest extends TestCase
     }
 
     #[DataProvider('rawSourcesForLimitedWrites')]
-    public function testDeleteWithRawSourceAndLimit(string $database, ?string $alias, string $source, string $rowIdentifier, string $selection): void
+    public function testDeleteWithRawSourceAndLimit(string $database, ?string $alias, string $source, string $rowIdentifier, string $selection, bool $withJoin = false): void
     {
         $builder = $database === 'Postgres' ? $this->getPostgresBuilder('prefix_') : $this->getSQLiteBuilder('prefix_');
         $builder->from(new Raw('"prefix_users"'), $alias);
-        $builder->getConnection()->shouldReceive('delete')->once()->with(
-            'delete from ' . $source . ' where ' . $rowIdentifier . ' in (select ' . $selection . ' from ' . $source . ' where "active" = ? limit 1)',
-            [1],
-        )->andReturn(1);
+        $join = '';
+
+        if ($withJoin) {
+            $builder->join('profiles', 'profiles.user_id', '=', ($alias ?? 'users') . '.id');
+            $join = ' inner join "prefix_profiles" on "prefix_profiles"."user_id" = "prefix_target"."id"';
+        }
+
+        if ($withJoin && $alias === null) {
+            $this->expectException(InvalidArgumentException::class);
+        } else {
+            $builder->getConnection()->shouldReceive('delete')->once()->with(
+                'delete from ' . $source . ' where ' . $rowIdentifier . ' in (select ' . $selection . ' from ' . $source . $join . ' where "active" = ? limit 1)',
+                [1],
+            )->andReturn(1);
+        }
 
         $this->assertSame(1, $builder->where('active', 1)->limit(1)->delete());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -41,6 +41,7 @@ use Hypervel\Tests\Database\Fixtures\Enums\NonBackedStatus;
 use Hypervel\Tests\TestCase;
 use InvalidArgumentException;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use RuntimeException;
 use SortDirection;
@@ -185,7 +186,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $subquery = (clone $builder)->fromSub('select 2 as id', 'new')->addSelect(['bonus' => $this->getBuilder()->selectRaw('42')]);
         $this->assertSame('select "prefix_new".*, (select 42) as "bonus" from (select 2 as id) as "prefix_new"', $subquery->toSql());
 
-        $this->expectException(TypeError::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $builder->fromRaw('users')->addSelect(['bonus' => $this->getBuilder()->selectRaw('42')]);
     }
@@ -5138,6 +5139,32 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    #[DataProvider('rawSourcesForLimitedWrites')]
+    public function testUpdateWithRawSourceAndLimit(string $database, ?string $alias, string $source, string $rowIdentifier, string $selection): void
+    {
+        $builder = $database === 'Postgres' ? $this->getPostgresBuilder('prefix_') : $this->getSQLiteBuilder('prefix_');
+        $builder->from(new Raw('"prefix_users"'), $alias);
+        $builder->getConnection()->shouldReceive('update')->once()->with(
+            'update ' . $source . ' set "email" = ? where ' . $rowIdentifier . ' in (select ' . $selection . ' from ' . $source . ' where "active" = ? limit 1)',
+            ['new@example.com', 1],
+        )->andReturn(1);
+
+        $this->assertSame(1, $builder->where('active', 1)->limit(1)->update(['email' => 'new@example.com']));
+    }
+
+    /**
+     * Provide opaque and explicitly aliased sources for limited writes.
+     */
+    public static function rawSourcesForLimitedWrites(): array
+    {
+        return [
+            'Postgres opaque source' => ['Postgres', null, '"prefix_users"', '"ctid"', '"ctid"'],
+            'Postgres explicit alias' => ['Postgres', 'target', '"prefix_users" as "prefix_target"', '"ctid"', '"prefix_target"."ctid"'],
+            'SQLite opaque source' => ['SQLite', null, '"prefix_users"', '"rowid"', '"rowid"'],
+            'SQLite explicit alias' => ['SQLite', 'target', '"prefix_users" as "prefix_target"', '"rowid"', '"prefix_target"."rowid"'],
+        ];
+    }
+
     public function testUpdateFromMethodWithJoinsOnPostgres()
     {
         $builder = $this->getPostgresBuilder();
@@ -5321,6 +5348,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "ctid" in (select "users"."ctid" from "users" inner join "contacts" on "users"."id" = "contacts"."id")', [])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->delete();
         $this->assertEquals(1, $result);
+    }
+
+    #[DataProvider('rawSourcesForLimitedWrites')]
+    public function testDeleteWithRawSourceAndLimit(string $database, ?string $alias, string $source, string $rowIdentifier, string $selection): void
+    {
+        $builder = $database === 'Postgres' ? $this->getPostgresBuilder('prefix_') : $this->getSQLiteBuilder('prefix_');
+        $builder->from(new Raw('"prefix_users"'), $alias);
+        $builder->getConnection()->shouldReceive('delete')->once()->with(
+            'delete from ' . $source . ' where ' . $rowIdentifier . ' in (select ' . $selection . ' from ' . $source . ' where "active" = ? limit 1)',
+            [1],
+        )->andReturn(1);
+
+        $this->assertSame(1, $builder->where('active', 1)->limit(1)->delete());
     }
 
     public function testTruncateMethod()

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -39,6 +39,10 @@ function test(
     assertType("Hypervel\\Database\\Query\\Builder<int, Hypervel\\Types\\Builder\\User, 'from'|'groupBy'|'having'|'join'|'order'|'select'|'union'|'unionOrder'|'where'>", $query->dumpRawSql());
     assertType('stdClass|null', $query->toBase()->first());
     assertType('stdClass|null', $query->getQuery()->first());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->newQuery());
+    assertType('Hypervel\Types\Builder\User|null', $query->newQuery()->first());
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->cloneWithout(['orders']));
+    assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->cloneWithoutBindings(['order']));
     assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->with('relation'));
     assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->with(['relation' => ['foo' => fn ($q) => $q]]));
     assertType('Hypervel\Database\Eloquent\Builder<Hypervel\Types\Builder\User>', $query->with(['relation' => function ($query) {


### PR DESCRIPTION
## Summary

Correct the results of seven query-builder methods when called through Eloquent. All seven currently discard the underlying return value and return the original Eloquent builder; the two write methods also bypass global scopes. This can update a row excluded by the model's scopes, hide a write result, or leave a supposedly fresh query carrying the original conditions.

These changes use Eloquent's existing result-forwarding and model-building patterns. The general forwarding behavior stays in place, with explicit methods where Eloquent needs to preserve model behavior.

## Changes

### Return write results and honor global scopes

`updateOrInsert()` now returns the underlying boolean result and applies global scopes to its lookup and update. Previously, calling it on a model returned a builder and could match a soft-deleted row that ordinary model queries exclude. The return-value behavior was reported in Laravel issues [#38839](https://github.com/laravel/framework/issues/38839) and [#56664](https://github.com/laravel/framework/issues/56664).

The correction adds the method to Eloquent's existing `$passthru` list, which applies scopes through `toBase()`. Laravel used the same approach for `existsOr()` and `doesntExistOr()` in [#44795](https://github.com/laravel/framework/pull/44795). Scope conditions restrict which rows can be matched; they do not populate inserted attributes. Callers still supply the values to insert.

`updateFrom()` now has an explicit Eloquent implementation. It applies global scopes and returns the affected-row count from PostgreSQL, making joined updates behave consistently with Eloquent's `update()`. The underlying PostgreSQL operation remains the one introduced in Laravel [#39151](https://github.com/laravel/framework/pull/39151).

It also maintains `updated_at`, using the same timestamp handling as `update()`. This is a deliberate Eloquent consistency improvement over Laravel's current forwarding behavior: changing a model through a joined update should maintain its timestamp just as an ordinary mass update does. Disabled timestamps and explicitly supplied timestamp values, including `null`, are respected. The timestamp is written in the same update statement.

For raw sources, automatic timestamps require an explicit alias supplied through `from(DB::raw(...), 'alias')`. Bare `fromRaw()` passes the supplied values through unchanged, so callers manage timestamps themselves. This avoids guessing a table alias from arbitrary SQL or conflicting with a caller's qualified timestamp value.

Both methods return the result already produced by the database operation; no additional query is needed to obtain it. They remain direct database writes and do not retrieve models or fire per-model save events.

### Return query information

`getColumns()` and `getProcessor()` now return the selected-column array and query processor, respectively. Previously, the underlying getters ran but their values were discarded. They now use the same result-forwarding list as `getBindings()`, `getGrammar()` and `getConnection()`.

Laravel [#35837](https://github.com/laravel/framework/pull/35837) added `getProcessor()` and `newQuery()` to this list. After [#37956](https://github.com/laravel/framework/pull/37956) was [reverted](https://github.com/laravel/framework/commit/35789fd0701376cbc1c2fdb6ef519cebc5512034), the restored list omitted both entries.

Use the query builder's existing alias metadata through a shared `getFromAlias()` accessor. Timestamp handling and PostgreSQL/SQLite limited updates and deletes previously tried to split raw expression objects as strings, causing a `TypeError`. They now use the explicit alias where available. Joined update/delete rewrites require an explicit source alias: an unqualified row identifier can silently target the wrong rows. Raw limited writes without joins remain supported. Raw sources still require an explicit alias or selection when inferring a wildcard, because an unqualified wildcard can introduce duplicate columns in joined pagination queries.

### Create fresh queries and useful clones

`newQuery()` now returns a fresh Eloquent builder from the associated model. Previously, forwarding created a new base query, discarded it and returned the original Eloquent builder. Conditions on the original therefore remained in effect.

Using the model's `newQuery()` preserves its configured builder class, connection, table, global scopes and default eager loads. Conditions, eager loads, removed scopes and local macros set on the current builder are not carried over, and the original builder is left untouched.

`cloneWithout()` and `cloneWithoutBindings()` now return an Eloquent clone with the requested query properties or binding groups removed. Previously, forwarding discarded the base query's clone and returned the original builder, so these calls had no effect on the returned query. The new methods preserve the model and Eloquent configuration, run clone callbacks once, and leave the original unchanged. This follows the explicit Eloquent cloning approach established by Laravel [#36924](https://github.com/laravel/framework/pull/36924).

The fresh-query and clone methods also retain the model type in static analysis.

### Keep the changes specific and document their effects

The [Laravel discussion about general forwarding](https://github.com/laravel/framework/discussions/56680) highlights why returning every underlying result is insufficient: Eloquent must also decide when to apply global scopes. This PR keeps that distinction and corrects the methods above individually.

Add a joined-update example to the Eloquent documentation and record the timestamp difference in the database README. The porting guide calls out the practical effects: writes honor scopes, return their write results rather than a chainable builder, and `updateFrom()` maintains timestamps. It also clarifies that the existing `static` return guidance applies to base query builders.

## Verification

The new regression tests fail against the original builder, covering discarded results, bypassed scopes and ineffective fresh-query and clone operations.
